### PR TITLE
Improve ledger explorer bounty scanability

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -69,6 +69,38 @@ table { width: 100%; border-collapse: collapse; background: var(--panel); }
 th, td { border-bottom: 1px solid var(--line); padding: 10px; text-align: left; }
 code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 code.hash { overflow-wrap: anywhere; }
+.ledger-row-bounty-payment td:first-child { border-left: 4px solid #15803d; }
+.ledger-row-bounty-release td:first-child { border-left: 4px solid #b45309; }
+.ledger-row-bounty-reserve td:first-child { border-left: 4px solid var(--accent); }
+.type-badge {
+  display: inline-block;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 3px 9px;
+  background: var(--bg);
+  font-size: .88rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+.type-badge-bounty-payment {
+  border-color: #86efac;
+  background: #dcfce7;
+  color: #166534;
+}
+.type-badge-bounty-release {
+  border-color: #facc15;
+  background: #fef9c3;
+  color: #854d0e;
+}
+.type-badge-bounty-reserve {
+  border-color: #99f6e4;
+  background: #ccfbf1;
+  color: #115e59;
+}
+.reference-cell {
+  max-width: 220px;
+  overflow-wrap: anywhere;
+}
 .lead { color: var(--muted); font-size: 1.15rem; }
 .eyebrow { color: var(--accent); font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
 .detail dl { display: grid; grid-template-columns: 160px 1fr; gap: 10px 18px; }

--- a/app/templates/ledger.html
+++ b/app/templates/ledger.html
@@ -3,13 +3,32 @@
 {% block content %}
 <h1>Ledger</h1>
 <p class="lead">Every MRWK reserve and payout is recorded as a hash-linked ledger entry.</p>
+{% set type_labels = {
+  "bounty_reserve": "Bounty reserve",
+  "bounty_payment": "Bounty payment",
+  "bounty_release": "Bounty release",
+  "github_claim": "GitHub claim",
+  "wallet_transfer": "Wallet transfer",
+  "genesis": "Genesis"
+} %}
 <table>
-  <thead><tr><th>Entry</th><th>Type</th><th>From</th><th>To</th><th>Amount</th><th>Proof</th><th>Entry hash</th></tr></thead>
+  <thead><tr><th>Entry</th><th>Type</th><th>Reference</th><th>From</th><th>To</th><th>Amount</th><th>Proof</th><th>Entry hash</th></tr></thead>
   <tbody>
     {% for entry in entries %}
-    <tr>
+    {% set type_token = entry.type | replace("_", "-") %}
+    {% set reference_url = safe_public_url(entry.reference) %}
+    <tr class="ledger-row ledger-row-{{ type_token }}">
       <td><a href="/ledger/{{ entry.sequence }}">#{{ entry.sequence }}</a></td>
-      <td>{{ entry.type }}</td>
+      <td><span class="type-badge type-badge-{{ type_token }}">{{ type_labels.get(entry.type, entry.type | replace("_", " ") | title) }}</span></td>
+      <td class="reference-cell">
+        {% if reference_url %}
+          <a href="{{ reference_url }}">{{ entry.reference | replace("https://github.com/", "") }}</a>
+        {% elif entry.reference %}
+          <code>{{ entry.reference }}</code>
+        {% else %}
+          -
+        {% endif %}
+      </td>
       <td>{% if entry.from %}<a href="/accounts/{{ entry.from }}">{{ entry.from }}</a>{% else %}-{% endif %}</td>
       <td>{% if entry.to %}<a href="/accounts/{{ entry.to }}">{{ entry.to }}</a>{% else %}-{% endif %}</td>
       <td>{{ entry.amount_mrwk }} MRWK</td>

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
-from app.ledger.service import create_bounty, ensure_genesis, pay_bounty
+from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
 
 
@@ -156,6 +156,51 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     assert "github:alice" in proof_page
     assert "Ledger address" in account
     assert "MRWK wallet transfers are enabled" in account
+
+
+def test_ledger_page_highlights_bounty_payment_and_release(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=23,
+            issue_url="https://github.com/ramimbo/mergework/issues/23",
+            title="Improve ledger explorer payment scanning",
+            reward_mrwk="150",
+            max_awards=2,
+            acceptance="Ledger explorer highlights bounty payments and releases.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/24",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        close_bounty(
+            session,
+            bounty_id=bounty.id,
+            closed_by="maintainer",
+            reference="https://github.com/ramimbo/mergework/issues/23",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    ledger = client.get("/ledger").text
+
+    assert "Reference" in ledger
+    assert "Bounty payment" in ledger
+    assert "Bounty release" in ledger
+    assert "type-badge type-badge-bounty-payment" in ledger
+    assert "type-badge type-badge-bounty-release" in ledger
+    assert "ledger-row ledger-row-bounty-payment" in ledger
+    assert "ledger-row ledger-row-bounty-release" in ledger
+    assert "ramimbo/mergework/pull/24" in ledger
+    assert "ramimbo/mergework/issues/23" in ledger
+    assert f"/proofs/{proof.hash}" in ledger
 
 
 def test_mcp_can_register_and_fetch_wallet(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #23

## Summary
- Add readable labels and visual emphasis for bounty reserve, bounty payment, and bounty release rows in the ledger explorer.
- Add a Reference column so bounty issue and submission links are visible directly from the ledger table.
- Cover bounty payment and release readability with a regression test while leaving ledger entries, balances, proofs, and hashes unchanged.

## Validation
- `python -m pytest tests/test_api_mcp.py::test_ledger_page_highlights_bounty_payment_and_release`
- `python -m pytest`
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy app`
