### PR TITLE
test: reject non-origin public base URLs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -64,6 +64,10 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
         errors.append("MERGEWORK_PUBLIC_BASE_URL must use https")
     if not parsed_base_url.netloc:
         errors.append("MERGEWORK_PUBLIC_BASE_URL must include a host")
+    if parsed_base_url.path not in ("", "/") or parsed_base_url.params:
+        errors.append("MERGEWORK_PUBLIC_BASE_URL must be an origin without a path")
+    if parsed_base_url.query or parsed_base_url.fragment:
+        errors.append("MERGEWORK_PUBLIC_BASE_URL must not include query or fragment")
     return errors
 
 

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -59,3 +59,19 @@ def test_deploy_readiness_requires_https_oauth_and_allowed_labelers() -> None:
     assert "MERGEWORK_PUBLIC_BASE_URL must use https" in errors
     assert "MERGEWORK_GITHUB_OAUTH_CLIENT_ID is required" in errors
     assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS must list maintainer logins" in errors
+
+
+def test_deploy_readiness_rejects_public_base_url_path_query_or_fragment() -> None:
+    path_errors = validate_deploy_settings(
+        _settings(public_base_url="https://mrwk.example.test/app")
+    )
+    query_errors = validate_deploy_settings(
+        _settings(public_base_url="https://mrwk.example.test?next=/admin")
+    )
+    fragment_errors = validate_deploy_settings(
+        _settings(public_base_url="https://mrwk.example.test#callback")
+    )
+
+    assert "MERGEWORK_PUBLIC_BASE_URL must be an origin without a path" in path_errors
+    assert "MERGEWORK_PUBLIC_BASE_URL must not include query or fragment" in query_errors
+    assert "MERGEWORK_PUBLIC_BASE_URL must not include query or fragment" in fragment_errors


### PR DESCRIPTION
Refs #55

## Summary
- reject deploy configs where `MERGEWORK_PUBLIC_BASE_URL` includes a path, params, query, or fragment instead of just the public origin
- add focused deploy-readiness regression coverage for path/query/fragment cases

## Observed problem
`MERGEWORK_PUBLIC_BASE_URL` is reused to build OAuth callback URLs with `f"{settings.public_base_url}/auth/github/callback"`. If an operator accidentally configures a path, query, or fragment, the deploy readiness check currently passes even though generated callback URLs become ambiguous or wrong.

## Validation
- `./.venv/bin/python -m pytest -q` -> 80 passed
- `./.venv/bin/python -m ruff format --check .` -> 30 files already formatted
- `./.venv/bin/python -m ruff check .` -> All checks passed
- `./.venv/bin/python -m mypy app` -> Success: no issues found in 11 source files
