### PR TITLE
Clarify wallet troubleshooting copy

### DIFF
--- a/app/templates/me.html
+++ b/app/templates/me.html
@@ -24,6 +24,7 @@
   <form data-action="link-github">
     <label>Wallet address <input name="address" placeholder="mrwk1..." required></label>
     <label>Private key <textarea name="private_key_hex" rows="5" required></textarea></label>
+    <p class="notice">Use the private key for this wallet address; a different key will be rejected.</p>
     <p class="notice" data-link-nonce-status>Transaction number is handled automatically.</p>
     <button type="submit">Sign and link</button>
   </form>
@@ -33,6 +34,7 @@
   <form data-action="claim-github">
     <label>Wallet address <input name="address" placeholder="mrwk1..." required></label>
     <label>Private key <textarea name="private_key_hex" rows="5" required></textarea></label>
+    <p class="notice">Claim works only after this GitHub account is linked to the wallet.</p>
     <p class="notice" data-claim-nonce-status>Transaction number is handled automatically.</p>
     <button type="submit">Sign and claim</button>
   </form>

--- a/app/templates/transfer.html
+++ b/app/templates/transfer.html
@@ -14,6 +14,7 @@
     <label>Amount MRWK <input name="amount_mrwk" inputmode="decimal" placeholder="1.5" required></label>
     <label>Memo <input name="memo" maxlength="240" placeholder="optional"></label>
     <label>Private key <textarea name="private_key_hex" rows="5" required></textarea></label>
+    <p class="notice">If a transfer fails, check that both wallets are registered and the sender has spendable MRWK.</p>
     <p class="notice" data-transfer-nonce-status>Transaction number is handled automatically.</p>
     <button type="submit">Sign and send</button>
   </form>

--- a/app/templates/wallets.html
+++ b/app/templates/wallets.html
@@ -20,6 +20,7 @@
     <button type="submit">Register public key</button>
   </form>
   <p class="notice">Private key stays in this browser. Store it yourself; the server cannot recover it.</p>
+  <p class="notice">If you lose the private key, generate a new wallet and register that public key instead.</p>
   <pre class="result" data-wallet-result></pre>
 </section>
 

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -348,8 +348,10 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
 
     assert "Generate wallet" in wallets
     assert "Private key stays in this browser" in wallets
+    assert "If you lose the private key" in wallets
     assert address in detail
     assert "Signed transfer" in transfer
+    assert "both wallets are registered" in transfer
     assert "/static/wallet.js" in transfer
     assert "Link a wallet" in me
 
@@ -369,3 +371,5 @@ def test_wallet_pages_do_not_require_manual_nonce(sqlite_url: str, monkeypatch) 
     assert 'name="nonce"' not in me
     assert "Transaction number is handled automatically" in transfer
     assert "Transaction number is handled automatically" in me
+    assert "different key will be rejected" in me
+    assert "GitHub account is linked to the wallet" in me


### PR DESCRIPTION
Refs #21
Bounty #21

This adds small, inline hints around the wallet flows that tend to fail silently for new users:

- lost private keys need a new wallet
- transfers need registered wallets and spendable MRWK
- GitHub linking needs the matching private key
- claims require a linked GitHub account first

Checks:

- python -m pytest
- ruff format --check .
- ruff check .
- mypy app
- git diff --check