### PR TITLE
Improve ledger entry payout metadata

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -606,8 +606,10 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/ledger/{sequence}", response_class=HTMLResponse)
     def ledger_entry_page(request: Request, sequence: int) -> HTMLResponse:
+        entry = api_ledger_entry(sequence)
+        proof = api_proof(entry["proof_hash"]) if entry.get("proof_hash") else None
         return templates.TemplateResponse(
-            request, "ledger_entry.html", {"entry": api_ledger_entry(sequence)}
+            request, "ledger_entry.html", {"entry": entry, "proof": proof}
         )
 
     @app.get("/accounts/{account:path}", response_class=HTMLResponse)

--- a/app/templates/ledger.html
+++ b/app/templates/ledger.html
@@ -13,7 +13,7 @@
       <td>{% if entry.from %}<a href="/accounts/{{ entry.from }}">{{ entry.from }}</a>{% else %}-{% endif %}</td>
       <td>{% if entry.to %}<a href="/accounts/{{ entry.to }}">{{ entry.to }}</a>{% else %}-{% endif %}</td>
       <td>{{ entry.amount_mrwk }} MRWK</td>
-      <td>{% if entry.proof_hash %}<a href="/proofs/{{ entry.proof_hash }}">proof</a>{% else %}-{% endif %}</td>
+      <td>{% if entry.proof_hash %}<a href="/proofs/{{ entry.proof_hash }}">proof {{ entry.proof_hash[:8] }}</a>{% else %}-{% endif %}</td>
       <td><code>{{ entry.entry_hash[:16] }}</code></td>
     </tr>
     {% endfor %}

--- a/app/templates/ledger_entry.html
+++ b/app/templates/ledger_entry.html
@@ -24,5 +24,22 @@
     <dd><a href="/proofs/{{ entry.proof_hash }}">{{ entry.proof_hash }}</a></dd>
     {% endif %}
   </dl>
+  {% if proof %}
+  <section class="panel proof-summary">
+    <h2>Payout proof</h2>
+    <dl>
+      <dt>GitHub issue</dt>
+      {% set issue_url = safe_public_url("https://github.com/" ~ proof.repo ~ "/issues/" ~ proof.issue_number) %}
+      <dd>{% if issue_url %}<a href="{{ issue_url }}">{{ proof.repo }} #{{ proof.issue_number }}</a>{% else %}{{ proof.repo }} #{{ proof.issue_number }}{% endif %}</dd>
+      <dt>Submission</dt>
+      {% set submission_url = safe_public_url(proof.submission_url) %}
+      <dd>{% if submission_url %}<a href="{{ submission_url }}">{{ proof.submission_url }}</a>{% else %}{{ proof.submission_url }}{% endif %}</dd>
+      <dt>Accepted by</dt>
+      <dd>{{ proof.accepted_by }}</dd>
+      <dt>Paid to</dt>
+      <dd><a href="/accounts/{{ proof.to_account }}">{{ proof.to_account }}</a></dd>
+    </dl>
+  </section>
+  {% endif %}
 </section>
 {% endblock %}

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -116,7 +116,13 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
 
     assert "/ledger/3" in ledger
     assert f"/proofs/{proof.hash}" in ledger
+    assert f"proof {proof.hash[:8]}" in ledger
     assert "Previous hash" in entry
+    assert "Payout proof" in entry
+    assert "GitHub issue" in entry
+    assert "ramimbo/mergework #2" in entry
+    assert "Accepted by" in entry
+    assert "maintainer" in entry
     assert "github:alice" in proof_page
     assert "Ledger address" in account
     assert "MRWK wallet transfers are enabled" in account


### PR DESCRIPTION
Closes #6.

## Summary
- Show the short proof hash directly in the ledger table.
- Add a payout proof section on ledger entry pages with the GitHub issue, submission link, accepted-by value, and paid-to account.
- Reuse the existing public proof payload; no ledger data, proof payload, or ledger behavior changes.

## Verification
- `.venv/bin/python -m pytest tests/test_api_mcp.py` -> 6 passed
- `.venv/bin/python -m pytest` -> 48 passed
- `.venv/bin/python -m ruff format --check .` -> 26 files already formatted
- `.venv/bin/python -m ruff check .` -> All checks passed
- `.venv/bin/python -m mypy app` -> Success: no issues found in 10 source files

No private keys, secrets, exploit details, deployment changes, or price claims included.