### PR TITLE
Validate bounty issue numbers are positive

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -360,6 +360,8 @@ def create_bounty(
 ) -> Bounty:
     ensure_genesis(session)
     reward = parse_mrwk_amount(reward_mrwk)
+    if issue_number <= 0:
+        raise LedgerError("issue_number must be positive")
     if max_awards <= 0:
         raise LedgerError("max_awards must be positive")
     if max_awards > 1_000:

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -68,6 +68,24 @@ def test_bounty_reserve_and_payout_conserve_supply(sqlite_url: str) -> None:
         assert verify_supply_conservation(session) is True
 
 
+def test_create_bounty_rejects_non_positive_issue_number(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        for issue_number in (0, -1):
+            with pytest.raises(LedgerError, match="issue_number must be positive"):
+                create_bounty(
+                    session,
+                    repo="ramimbo/mergework",
+                    issue_number=issue_number,
+                    issue_url=f"https://github.com/ramimbo/mergework/issues/{issue_number}",
+                    title="Invalid bounty",
+                    reward_mrwk="1",
+                    acceptance="Should not be created",
+                )
+
+
 def test_multi_award_bounty_pays_distinct_submissions_until_exhausted(
     sqlite_url: str,
 ) -> None:


### PR DESCRIPTION
Refs #50

## Summary
- reject bounty creation when `issue_number` is zero or negative
- add ledger regression coverage for invalid issue numbers

## Why
GitHub issue numbers are positive integers. The HTML admin form already hints this with `min="1"`, but the service/API layer accepted invalid values like `0` and `-1`, which could create impossible public bounty references while reserving treasury funds.

## Tests
- `uv run --with '.[dev]' pytest tests/test_ledger.py -q`
- `uv run --with '.[dev]' pytest -q`
- `uv run --with '.[dev]' ruff format --check .`
- `uv run --with '.[dev]' ruff check .`
- `uv run --with '.[dev]' mypy app`
