### PR TITLE
Reject non-persistent SQLite URLs in deploy readiness

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -47,6 +47,14 @@ def _secret_errors(name: str, value: str) -> list[str]:
 
 def validate_deploy_settings(settings: Settings) -> list[str]:
     errors: list[str] = []
+    parsed_database_url = urlparse(settings.database_url)
+    if parsed_database_url.scheme == "sqlite":
+        if parsed_database_url.path in {"", "/", "/:memory:"}:
+            errors.append(
+                "MERGEWORK_DATABASE_URL must point at a persistent SQLite file for deploys"
+            )
+        elif not settings.database_url.startswith("sqlite:////"):
+            errors.append("MERGEWORK_DATABASE_URL SQLite path must be absolute for deploys")
     errors.extend(_secret_errors("MERGEWORK_GITHUB_WEBHOOK_SECRET", settings.github_webhook_secret))
     errors.extend(
         _secret_errors("MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", settings.github_oauth_client_secret)

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -47,6 +47,18 @@ def test_deploy_readiness_rejects_low_diversity_secrets() -> None:
     assert "MERGEWORK_GITHUB_WEBHOOK_SECRET must look randomly generated" in errors
 
 
+def test_deploy_readiness_rejects_non_persistent_sqlite_database_url() -> None:
+    errors = validate_deploy_settings(_settings(database_url="sqlite:///:memory:"))
+
+    assert "MERGEWORK_DATABASE_URL must point at a persistent SQLite file for deploys" in errors
+
+
+def test_deploy_readiness_rejects_relative_sqlite_database_url() -> None:
+    errors = validate_deploy_settings(_settings(database_url="sqlite:///./mergework.sqlite3"))
+
+    assert "MERGEWORK_DATABASE_URL SQLite path must be absolute for deploys" in errors
+
+
 def test_deploy_readiness_requires_https_oauth_and_allowed_labelers() -> None:
     errors = validate_deploy_settings(
         _settings(


### PR DESCRIPTION
Bounty #55

## Summary
- Add a deploy-readiness validation for SQLite database URLs so deploys reject in-memory or relative/local SQLite paths.
- Keep the existing absolute persistent SQLite deployment URL accepted.
- Add focused deploy-readiness tests for the new failure modes.

## Problem observed
With otherwise-valid deploy settings, the gate did not validate `MERGEWORK_DATABASE_URL`. That means a deployment could pass readiness while using a non-persistent local/default SQLite URL such as `sqlite:///./mergework.sqlite3` or `sqlite:///:memory:`.

## Verification
- `uv run --extra dev pytest tests/test_deploy_readiness.py -q` -> 6 passed
- `uv run --extra dev pytest -q` -> 81 passed
- `uv run --extra dev ruff format --check .` -> 30 files already formatted
- `uv run --extra dev ruff check .` -> All checks passed
- `uv run --extra dev mypy app` -> Success
- `python scripts/check_deploy_ready.py` with CI-style env -> Deploy readiness check passed
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `docker build -t mergework:ci .` -> built successfully

No CI coverage was reduced; this only adds a stricter deploy readiness gate.