### PR TITLE
Normalize wallet created_at responses

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ import hmac
 import json
 import secrets
 import time
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlencode
@@ -98,6 +99,12 @@ def ledger_to_dict(entry: LedgerEntry, proof_hash: str | None = None) -> dict[st
     }
 
 
+def _wallet_timestamp(value: datetime) -> str:
+    if value.tzinfo is not None:
+        value = value.replace(tzinfo=None)
+    return value.isoformat()
+
+
 def wallet_to_dict(session: Session, wallet: Wallet) -> dict[str, Any]:
     return {
         "address": wallet.address,
@@ -107,7 +114,7 @@ def wallet_to_dict(session: Session, wallet: Wallet) -> dict[str, Any]:
         "balance_mrwk": format_mrwk(get_balance(session, wallet.address)),
         "nonce": wallet.nonce,
         "next_nonce": wallet.nonce + 1,
-        "created_at": wallet.created_at.isoformat(),
+        "created_at": _wallet_timestamp(wallet.created_at),
     }
 
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -486,4 +486,23 @@ def test_mcp_can_register_and_fetch_wallet(sqlite_url: str) -> None:
             },
         },
     ).json()
-    assert "mrwk1" in registered["result"]["content"][0]["text"]
+    registered_wallet = json.loads(registered["result"]["content"][0]["text"])
+    assert registered_wallet["address"].startswith("mrwk1")
+
+    fetched = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "get_wallet",
+                "arguments": {"address": registered_wallet["address"]},
+            },
+        },
+    ).json()
+    fetched_wallet = json.loads(fetched["result"]["content"][0]["text"])
+
+    assert fetched_wallet["address"] == registered_wallet["address"]
+    assert fetched_wallet["label"] == "MCP wallet"
+    assert fetched_wallet["created_at"] == registered_wallet["created_at"]


### PR DESCRIPTION
Refs #50

MCP wallet responses could show the same wallet timestamp in two formats: the newly registered object included `+00:00`, while a later `get_wallet` read returned the DB value without an offset.

This normalizes the public wallet timestamp formatting and extends the MCP register/fetch test to cover the round trip.

Checks:
- `python -m pytest`
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy app`
- `git diff --check`