### PR TITLE
Normalize wallet account casing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -156,6 +156,12 @@ def _safe_next_path(next_path: str | None) -> str:
     return next_path
 
 
+def _normalized_account(account: str) -> str:
+    if account.lower().startswith("mrwk1"):
+        return account.lower()
+    return account
+
+
 def _signed_value(value: str, secret: str) -> str:
     timestamp = str(int(time.time()))
     body = f"{value}|{timestamp}"
@@ -430,6 +436,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/api/v1/accounts/{account:path}")
     def api_account(account: str) -> dict[str, Any]:
+        account = _normalized_account(account)
         with session_scope(db_url) as session:
             account_row = session.get(Account, account)
             return {
@@ -693,6 +700,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/accounts/{account:path}", response_class=HTMLResponse)
     def account_page(request: Request, account: str) -> HTMLResponse:
+        account = _normalized_account(account)
         with session_scope(db_url) as session:
             account_data = api_account(account)
             entries = session.scalars(
@@ -939,7 +947,7 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
                 return "bounty not found"
             return json.dumps(bounty_to_dict(bounty))
         if name == "get_balance":
-            account = str(args["account"])
+            account = _normalized_account(str(args["account"]))
             return f"{account}: {format_mrwk(get_balance(session, account))} MRWK"
         if name == "register_wallet":
             wallet = register_wallet(

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -386,6 +386,47 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     assert 'href="/accounts/github:alice"' in account
 
 
+def test_wallet_account_views_normalize_mixed_case_addresses(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    wallet_address = "mrwk1" + "a" * 40
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        proof = pay_bounty(
+            session,
+            bounty_id=create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=50,
+                issue_url="https://github.com/ramimbo/mergework/issues/50",
+                title="Normalize wallet account links",
+                reward_mrwk="50",
+                acceptance="Wallet account views normalize address casing.",
+            ).id,
+            to_account=wallet_address,
+            submission_url="https://github.com/ramimbo/mergework/pull/50",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    mixed_case_address = "MRWK1" + "A" * 40
+
+    account = client.get(f"/accounts/{mixed_case_address}").text
+    balance = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "get_balance", "arguments": {"account": mixed_case_address}},
+        },
+    ).json()
+
+    assert "50 MRWK" in account
+    assert f"/proofs/{proof.hash}" in account
+    assert f"{wallet_address}: 50 MRWK" in balance["result"]["content"][0]["text"]
+
+
 def test_ledger_page_highlights_bounty_payment_and_release(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Refs #50

## Observed Problem

`/wallets/{address}` and the wallet API already accept mixed-case `mrwk1` addresses by lowercasing at lookup time, but `/accounts/{account}` and the MCP `get_balance` tool used the raw account string. A mixed-case wallet account URL could therefore show `0 MRWK` and no transactions even when the lowercase wallet account had ledger activity.

## Changed Behavior

- Normalize `mrwk1...` account paths at the account API/page boundary.
- Normalize `mrwk1...` arguments for MCP `get_balance`.
- Add a regression test that funds a lowercase wallet account, then checks a mixed-case `/accounts/...` page and MCP balance lookup return the real balance and proof link.

## Validation

- `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_wallet_account_views_normalize_mixed_case_addresses -q` -> 1 passed
- `uv run --extra dev python -m pytest tests/test_api_mcp.py -q` -> 15 passed
- `uv run --extra dev python -m pytest -q` -> 80 passed
- `uv run --extra dev ruff format --check app/main.py tests/test_api_mcp.py` -> 2 files already formatted
- `uv run --extra dev ruff check app/main.py tests/test_api_mcp.py` -> All checks passed
- `uv run --extra dev mypy app` -> Success
- `git diff --check -- app/main.py tests/test_api_mcp.py` -> no whitespace errors

No private keys, secrets, deployment changes, price claims, or CI coverage reductions included.
