### PR TITLE
Add payout reconciliation check

### DIFF
--- a/app/ledger/reconciliation.py
+++ b/app/ledger/reconciliation.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.ledger.service import reserve_account_for_bounty
+from app.models import Bounty, LedgerEntry, Proof, Submission
+
+
+@dataclass(frozen=True)
+class PayoutReconciliationFinding:
+    code: str
+    bounty_id: int
+    submission_id: int
+    submission_url: str
+    detail: str
+
+    def to_dict(self) -> dict[str, str | int]:
+        return asdict(self)
+
+
+def reconcile_accepted_submission_payouts(
+    session: Session,
+) -> list[PayoutReconciliationFinding]:
+    """Report accepted submissions that lack exactly one matching payment proof."""
+    submissions = session.scalars(
+        select(Submission).where(Submission.status == "accepted").order_by(Submission.id)
+    ).all()
+    findings: list[PayoutReconciliationFinding] = []
+
+    for submission in submissions:
+        bounty = session.get(Bounty, submission.bounty_id)
+        proofs = session.scalars(
+            select(Proof).where(Proof.submission_id == submission.id).order_by(Proof.hash)
+        ).all()
+        payments = session.scalars(
+            select(LedgerEntry)
+            .where(
+                LedgerEntry.entry_type == "bounty_payment",
+                LedgerEntry.reference == submission.url,
+            )
+            .order_by(LedgerEntry.sequence)
+        ).all()
+
+        if not proofs:
+            findings.append(
+                _finding(
+                    "missing_proof",
+                    submission,
+                    "accepted submission has no public proof row",
+                )
+            )
+        elif len(proofs) > 1:
+            findings.append(
+                _finding(
+                    "duplicate_proof",
+                    submission,
+                    f"accepted submission has {len(proofs)} public proof rows",
+                )
+            )
+
+        if not payments:
+            findings.append(
+                _finding(
+                    "missing_payment",
+                    submission,
+                    "accepted submission has no bounty payment ledger entry",
+                )
+            )
+        elif len(payments) > 1:
+            findings.append(
+                _finding(
+                    "duplicate_payment",
+                    submission,
+                    f"accepted submission has {len(payments)} matching payment ledger entries",
+                )
+            )
+
+        if bounty is None:
+            findings.append(
+                _finding(
+                    "missing_bounty",
+                    submission,
+                    "accepted submission references a missing bounty",
+                )
+            )
+            continue
+
+        reserve_account = reserve_account_for_bounty(bounty.id)
+        for payment in payments:
+            if payment.from_account != reserve_account:
+                findings.append(
+                    _finding(
+                        "payment_source_mismatch",
+                        submission,
+                        f"payment entry {payment.sequence} is from {payment.from_account}",
+                    )
+                )
+            if payment.amount_microunits != bounty.reward_microunits:
+                findings.append(
+                    _finding(
+                        "payment_amount_mismatch",
+                        submission,
+                        f"payment entry {payment.sequence} amount does not match bounty reward",
+                    )
+                )
+
+        for proof in proofs:
+            findings.extend(_proof_findings(session, submission, bounty, proof))
+
+    return findings
+
+
+def reconciliation_findings_to_dicts(
+    findings: list[PayoutReconciliationFinding],
+) -> list[dict[str, str | int]]:
+    return [finding.to_dict() for finding in findings]
+
+
+def _finding(
+    code: str,
+    submission: Submission,
+    detail: str,
+) -> PayoutReconciliationFinding:
+    return PayoutReconciliationFinding(
+        code=code,
+        bounty_id=submission.bounty_id,
+        submission_id=submission.id,
+        submission_url=submission.url,
+        detail=detail,
+    )
+
+
+def _proof_findings(
+    session: Session,
+    submission: Submission,
+    bounty: Bounty,
+    proof: Proof,
+) -> list[PayoutReconciliationFinding]:
+    findings: list[PayoutReconciliationFinding] = []
+    ledger_entry = session.get(LedgerEntry, proof.ledger_sequence)
+    if ledger_entry is None:
+        return [
+            _finding(
+                "proof_ledger_missing",
+                submission,
+                f"proof {proof.hash} references missing ledger entry {proof.ledger_sequence}",
+            )
+        ]
+
+    if ledger_entry.reference != submission.url:
+        findings.append(
+            _finding(
+                "proof_ledger_reference_mismatch",
+                submission,
+                (
+                    f"proof {proof.hash} references ledger entry {ledger_entry.sequence} "
+                    "with a different reference"
+                ),
+            )
+        )
+
+    try:
+        public_payload: Any = json.loads(proof.public_json)
+    except json.JSONDecodeError:
+        findings.append(
+            _finding("invalid_proof_payload", submission, f"proof {proof.hash} is not JSON")
+        )
+        return findings
+    if not isinstance(public_payload, dict):
+        findings.append(
+            _finding(
+                "invalid_proof_payload", submission, f"proof {proof.hash} payload is not an object"
+            )
+        )
+        return findings
+
+    if public_payload.get("bounty_id") != bounty.id:
+        findings.append(
+            _finding(
+                "proof_bounty_mismatch",
+                submission,
+                f"proof {proof.hash} does not point at bounty {bounty.id}",
+            )
+        )
+    if public_payload.get("submission_url") != submission.url:
+        findings.append(
+            _finding(
+                "proof_submission_mismatch",
+                submission,
+                f"proof {proof.hash} does not point at the accepted submission URL",
+            )
+        )
+    if public_payload.get("ledger_sequence") != ledger_entry.sequence:
+        findings.append(
+            _finding(
+                "proof_sequence_mismatch",
+                submission,
+                f"proof {proof.hash} sequence does not match its ledger entry",
+            )
+        )
+    if public_payload.get("ledger_hash") != ledger_entry.entry_hash:
+        findings.append(
+            _finding(
+                "proof_hash_mismatch",
+                submission,
+                f"proof {proof.hash} ledger hash does not match entry {ledger_entry.sequence}",
+            )
+        )
+
+    return findings

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -78,7 +78,13 @@ those issues require the manual payout path.
 
 1. Confirm the webhook or admin API records one ledger payment for that award.
 2. Confirm the proof pays the intended contributor account.
