### PR TITLE
Return proof hashes from MCP ledger entries

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -968,7 +968,10 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
             entry = session.get(LedgerEntry, int(args["sequence"]))
             if entry is None:
                 return "ledger entry not found"
-            return json.dumps(ledger_to_dict(entry))
+            proof = session.scalar(
+                select(Proof).where(Proof.ledger_sequence == entry.sequence).limit(1)
+            )
+            return json.dumps(ledger_to_dict(entry, proof.hash if proof else None))
         if name == "get_proof":
             proof = session.get(Proof, str(args["hash"]))
             if proof is None:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -238,6 +238,50 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert "100000000" in balance["result"]["content"][0]["text"]
 
 
+def test_mcp_get_ledger_entry_includes_payment_proof_hash(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=45,
+            issue_url="https://github.com/ramimbo/mergework/issues/45",
+            title="MCP ledger proof hash",
+            reward_mrwk="75",
+            acceptance="MCP ledger entry agrees with REST ledger detail.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/54",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        ledger_sequence = proof.ledger_sequence
+        proof_hash = proof.hash
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "get_ledger_entry",
+                "arguments": {"sequence": ledger_sequence},
+            },
+        },
+    ).json()
+    payload = json.loads(result["result"]["content"][0]["text"])
+
+    assert payload["sequence"] == ledger_sequence
+    assert payload["proof_hash"] == proof_hash
+
+
 def test_mcp_get_proof_returns_public_proof_details(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Refs #45
Bounty #45

## Summary

Return the payment proof hash from MCP `get_ledger_entry` responses when the ledger entry has an associated public proof.

## Observed problem

The REST ledger-detail API includes `proof_hash` for paid ledger entries, but the MCP `get_ledger_entry` tool currently omits it for the same sequence.

Live smoke check before this fix:

- `GET https://api.mrwk.ltclab.site/api/v1/ledger/40` returned `proof_hash=a30ebe6c7af19b17dd7798bcceac9e9877f0059d75bf84b0fec420f0114fe72f`.
- MCP `get_ledger_entry` for sequence `40` returned the same ledger entry with `proof_hash=null`.

## What changed

- Look up a `Proof` by `ledger_sequence` when MCP `get_ledger_entry` serializes a ledger entry.
- Pass the proof hash into the existing `ledger_to_dict` serializer, matching the REST ledger-detail behavior.
- Add a regression test that pays a bounty, calls MCP `get_ledger_entry`, and asserts the returned `proof_hash` matches the payment proof.

## Validation

- `uv run --extra dev pytest tests/test_api_mcp.py::test_mcp_get_ledger_entry_includes_payment_proof_hash -q` -> 1 passed
- `uv run --extra dev pytest tests/test_api_mcp.py -q` -> 15 passed
- `uv run --extra dev pytest -q` -> 80 passed
- `uv run --extra dev ruff format --check .` -> 30 files already formatted
- `uv run --extra dev ruff check .` -> All checks passed
- `uv run --extra dev mypy app` -> Success
- `git diff --check -- app/main.py tests/test_api_mcp.py` -> no whitespace errors

## Notes

No private keys, secrets, deployment changes, CI coverage reduction, security exploit details, or MRWK price claims are included.
