### PR TITLE
Harden GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,14 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
-  test:
+  checks:
+    name: Quality, readiness, docs, and image checks
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -19,6 +24,8 @@ jobs:
           python -m pip install -e '.[dev]'
       - name: Check AGENTS.md
         run: python scripts/check_agents.py
+      - name: Test
+        run: pytest
       - name: Check formatting
         run: ruff format --check .
       - name: Lint
@@ -37,8 +44,6 @@ jobs:
           MERGEWORK_ADMIN_TOKEN: admin-14dcaab83bb245f2bfb5d5c21a9bb55b
           MERGEWORK_COOKIE_SECRET: cookie-27fd1c41324a4bdcb2e4014adc3a6108
         run: python scripts/check_deploy_ready.py
-      - name: Test
-        run: pytest
       - name: Docs smoke
         run: python scripts/docs_smoke.py
       - name: Build Docker image


### PR DESCRIPTION
Refs #34

## Summary

- preserve the existing MergeWork CI gates: AGENTS check, deploy readiness, docs smoke, and Docker image build
- keep the bounty-required Python 3.12 checks in the workflow: pytest, ruff format --check ., ruff check ., and mypy app
- harden the workflow with least-privilege read-only repository permissions and a bounded job timeout

## Response to review

This revision addresses maintainer feedback by restoring the deploy/docs/Docker safety checks instead of reducing CI coverage.

## Validation

- uv run pytest -> 72 passed
- uv run ruff format --check . -> 28 files already formatted
- uv run ruff check . -> All checks passed
- uv run mypy app -> Success: no issues found in 10 source files
- scripts/check_deploy_ready.py passed locally with the same placeholder env values used by CI
- scripts/check_agents.py passed locally
- scripts/docs_smoke.py is covered by GitHub Actions; local sparse checkout excludes docs because macOS cannot hold both docs/AGENTS.md and docs/agents.md
