### PR TITLE
Add accepted payout reconciliation check

### DIFF
--- a/app/ledger/reconciliation.py
+++ b/app/ledger/reconciliation.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.ledger.service import format_mrwk
+from app.models import Bounty, LedgerEntry, Proof, Submission
+
+PayoutReconciliationStatus = Literal[
+    "paid",
+    "missing_payment",
+    "duplicate_payment_evidence",
+    "mismatched_payment_evidence",
+]
+
+
+@dataclass(frozen=True)
+class PayoutEvidence:
+    proof_hash: str
+    ledger_sequence: int
+    ledger_type: str | None
+    reference: str | None
+    to_account: str | None
+    amount_mrwk: str | None
+    matches_submission: bool
+
+
+@dataclass(frozen=True)
+class AcceptedPayoutCheck:
+    status: PayoutReconciliationStatus
+    bounty_id: int
+    bounty_issue: str
+    submission_id: int
+    submitter_account: str
+    submission_url: str
+    evidence: tuple[PayoutEvidence, ...]
+
+
+def reconcile_accepted_payouts(session: Session) -> list[AcceptedPayoutCheck]:
+    submissions = session.scalars(
+        select(Submission).where(Submission.status == "accepted").order_by(Submission.id)
+    ).all()
+    checks: list[AcceptedPayoutCheck] = []
+    for submission in submissions:
+        bounty = session.get(Bounty, submission.bounty_id)
+        if bounty is None:
+            continue
+        evidence = _payout_evidence(session, submission, bounty)
+        checks.append(
+            AcceptedPayoutCheck(
+                status=_reconciliation_status(evidence),
+                bounty_id=bounty.id,
+                bounty_issue=f"{bounty.repo}#{bounty.issue_number}",
+                submission_id=submission.id,
+                submitter_account=submission.submitter_account,
+                submission_url=submission.url,
+                evidence=evidence,
+            )
+        )
+    return checks
+
+
+def payout_reconciliation_summary(checks: Sequence[AcceptedPayoutCheck]) -> dict[str, int]:
+    summary = {
+        "accepted_submissions": len(checks),
+        "paid": 0,
+        "missing_payment": 0,
+        "duplicate_payment_evidence": 0,
+        "mismatched_payment_evidence": 0,
+    }
+    for check in checks:
+        summary[check.status] += 1
+    return summary
+
+
+def _payout_evidence(
+    session: Session, submission: Submission, bounty: Bounty
+) -> tuple[PayoutEvidence, ...]:
+    proofs = session.scalars(
+        select(Proof)
+        .where(Proof.submission_id == submission.id, Proof.kind == "bounty_payment")
+        .order_by(Proof.created_at, Proof.hash)
+    ).all()
+    evidence: list[PayoutEvidence] = []
+    for proof in proofs:
+        entry = session.get(LedgerEntry, proof.ledger_sequence)
+        evidence.append(
+            PayoutEvidence(
+                proof_hash=proof.hash,
+                ledger_sequence=proof.ledger_sequence,
+                ledger_type=entry.entry_type if entry else None,
+                reference=entry.reference if entry else None,
+                to_account=entry.to_account if entry else None,
+                amount_mrwk=format_mrwk(entry.amount_microunits) if entry else None,
+                matches_submission=_matches_submission(entry, proof, submission, bounty),
+            )
+        )
+    return tuple(evidence)
+
+
+def _matches_submission(
+    entry: LedgerEntry | None, proof: Proof, submission: Submission, bounty: Bounty
+) -> bool:
+    return (
+        proof.bounty_id == bounty.id
+        and entry is not None
+        and entry.entry_type == "bounty_payment"
+        and entry.reference == submission.url
+        and entry.to_account == submission.submitter_account
+        and entry.amount_microunits == bounty.reward_microunits
+    )
+
+
+def _reconciliation_status(
+    evidence: Sequence[PayoutEvidence],
+) -> PayoutReconciliationStatus:
+    if not evidence:
+        return "missing_payment"
+    if len(evidence) > 1:
+        return "duplicate_payment_evidence"
+    if not evidence[0].matches_submission:
+        return "mismatched_payment_evidence"
+    return "paid"

--- a/scripts/reconcile_payouts.py
+++ b/scripts/reconcile_payouts.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+from app.config import get_settings
+from app.db import session_scope
+from app.ledger.reconciliation import (
+    payout_reconciliation_summary,
+    reconcile_accepted_payouts,
+)
+
+
+def main() -> int:
+    settings = get_settings()
+    with session_scope(settings.database_url) as session:
+        checks = reconcile_accepted_payouts(session)
+    summary = payout_reconciliation_summary(checks)
+    issues = [asdict(check) for check in checks if check.status != "paid"]
+    print(json.dumps({"summary": summary, "issues": issues}, indent=2, sort_keys=True))
+    return 1 if issues else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 import pytest
 
 from app.db import create_schema, make_engine, session_scope
