### PR TITLE
Improve bounty ledger scanability

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -69,6 +69,32 @@ table { width: 100%; border-collapse: collapse; background: var(--panel); }
 th, td { border-bottom: 1px solid var(--line); padding: 10px; text-align: left; }
 code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 code.hash { overflow-wrap: anywhere; }
+.ledger-table td { vertical-align: top; }
+.ledger-row--bounty-reserve,
+.ledger-row--bounty-payment,
+.ledger-row--bounty-release {
+  background: color-mix(in srgb, var(--accent) 7%, var(--panel));
+}
+.ledger-type {
+  display: inline-block;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: .85rem;
+  font-weight: 700;
+  padding: 3px 8px;
+}
+.ledger-type--bounty-payment {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+  color: var(--accent);
+}
+.ledger-scan-note {
+  display: block;
+  color: var(--muted);
+  font-size: .85rem;
+  margin-top: 4px;
+}
 .lead { color: var(--muted); font-size: 1.15rem; }
 .eyebrow { color: var(--accent); font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
 .detail dl { display: grid; grid-template-columns: 160px 1fr; gap: 10px 18px; }

--- a/app/templates/ledger.html
+++ b/app/templates/ledger.html
@@ -3,17 +3,29 @@
 {% block content %}
 <h1>Ledger</h1>
 <p class="lead">Every MRWK reserve and payout is recorded as a hash-linked ledger entry.</p>
-<table>
-  <thead><tr><th>Entry</th><th>Type</th><th>From</th><th>To</th><th>Amount</th><th>Proof</th><th>Entry hash</th></tr></thead>
+<table class="ledger-table">
+  <thead><tr><th>Entry</th><th>Type</th><th>From</th><th>To</th><th>Amount</th><th>Reference</th><th>Proof</th><th>Entry hash</th></tr></thead>
   <tbody>
     {% for entry in entries %}
-    <tr>
+    {% set type_class = entry.type | replace("_", "-") %}
+    <tr class="ledger-row ledger-row--{{ type_class }}">
       <td><a href="/ledger/{{ entry.sequence }}">#{{ entry.sequence }}</a></td>
-      <td>{{ entry.type }}</td>
+      <td>
+        <span class="ledger-type ledger-type--{{ type_class }}">{{ entry.type | replace("_", " ") | title }}</span>
+        {% if entry.type == "bounty_reserve" %}
+        <span class="ledger-scan-note">Funds reserved</span>
+        {% elif entry.type == "bounty_payment" %}
+        <span class="ledger-scan-note">Award paid</span>
+        {% elif entry.type == "bounty_release" %}
+        <span class="ledger-scan-note">Unused reserve released</span>
+        {% endif %}
+      </td>
       <td>{% if entry.from %}<a href="/accounts/{{ entry.from }}">{{ entry.from }}</a>{% else %}-{% endif %}</td>
       <td>{% if entry.to %}<a href="/accounts/{{ entry.to }}">{{ entry.to }}</a>{% else %}-{% endif %}</td>
       <td>{{ entry.amount_mrwk }} MRWK</td>
-      <td>{% if entry.proof_hash %}<a href="/proofs/{{ entry.proof_hash }}">View proof</a>{% else %}-{% endif %}</td>
+      {% set reference_url = safe_public_url(entry.reference) %}
+      <td>{% if reference_url %}<a href="{{ reference_url }}">Open reference</a>{% elif entry.reference %}<code>{{ entry.reference }}</code>{% else %}-{% endif %}</td>
+      <td>{% if entry.proof_hash %}<a href="/proofs/{{ entry.proof_hash }}">Payment proof</a>{% else %}-{% endif %}</td>
       <td><code class="hash">{{ entry.entry_hash[:16] }}</code></td>
     </tr>
     {% endfor %}

--- a/app/templates/ledger_entry.html
+++ b/app/templates/ledger_entry.html
@@ -3,9 +3,26 @@
 {% block content %}
 <section class="detail">
   <p class="eyebrow">Ledger entry</p>
-  <h1>#{{ entry.sequence }} {{ entry.type }}</h1>
+  {% set type_class = entry.type | replace("_", "-") %}
+  <h1>#{{ entry.sequence }} <span class="ledger-type ledger-type--{{ type_class }}">{{ entry.type | replace("_", " ") | title }}</span></h1>
   <p class="lead">{{ entry.amount_mrwk }} MRWK</p>
   <div class="meta-grid">
+    {% if entry.type == "bounty_reserve" %}
+    <article>
+      <span>Bounty scan status</span>
+      <strong>Funds reserved</strong>
+    </article>
+    {% elif entry.type == "bounty_payment" %}
+    <article>
+      <span>Bounty scan status</span>
+      <strong>Award paid</strong>
+    </article>
+    {% elif entry.type == "bounty_release" %}
+    <article>
+      <span>Bounty scan status</span>
+      <strong>Unused reserve released</strong>
+    </article>
+    {% endif %}
     <article>
       <span>Entry hash</span>
       <code class="hash">{{ entry.entry_hash }}</code>

--- a/app/templates/proof.html
+++ b/app/templates/proof.html
@@ -2,10 +2,21 @@
 {% block title %}MRWK Proof{% endblock %}
 {% block content %}
 <section class="detail">
-  <p class="eyebrow">Proof</p>
-  <h1>Accepted work proof</h1>
+  <p class="eyebrow">{% if proof.kind == "bounty_payment" %}Bounty payment proof{% else %}Proof{% endif %}</p>
+  <h1>{% if proof.kind == "bounty_payment" %}Accepted bounty payment{% else %}Accepted work proof{% endif %}</h1>
   <p class="lead">{{ proof.amount_mrwk }} MRWK paid to <a href="/accounts/{{ proof.to_account }}">{{ proof.to_account }}</a>.</p>
   <div class="meta-grid">
+    {% if proof.kind == "bounty_payment" %}
+    <article>
+      <span>Bounty issue</span>
+      {% set issue_card_url = safe_public_url("https://github.com/" ~ proof.repo ~ "/issues/" ~ proof.issue_number) %}
+      <strong>{% if issue_card_url %}<a href="{{ issue_card_url }}">{{ proof.repo }} #{{ proof.issue_number }}</a>{% else %}{{ proof.repo }} #{{ proof.issue_number }}{% endif %}</strong>
+    </article>
+    <article>
+      <span>Ledger entry</span>
+      <strong><a href="/ledger/{{ proof.ledger_sequence }}">#{{ proof.ledger_sequence }}</a></strong>
+    </article>
+    {% endif %}
     <article>
       <span>Proof hash</span>
       <code class="hash">{{ proof_hash }}</code>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
-from app.ledger.service import create_bounty, ensure_genesis
+from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
 
 
@@ -34,3 +34,62 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert "100 MRWK" in response.text
     assert "What has to be true" in response.text
     assert "Focused PR improves status, reward, issue link, and acceptance text." in response.text
+
+
+def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=23,
+            issue_url="https://github.com/ramimbo/mergework/issues/23",
+            title="Improve ledger bounty payment scanning",
+            reward_mrwk="150",
+            max_awards=2,
+            acceptance="Ledger and proof explorers clearly identify bounty payment entries.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:contributor",
+            submission_url="https://github.com/ramimbo/mergework/pull/99",
+            accepted_by="maintainer",
+            verifier_result={"result": "accepted"},
+        )
+        close_bounty(
+            session,
+            bounty_id=bounty.id,
+            closed_by="maintainer",
+            reference="https://github.com/ramimbo/mergework/issues/23",
+        )
+        proof_hash = proof.hash
+        payment_sequence = proof.ledger_sequence
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    ledger_page = client.get("/ledger")
+    assert ledger_page.status_code == 200
+    assert "Bounty Reserve" in ledger_page.text
+    assert "Bounty Payment" in ledger_page.text
+    assert "Bounty Release" in ledger_page.text
+    assert "Funds reserved" in ledger_page.text
+    assert "Award paid" in ledger_page.text
+    assert "Unused reserve released" in ledger_page.text
+    assert 'class="ledger-row ledger-row--bounty-payment"' in ledger_page.text
+    assert 'href="https://github.com/ramimbo/mergework/pull/99"' in ledger_page.text
+    assert f'href="/proofs/{proof_hash}">Payment proof</a>' in ledger_page.text
+
+    ledger_entry_page = client.get(f"/ledger/{payment_sequence}")
+    assert ledger_entry_page.status_code == 200
+    assert "Bounty Payment" in ledger_entry_page.text
+    assert "Bounty scan status" in ledger_entry_page.text
+    assert "Award paid" in ledger_entry_page.text
+
+    proof_page = client.get(f"/proofs/{proof_hash}")
+    assert proof_page.status_code == 200
+    assert "Bounty payment proof" in proof_page.text
+    assert "Accepted bounty payment" in proof_page.text
+    assert "Bounty issue" in proof_page.text
+    assert f'href="/ledger/{payment_sequence}"' in proof_page.text


### PR DESCRIPTION
Bounty #23

## Summary
- add scan-friendly badges and row highlighting for bounty reserve, payment, and release ledger entries
- surface ledger entry references directly in the explorer table without changing ledger data or proof payloads
- make bounty payment proof pages call out the bounty issue and ledger entry near the top
- add regression coverage for bounty reserve/payment/release readability

## Validation
- `uv run pytest` -> 67 passed
- `uv run ruff format --check .` -> 28 files already formatted
- `uv run ruff check .` -> All checks passed
- `uv run mypy app` -> Success: no issues found in 10 source files

Ledger data, proof payloads, balances, and hash behavior are unchanged; this PR only improves explorer presentation and tests the rendered pages.