### PR TITLE
Improve bounty detail page clarity for issue #4

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -70,9 +70,58 @@ th, td { border-bottom: 1px solid var(--line); padding: 10px; text-align: left; 
 code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 .lead { color: var(--muted); font-size: 1.15rem; }
 .eyebrow { color: var(--accent); font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
-.detail dl { display: grid; grid-template-columns: 160px 1fr; gap: 10px 18px; }
-.detail dt { color: var(--muted); }
+.bounty-summary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(180px, 1fr));
+  gap: 12px;
+  margin: 24px 0;
+}
+.bounty-summary > div {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 6px;
+  padding: 14px;
+}
+.meta-label {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+.meta-value {
+  margin: 6px 0 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+.status-pill {
+  display: inline-block;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  padding: 4px 10px;
+  font-size: .95rem;
+  line-height: 1.25;
+}
+.status-open { background: color-mix(in srgb, var(--accent) 12%, transparent); }
+.status-closed {
+  background: color-mix(in srgb, #8f9aad 20%, transparent);
+  color: var(--muted);
+}
+.detail-list {
+  display: grid;
+  grid-template-columns: 180px 1fr;
+  gap: 12px 20px;
+  margin: 0;
+}
+.detail dt {
+  color: var(--muted);
+  font-weight: 600;
+}
 .detail dd { margin: 0; overflow-wrap: anywhere; }
+.acceptance-text {
+  white-space: pre-wrap;
+  line-height: 1.6;
+}
 .section-head { display: flex; justify-content: space-between; gap: 18px; align-items: end; margin-top: 42px; }
 .section-head h2 { margin-bottom: 0; }
 .project-list article { min-height: 190px; }
@@ -102,5 +151,6 @@ button { cursor: pointer; color: white; background: var(--accent); border-color:
 .wallet-tool form + h2 { margin-top: 34px; }
 @media (max-width: 640px) {
   header { align-items: flex-start; flex-direction: column; }
-  .detail dl { grid-template-columns: 1fr; }
+  .bounty-summary { grid-template-columns: 1fr; }
+  .detail-list { grid-template-columns: 1fr; }
 }

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -4,15 +4,30 @@
 <section class="detail">
   <p class="eyebrow">Bounty #{{ bounty.id }}</p>
   <h1>{{ bounty.title }}</h1>
-  <p class="lead">{{ bounty.reward_mrwk }} MRWK · {{ bounty.status }}</p>
-  <dl>
+  <div class="bounty-summary" aria-label="Bounty summary">
+    <div>
+      <p class="meta-label">Reward</p>
+      <p class="meta-value">{{ bounty.reward_mrwk }} MRWK</p>
+    </div>
+    <div>
+      <p class="meta-label">Status</p>
+      <p class="meta-value"><span class="status-pill status-{{ bounty.status|lower|replace(' ', '-') }}">{{ bounty.status }}</span></p>
+    </div>
+  </div>
+  <dl class="detail-list">
     <dt>Repository</dt>
-    <dd>{{ bounty.repo }}</dd>
+    <dd><code>{{ bounty.repo }}</code></dd>
     <dt>GitHub issue</dt>
     {% set issue_url = safe_public_url(bounty.issue_url) %}
-    <dd>{% if issue_url %}<a href="{{ issue_url }}">{{ bounty.repo }} #{{ bounty.issue_number }}</a>{% else %}{{ bounty.repo }} #{{ bounty.issue_number }}{% endif %}</dd>
-    <dt>Acceptance</dt>
-    <dd>{{ bounty.acceptance }}</dd>
+    <dd>
+      {% if issue_url %}
+      <a href="{{ issue_url }}" rel="noopener noreferrer">{{ bounty.repo }} #{{ bounty.issue_number }}</a>
+      {% else %}
+      {{ bounty.repo }} #{{ bounty.issue_number }}
+      {% endif %}
+    </dd>
+    <dt>Acceptance criteria</dt>
+    <dd class="acceptance-text">{{ bounty.acceptance }}</dd>
   </dl>
 </section>
 {% endblock %}


### PR DESCRIPTION
This PR addresses #4 with a focused bounty detail page clarity update.

## What changed
- Added a compact summary panel for **Reward** and **Status** at the top of the detail page
- Introduced a status pill style for better scanability
- Reformatted detail fields into clearer label/value rows
- Kept GitHub issue link explicit and safe (`rel="noopener noreferrer"`)
- Preserved acceptance text formatting with `white-space: pre-wrap`
- Added mobile adjustments so summary and detail rows stack cleanly

## Acceptance criteria mapping
- Status/reward/issue link/acceptance text are now more readable and actionable
- Copy remains short and direct
- No layout-heavy redesign or marketing copy

## Checks run
- `pytest`
- `ruff format --check .`
- `ruff check .`
- `mypy app`

All checks passed locally.