### PR TITLE
Add controlled 4xx tests for malformed wallet API requests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -172,6 +172,42 @@ def _verified_value(token: str | None, secret: str, max_age_seconds: int) -> str
     return value
 
 
+async def _json_object(request: Request) -> dict[str, Any]:
+    try:
+        data = await request.json()
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid json body") from exc
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=400, detail="json body must be an object")
+    return data
+
+
+def _required_str(data: dict[str, Any], field: str) -> str:
+    value = data.get(field)
+    if not isinstance(value, str):
+        raise HTTPException(status_code=400, detail=f"{field} is required")
+    return value
+
+
+def _optional_str(data: dict[str, Any], field: str, default: str = "") -> str:
+    value = data.get(field, default)
+    if value is None:
+        return default
+    if not isinstance(value, str):
+        raise HTTPException(status_code=400, detail=f"{field} must be a string")
+    return value
+
+
+def _required_int(data: dict[str, Any], field: str) -> int:
+    value = data.get(field)
+    if value is None or isinstance(value, bool):
+        raise HTTPException(status_code=400, detail=f"{field} must be an integer")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=f"{field} must be an integer") from exc
+
+
 def _csrf_token(action: str, login: str, secret: str) -> str:
     return _signed_value(f"{action}:{login}", secret)
 
@@ -324,13 +360,13 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.post("/api/v1/wallets/register")
     async def api_register_wallet(request: Request) -> dict[str, Any]:
-        data = await request.json()
+        data = await _json_object(request)
         with session_scope(db_url) as session:
             try:
                 wallet = register_wallet(
                     session,
-                    public_key_hex=str(data["public_key_hex"]),
-                    label=str(data["label"]) if data.get("label") is not None else None,
+                    public_key_hex=_required_str(data, "public_key_hex"),
+                    label=_optional_str(data, "label") if data.get("label") is not None else None,
                 )
             except LedgerError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -348,15 +384,15 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     async def api_link_wallet_github(
         request: Request, github_login: str = Depends(require_github_login)
     ) -> dict[str, Any]:
-        data = await request.json()
+        data = await _json_object(request)
         with session_scope(db_url) as session:
             try:
                 wallet = link_wallet_to_github(
                     session,
-                    address=str(data["address"]),
+                    address=_required_str(data, "address"),
                     github_login=github_login,
-                    nonce=int(data["nonce"]),
-                    signature_hex=str(data["signature_hex"]),
+                    nonce=_required_int(data, "nonce"),
+                    signature_hex=_required_str(data, "signature_hex"),
                 )
             except LedgerError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -366,15 +402,15 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     async def api_github_claim(
         request: Request, github_login: str = Depends(require_github_login)
     ) -> dict[str, Any]:
-        data = await request.json()
+        data = await _json_object(request)
         with session_scope(db_url) as session:
             try:
                 entry = submit_github_claim(
                     session,
-                    address=str(data["address"]),
+                    address=_required_str(data, "address"),
                     github_login=github_login,
-                    nonce=int(data["nonce"]),
-                    signature_hex=str(data["signature_hex"]),
+                    nonce=_required_int(data, "nonce"),
+                    signature_hex=_required_str(data, "signature_hex"),
                 )
             except LedgerError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -382,17 +418,17 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.post("/api/v1/transfers")
     async def api_submit_transfer(request: Request) -> dict[str, Any]:
-        data = await request.json()
+        data = await _json_object(request)
         with session_scope(db_url) as session:
             try:
                 transfer = submit_wallet_transfer(
                     session,
-                    from_address=str(data["from_address"]),
-                    to_address=str(data["to_address"]),
-                    amount_mrwk=str(data["amount_mrwk"]),
-                    nonce=int(data["nonce"]),
-                    memo=str(data.get("memo", "")),
-                    signature_hex=str(data["signature_hex"]),
+                    from_address=_required_str(data, "from_address"),
+                    to_address=_required_str(data, "to_address"),
+                    amount_mrwk=_required_str(data, "amount_mrwk"),
+                    nonce=_required_int(data, "nonce"),
+                    memo=_optional_str(data, "memo"),
+                    signature_hex=_required_str(data, "signature_hex"),
                 )
             except LedgerError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -110,6 +110,85 @@ def test_wallet_transfer_api_returns_validation_error(sqlite_url: str) -> None:
     assert response.json()["detail"] in {"invalid signature", "insufficient balance"}
 
 
