### PR TITLE
Show wallet labels on wallet detail pages

### DIFF
--- a/app/templates/wallet_detail.html
+++ b/app/templates/wallet_detail.html
@@ -6,6 +6,10 @@
   <h1><code>{{ wallet.address }}</code></h1>
   <p class="lead">{{ wallet.balance_mrwk }} MRWK</p>
   <dl>
+    {% if wallet.label %}
+    <dt>Label</dt>
+    <dd>{{ wallet.label }}</dd>
+    {% endif %}
     <dt>Public key</dt>
     <dd><code>{{ wallet.public_key_hex }}</code></dd>
     <dt>GitHub login</dt>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -339,7 +339,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     create_schema(sqlite_url)
     _, public_hex, address = _keypair()
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
-    _register_wallet(client, public_hex)
+    _register_wallet(client, public_hex, "Primary wallet")
 
     wallets = client.get("/wallets").text
     detail = client.get(f"/wallets/{address}").text
@@ -350,6 +350,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Private key stays in this browser" in wallets
     assert "If you lose the private key" in wallets
     assert address in detail
+    assert "Primary wallet" in detail
     assert "Signed transfer" in transfer
     assert "both wallets are registered" in transfer
     assert "/static/wallet.js" in transfer


### PR DESCRIPTION
Bounty #45

## Summary
- Show the stored wallet label on wallet detail pages when a label exists.
- Add a targeted wallet page test that registers a labelled wallet and verifies the label renders on `/wallets/{address}`.

## Observed problem
A live #38 smoke check noted that wallet registration/readback APIs store and return labels, but the public wallet detail page did not show the label. That made labelled wallets harder to identify once users clicked into a wallet.

## Changed behavior
`/wallets/{address}` now includes a short `Label` row only when `wallet.label` is present. Wallets without labels keep the existing layout.

## Validation
- Windows local: `ruff format --check tests/test_wallet_api.py`
- Windows local: `ruff check app tests/test_wallet_api.py`
- Windows local: `mypy app`
- Linux container: `pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows` -> 1 passed
- Linux container: `pytest` -> 79 passed
- Linux container: `ruff format --check .`
- Linux container: `ruff check --no-cache --exclude .venv --exclude pytest-tmp --exclude .pytest_cache .`
- Linux container: `mypy --cache-dir /tmp/mypy_cache app`