### PR TITLE
Link bounty list items to source issues

### DIFF
--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -6,8 +6,14 @@
   {% for bounty in bounties %}
   <article>
     <h2><a href="/bounties/{{ bounty.id }}">{{ bounty.title }}</a></h2>
+    {% set issue_url = safe_public_url(bounty.issue_url) %}
     <p>
-      {{ bounty.repo }} #{{ bounty.issue_number }} ·
+      {% if issue_url %}
+        <a href="{{ issue_url }}">{{ bounty.repo }} #{{ bounty.issue_number }}</a>
+      {% else %}
+        {{ bounty.repo }} #{{ bounty.issue_number }}
+      {% endif %}
+      ·
       {{ bounty.reward_mrwk }} MRWK per award ·
       {{ bounty.awards_remaining }}/{{ bounty.max_awards }} awards open ·
       {{ bounty.status }}

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -7,6 +7,29 @@ from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_
 from app.main import create_app
 
 
+def test_bounty_list_links_safe_source_issue(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=45,
+            issue_url="https://github.com/ramimbo/mergework/issues/45",
+            title="Link bounty list source issues",
+            reward_mrwk="75",
+            acceptance="Bounty list links the source GitHub issue.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/bounties")
+
+    assert response.status_code == 200
+    assert 'href="https://github.com/ramimbo/mergework/issues/45"' in response.text
+    assert "ramimbo/mergework #45" in response.text
+
+
 def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
## Summary
- Link each bounty list repo/issue label to the source GitHub issue when the stored URL is safe and public.
- Keep the existing plain-text fallback for unsafe or unsupported issue URLs via `safe_public_url`.
- Add a regression test covering the bounty list issue link.

Bounty #45

## Verification
- `uv run --extra dev pytest tests/test_bounty_pages.py -q`
- `uv run --extra dev pytest -q`
- `uv run --extra dev ruff format --check .`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy app`
- `MERGEWORK_DATABASE_URL=sqlite:////srv/mergework/data/mergework.sqlite3 MERGEWORK_PUBLIC_BASE_URL=https://staging.mrwk.example.test MERGEWORK_GITHUB_WEBHOOK_SECRET=webhook-8efc3925bb8746b8a8fd3392c4c48e32 MERGEWORK_GITHUB_OAUTH_CLIENT_ID=client-id MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET=oauth-7818e79f9d3a4a1d82ff0e1b9f0b8e42 MERGEWORK_ADMIN_LOGINS=alice MERGEWORK_GITHUB_ACCEPTED_LABELERS=alice MERGEWORK_ADMIN_TOKEN=admin-14dcaab83bb245f2bfb5d5c21a9bb55b MERGEWORK_COOKIE_SECRET=cookie-27fd1c41324a4bdcb2e4014adc3a6108 uv run --extra dev python scripts/check_deploy_ready.py`
- `uv run --extra dev python scripts/docs_smoke.py`