-3. Add the paid bounty row to
+3. Run the read-only reconciliation check:
+
+   ```bash
+   python scripts/reconcile_payouts.py
+   ```
+
+4. Add the paid bounty row to
    [docs/paid-bounties.md](paid-bounties.md) and
    [GitHub Discussions #16](https://github.com/ramimbo/mergework/discussions/16).
 

--- a/scripts/reconcile_payouts.py
+++ b/scripts/reconcile_payouts.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from app.config import get_settings
+from app.db import session_scope
+from app.ledger.reconciliation import (
+    reconcile_accepted_submission_payouts,
+    reconciliation_findings_to_dicts,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Report accepted submissions missing matching MRWK payment evidence."
+    )
+    parser.add_argument("--database-url", default=get_settings().database_url)
+    parser.add_argument("--json", action="store_true", help="Print findings as JSON")
+    args = parser.parse_args()
+
+    with session_scope(args.database_url) as session:
+        findings = reconcile_accepted_submission_payouts(session)
+
+    if args.json:
+        print(json.dumps(reconciliation_findings_to_dicts(findings), indent=2, sort_keys=True))
+    elif not findings:
+        print("payout reconciliation ok: no accepted submissions missing payment evidence")
+    else:
+        print(f"payout reconciliation found {len(findings)} issue(s):")
+        for finding in findings:
+            print(
+                f"- {finding.code}: bounty #{finding.bounty_id}, "
+                f"submission #{finding.submission_id}, {finding.submission_url} - {finding.detail}"
+            )
+
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_payout_reconciliation.py
+++ b/tests/test_payout_reconciliation.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from app.db import create_schema, session_scope
+from app.ledger.reconciliation import reconcile_accepted_submission_payouts
+from app.ledger.service import create_bounty, ensure_genesis, pay_bounty
+from app.models import LedgerEntry, Proof, Submission
+
+
+def test_reconciliation_reports_missing_payment_evidence(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=35,
+            issue_url="https://github.com/ramimbo/mergework/issues/35",
+            title="Reconcile accepted work",
+            reward_mrwk="250",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+        session.add(
+            Submission(
+                bounty_id=bounty.id,
+                submitter_account="github:alice",
+                url="https://github.com/ramimbo/mergework/pull/35",
+                status="accepted",
+                verifier_result='{"label":"mrwk:accepted"}',
+            )
+        )
+        before_height = session.scalar(
+            select(LedgerEntry.sequence).order_by(LedgerEntry.sequence.desc())
+        )
+
+        findings = reconcile_accepted_submission_payouts(session)
+        after_height = session.scalar(
+            select(LedgerEntry.sequence).order_by(LedgerEntry.sequence.desc())
+        )
+
+    assert before_height == after_height
+    assert {finding.code for finding in findings} == {"missing_proof", "missing_payment"}
+    assert findings[0].submission_url == "https://github.com/ramimbo/mergework/pull/35"
+
+
+def test_reconciliation_accepts_already_paid_submission(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=36,
+            issue_url="https://github.com/ramimbo/mergework/issues/36",
+            title="Paid accepted work",
+            reward_mrwk="100",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+        pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/36",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+        findings = reconcile_accepted_submission_payouts(session)
+
+    assert findings == []
+
+
+def test_reconciliation_reports_duplicate_payment_evidence(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=37,
+            issue_url="https://github.com/ramimbo/mergework/issues/37",
+            title="Duplicate proof guard",
+            reward_mrwk="150",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/37",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        session.add(
+            Proof(
+                hash="1" * 64,
+                ledger_sequence=proof.ledger_sequence,
+                bounty_id=proof.bounty_id,
+                submission_id=proof.submission_id,
+                kind=proof.kind,
+                public_json=proof.public_json,
+            )
+        )
+
+        findings = reconcile_accepted_submission_payouts(session)
+
+    assert [finding.code for finding in findings] == ["duplicate_proof"]


### PR DESCRIPTION
Summary:
Adds a read-only payout reconciliation helper and maintainer script for accepted submissions that are missing or have duplicated payment evidence.

Related bounty or issue:
Fixes #35.

What changed:
- Added `reconcile_accepted_submission_payouts` to report accepted submissions with missing, duplicated, or mismatched proof/payment records.
- Added `scripts/reconcile_payouts.py` for maintainers to run the reconciliation check from the command line.
- Added regression coverage for missing payment evidence, already-paid submissions, and duplicate proof evidence.
- Added the reconciliation command to the admin runbook final checks.

Validation:
- `PYTHONPATH=. ../mergework-bounty-20/.venv/bin/python -m pytest tests/test_payout_reconciliation.py -q`
- `PYTHONPATH=. ../mergework-bounty-20/.venv/bin/python -m pytest -q`
- `PYTHONPATH=. ../mergework-bounty-20/.venv/bin/python -m ruff format --check .`
- `PYTHONPATH=. ../mergework-bounty-20/.venv/bin/python -m ruff check .`
- `PYTHONPATH=. ../mergework-bounty-20/.venv/bin/python -m mypy app`
- `PYTHONPATH=. ../mergework-bounty-20/.venv/bin/python scripts/docs_smoke.py`
- `PYTHONPATH=. ../mergework-bounty-20/.venv/bin/python scripts/check_agents.py`
- `PYTHONPATH=. ../mergework-bounty-20/.venv/bin/python scripts/reconcile_payouts.py --database-url sqlite:////private/tmp/mergework-reconcile-empty-20260523.sqlite3 --json`
- `git diff --cached --check`

Notes:
The reconciliation check is read-only. It does not mutate production data, include secrets, touch deployment behavior, or make any MRWK price/conversion claim.