+def test_wallet_api_malformed_register_requests_return_4xx(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    missing_key = client.post("/api/v1/wallets/register", json={"label": "No key"})
+    assert missing_key.status_code == 400
+    assert missing_key.json()["detail"] == "public_key_hex is required"
+
+    non_object = client.post("/api/v1/wallets/register", json=["not", "an", "object"])
+    assert non_object.status_code == 400
+    assert non_object.json()["detail"] == "json body must be an object"
+
+
+def test_wallet_api_malformed_transfer_requests_return_4xx(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    _, sender_public, sender_address = _keypair()
+    _, receiver_public, receiver_address = _keypair()
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    client.post("/api/v1/wallets/register", json={"public_key_hex": sender_public})
+    client.post("/api/v1/wallets/register", json={"public_key_hex": receiver_public})
+
+    missing_sender = client.post(
+        "/api/v1/transfers",
+        json={
+            "to_address": receiver_address,
+            "amount_mrwk": "1",
+            "nonce": 1,
+            "signature_hex": "00" * 64,
+        },
+    )
+    assert missing_sender.status_code == 400
+    assert missing_sender.json()["detail"] == "from_address is required"
+
+    malformed_nonce = client.post(
+        "/api/v1/transfers",
+        json={
+            "from_address": sender_address,
+            "to_address": receiver_address,
+            "amount_mrwk": "1",
+            "nonce": "not-an-int",
+            "signature_hex": "00" * 64,
+        },
+    )
+    assert malformed_nonce.status_code == 400
+    assert malformed_nonce.json()["detail"] == "nonce must be an integer"
+
+
+def test_wallet_api_malformed_link_and_claim_requests_return_4xx(
+    sqlite_url: str, monkeypatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    create_schema(sqlite_url)
+    _, public_hex, _ = _keypair()
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    client.cookies.set("mrwk_user", _signed_value("alice", "test-cookie-secret"))
+    client.post("/api/v1/wallets/register", json={"public_key_hex": public_hex})
+
+    missing_signature = client.post(
+        "/api/v1/wallets/link-github",
+        json={"address": "mrwk1" + "0" * 40, "nonce": 1},
+    )
+    assert missing_signature.status_code == 400
+    assert missing_signature.json()["detail"] == "signature_hex is required"
+
+    malformed_nonce = client.post(
+        "/api/v1/github/claim",
+        json={
+            "address": "mrwk1" + "0" * 40,
+            "nonce": None,
+            "signature_hex": "00" * 64,
+        },
+    )
+    assert malformed_nonce.status_code == 400
+    assert malformed_nonce.json()["detail"] == "nonce must be an integer"
+
+
 def test_wallet_link_and_claim_require_github_login(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     private_key, public_hex, address = _keypair()


### PR DESCRIPTION
## Summary

- Adds shared wallet API request parsing helpers so malformed JSON, non-object bodies, missing required string fields, and malformed integer fields return controlled `400` responses instead of leaking `KeyError`/`ValueError` as server errors.
- Adds focused wallet API tests for malformed registration, transfer, GitHub link, and GitHub claim requests.

## Bounty

Fixes #5

## Verification

- `.venv/bin/python -m pytest tests/test_wallet_api.py` -> 11 passed
- `.venv/bin/python -m pytest` -> 48 passed
- `.venv/bin/python -m ruff format --check .` -> 26 files already formatted
- `.venv/bin/python -m ruff check .` -> All checks passed
- `.venv/bin/python -m mypy app` -> Success: no issues found in 10 source files

## Safety

No private keys, secrets, exploit details, deployment changes, or price claims are included.
