### PR TITLE
Clarify wallet flow recovery copy

### DIFF
--- a/app/templates/me.html
+++ b/app/templates/me.html
@@ -5,7 +5,7 @@
   <p class="eyebrow">GitHub</p>
   <h1>Contributor account</h1>
   {% if github_login %}
-  <p class="lead">Signed in as {{ github_login }}.</p>
+  <p class="lead">Signed in as {{ github_login }}. Register a wallet first, then sign link and claim actions with that wallet's private key.</p>
   <form method="post" action="/auth/logout" class="inline-form">
     <button type="submit">Sign out</button>
   </form>
@@ -21,6 +21,7 @@
 {% if github_login %}
 <section class="panel wallet-tool" data-github-tool data-github-login="{{ github_login }}">
   <h2>Link a wallet</h2>
+  <p class="notice">Use the registered wallet address you want future accepted work paid to.</p>
   <form data-action="link-github">
     <label>Wallet address <input name="address" placeholder="mrwk1..." required></label>
     <label>Private key <textarea name="private_key_hex" rows="5" required></textarea></label>
@@ -31,6 +32,7 @@
   <pre class="result" data-link-result></pre>
 
   <h2>Claim GitHub balance</h2>
+  <p class="notice">Claim moves the full positive <code>github:{{ github_login }}</code> balance into the linked wallet.</p>
   <form data-action="claim-github">
     <label>Wallet address <input name="address" placeholder="mrwk1..." required></label>
     <label>Private key <textarea name="private_key_hex" rows="5" required></textarea></label>

--- a/app/templates/transfer.html
+++ b/app/templates/transfer.html
@@ -4,7 +4,7 @@
 <section class="detail">
   <p class="eyebrow">Transfer</p>
   <h1>Signed transfer</h1>
-  <p class="lead">Move spendable MRWK between registered wallet addresses.</p>
+  <p class="lead">Move spendable MRWK between registered wallet addresses. The sender must have enough balance before signing.</p>
 </section>
 
 <section class="panel wallet-tool" data-transfer-tool>
@@ -14,8 +14,8 @@
     <label>Amount MRWK <input name="amount_mrwk" inputmode="decimal" placeholder="1.5" required></label>
     <label>Memo <input name="memo" maxlength="240" placeholder="optional"></label>
     <label>Private key <textarea name="private_key_hex" rows="5" required></textarea></label>
-    <p class="notice">If a transfer fails, check that both wallets are registered and the sender has spendable MRWK.</p>
     <p class="notice" data-transfer-nonce-status>Transaction number is handled automatically.</p>
+    <p class="notice">If a transfer fails, check that both wallets are registered, confirm the sender has spendable MRWK, refresh the sender address status, and retry.</p>
     <button type="submit">Sign and send</button>
   </form>
   <pre class="result" data-transfer-result></pre>

--- a/app/templates/wallets.html
+++ b/app/templates/wallets.html
@@ -4,7 +4,7 @@
 <section class="detail">
   <p class="eyebrow">Wallets</p>
   <h1>MRWK wallets</h1>
-  <p class="lead">Create a native <code>mrwk1</code> address, register the public key, and use signed transactions to move MRWK.</p>
+  <p class="lead">Create a native <code>mrwk1</code> address, register the public key, and save the private key before leaving this page.</p>
 </section>
 
 <section class="panel wallet-tool" data-wallet-tool>
@@ -19,8 +19,9 @@
     <label>Private key <textarea id="wallet-private-key" name="private_key_hex" rows="5" readonly></textarea></label>
     <button type="submit">Register public key</button>
   </form>
-  <p class="notice">Private key stays in this browser. Store it yourself; the server cannot recover it.</p>
+  <p class="notice">Private key stays in this browser. The server stores only the public key and cannot recover lost keys.</p>
   <p class="notice">If you lose the private key, generate a new wallet and register that public key instead.</p>
+  <p class="notice">If registration says the wallet already exists, use the existing address or generate a new wallet.</p>
   <pre class="result" data-wallet-result></pre>
 </section>
 

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -349,11 +349,13 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Generate wallet" in wallets
     assert "Private key stays in this browser" in wallets
     assert "If you lose the private key" in wallets
+    assert "cannot recover lost keys" in wallets
     assert address in detail
     assert "Main smoke wallet" in wallets
     assert "Main smoke wallet" in detail
     assert "Signed transfer" in transfer
     assert "both wallets are registered" in transfer
+    assert "sender must have enough balance" in transfer
     assert "/static/wallet.js" in transfer
     assert "Link a wallet" in me
 
@@ -372,6 +374,9 @@ def test_wallet_pages_do_not_require_manual_nonce(sqlite_url: str, monkeypatch) 
     assert 'name="nonce"' not in transfer
     assert 'name="nonce"' not in me
     assert "Transaction number is handled automatically" in transfer
+    assert "refresh the sender address status" in transfer
+    assert "future accepted work paid to" in me
+    assert "full positive <code>github:alice</code> balance" in me
     assert "Transaction number is handled automatically" in me
     assert "different key will be rejected" in me
     assert "GitHub account is linked to the wallet" in me


### PR DESCRIPTION
Bounty #21

## Summary
- Clarify wallet generation copy so contributors know to save private keys and that the server cannot recover them.
- Add short recovery guidance for existing-wallet registration, GitHub link/claim flow, and transfer balance/nonce failures.
- Add page-level regression assertions for the new wallet troubleshooting copy.

## Validation
- `python -m pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows tests/test_wallet_api.py::test_wallet_pages_do_not_require_manual_nonce`
- `python -m pytest`
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy app`
