### PR TITLE
test: cover repo-qualified bounty references

### DIFF
--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
-from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
+from app.ledger.service import create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
 
 
@@ -56,80 +56,6 @@ def test_bounty_api_reports_multi_award_capacity(sqlite_url: str) -> None:
     assert bounty["max_awards"] == 4
     assert bounty["awards_paid"] == 0
     assert bounty["awards_remaining"] == 4
-
-
-def test_bounty_api_reports_multi_award_paid_and_closed_status(sqlite_url: str) -> None:
-    create_schema(sqlite_url)
-    with session_scope(sqlite_url) as session:
-        ensure_genesis(session)
-        paid_bounty = create_bounty(
-            session,
-            repo="ramimbo/mergework",
-            issue_number=12,
-            issue_url="https://github.com/ramimbo/mergework/issues/12",
-            title="Paid multi-award bounty",
-            reward_mrwk="25",
-            max_awards=2,
-            acceptance="Each accepted submission earns one award.",
-        )
-        closed_bounty = create_bounty(
-            session,
-            repo="ramimbo/mergework",
-            issue_number=13,
-            issue_url="https://github.com/ramimbo/mergework/issues/13",
-            title="Closed multi-award bounty",
-            reward_mrwk="10",
-            max_awards=3,
-            acceptance="Each accepted submission earns one award.",
-        )
-        paid_id = paid_bounty.id
-        closed_id = closed_bounty.id
-
-        pay_bounty(
-            session,
-            bounty_id=paid_id,
-            to_account="github:alice",
-            submission_url="https://github.com/ramimbo/mergework/pull/12",
-            accepted_by="maintainer",
-            verifier_result={"label": "mrwk:accepted"},
-        )
-        pay_bounty(
-            session,
-            bounty_id=paid_id,
-            to_account="github:bob",
-            submission_url="https://github.com/ramimbo/mergework/pull/13",
-            accepted_by="maintainer",
-            verifier_result={"label": "mrwk:accepted"},
-        )
-        pay_bounty(
-            session,
-            bounty_id=closed_id,
-            to_account="github:carol",
-            submission_url="https://github.com/ramimbo/mergework/pull/14",
-            accepted_by="maintainer",
-            verifier_result={"label": "mrwk:accepted"},
-        )
-        close_bounty(
-            session,
-            bounty_id=closed_id,
-            closed_by="maintainer",
-            reference="https://github.com/ramimbo/mergework/issues/13#close",
-        )
-
-    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
-
-    paid = client.get(f"/api/v1/bounties/{paid_id}").json()
-    closed = client.get(f"/api/v1/bounties/{closed_id}").json()
-
-    assert paid["status"] == "paid"
-    assert paid["max_awards"] == 2
-    assert paid["awards_paid"] == 2
-    assert paid["awards_remaining"] == 0
-
-    assert closed["status"] == "closed"
-    assert closed["max_awards"] == 3
-    assert closed["awards_paid"] == 1
-    assert closed["awards_remaining"] == 0
 
 
 def test_mcp_tools_list_and_call(sqlite_url: str) -> None:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
-from app.ledger.service import create_bounty, ensure_genesis, pay_bounty
+from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
 
 
@@ -56,6 +56,80 @@ def test_bounty_api_reports_multi_award_capacity(sqlite_url: str) -> None:
     assert bounty["max_awards"] == 4
     assert bounty["awards_paid"] == 0
     assert bounty["awards_remaining"] == 4
+
+
+def test_bounty_api_reports_multi_award_paid_and_closed_status(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        paid_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=12,
+            issue_url="https://github.com/ramimbo/mergework/issues/12",
+            title="Paid multi-award bounty",
+            reward_mrwk="25",
+            max_awards=2,
+            acceptance="Each accepted submission earns one award.",
+        )
+        closed_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=13,
+            issue_url="https://github.com/ramimbo/mergework/issues/13",
+            title="Closed multi-award bounty",
+            reward_mrwk="10",
+            max_awards=3,
+            acceptance="Each accepted submission earns one award.",
+        )
+        paid_id = paid_bounty.id
+        closed_id = closed_bounty.id
+
+        pay_bounty(
+            session,
+            bounty_id=paid_id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/12",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        pay_bounty(
+            session,
+            bounty_id=paid_id,
+            to_account="github:bob",
+            submission_url="https://github.com/ramimbo/mergework/pull/13",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        pay_bounty(
+            session,
+            bounty_id=closed_id,
+            to_account="github:carol",
+            submission_url="https://github.com/ramimbo/mergework/pull/14",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        close_bounty(
+            session,
+            bounty_id=closed_id,
+            closed_by="maintainer",
+            reference="https://github.com/ramimbo/mergework/issues/13#close",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    paid = client.get(f"/api/v1/bounties/{paid_id}").json()
+    closed = client.get(f"/api/v1/bounties/{closed_id}").json()
+
+    assert paid["status"] == "paid"
+    assert paid["max_awards"] == 2
+    assert paid["awards_paid"] == 2
+    assert paid["awards_remaining"] == 0
+
+    assert closed["status"] == "closed"
+    assert closed["max_awards"] == 3
+    assert closed["awards_paid"] == 1
+    assert closed["awards_remaining"] == 0
 
 
 def test_mcp_tools_list_and_call(sqlite_url: str) -> None:

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -276,6 +276,53 @@ def test_accepted_pr_label_can_pay_referenced_multi_award_issue(sqlite_url: str)
         assert get_balance(session, "github:reviewer") == 25_000_000
 
 
+def test_accepted_pr_label_pays_repo_qualified_multi_award_issue(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "labeled",
+            "label": {"name": "mrwk:accepted"},
+            "pull_request": {
+                "number": 11,
+                "html_url": "https://github.com/ramimbo/mergework/pull/11",
+                "body": "Refs other/project#3\n\nBounty ramimbo/mergework#4",
+                "user": {"login": "reviewer"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "maintainer"},
+        },
+        separators=(",", ":"),
+    ).encode()
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=4,
+            issue_url="https://github.com/ramimbo/mergework/issues/4",
+            title="Repo-qualified multi-award issue",
+            reward_mrwk="25",
+            max_awards=2,
+            acceptance="Each accepted PR can earn one award.",
+        )
+
+    result = handle_github_webhook(
+        sqlite_url,
+        {
+            "X-GitHub-Delivery": "delivery-repo-qualified-pr",
+            "X-GitHub-Event": "pull_request",
+            "X-Hub-Signature-256": _signature("secret", body),
+        },
+        body,
+        "secret",
+    )
+
+    assert result["status"] == "paid"
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:reviewer") == 25_000_000
+
+
 def test_accepted_maintainer_issue_label_requires_manual_payout(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     body = json.dumps(


### PR DESCRIPTION
## Summary

- Add webhook coverage for repo-qualified multi-award bounty references in PR bodies.
- Verify an out-of-repo reference is ignored while `Bounty ramimbo/mergework#4` resolves the current repo bounty.
- Keep payout behavior unchanged while covering a linked-issue parsing edge case.

## Test Evidence

- [x] `.venv/bin/python -m pytest`
- [x] `.venv/bin/python -m ruff format --check .`
- [x] `.venv/bin/python -m ruff check .`
- [x] `.venv/bin/python -m mypy app`

## MRWK

Bounty #20
