### PR TITLE
Show wallet labels on detail pages

### DIFF
--- a/app/templates/wallet_detail.html
+++ b/app/templates/wallet_detail.html
@@ -6,6 +6,10 @@
   <h1><code>{{ wallet.address }}</code></h1>
   <p class="lead">{{ wallet.balance_mrwk }} MRWK</p>
   <dl>
+    {% if wallet.label %}
+    <dt>Label</dt>
+    <dd>{{ wallet.label }}</dd>
+    {% endif %}
     <dt>Public key</dt>
     <dd><code>{{ wallet.public_key_hex }}</code></dd>
     <dt>GitHub login</dt>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -339,7 +339,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     create_schema(sqlite_url)
     _, public_hex, address = _keypair()
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
-    _register_wallet(client, public_hex)
+    _register_wallet(client, public_hex, "Main smoke wallet")
 
     wallets = client.get("/wallets").text
     detail = client.get(f"/wallets/{address}").text
@@ -350,6 +350,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Private key stays in this browser" in wallets
     assert "If you lose the private key" in wallets
     assert address in detail
+    assert "Main smoke wallet" in detail
     assert "Signed transfer" in transfer
     assert "both wallets are registered" in transfer
     assert "/static/wallet.js" in transfer


### PR DESCRIPTION
Refs #45
Bounty #45

Observed problem:

- A live smoke check found that wallet labels are stored and returned by the wallet API, but the public wallet detail page only shows the address and balance.

Changed behavior:

- Wallet detail pages now show a `Label` field when the wallet has one.
- Unlabeled wallets keep the existing compact layout.
- The existing wallet page regression test now registers a labeled wallet and checks that the label appears on the detail page.

Checks:

- python -m pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows -q
- python -m pytest
- ruff format --check .
- ruff check .
- mypy app
- git diff --check