### PR TITLE
Improve bounty detail page clarity

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -73,6 +73,47 @@ code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 .detail dl { display: grid; grid-template-columns: 160px 1fr; gap: 10px 18px; }
 .detail dt { color: var(--muted); }
 .detail dd { margin: 0; overflow-wrap: anywhere; }
+.bounty-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin: 28px 0;
+}
+.bounty-summary article,
+.acceptance-card {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 8px;
+  padding: 18px;
+}
+.bounty-summary span {
+  display: block;
+  color: var(--muted);
+  font-size: .9rem;
+  margin-bottom: 8px;
+}
+.bounty-summary strong {
+  display: block;
+  overflow-wrap: anywhere;
+  font-size: 1.2rem;
+}
+.status-pill {
+  display: inline-block;
+  width: fit-content;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--bg);
+  color: var(--accent);
+  padding: 4px 10px;
+  text-transform: capitalize;
+}
+.acceptance-card h2 {
+  margin: 0 0 10px;
+}
+.acceptance-card p:last-child {
+  margin-bottom: 0;
+  overflow-wrap: anywhere;
+}
 .section-head { display: flex; justify-content: space-between; gap: 18px; align-items: end; margin-top: 42px; }
 .section-head h2 { margin-bottom: 0; }
 .project-list article { min-height: 190px; }
@@ -103,4 +144,5 @@ button { cursor: pointer; color: white; background: var(--accent); border-color:
 @media (max-width: 640px) {
   header { align-items: flex-start; flex-direction: column; }
   .detail dl { grid-template-columns: 1fr; }
+  .bounty-summary { grid-template-columns: 1fr; }
 }

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -4,15 +4,34 @@
 <section class="detail">
   <p class="eyebrow">Bounty #{{ bounty.id }}</p>
   <h1>{{ bounty.title }}</h1>
-  <p class="lead">{{ bounty.reward_mrwk }} MRWK · {{ bounty.status }}</p>
-  <dl>
-    <dt>Repository</dt>
-    <dd>{{ bounty.repo }}</dd>
-    <dt>GitHub issue</dt>
-    {% set issue_url = safe_public_url(bounty.issue_url) %}
-    <dd>{% if issue_url %}<a href="{{ issue_url }}">{{ bounty.repo }} #{{ bounty.issue_number }}</a>{% else %}{{ bounty.repo }} #{{ bounty.issue_number }}{% endif %}</dd>
-    <dt>Acceptance</dt>
-    <dd>{{ bounty.acceptance }}</dd>
-  </dl>
+  <p class="lead">Review the reward, status, source issue, and acceptance criteria before starting.</p>
+
+  {% set issue_url = safe_public_url(bounty.issue_url) %}
+  <div class="bounty-summary" aria-label="Bounty summary">
+    <article>
+      <span>Status</span>
+      <strong class="status-pill">{{ bounty.status }}</strong>
+    </article>
+    <article>
+      <span>Reward</span>
+      <strong>{{ bounty.reward_mrwk }} MRWK</strong>
+    </article>
+    <article>
+      <span>Issue</span>
+      <strong>
+        {% if issue_url %}
+          <a href="{{ issue_url }}">{{ bounty.repo }} #{{ bounty.issue_number }}</a>
+        {% else %}
+          {{ bounty.repo }} #{{ bounty.issue_number }}
+        {% endif %}
+      </strong>
+    </article>
+  </div>
+
+  <section class="acceptance-card" aria-labelledby="acceptance-heading">
+    <p class="eyebrow">Acceptance</p>
+    <h2 id="acceptance-heading">What has to be true</h2>
+    <p>{{ bounty.acceptance }}</p>
+  </section>
 </section>
 {% endblock %}

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.db import create_schema, session_scope
+from app.ledger.service import create_bounty, ensure_genesis
+from app.main import create_app
+
+
+def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=4,
+            issue_url="https://github.com/ramimbo/mergework/issues/4",
+            title="Improve bounty detail page clarity",
+            reward_mrwk="100",
+            acceptance="Focused PR improves status, reward, issue link, and acceptance text.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(f"/bounties/{bounty.id}")
+
+    assert response.status_code == 200
+    assert "Bounty summary" in response.text
+    assert "<span>Status</span>" in response.text
+    assert "<span>Reward</span>" in response.text
+    assert "<span>Issue</span>" in response.text
+    assert "100 MRWK" in response.text
+    assert "What has to be true" in response.text
+    assert "Focused PR improves status, reward, issue link, and acceptance text." in response.text


### PR DESCRIPTION
Closes #4

This makes the bounty detail page easier to scan before someone starts work:
- separates status, reward, and source issue into summary cards
- keeps the GitHub issue link prominent
- moves acceptance text into its own short section
- adds a regression test for the key fields on the detail page

Checks run:
- ./.venv/bin/python -m pytest
- ./.venv/bin/python -m ruff format --check .
- ./.venv/bin/python -m ruff check .
- ./.venv/bin/python -m mypy app