### PR TITLE
Add malformed wallet API request tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -59,6 +59,30 @@ SECURITY_HEADERS = {
 }
 
 
+async def json_object_body(request: Request) -> dict[str, Any]:
+    try:
+        data = await request.json()
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail="invalid json body") from exc
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=400, detail="json body must be an object")
+    return data
+
+
+def required_body_field(data: dict[str, Any], field: str) -> Any:
+    try:
+        return data[field]
+    except KeyError as exc:
+        raise HTTPException(status_code=400, detail=f"missing required field: {field}") from exc
+
+
+def required_int_body_field(data: dict[str, Any], field: str) -> int:
+    try:
+        return int(required_body_field(data, field))
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=f"invalid integer field: {field}") from exc
+
+
 def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
     return {
         "id": bounty.id,
@@ -319,12 +343,12 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.post("/api/v1/wallets/register")
     async def api_register_wallet(request: Request) -> dict[str, Any]:
-        data = await request.json()
+        data = await json_object_body(request)
         with session_scope(db_url) as session:
             try:
                 wallet = register_wallet(
                     session,
-                    public_key_hex=str(data["public_key_hex"]),
+                    public_key_hex=str(required_body_field(data, "public_key_hex")),
                     label=str(data["label"]) if data.get("label") is not None else None,
                 )
             except LedgerError as exc:
@@ -343,15 +367,15 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     async def api_link_wallet_github(
         request: Request, github_login: str = Depends(require_github_login)
     ) -> dict[str, Any]:
-        data = await request.json()
+        data = await json_object_body(request)
         with session_scope(db_url) as session:
             try:
                 wallet = link_wallet_to_github(
                     session,
-                    address=str(data["address"]),
+                    address=str(required_body_field(data, "address")),
                     github_login=github_login,
-                    nonce=int(data["nonce"]),
-                    signature_hex=str(data["signature_hex"]),
+                    nonce=required_int_body_field(data, "nonce"),
+                    signature_hex=str(required_body_field(data, "signature_hex")),
                 )
             except LedgerError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -361,15 +385,15 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     async def api_github_claim(
         request: Request, github_login: str = Depends(require_github_login)
     ) -> dict[str, Any]:
-        data = await request.json()
+        data = await json_object_body(request)
         with session_scope(db_url) as session:
             try:
                 entry = submit_github_claim(
                     session,
-                    address=str(data["address"]),
+                    address=str(required_body_field(data, "address")),
                     github_login=github_login,
-                    nonce=int(data["nonce"]),
-                    signature_hex=str(data["signature_hex"]),
+                    nonce=required_int_body_field(data, "nonce"),
+                    signature_hex=str(required_body_field(data, "signature_hex")),
                 )
             except LedgerError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -377,17 +401,17 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.post("/api/v1/transfers")
     async def api_submit_transfer(request: Request) -> dict[str, Any]:
-        data = await request.json()
+        data = await json_object_body(request)
         with session_scope(db_url) as session:
             try:
                 transfer = submit_wallet_transfer(
                     session,
-                    from_address=str(data["from_address"]),
-                    to_address=str(data["to_address"]),
-                    amount_mrwk=str(data["amount_mrwk"]),
-                    nonce=int(data["nonce"]),
+                    from_address=str(required_body_field(data, "from_address")),
+                    to_address=str(required_body_field(data, "to_address")),
+                    amount_mrwk=str(required_body_field(data, "amount_mrwk")),
+                    nonce=required_int_body_field(data, "nonce"),
                     memo=str(data.get("memo", "")),
-                    signature_hex=str(data["signature_hex"]),
+                    signature_hex=str(required_body_field(data, "signature_hex")),
                 )
             except LedgerError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from fastapi.testclient import TestClient
@@ -108,6 +109,59 @@ def test_wallet_transfer_api_returns_validation_error(sqlite_url: str) -> None:
 
     assert response.status_code == 400
     assert response.json()["detail"] in {"invalid signature", "insufficient balance"}
+
+
+@pytest.mark.parametrize(
+    ("path", "payload", "expected_detail"),
+    [
+        (
+            "/api/v1/wallets/register",
+            {"label": "missing public key"},
+            "missing required field: public_key_hex",
+        ),
+        (
+            "/api/v1/transfers",
+            {
+                "from_address": "mrwk1bad",
+                "to_address": "mrwk1also_bad",
+                "amount_mrwk": "1",
+                "nonce": "not-a-number",
+                "signature_hex": "00",
+            },
+            "invalid integer field: nonce",
+        ),
+        (
+            "/api/v1/wallets/link-github",
+            {"address": "mrwk1bad", "nonce": "not-a-number", "signature_hex": "00"},
+            "invalid integer field: nonce",
+        ),
+        (
+            "/api/v1/github/claim",
+            {"address": "mrwk1bad", "nonce": 1},
+            "missing required field: signature_hex",
+        ),
+    ],
+)
+def test_wallet_api_malformed_requests_return_controlled_4xx(
+    sqlite_url: str,
+    monkeypatch,
+    path: str,
+    payload: dict[str, object],
+    expected_detail: str,
+) -> None:
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    create_schema(sqlite_url)
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+        raise_server_exceptions=False,
+    )
+    client.cookies.set("mrwk_user", _signed_value("alice", "test-cookie-secret"))
+
+    response = client.post(path, json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == expected_detail
 
 
 def test_wallet_link_and_claim_require_github_login(sqlite_url: str) -> None:


### PR DESCRIPTION
Closes #5

## Summary
- add request-body guards for wallet register, transfer, GitHub link, and GitHub claim endpoints
- return controlled 400 responses for missing required fields, non-object JSON, invalid JSON, and malformed integer nonce values
- add regression coverage for malformed wallet API requests

## Verification
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m mypy app`