### PR TITLE
Add MCP proof lookup tool

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -592,6 +592,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                             "description": "Submit a signed MRWK wallet transfer",
                         },
                         {"name": "get_ledger_entry", "description": "Get a ledger entry"},
+                        {"name": "get_proof", "description": "Get a public proof by hash"},
                         {
                             "name": "submit_work_proof",
                             "description": "Return submission instructions",
@@ -968,6 +969,24 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
             if entry is None:
                 return "ledger entry not found"
             return json.dumps(ledger_to_dict(entry))
+        if name == "get_proof":
+            proof = session.get(Proof, str(args["hash"]))
+            if proof is None:
+                return "proof not found"
+            public_payload = json.loads(proof.public_json)
+            if not isinstance(public_payload, dict):
+                raise ValueError("invalid proof payload")
+            return json.dumps(
+                {
+                    "hash": proof.hash,
+                    "kind": proof.kind,
+                    "ledger_sequence": proof.ledger_sequence,
+                    "bounty_id": proof.bounty_id,
+                    "submission_id": proof.submission_id,
+                    "created_at": proof.created_at.isoformat(),
+                    "proof": public_payload,
+                }
+            )
         if name == "submit_work_proof":
             return (
                 "Open a focused PR or issue, reference the MRWK bounty, include test evidence, "

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -125,6 +125,14 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_bounties","arguments":{}}}'
 ```
 
+Look up a public proof by hash:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_proof","arguments":{"hash":"<proof_hash>"}}}'
+```
+
 Tools:
 
 - `list_bounties`
@@ -134,6 +142,7 @@ Tools:
 - `get_wallet`
 - `submit_wallet_transfer`
 - `get_ledger_entry`
+- `get_proof`
 - `submit_work_proof`
 
 ## Contribution Rules

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
@@ -163,6 +165,74 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     ).json()
     assert balance["result"]["content"][0]["type"] == "text"
     assert "100000000" in balance["result"]["content"][0]["text"]
+
+
+def test_mcp_get_proof_returns_public_proof_details(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=37,
+            issue_url="https://github.com/ramimbo/mergework/issues/37",
+            title="MCP proof lookup",
+            reward_mrwk="150",
+            acceptance="Accepted label",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/37",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()
+    assert "get_proof" in {tool["name"] for tool in tools["result"]["tools"]}
+
+    result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "get_proof", "arguments": {"hash": proof.hash}},
+        },
+    ).json()
+
+    content = result["result"]["content"][0]
+    payload = json.loads(content["text"])
+    assert content["type"] == "text"
+    assert payload["hash"] == proof.hash
+    assert payload["kind"] == "bounty_payment"
+    assert payload["ledger_sequence"] == proof.ledger_sequence
+    assert payload["proof"]["repo"] == "ramimbo/mergework"
+    assert payload["proof"]["submission_url"] == "https://github.com/ramimbo/mergework/pull/37"
+    assert payload["proof"]["accepted_by"] == "maintainer"
+
+
+def test_mcp_get_proof_reports_unknown_hash(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "get_proof", "arguments": {"hash": "0" * 64}},
+        },
+    ).json()
+
+    assert result["result"]["content"][0]["text"] == "proof not found"
 
 
 def test_host_specific_homepages(sqlite_url: str) -> None:


### PR DESCRIPTION
Summary:
Adds a read-only `get_proof` MCP tool for looking up public proof records by hash.

Related bounty or issue:
Bounty #37

What changed:
- Added `get_proof` to the MCP `tools/list` response.
- Implemented `tools/call` handling for `get_proof` using existing `Proof` rows and stored public proof JSON.
- Returned useful wrapper metadata (`hash`, `kind`, ledger/submission ids, creation time) without changing proof payloads, ledger hashes, or payout behavior.
- Added a short `get_proof` MCP example to `docs/agents.md`.
- Added tests for a found proof and an unknown proof hash.

Validation:
- `../mergework-bounty-20/.venv/bin/python -m pytest tests/test_api_mcp.py::test_mcp_get_proof_returns_public_proof_details tests/test_api_mcp.py::test_mcp_get_proof_reports_unknown_hash -q` -> 2 passed.
- `../mergework-bounty-20/.venv/bin/python -m pytest tests/test_api_mcp.py -q` -> 13 passed.
- `../mergework-bounty-20/.venv/bin/python -m pytest -q` -> 74 passed.
- `../mergework-bounty-20/.venv/bin/python -m ruff format --check .` -> 28 files already formatted.
- `../mergework-bounty-20/.venv/bin/python -m ruff check .` -> All checks passed.
- `../mergework-bounty-20/.venv/bin/python -m mypy app` -> Success.
- `../mergework-bounty-20/.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok.
- `../mergework-bounty-20/.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok.

Notes:
Documentation and MCP behavior only; no deployment, secrets, ledger mutation, proof payload mutation, or payout behavior changes.
