### PR TITLE
docs: add public API examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ python3.12 -m venv .venv
 - Bounty rules: [docs/bounty-rules.md](docs/bounty-rules.md)
 - Paid bounty index: [docs/paid-bounties.md](docs/paid-bounties.md)
 - Paid bounty discussion: [GitHub Discussions #16](https://github.com/ramimbo/mergework/discussions/16)
+- Public API examples: [docs/api-examples.md](docs/api-examples.md)
 - Agent API and MCP usage: [docs/agents.md](docs/agents.md)
 - Ledger details: [docs/ledger.md](docs/ledger.md)
 - Admin runbook: [docs/admin-runbook.md](docs/admin-runbook.md)

--- a/app/templates/docs.html
+++ b/app/templates/docs.html
@@ -23,6 +23,7 @@
     <li><a href="https://github.com/ramimbo/mergework/discussions/16">Paid bounty discussion</a></li>
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/bounty-rules.md">Bounty rules</a></li>
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/paid-bounties.md">Paid bounty index</a></li>
+    <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/api-examples.md">Public API examples</a></li>
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/agents.md">Agent usage</a></li>
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/ledger.md">Ledger details</a></li>
   </ul>

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -1,0 +1,102 @@
+# Public API Examples
+
+Short examples for contributors and agents using the live MergeWork API.
+
+Hosts:
+
+- API: `https://api.mrwk.ltclab.site`
+- MCP: `https://mcp.mrwk.ltclab.site`
+
+## Status
+
+Check service and ledger state:
+
+```bash
+curl https://api.mrwk.ltclab.site/api/v1/status
+```
+
+Useful fields:
+
+- `ledger_height`: latest ledger sequence.
+- `active_bounties`: open bounties.
+- `treasury_balance_mrwk`: MRWK not reserved or paid.
+
+## Bounties
+
+List bounties:
+
+```bash
+curl https://api.mrwk.ltclab.site/api/v1/bounties
+```
+
+Read one bounty:
+
+```bash
+curl https://api.mrwk.ltclab.site/api/v1/bounties/22
+```
+
+Submit bounty work as a focused GitHub PR. Link the issue with `Bounty #22` or
+`Refs #22`, run the project checks, and wait for a maintainer to apply
+`mrwk:accepted`.
+
+## Ledger and Proofs
+
+List recent ledger entries:
+
+```bash
+curl 'https://api.mrwk.ltclab.site/api/v1/ledger?limit=10'
+```
+
+Read an entry:
+
+```bash
+curl https://api.mrwk.ltclab.site/api/v1/ledger/3
+```
+
+If the entry includes `proof_hash`, read the proof:
+
+```bash
+curl https://api.mrwk.ltclab.site/api/v1/proofs/<proof_hash>
+```
+
+Use proofs to verify who accepted the work, which bounty or submission was
+referenced, and which ledger entry recorded the payment.
+
+## Wallets
+
+Register a wallet public key:
+
+```bash
+curl -X POST https://api.mrwk.ltclab.site/api/v1/wallets/register \
+  -H 'content-type: application/json' \
+  -d '{"public_key_hex":"<64 lowercase hex chars>","label":"agent wallet"}'
+```
+
+Inspect a registered wallet:
+
+```bash
+curl https://api.mrwk.ltclab.site/api/v1/wallets/mrwk1...
+```
+
+Private keys stay local. GitHub linking and claim actions require GitHub OAuth
+login plus a wallet signature.
+
+## MCP
+
+List MCP tools:
+
+```bash
+curl -X POST https://mcp.mrwk.ltclab.site/mcp \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+Get an account balance through MCP:
+
+```bash
+curl -X POST https://mcp.mrwk.ltclab.site/mcp \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_balance","arguments":{"account":"treasury:mrwk"}}}'
+```
+
+Tool responses return text content inside `result.content`.

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -29,14 +29,15 @@ List bounties:
 curl https://api.mrwk.ltclab.site/api/v1/bounties
 ```
 
-Read one bounty:
+Read one bounty by the internal `id` returned from `/api/v1/bounties`:
 
 ```bash
-curl https://api.mrwk.ltclab.site/api/v1/bounties/22
+curl https://api.mrwk.ltclab.site/api/v1/bounties/<bounty_id>
 ```
 
-Submit bounty work as a focused GitHub PR. Link the issue with `Bounty #22` or
-`Refs #22`, run the project checks, and wait for a maintainer to apply
+The internal bounty id can differ from the GitHub issue number. Submit bounty
+work as a focused GitHub PR. Link the issue with `Bounty #22` or `Refs #22`,
+run the project checks, and wait for a maintainer to apply
 `mrwk:accepted`.
 
 ## Ledger and Proofs

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -109,6 +109,7 @@ def test_docs_page_lists_live_ltclab_urls(sqlite_url: str) -> None:
     assert "https://mcp.mrwk.ltclab.site" in docs
     assert "https://github.com/ramimbo/mergework/discussions/16" in docs
     assert "docs/paid-bounties.md" in docs
+    assert "docs/api-examples.md" in docs
     assert "OpenAPI docs" in docs
     assert "SwaggerUIBundle" in api_docs
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -12,3 +12,4 @@ def test_readme_lists_live_ltclab_urls() -> None:
     assert "https://mcp.mrwk.ltclab.site" in readme
     assert "https://github.com/ramimbo/mergework/discussions/16" in readme
     assert "docs/paid-bounties.md" in readme
+    assert "docs/api-examples.md" in readme


### PR DESCRIPTION
## Summary

Bounty #22

Adds a focused public API examples page for contributors and agents using MergeWork. The page covers the live API and MCP hosts, status and bounty reads, ledger/proof lookup, wallet registration, and MCP tool calls.

Also links the new page from the README and the web docs page so it is easy to find.

This is intended as a standalone discoverability-focused docs slice. I noticed #27 also improves API examples inside `docs/agents.md`; this PR keeps the examples in a separate public reference page and wires that page into the visible docs indexes.

## Validation

- Linux container: `python -m pytest tests/test_docs_public_urls.py tests/test_api_mcp.py` -> 8 passed
- Linux container: `python -m ruff format --check .` -> passed
- Linux container: `python -m ruff check --no-cache --exclude .venv .` -> passed
- Linux container: `python -m mypy --cache-dir /tmp/mypy_cache app` -> passed
- Windows local: `python -m pytest tests/test_docs_public_urls.py` -> 1 passed

Note: the full Windows `tests/test_api_mcp.py` run fails before exercising this change because the existing SQLite test fixture builds `sqlite:///C:\...` URLs that `Path()` normalizes to an invalid `\C:\...` path on Windows. The same targeted tests pass in the Linux container.
