### PR TITLE
Clarify GitHub account claim status copy

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -438,7 +438,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 "exists": account_row is not None,
                 "balance_mrwk": format_mrwk(get_balance(session, account)),
                 "transfer_status": (
-                    "MRWK wallet transfers are enabled for registered mrwk1 addresses."
+                    "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
+                    if account.startswith("github:")
+                    else "MRWK wallet transfers are enabled for registered mrwk1 addresses."
                 ),
             }
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -381,7 +381,7 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     assert "maintainer" in proof_page
     assert "github:alice" in proof_page
     assert "Ledger address" in account
-    assert "MRWK wallet transfers are enabled" in account
+    assert "Claim GitHub balances from /me" in account
     assert 'href="/accounts/reserve:bounty:1"' in account
     assert 'href="/accounts/github:alice"' in account
 


### PR DESCRIPTION
Bounty #50
Refs #45

## Observed problem
Public account pages use the same `Send status` copy for every ledger account. On `github:*` bounty-balance pages, that copy currently says MRWK wallet transfers are enabled for registered `mrwk1` addresses, which can make a GitHub ledger balance look like a directly spendable wallet account.

## Changed behavior
- `github:*` account API/page responses now say: `Claim GitHub balances from /me after linking a registered mrwk1 wallet.`
- Non-GitHub ledger accounts keep the existing registered-wallet transfer status copy.
- The explorer/account regression test now checks the GitHub account claim guidance.

## Validation
- Windows local: `ruff format --check app/main.py tests/test_api_mcp.py`
- Windows local: `ruff check app/main.py tests/test_api_mcp.py`
- Windows local: `mypy app`
- Linux container: `pytest tests/test_api_mcp.py::test_explorer_links_ledger_proof_and_account -q` -> 1 passed
- Linux container: `ruff format --check .` -> passed
- Linux container: `ruff check --no-cache app tests scripts` -> passed
- Linux container: `mypy --cache-dir /tmp/mypy_cache app` -> passed