### PR TITLE
fix: improve ledger proof readability

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -68,6 +68,37 @@ main { max-width: 980px; margin: 0 auto; padding: 48px 20px; }
 table { width: 100%; border-collapse: collapse; background: var(--panel); }
 th, td { border-bottom: 1px solid var(--line); padding: 10px; text-align: left; }
 code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.pill {
+  display: inline-block;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 2px 8px;
+  background: var(--bg);
+  font-size: .9rem;
+}
+.stacked-cell { display: grid; gap: 4px; min-width: 220px; }
+.muted-label { color: var(--muted); display: inline-block; min-width: 42px; }
+.truncate-cell { max-width: 260px; overflow-wrap: anywhere; }
+.hash-block {
+  display: inline-block;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-all;
+}
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin: 24px 0;
+}
+.summary-grid article {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 6px;
+  padding: 14px;
+  overflow-wrap: anywhere;
+}
+.summary-grid span { display: block; color: var(--muted); font-size: .9rem; margin-bottom: 6px; }
 .lead { color: var(--muted); font-size: 1.15rem; }
 .eyebrow { color: var(--accent); font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
 .detail dl { display: grid; grid-template-columns: 160px 1fr; gap: 10px 18px; }

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -175,10 +175,16 @@ input, textarea, button {
 }
 button { cursor: pointer; color: white; background: var(--accent); border-color: var(--accent); }
 .inline-form { margin-top: 18px; max-width: 180px; }
+.wallet-tool form + h2 { margin-top: 34px; }
 .flash {
   border: 1px solid var(--line);
   background: var(--panel);
   border-radius: 6px;
   padding: 12px 14px;
   margin-bottom: 24px;
+}
+@media (max-width: 640px) {
+  header { align-items: flex-start; flex-direction: column; }
+  .detail dl { grid-template-columns: 1fr; }
+  .bounty-summary { grid-template-columns: 1fr; }
 }

--- a/app/templates/ledger.html
+++ b/app/templates/ledger.html
@@ -4,17 +4,21 @@
 <h1>Ledger</h1>
 <p class="lead">Every MRWK reserve and payout is recorded as a hash-linked ledger entry.</p>
 <table>
-  <thead><tr><th>#</th><th>Type</th><th>From</th><th>To</th><th>Amount</th><th>Proof</th><th>Hash</th></tr></thead>
+  <thead><tr><th>#</th><th>Type</th><th>Parties</th><th>Amount</th><th>Reference</th><th>Proof</th><th>Hash</th></tr></thead>
   <tbody>
     {% for entry in entries %}
     <tr>
       <td><a href="/ledger/{{ entry.sequence }}">{{ entry.sequence }}</a></td>
-      <td>{{ entry.type }}</td>
-      <td>{% if entry.from %}<a href="/accounts/{{ entry.from }}">{{ entry.from }}</a>{% else %}-{% endif %}</td>
-      <td>{% if entry.to %}<a href="/accounts/{{ entry.to }}">{{ entry.to }}</a>{% else %}-{% endif %}</td>
-      <td>{{ entry.amount_mrwk }} MRWK</td>
-      <td>{% if entry.proof_hash %}<a href="/proofs/{{ entry.proof_hash }}">proof</a>{% else %}-{% endif %}</td>
-      <td><code>{{ entry.entry_hash[:16] }}</code></td>
+      <td><span class="pill">{{ entry.type }}</span></td>
+      <td class="stacked-cell">
+        <span><span class="muted-label">From</span> {% if entry.from %}<a href="/accounts/{{ entry.from }}">{{ entry.from }}</a>{% else %}-{% endif %}</span>
+        <span><span class="muted-label">To</span> {% if entry.to %}<a href="/accounts/{{ entry.to }}">{{ entry.to }}</a>{% else %}-{% endif %}</span>
+      </td>
+      <td><strong>{{ entry.amount_mrwk }}</strong> MRWK</td>
+      {% set reference_url = safe_public_url(entry.reference) %}
+      <td class="truncate-cell">{% if entry.reference %}{% if reference_url %}<a href="{{ reference_url }}">{{ entry.reference }}</a>{% else %}{{ entry.reference }}{% endif %}{% else %}-{% endif %}</td>
+      <td>{% if entry.proof_hash %}<a href="/proofs/{{ entry.proof_hash }}"><code>{{ entry.proof_hash[:12] }}</code></a>{% else %}-{% endif %}</td>
+      <td><a href="/ledger/{{ entry.sequence }}"><code>{{ entry.entry_hash[:16] }}</code></a></td>
     </tr>
     {% endfor %}
   </tbody>

--- a/app/templates/ledger.html
+++ b/app/templates/ledger.html
@@ -4,7 +4,7 @@
 <h1>Ledger</h1>
 <p class="lead">Every MRWK reserve and payout is recorded as a hash-linked ledger entry.</p>
 <table>
-  <thead><tr><th>#</th><th>Type</th><th>Parties</th><th>Amount</th><th>Reference</th><th>Proof</th><th>Hash</th></tr></thead>
+  <thead><tr><th>#</th><th>Type</th><th>Parties</th><th>Amount</th><th>Reference</th><th>Proof</th><th>Entry hash</th></tr></thead>
   <tbody>
     {% for entry in entries %}
     <tr>

--- a/app/templates/ledger_entry.html
+++ b/app/templates/ledger_entry.html
@@ -5,6 +5,20 @@
   <p class="eyebrow">Ledger entry</p>
   <h1>#{{ entry.sequence }} {{ entry.type }}</h1>
   <p class="lead">{{ entry.amount_mrwk }} MRWK</p>
+  <div class="summary-grid">
+    <article>
+      <span>From</span>
+      {% if entry.from %}<a href="/accounts/{{ entry.from }}">{{ entry.from }}</a>{% else %}<strong>-</strong>{% endif %}
+    </article>
+    <article>
+      <span>To</span>
+      {% if entry.to %}<a href="/accounts/{{ entry.to }}">{{ entry.to }}</a>{% else %}<strong>-</strong>{% endif %}
+    </article>
+    <article>
+      <span>Amount</span>
+      <strong>{{ entry.amount_mrwk }} MRWK</strong>
+    </article>
+  </div>
   <dl>
     <dt>From</dt>
     <dd>{% if entry.from %}<a href="/accounts/{{ entry.from }}">{{ entry.from }}</a>{% else %}-{% endif %}</dd>
@@ -14,14 +28,14 @@
     {% set reference_url = safe_public_url(entry.reference) %}
     <dd>{% if reference_url %}<a href="{{ reference_url }}">{{ entry.reference }}</a>{% else %}{{ entry.reference }}{% endif %}</dd>
     <dt>Previous hash</dt>
-    <dd><code>{{ entry.previous_hash }}</code></dd>
+    <dd><code class="hash-block">{{ entry.previous_hash }}</code></dd>
     <dt>Entry hash</dt>
-    <dd><code>{{ entry.entry_hash }}</code></dd>
+    <dd><code class="hash-block">{{ entry.entry_hash }}</code></dd>
     <dt>Created</dt>
     <dd>{{ entry.created_at }}</dd>
     {% if entry.proof_hash %}
     <dt>Proof</dt>
-    <dd><a href="/proofs/{{ entry.proof_hash }}">{{ entry.proof_hash }}</a></dd>
+    <dd><a href="/proofs/{{ entry.proof_hash }}"><code class="hash-block">{{ entry.proof_hash }}</code></a></dd>
     {% endif %}
   </dl>
 </section>

--- a/app/templates/proof.html
+++ b/app/templates/proof.html
@@ -5,15 +5,30 @@
   <p class="eyebrow">Proof</p>
   <h1>Accepted work proof</h1>
   <p class="lead">{{ proof.amount_mrwk }} MRWK paid to <a href="/accounts/{{ proof.to_account }}">{{ proof.to_account }}</a>.</p>
+  <div class="summary-grid">
+    <article>
+      <span>Ledger entry</span>
+      <a href="/ledger/{{ proof.ledger_sequence }}">#{{ proof.ledger_sequence }}</a>
+    </article>
+    <article>
+      <span>Recipient</span>
+      <a href="/accounts/{{ proof.to_account }}">{{ proof.to_account }}</a>
+    </article>
+    <article>
+      <span>Amount</span>
+      <strong>{{ proof.amount_mrwk }} MRWK</strong>
+    </article>
+  </div>
   <dl>
     <dt>Ledger entry</dt>
     <dd><a href="/ledger/{{ proof.ledger_sequence }}">#{{ proof.ledger_sequence }}</a></dd>
     <dt>Ledger hash</dt>
-    <dd><code>{{ proof.ledger_hash }}</code></dd>
+    <dd><code class="hash-block">{{ proof.ledger_hash }}</code></dd>
     <dt>Submission</dt>
     {% set submission_url = safe_public_url(proof.submission_url) %}
     <dd>{% if submission_url %}<a href="{{ submission_url }}">{{ proof.submission_url }}</a>{% else %}{{ proof.submission_url }}{% endif %}</dd>
   </dl>
+  <h2>Public proof payload</h2>
   <pre>{{ proof | tojson(indent=2) }}</pre>
 </section>
 {% endblock %}

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -281,6 +281,41 @@ def test_ledger_and_proof_pages_surface_readable_metadata(sqlite_url: str) -> No
     assert "100" in proof_page
 
 
+def test_ledger_surfaces_bounty_release_entries(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=23,
+            issue_url="https://github.com/ramimbo/mergework/issues/23",
+            title="Scan bounty payments and releases",
+            reward_mrwk="15",
+            acceptance="Visible handling for bounty payment and release scanning.",
+        )
+        release_entry = add_ledger_entry(
+            session,
+            entry_type="bounty_release",
+            from_account=f"reserve:bounty:{bounty.id}",
+            to_account=TREASURY_ACCOUNT,
+            amount_microunits=parse_mrwk_amount("15"),
+            reference="https://github.com/ramimbo/mergework/issues/23#bounty-release",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    ledger_page = client.get("/ledger").text
+    assert "bounty_release" in ledger_page
+    assert "https://github.com/ramimbo/mergework/issues/23#bounty-release" in ledger_page
+    assert f"/ledger/{release_entry.sequence}" in ledger_page
+
+    entry_page = client.get(f"/ledger/{release_entry.sequence}").text
+    assert "bounty_release" in entry_page
+    assert "reserve:bounty:" in entry_page
+    assert "treasury:mrwk" in entry_page
+
+
 def test_signed_webhook_with_invalid_json_is_rejected(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     body = b"not-json"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -191,6 +191,48 @@ def test_ledger_reference_unsafe_urls_are_not_rendered_as_links(sqlite_url: str)
     assert 'href="javascript:alert(1)"' not in page
 
 
+def test_ledger_and_proof_pages_surface_readable_metadata(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=6,
+            issue_url="https://github.com/ramimbo/mergework/issues/6",
+            title="Improve ledger explorer proof readability",
+            reward_mrwk="100",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/12",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    ledger_page = client.get("/ledger").text
+    assert "Parties" in ledger_page
+    assert "Reference" in ledger_page
+    assert "github:alice" in ledger_page
+    assert "/proofs/" in ledger_page
+
+    entry_page = client.get(f"/ledger/{proof.ledger_sequence}").text
+    assert "summary-grid" in entry_page
+    assert "hash-block" in entry_page
+    assert proof.hash in entry_page
+
+    proof_page = client.get(f"/proofs/{proof.hash}").text
+    assert "Public proof payload" in proof_page
+    assert "Recipient" in proof_page
+    assert "github:alice" in proof_page
+    assert "100" in proof_page
+
+
 def test_signed_webhook_with_invalid_json_is_rejected(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     body = b"not-json"


### PR DESCRIPTION
## Summary
- Improve the ledger table so entries show parties, reference links, proof links, and clickable hash snippets.
- Add summary cards and safer long-hash wrapping to ledger entry and proof detail pages.
- Add page-level regression coverage for readable ledger/proof metadata.
- Preserve wallet-tool/mobile CSS rules while adding readability styles.
- Add coverage that `bounty_release` ledger entries remain visible for bounty payment/release scanning.

Refs #23

## Test plan
- ./.venv/bin/python -m pytest -q (58 passed)
- ./.venv/bin/python -m ruff format --check .
- ./.venv/bin/python -m ruff check .
- ./.venv/bin/python -m mypy app
- git diff --check
