### PR TITLE
Cover API examples in docs smoke

### DIFF
--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -11,6 +11,7 @@ REQUIRED = [
     "docs/bounty-rules.md",
     "docs/paid-bounties.md",
     "docs/agents.md",
+    "docs/api-examples.md",
     "docs/ledger.md",
     "docs/admin-runbook.md",
     "SECURITY.md",

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from scripts.docs_smoke import REQUIRED
+
 
 def test_readme_lists_live_ltclab_urls() -> None:
     readme = Path("README.md").read_text(encoding="utf-8")
@@ -23,3 +25,7 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "/api/v1/bounties/<bounty_id>" in examples
     assert "not the GitHub issue" in examples
     assert "public_key_hex" in examples
+
+
+def test_docs_smoke_covers_public_api_examples() -> None:
+    assert "docs/api-examples.md" in REQUIRED


### PR DESCRIPTION
Refs #55

`docs/api-examples.md` is linked from the README and covered by a pytest assertion, but the standalone docs smoke script did not require it. That left the CI docs-smoke gate a little weaker than the public docs surface it is meant to protect.

This adds the API examples doc to the smoke list and keeps a regression assertion around that coverage.

Checks:
- `python -m pytest`
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy app`
- `python scripts/docs_smoke.py`
- `git diff --check`