### PR TITLE
Link accounts from account transaction rows

### DIFF
--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -26,8 +26,8 @@
       <tr>
         <td><a href="/ledger/{{ entry.sequence }}">{{ entry.sequence }}</a></td>
         <td>{{ entry.type }}</td>
-        <td>{{ entry.from or "-" }}</td>
-        <td>{{ entry.to or "-" }}</td>
+        <td>{% if entry.from %}<a href="/accounts/{{ entry.from }}">{{ entry.from }}</a>{% else %}-{% endif %}</td>
+        <td>{% if entry.to %}<a href="/accounts/{{ entry.to }}">{{ entry.to }}</a>{% else %}-{% endif %}</td>
         <td>{{ entry.amount_mrwk }} MRWK</td>
         <td>{% if entry.proof_hash %}<a href="/proofs/{{ entry.proof_hash }}">proof</a>{% else %}-{% endif %}</td>
       </tr>

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -382,6 +382,8 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     assert "github:alice" in proof_page
     assert "Ledger address" in account
     assert "MRWK wallet transfers are enabled" in account
+    assert 'href="/accounts/reserve:bounty:1"' in account
+    assert 'href="/accounts/github:alice"' in account
 
 
 def test_ledger_page_highlights_bounty_payment_and_release(sqlite_url: str) -> None:


### PR DESCRIPTION
Refs #50

## Observed problem

On the live public account page, transaction rows show `From` and `To` accounts as plain text. For example, `https://mrwk.ltclab.site/accounts/github:royzhao1991` lists rows such as `reserve:bounty:8 -> github:royzhao1991` without account links.

The public ledger page already links the same account fields, for example `https://mrwk.ltclab.site/ledger` links `treasury:mrwk` and `reserve:bounty:*` to `/accounts/...`. The account detail page should offer the same drill-down path when a user is already looking at account-specific activity.

## Changed behavior

- Account transaction rows now link non-empty `From` accounts to `/accounts/{account}`.
- Account transaction rows now link non-empty `To` accounts to `/accounts/{account}`.
- Empty account fields still render as `-`.
- The existing explorer/account regression now asserts account transaction rows link both the reserve account and the GitHub account.

## Validation

- `uv run --extra dev pytest tests/test_api_mcp.py::test_explorer_links_ledger_proof_and_account -q` -> 1 passed
- `uv run --extra dev pytest tests/test_api_mcp.py -q` -> 14 passed
- `uv run --extra dev pytest -q` -> 79 passed
- `uv run --extra dev ruff format --check .` -> 30 files already formatted
- `uv run --extra dev ruff check app tests/test_api_mcp.py` -> All checks passed
- `uv run --extra dev mypy app` -> Success: no issues found in 11 source files
- `git diff --check` -> no whitespace errors

No private keys, secrets, security exploit details, deployment changes, CI coverage reduction, or MRWK price claims included.