### PR TITLE
Add accepted-work payout reconciliation check

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -532,6 +532,69 @@ def submit_github_claim(
     return ledger_entry
 
 
+def reconcile_accepted_work_payouts(session: Session) -> list[dict[str, str]]:
+    accepted_submissions = session.scalars(
+        select(Submission).where(Submission.status == "accepted").order_by(Submission.id)
+    ).all()
+    issues: list[dict[str, str]] = []
+    for submission in accepted_submissions:
+        proofs = session.scalars(
+            select(Proof)
+            .where(Proof.submission_id == submission.id, Proof.kind == "bounty_payment")
+            .order_by(Proof.hash)
+        ).all()
+        payments = session.scalars(
+            select(LedgerEntry)
+            .where(
+                LedgerEntry.entry_type == "bounty_payment",
+                LedgerEntry.reference == submission.url,
+            )
+            .order_by(LedgerEntry.sequence)
+        ).all()
+        base = {
+            "submission_id": str(submission.id),
+            "bounty_id": str(submission.bounty_id),
+            "submitter_account": submission.submitter_account,
+            "submission_url": submission.url,
+        }
+        if not proofs or not payments:
+            issues.append(
+                {
+                    **base,
+                    "problem": "missing_payment_evidence",
+                    "detail": (
+                        f"proofs={len(proofs)} ledger_payments={len(payments)}; "
+                        "expected one proof and one matching bounty_payment ledger entry"
+                    ),
+                }
+            )
+            continue
+        if len(proofs) > 1 or len(payments) > 1:
+            issues.append(
+                {
+                    **base,
+                    "problem": "duplicate_payment_evidence",
+                    "detail": (
+                        f"proofs={len(proofs)} ledger_payments={len(payments)}; "
+                        "expected exactly one proof and one matching bounty_payment ledger entry"
+                    ),
+                }
+            )
+            continue
+        if proofs[0].ledger_sequence != payments[0].sequence:
+            issues.append(
+                {
+                    **base,
+                    "problem": "mismatched_payment_evidence",
+                    "detail": (
+                        f"proof ledger_sequence={proofs[0].ledger_sequence} "
+                        f"but payment sequence={payments[0].sequence}"
+                    ),
+                }
+            )
+    return issues
+
+
 def pay_bounty(
     session: Session,
     *,

--- a/scripts/reconcile_payouts.py
+++ b/scripts/reconcile_payouts.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import os
+
+from app.db import session_scope
+from app.ledger.service import reconcile_accepted_work_payouts
+
+
+def main() -> int:
+    database_url = os.environ.get("MERGEWORK_DATABASE_URL", "sqlite:///data/mergework.sqlite3")
+    with session_scope(database_url) as session:
+        issues = reconcile_accepted_work_payouts(session)
+    if not issues:
+        print("Payout reconciliation ok: no missing or duplicate accepted-work payments.")
+        return 0
+    print(f"Payout reconciliation found {len(issues)} issue(s):")
+    for issue in issues:
+        print(
+            "- "
+            f"{issue['problem']} "
+            f"submission={issue['submission_id']} "
+            f"bounty={issue['bounty_id']} "
+            f"submitter={issue['submitter_account']} "
+            f"url={issue['submission_url']} "
+            f"detail={issue['detail']}"
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_payout_reconciliation.py
+++ b/tests/test_payout_reconciliation.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from app.db import create_schema, session_scope
+from app.ledger.service import (
+    add_ledger_entry,
+    create_bounty,
+    ensure_genesis,
+    pay_bounty,
+    reconcile_accepted_work_payouts,
+)
+from app.models import Submission
+
+
+def test_reconciliation_reports_missing_payment_evidence(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=35,
+            issue_url="https://github.com/ramimbo/mergework/issues/35",
+            title="Accepted work without payout proof",
+            reward_mrwk="25",
+            acceptance="Maintainer applies mrwk:accepted.",
+        )
+        session.add(
+            Submission(
+                bounty_id=bounty.id,
+                submitter_account="github:alice",
+                url="https://github.com/ramimbo/mergework/pull/35",
+                status="accepted",
+                verifier_result='{"label":"mrwk:accepted"}',
+            )
+        )
+        session.flush()
+
+        issues = reconcile_accepted_work_payouts(session)
+
+    assert issues == [
+        {
+            "submission_id": "1",
+            "bounty_id": "1",
+            "submitter_account": "github:alice",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/35",
+            "problem": "missing_payment_evidence",
+            "detail": (
+                "proofs=0 ledger_payments=0; expected one proof and one matching "
+                "bounty_payment ledger entry"
+            ),
+        }
+    ]
+
+
+def test_reconciliation_accepts_already_paid_submission(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=36,
+            issue_url="https://github.com/ramimbo/mergework/issues/36",
+            title="Accepted work with payout proof",
+            reward_mrwk="25",
+            acceptance="Maintainer applies mrwk:accepted.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/36",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+        issues = reconcile_accepted_work_payouts(session)
+
+    assert issues == []
+
+
+def test_reconciliation_reports_duplicate_payment_evidence(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=37,
+            issue_url="https://github.com/ramimbo/mergework/issues/37",
+            title="Duplicate payment evidence",
+            reward_mrwk="25",
+            acceptance="Maintainer applies mrwk:accepted.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/37",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        add_ledger_entry(
+            session,
+            entry_type="bounty_payment",
+            from_account="reserve:bounty:1",
+            to_account="github:alice",
+            amount_microunits=1,
+            reference="https://github.com/ramimbo/mergework/pull/37",
+        )
+
+        issues = reconcile_accepted_work_payouts(session)
+
+    assert issues[0]["problem"] == "duplicate_payment_evidence"
+    assert issues[0]["detail"].startswith("proofs=1 ledger_payments=2")


### PR DESCRIPTION
## Summary
- add a read-only reconciliation helper for accepted submissions without matching payout evidence
- add a maintainer script for concise missing/duplicate payout reporting
- cover missing-payment, already-paid, and duplicate-payment cases with tests

Refs #35

## Validation
- uv run --extra dev pytest tests/test_payout_reconciliation.py
- uv run --extra dev ruff format --check .
- uv run --extra dev ruff check .
- uv run --extra dev mypy app
- uv run --extra dev pytest