### PR TITLE
fix: show wallet labels on detail pages

### DIFF
--- a/app/templates/wallet_detail.html
+++ b/app/templates/wallet_detail.html
@@ -6,6 +6,10 @@
   <h1><code>{{ wallet.address }}</code></h1>
   <p class="lead">{{ wallet.balance_mrwk }} MRWK</p>
   <dl>
+    {% if wallet.label %}
+    <dt>Label</dt>
+    <dd>{{ wallet.label }}</dd>
+    {% endif %}
     <dt>Public key</dt>
     <dd><code>{{ wallet.public_key_hex }}</code></dd>
     <dt>GitHub login</dt>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -356,6 +356,19 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Link a wallet" in me
 
 
+def test_wallet_detail_page_shows_registered_label(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    _, public_hex, address = _keypair()
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _register_wallet(client, public_hex, "Ops payout wallet")
+
+    detail = client.get(f"/wallets/{address}")
+
+    assert detail.status_code == 200
+    assert "<dt>Label</dt>" in detail.text
+    assert "Ops payout wallet" in detail.text
+
+
 def test_wallet_pages_do_not_require_manual_nonce(sqlite_url: str, monkeypatch) -> None:
     monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
     client = TestClient(


### PR DESCRIPTION
## Summary
- show the stored wallet label on wallet detail pages when one exists
- keep unlabeled wallet pages unchanged
- add a regression check for a registered labeled wallet detail page

## Observed smoke finding
The public API exposes registered wallet labels, but the live wallet detail page does not render them. Example checked before the fix:

- API: `GET https://api.mrwk.ltclab.site/api/v1/wallets/mrwk1e7fad157825b1ec39e74c5dd80eccdb2b39f9525` returns `label: "ramimbo's wallet"`
- UI: `GET https://mrwk.ltclab.site/wallets/mrwk1e7fad157825b1ec39e74c5dd80eccdb2b39f9525` did not include that label

## Verification
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python tmp_wallet_label_smoke.py` with a safe relative SQLite URL before removing the temp script/db: passed and confirmed `<dt>Label</dt>` plus `Ops payout wallet` on `/wallets/{address}`
- `git diff --check -- app\templates\wallet_detail.html tests\test_wallet_api.py`

Local Windows note: `python -m pytest tests\test_wallet_api.py::test_wallet_detail_page_shows_registered_label -q` is blocked before reaching the assertion by the existing Windows SQLite temp URL path handling (`Path('/C:/Users/...')` in `app/db.py`). I did not change that unrelated path handling in this focused PR.

Refs #45 / Bounty #45
