### PR TITLE
Add multi-award API status regression

### DIFF
--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -142,6 +142,69 @@ def test_bounty_api_reports_closed_multi_award_as_unavailable(sqlite_url: str) -
     assert body["reserved_mrwk"] == "30"
 
 
+def test_bounty_api_lists_terminal_multi_award_statuses(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        paid_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=22,
+            issue_url="https://github.com/ramimbo/mergework/issues/22",
+            title="Paid multi-award list visibility",
+            reward_mrwk="8",
+            max_awards=2,
+            acceptance="Each accepted submission earns one award.",
+        )
+        closed_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=23,
+            issue_url="https://github.com/ramimbo/mergework/issues/23",
+            title="Closed multi-award list visibility",
+            reward_mrwk="6",
+            max_awards=3,
+            acceptance="Close releases unpaid awards.",
+        )
+        paid_bounty_id = paid_bounty.id
+        closed_bounty_id = closed_bounty.id
+
+        for pull_number, login in ((24, "alice"), (25, "bob")):
+            pay_bounty(
+                session,
+                bounty_id=paid_bounty_id,
+                to_account=f"github:{login}",
+                submission_url=f"https://github.com/ramimbo/mergework/pull/{pull_number}",
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted"},
+            )
+        pay_bounty(
+            session,
+            bounty_id=closed_bounty_id,
+            to_account="github:carol",
+            submission_url="https://github.com/ramimbo/mergework/pull/26",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        close_bounty(
+            session,
+            bounty_id=closed_bounty_id,
+            closed_by="maintainer",
+            reference="https://github.com/ramimbo/mergework/issues/23#close",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    bounties = {bounty["id"]: bounty for bounty in client.get("/api/v1/bounties").json()}
+    status = client.get("/api/v1/status").json()
+
+    assert bounties[paid_bounty_id]["status"] == "paid"
+    assert bounties[paid_bounty_id]["awards_remaining"] == 0
+    assert bounties[closed_bounty_id]["status"] == "closed"
+    assert bounties[closed_bounty_id]["awards_remaining"] == 0
+    assert status["active_bounties"] == 0
+
+
 def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Bounty #20

## Summary
- rebase onto latest `upstream/main` after related detail-API tests landed
- add complementary API regression coverage that terminal multi-award bounties remain visible in `/api/v1/bounties`
- assert paid and closed multi-award bounties report zero remaining awards and are excluded from `/api/v1/status` active bounty count

## Validation
- `uv run pytest tests/test_api_mcp.py::test_bounty_api_lists_terminal_multi_award_statuses` -> 1 passed
- `uv run pytest` -> 72 passed
- `uv run ruff format --check .` -> 28 files already formatted
- `uv run ruff check .` -> All checks passed
- `uv run mypy app` -> Success: no issues found in 10 source files