### PR TITLE
Improve ledger proof readability

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -622,7 +622,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/proofs/{proof_hash}", response_class=HTMLResponse)
     def proof_page(request: Request, proof_hash: str) -> HTMLResponse:
-        return templates.TemplateResponse(request, "proof.html", {"proof": api_proof(proof_hash)})
+        return templates.TemplateResponse(
+            request, "proof.html", {"proof": api_proof(proof_hash), "proof_hash": proof_hash}
+        )
 
     @app.get("/docs", response_class=HTMLResponse)
     def docs_page(request: Request) -> HTMLResponse:

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -68,11 +68,15 @@ main { max-width: 980px; margin: 0 auto; padding: 48px 20px; }
 table { width: 100%; border-collapse: collapse; background: var(--panel); }
 th, td { border-bottom: 1px solid var(--line); padding: 10px; text-align: left; }
 code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+code.hash { overflow-wrap: anywhere; }
 .lead { color: var(--muted); font-size: 1.15rem; }
 .eyebrow { color: var(--accent); font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
 .detail dl { display: grid; grid-template-columns: 160px 1fr; gap: 10px 18px; }
 .detail dt { color: var(--muted); }
 .detail dd { margin: 0; overflow-wrap: anywhere; }
+.meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin: 22px 0; }
+.meta-grid article { border: 1px solid var(--line); background: var(--panel); border-radius: 6px; padding: 14px; }
+.meta-grid span { display: block; color: var(--muted); margin-bottom: 6px; }
 .section-head { display: flex; justify-content: space-between; gap: 18px; align-items: end; margin-top: 42px; }
 .section-head h2 { margin-bottom: 0; }
 .project-list article { min-height: 190px; }

--- a/app/templates/ledger.html
+++ b/app/templates/ledger.html
@@ -4,17 +4,17 @@
 <h1>Ledger</h1>
 <p class="lead">Every MRWK reserve and payout is recorded as a hash-linked ledger entry.</p>
 <table>
-  <thead><tr><th>#</th><th>Type</th><th>From</th><th>To</th><th>Amount</th><th>Proof</th><th>Hash</th></tr></thead>
+  <thead><tr><th>Entry</th><th>Type</th><th>From</th><th>To</th><th>Amount</th><th>Proof</th><th>Entry hash</th></tr></thead>
   <tbody>
     {% for entry in entries %}
     <tr>
-      <td><a href="/ledger/{{ entry.sequence }}">{{ entry.sequence }}</a></td>
+      <td><a href="/ledger/{{ entry.sequence }}">#{{ entry.sequence }}</a></td>
       <td>{{ entry.type }}</td>
       <td>{% if entry.from %}<a href="/accounts/{{ entry.from }}">{{ entry.from }}</a>{% else %}-{% endif %}</td>
       <td>{% if entry.to %}<a href="/accounts/{{ entry.to }}">{{ entry.to }}</a>{% else %}-{% endif %}</td>
       <td>{{ entry.amount_mrwk }} MRWK</td>
-      <td>{% if entry.proof_hash %}<a href="/proofs/{{ entry.proof_hash }}">proof</a>{% else %}-{% endif %}</td>
-      <td><code>{{ entry.entry_hash[:16] }}</code></td>
+      <td>{% if entry.proof_hash %}<a href="/proofs/{{ entry.proof_hash }}">View proof</a>{% else %}-{% endif %}</td>
+      <td><code class="hash">{{ entry.entry_hash[:16] }}</code></td>
     </tr>
     {% endfor %}
   </tbody>

--- a/app/templates/ledger_entry.html
+++ b/app/templates/ledger_entry.html
@@ -5,6 +5,18 @@
   <p class="eyebrow">Ledger entry</p>
   <h1>#{{ entry.sequence }} {{ entry.type }}</h1>
   <p class="lead">{{ entry.amount_mrwk }} MRWK</p>
+  <div class="meta-grid">
+    <article>
+      <span>Entry hash</span>
+      <code class="hash">{{ entry.entry_hash }}</code>
+    </article>
+    {% if entry.proof_hash %}
+    <article>
+      <span>Proof hash</span>
+      <a href="/proofs/{{ entry.proof_hash }}"><code class="hash">{{ entry.proof_hash }}</code></a>
+    </article>
+    {% endif %}
+  </div>
   <dl>
     <dt>From</dt>
     <dd>{% if entry.from %}<a href="/accounts/{{ entry.from }}">{{ entry.from }}</a>{% else %}-{% endif %}</dd>
@@ -20,7 +32,7 @@
     <dt>Created</dt>
     <dd>{{ entry.created_at }}</dd>
     {% if entry.proof_hash %}
-    <dt>Proof</dt>
+    <dt>Proof hash</dt>
     <dd><a href="/proofs/{{ entry.proof_hash }}">{{ entry.proof_hash }}</a></dd>
     {% endif %}
   </dl>

--- a/app/templates/proof.html
+++ b/app/templates/proof.html
@@ -5,7 +5,26 @@
   <p class="eyebrow">Proof</p>
   <h1>Accepted work proof</h1>
   <p class="lead">{{ proof.amount_mrwk }} MRWK paid to <a href="/accounts/{{ proof.to_account }}">{{ proof.to_account }}</a>.</p>
+  <div class="meta-grid">
+    <article>
+      <span>Proof hash</span>
+      <code class="hash">{{ proof_hash }}</code>
+    </article>
+    <article>
+      <span>Ledger hash</span>
+      <code class="hash">{{ proof.ledger_hash }}</code>
+    </article>
+  </div>
   <dl>
+    <dt>Issue</dt>
+    {% set issue_url = safe_public_url("https://github.com/" ~ proof.repo ~ "/issues/" ~ proof.issue_number) %}
+    <dd>{% if issue_url %}<a href="{{ issue_url }}">{{ proof.repo }} #{{ proof.issue_number }}</a>{% else %}{{ proof.repo }} #{{ proof.issue_number }}{% endif %}</dd>
+    <dt>Accepted by</dt>
+    <dd>{{ proof.accepted_by }}</dd>
+    <dt>Paid to</dt>
+    <dd><a href="/accounts/{{ proof.to_account }}">{{ proof.to_account }}</a></dd>
+    <dt>Amount</dt>
+    <dd>{{ proof.amount_mrwk }} MRWK</dd>
     <dt>Ledger entry</dt>
     <dd><a href="/ledger/{{ proof.ledger_sequence }}">#{{ proof.ledger_sequence }}</a></dd>
     <dt>Ledger hash</dt>

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -116,7 +116,15 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
 
     assert "/ledger/3" in ledger
     assert f"/proofs/{proof.hash}" in ledger
+    assert "Entry hash" in ledger
     assert "Previous hash" in entry
+    assert "Proof hash" in entry
+    assert proof.hash in entry
+    assert "Accepted by" in proof_page
+    assert "Issue" in proof_page
+    assert "ramimbo/mergework #2" in proof_page
+    assert proof.hash in proof_page
+    assert "maintainer" in proof_page
     assert "github:alice" in proof_page
     assert "Ledger address" in account
     assert "MRWK wallet transfers are enabled" in account


### PR DESCRIPTION
Closes #6

## Summary
- show entry and proof hashes more clearly on ledger pages
- add proof page payout metadata for issue, accepted by, paid to, amount, submission, and ledger entry
- cover the explorer page fields in the existing API/MCP test

## Verification
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m mypy app`