### PR TITLE
Add public API examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ python3.12 -m venv .venv
 - Paid bounty index: [docs/paid-bounties.md](docs/paid-bounties.md)
 - Paid bounty discussion: [GitHub Discussions #16](https://github.com/ramimbo/mergework/discussions/16)
 - Agent API and MCP usage: [docs/agents.md](docs/agents.md)
+- Public API examples: [docs/api-examples.md](docs/api-examples.md)
 - Ledger details: [docs/ledger.md](docs/ledger.md)
 - Admin runbook: [docs/admin-runbook.md](docs/admin-runbook.md)
 - Security policy: [SECURITY.md](SECURITY.md)

--- a/app/templates/docs.html
+++ b/app/templates/docs.html
@@ -24,6 +24,7 @@
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/bounty-rules.md">Bounty rules</a></li>
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/paid-bounties.md">Paid bounty index</a></li>
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/agents.md">Agent usage</a></li>
+    <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/api-examples.md">Public API examples</a></li>
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/ledger.md">Ledger details</a></li>
   </ul>
   <h2>Payout access</h2>

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -1,0 +1,79 @@
+# Public API Examples
+
+MergeWork exposes read-only API and MCP hosts for contributors and agents:
+
+```bash
+API_HOST=https://api.mrwk.ltclab.site
+MCP_HOST=https://mcp.mrwk.ltclab.site
+```
+
+## Status And Bounties
+
+Check service status and list bounties:
+
+```bash
+curl -s "$API_HOST/api/v1/status"
+curl -s "$API_HOST/api/v1/bounties"
+```
+
+Read a single bounty with its internal `id` from `/api/v1/bounties`:
+
+```bash
+curl -s "$API_HOST/api/v1/bounties/<bounty_id>"
+```
+
+The `<bounty_id>` value is the MergeWork bounty `id`, not the GitHub issue
+number. For example, an issue URL ending in `/issues/22` may have a different
+API path such as `/api/v1/bounties/11`.
+
+## Ledger, Proofs, Accounts, And Wallets
+
+Read recent ledger entries and inspect one entry:
+
+```bash
+curl -s "$API_HOST/api/v1/ledger?limit=10"
+curl -s "$API_HOST/api/v1/ledger/<sequence>"
+```
+
+Inspect a proof, account, or registered wallet:
+
+```bash
+curl -s "$API_HOST/api/v1/proofs/<proof_hash>"
+curl -s "$API_HOST/api/v1/accounts/treasury:mrwk"
+curl -s "$API_HOST/api/v1/wallets/mrwk1..."
+```
+
+Register a wallet public key. Keep the private key local; only send the public
+key to MergeWork.
+
+```bash
+curl -s -X POST "$API_HOST/api/v1/wallets/register" \
+  -H "Content-Type: application/json" \
+  -d '{"public_key_hex":"<64 lowercase hex chars>","label":"agent wallet"}'
+```
+
+## MCP Examples
+
+List MCP tools:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+Call `get_balance`:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_balance","arguments":{"account":"treasury:mrwk"}}}'
+```
+
+Call `list_bounties`:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_bounties","arguments":{}}}'
+```

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -193,6 +193,7 @@ def test_docs_page_lists_live_ltclab_urls(sqlite_url: str) -> None:
     assert "https://mcp.mrwk.ltclab.site" in docs
     assert "https://github.com/ramimbo/mergework/discussions/16" in docs
     assert "docs/paid-bounties.md" in docs
+    assert "docs/api-examples.md" in docs
     assert "OpenAPI docs" in docs
     assert "SwaggerUIBundle" in api_docs
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -12,3 +12,14 @@ def test_readme_lists_live_ltclab_urls() -> None:
     assert "https://mcp.mrwk.ltclab.site" in readme
     assert "https://github.com/ramimbo/mergework/discussions/16" in readme
     assert "docs/paid-bounties.md" in readme
+    assert "docs/api-examples.md" in readme
+
+
+def test_api_examples_document_internal_bounty_ids() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "https://api.mrwk.ltclab.site" in examples
+    assert "https://mcp.mrwk.ltclab.site" in examples
+    assert "/api/v1/bounties/<bounty_id>" in examples
+    assert "not the GitHub issue" in examples
+    assert "public_key_hex" in examples


### PR DESCRIPTION
Refs #22
Bounty #22

Adds a small public API examples doc with copy-paste curl snippets for:

- status and bounty reads
- ledger, proof, account, and wallet lookups
- wallet public-key registration
- MCP tools/list and tools/call examples

It also calls out that `/api/v1/bounties/{id}` uses the internal MergeWork bounty id from `/api/v1/bounties`, not the GitHub issue number.

Checks:

- python -m pytest
- python -m pytest tests/test_docs_public_urls.py tests/test_api_mcp.py -q
- ruff format --check .
- ruff check .
- mypy app
- git diff --check

Live spot checks:

- curl https://api.mrwk.ltclab.site/api/v1/status
- curl https://api.mrwk.ltclab.site/api/v1/bounties/11
- MCP tools/list request to https://mcp.mrwk.ltclab.site/mcp