### PR TITLE
Show wallet labels in the wallet list

### DIFF
--- a/app/templates/wallet_detail.html
+++ b/app/templates/wallet_detail.html
@@ -6,6 +6,10 @@
   <h1><code>{{ wallet.address }}</code></h1>
   <p class="lead">{{ wallet.balance_mrwk }} MRWK</p>
   <dl>
+    {% if wallet.label %}
+    <dt>Label</dt>
+    <dd>{{ wallet.label }}</dd>
+    {% endif %}
     <dt>Public key</dt>
     <dd><code>{{ wallet.public_key_hex }}</code></dd>
     <dt>GitHub login</dt>

--- a/app/templates/wallet_detail.html
+++ b/app/templates/wallet_detail.html
@@ -6,10 +6,6 @@
   <h1><code>{{ wallet.address }}</code></h1>
   <p class="lead">{{ wallet.balance_mrwk }} MRWK</p>
   <dl>
-    {% if wallet.label %}
-    <dt>Label</dt>
-    <dd>{{ wallet.label }}</dd>
-    {% endif %}
     <dt>Public key</dt>
     <dd><code>{{ wallet.public_key_hex }}</code></dd>
     <dt>GitHub login</dt>

--- a/app/templates/wallets.html
+++ b/app/templates/wallets.html
@@ -30,17 +30,18 @@
     <p>Public addresses known to this ledger.</p>
   </div>
   <table>
-    <thead><tr><th>Address</th><th>Balance</th><th>GitHub</th><th>Signed actions</th></tr></thead>
+    <thead><tr><th>Address</th><th>Label</th><th>Balance</th><th>GitHub</th><th>Signed actions</th></tr></thead>
     <tbody>
       {% for wallet in wallets %}
       <tr>
         <td><a href="/wallets/{{ wallet.address }}"><code>{{ wallet.address }}</code></a></td>
+        <td>{{ wallet.label or "-" }}</td>
         <td>{{ wallet.balance_mrwk }} MRWK</td>
         <td>{{ wallet.github_login or "-" }}</td>
         <td>{{ wallet.nonce }}</td>
       </tr>
       {% else %}
-      <tr><td colspan="4">No registered wallets yet.</td></tr>
+      <tr><td colspan="5">No registered wallets yet.</td></tr>
       {% endfor %}
     </tbody>
   </table>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -350,7 +350,8 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Private key stays in this browser" in wallets
     assert "If you lose the private key" in wallets
     assert address in detail
-    assert "Smoke wallet" in detail
+    assert "Smoke wallet" in wallets
+    assert "Smoke wallet" not in detail
     assert "Signed transfer" in transfer
     assert "both wallets are registered" in transfer
     assert "/static/wallet.js" in transfer

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -339,7 +339,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     create_schema(sqlite_url)
     _, public_hex, address = _keypair()
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
-    _register_wallet(client, public_hex)
+    _register_wallet(client, public_hex, "Smoke wallet")
 
     wallets = client.get("/wallets").text
     detail = client.get(f"/wallets/{address}").text
@@ -350,6 +350,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Private key stays in this browser" in wallets
     assert "If you lose the private key" in wallets
     assert address in detail
+    assert "Smoke wallet" in detail
     assert "Signed transfer" in transfer
     assert "both wallets are registered" in transfer
     assert "/static/wallet.js" in transfer


### PR DESCRIPTION
Refs #45

## Observed problem

Wallet labels are accepted during registration and returned by the wallet API, but the public `/wallets` index only listed the wallet address, balance, GitHub login, and signed action count. That made labeled wallets harder to identify before opening a specific wallet.

## Changed behavior

- Adds a `Label` column to the public wallet list.
- Shows `-` for unlabeled wallets, preserving the existing empty-label behavior.
- Updates the wallet page regression test to register a labeled wallet and verify the label appears in `/wallets`.

This is intentionally distinct from the existing wallet-detail label PRs; it improves the list/index page rather than `/wallets/{address}`.

## Validation

- `uv run --extra dev pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows -q` -> 1 passed
- `uv run --extra dev pytest -q` -> 79 passed
- `uv run --extra dev ruff format --check .` -> 30 files already formatted
- `uv run --extra dev ruff check .` -> All checks passed
- `uv run --extra dev mypy app` -> Success: no issues found in 11 source files

No private keys, secrets, deployment changes, CI coverage reduction, or MRWK price claims included.