+from app.ledger.reconciliation import (
+    payout_reconciliation_summary,
+    reconcile_accepted_payouts,
+)
 from app.ledger.service import (
     GENESIS_SUPPLY_MICRO,
     TREASURY_ACCOUNT,
     LedgerError,
+    canonical_json,
     close_bounty,
     create_bounty,
     ensure_genesis,
@@ -16,7 +21,7 @@ from app.ledger.service import (
     verify_hash_chain,
     verify_supply_conservation,
 )
-from app.models import Bounty, LedgerEntry
+from app.models import Bounty, LedgerEntry, Proof, Submission
 
 
 def test_genesis_creates_fixed_supply_once(sqlite_url: str) -> None:
@@ -259,6 +264,123 @@ def test_payout_is_idempotent_for_same_bounty(sqlite_url: str) -> None:
                 accepted_by="maintainer",
                 verifier_result={"label": "mrwk:accepted"},
             )
+
+
+def test_reconcile_accepted_payouts_reports_already_paid_submission(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=35,
+            issue_url="https://github.com/ramimbo/mergework/issues/35",
+            title="Reconcile paid submissions",
+            reward_mrwk="12",
+            acceptance="Maintainer applies mrwk:accepted.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/35",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+        checks = reconcile_accepted_payouts(session)
+        summary = payout_reconciliation_summary(checks)
+
+        assert summary == {
+            "accepted_submissions": 1,
+            "paid": 1,
+            "missing_payment": 0,
+            "duplicate_payment_evidence": 0,
+            "mismatched_payment_evidence": 0,
+        }
+        assert checks[0].status == "paid"
+        assert checks[0].submission_url == "https://github.com/ramimbo/mergework/pull/35"
+        assert checks[0].evidence[0].proof_hash == proof.hash
+        assert checks[0].evidence[0].matches_submission is True
+
+
+def test_reconcile_accepted_payouts_reports_missing_payment(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=36,
+            issue_url="https://github.com/ramimbo/mergework/issues/36",
+            title="Reconcile missing payments",
+            reward_mrwk="12",
+            acceptance="Maintainer applies mrwk:accepted.",
+        )
+        session.add(
+            Submission(
+                bounty_id=bounty.id,
+                submitter_account="github:bob",
+                url="https://github.com/ramimbo/mergework/pull/36",
+                status="accepted",
+                verifier_result=canonical_json({"label": "mrwk:accepted"}),
+            )
+        )
+        session.flush()
+
+        checks = reconcile_accepted_payouts(session)
+        summary = payout_reconciliation_summary(checks)
+
+        assert summary["accepted_submissions"] == 1
+        assert summary["missing_payment"] == 1
+        assert checks[0].status == "missing_payment"
+        assert checks[0].evidence == ()
+
+
+def test_reconcile_accepted_payouts_reports_duplicate_payment_evidence(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=37,
+            issue_url="https://github.com/ramimbo/mergework/issues/37",
+            title="Reconcile duplicate payments",
+            reward_mrwk="12",
+            acceptance="Maintainer applies mrwk:accepted.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:carol",
+            submission_url="https://github.com/ramimbo/mergework/pull/37",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        session.add(
+            Proof(
+                hash="f" * 64,
+                ledger_sequence=proof.ledger_sequence,
+                bounty_id=bounty.id,
+                submission_id=proof.submission_id,
+                kind="bounty_payment",
+                public_json=proof.public_json,
+            )
+        )
+        session.flush()
+
+        checks = reconcile_accepted_payouts(session)
+        summary = payout_reconciliation_summary(checks)
+
+        assert summary["duplicate_payment_evidence"] == 1
+        assert checks[0].status == "duplicate_payment_evidence"
+        assert len(checks[0].evidence) == 2
 
 
 def test_bounty_max_awards_must_be_positive(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #35

## Summary
- add a read-only accepted payout reconciliation helper for maintainers
- compare accepted submissions against bounty payment proofs and ledger entries
- report paid, missing-payment, duplicate-evidence, and mismatched-evidence states without writing production data
- add `scripts/reconcile_payouts.py` for concise JSON summaries and actionable issue rows
- cover already-paid, missing-payment, and duplicate-evidence cases in tests

## Validation
- `uv run pytest tests/test_ledger.py::test_reconcile_accepted_payouts_reports_already_paid_submission tests/test_ledger.py::test_reconcile_accepted_payouts_reports_missing_payment tests/test_ledger.py::test_reconcile_accepted_payouts_reports_duplicate_payment_evidence` -> 3 passed
- `uv run pytest` -> 75 passed
- `uv run ruff format --check .` -> 30 files already formatted
- `uv run ruff check .` -> All checks passed
- `uv run mypy app` -> Success: no issues found in 11 source files