### PR TITLE
Return 4xx for malformed wallet API payloads

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -147,6 +147,30 @@ def _safe_next_path(next_path: str | None) -> str:
     return next_path
 
 
+async def _json_object(request: Request) -> dict[str, Any]:
+    try:
+        data = await request.json()
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid JSON body") from exc
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=400, detail="JSON body must be an object")
+    return data
+
+
+def _required_field(data: dict[str, Any], field: str) -> Any:
+    try:
+        return data[field]
+    except KeyError as exc:
+        raise HTTPException(status_code=400, detail=f"{field} is required") from exc
+
+
+def _required_int(data: dict[str, Any], field: str) -> int:
+    try:
+        return int(_required_field(data, field))
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=f"{field} must be an integer") from exc
+
+
 def _signed_value(value: str, secret: str) -> str:
     timestamp = str(int(time.time()))
     body = f"{value}|{timestamp}"
@@ -324,12 +348,12 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.post("/api/v1/wallets/register")
     async def api_register_wallet(request: Request) -> dict[str, Any]:
-        data = await request.json()
+        data = await _json_object(request)
         with session_scope(db_url) as session:
             try:
                 wallet = register_wallet(
                     session,
-                    public_key_hex=str(data["public_key_hex"]),
+                    public_key_hex=str(_required_field(data, "public_key_hex")),
                     label=str(data["label"]) if data.get("label") is not None else None,
                 )
             except LedgerError as exc:
@@ -348,15 +372,15 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     async def api_link_wallet_github(
         request: Request, github_login: str = Depends(require_github_login)
     ) -> dict[str, Any]:
-        data = await request.json()
+        data = await _json_object(request)
         with session_scope(db_url) as session:
             try:
                 wallet = link_wallet_to_github(
                     session,
-                    address=str(data["address"]),
+                    address=str(_required_field(data, "address")),
                     github_login=github_login,
-                    nonce=int(data["nonce"]),
-                    signature_hex=str(data["signature_hex"]),
+                    nonce=_required_int(data, "nonce"),
+                    signature_hex=str(_required_field(data, "signature_hex")),
                 )
             except LedgerError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -366,15 +390,15 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     async def api_github_claim(
         request: Request, github_login: str = Depends(require_github_login)
     ) -> dict[str, Any]:
-        data = await request.json()
+        data = await _json_object(request)
         with session_scope(db_url) as session:
             try:
                 entry = submit_github_claim(
                     session,
-                    address=str(data["address"]),
+                    address=str(_required_field(data, "address")),
                     github_login=github_login,
-                    nonce=int(data["nonce"]),
-                    signature_hex=str(data["signature_hex"]),
+                    nonce=_required_int(data, "nonce"),
+                    signature_hex=str(_required_field(data, "signature_hex")),
                 )
             except LedgerError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -382,17 +406,17 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.post("/api/v1/transfers")
     async def api_submit_transfer(request: Request) -> dict[str, Any]:
-        data = await request.json()
+        data = await _json_object(request)
         with session_scope(db_url) as session:
             try:
                 transfer = submit_wallet_transfer(
                     session,
-                    from_address=str(data["from_address"]),
-                    to_address=str(data["to_address"]),
-                    amount_mrwk=str(data["amount_mrwk"]),
-                    nonce=int(data["nonce"]),
+                    from_address=str(_required_field(data, "from_address")),
+                    to_address=str(_required_field(data, "to_address")),
+                    amount_mrwk=str(_required_field(data, "amount_mrwk")),
+                    nonce=_required_int(data, "nonce"),
                     memo=str(data.get("memo", "")),
-                    signature_hex=str(data["signature_hex"]),
+                    signature_hex=str(_required_field(data, "signature_hex")),
                 )
             except LedgerError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/tests/test_wallet_api_malformed.py
+++ b/tests/test_wallet_api_malformed.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import _signed_value, create_app
+
+
+def test_wallet_register_missing_public_key_returns_400(sqlite_url: str) -> None:
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        raise_server_exceptions=False,
+    )
+
+    response = client.post("/api/v1/wallets/register", json={"label": "Missing key"})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "public_key_hex is required"
+
+
+def test_wallet_transfer_bad_nonce_returns_400(sqlite_url: str) -> None:
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        raise_server_exceptions=False,
+    )
+
+    response = client.post(
+        "/api/v1/transfers",
+        json={
+            "from_address": "mrwk1" + "1" * 40,
+            "to_address": "mrwk1" + "2" * 40,
+            "amount_mrwk": "1",
+            "nonce": "not-a-number",
+            "signature_hex": "0" * 128,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "nonce must be an integer"
+
+
+def test_wallet_link_non_object_body_returns_400(sqlite_url: str, monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+        raise_server_exceptions=False,
+    )
+    client.cookies.set("mrwk_user", _signed_value("alice", "test-cookie-secret"))
+
+    response = client.post("/api/v1/wallets/link-github", json=["not", "an", "object"])
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "JSON body must be an object"
+
+
+def test_github_claim_invalid_json_returns_400(sqlite_url: str, monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+        raise_server_exceptions=False,
+    )
+    client.cookies.set("mrwk_user", _signed_value("alice", "test-cookie-secret"))
+
+    response = client.post(
+        "/api/v1/github/claim",
+        content=b"{not json",
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "invalid JSON body"


### PR DESCRIPTION
Closes #5

This tightens the wallet-facing API paths so malformed payloads return controlled 400 responses instead of leaking KeyError/ValueError paths into 500s.

What changed:
- validates wallet API request bodies are JSON objects
- returns clear 400s for missing required fields and bad integer nonce values
- covers register, transfer, wallet link, and GitHub claim malformed payload cases

Checks run:
- /Users/jimmy/Documents/Playground/bounty-work/mergework/.venv/bin/python -m pytest
- /Users/jimmy/Documents/Playground/bounty-work/mergework/.venv/bin/python -m ruff format --check .
- /Users/jimmy/Documents/Playground/bounty-work/mergework/.venv/bin/python -m ruff check .
- /Users/jimmy/Documents/Playground/bounty-work/mergework/.venv/bin/python -m mypy app