### PR TITLE
Show GitHub claim balance on account page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -860,7 +860,15 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     @app.get("/me", response_class=HTMLResponse)
     def me_page(request: Request) -> HTMLResponse:
         login = github_login_from_request(request)
-        return templates.TemplateResponse(request, "me.html", {"github_login": login})
+        github_balance_mrwk = "0"
+        if login:
+            with session_scope(db_url) as session:
+                github_balance_mrwk = format_mrwk(get_balance(session, f"github:{login}"))
+        return templates.TemplateResponse(
+            request,
+            "me.html",
+            {"github_login": login, "github_balance_mrwk": github_balance_mrwk},
+        )
 
     @app.post("/admin/logout")
     def admin_logout() -> RedirectResponse:

--- a/app/templates/me.html
+++ b/app/templates/me.html
@@ -6,6 +6,7 @@
   <h1>Contributor account</h1>
   {% if github_login %}
   <p class="lead">Signed in as {{ github_login }}.</p>
+  <p class="notice"><code>github:{{ github_login }}</code> has {{ github_balance_mrwk }} MRWK available to claim.</p>
   <form method="post" action="/auth/logout" class="inline-form">
     <button type="submit">Sign out</button>
   </form>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -358,6 +358,32 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Link a wallet" in me
 
 
+def test_me_page_shows_signed_in_github_claim_balance(sqlite_url: str, monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        add_ledger_entry(
+            session,
+            entry_type="test_github_balance",
+            from_account=TREASURY_ACCOUNT,
+            to_account="github:alice",
+            amount_microunits=4_000_000,
+            reference="test-github-balance",
+        )
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    client.cookies.set("mrwk_user", _signed_value("alice", "test-cookie-secret"))
+
+    me = client.get("/me").text
+
+    assert "Signed in as alice." in me
+    assert "github:alice" in me
+    assert "4 MRWK available to claim" in me
+
+
 def test_wallet_pages_do_not_require_manual_nonce(sqlite_url: str, monkeypatch) -> None:
     monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
     client = TestClient(


### PR DESCRIPTION
Refs #45

## Observed Problem

Signed-in contributors can link a wallet and claim older GitHub balances from `/me`, but the page does not show the current `github:<login>` ledger balance. A contributor has to inspect the API or ledger separately to know whether there is anything to claim.

## Changed Behavior

- `/me` now looks up the signed-in user's `github:<login>` balance.
- The page shows that account and the MRWK amount available to claim before the claim form.
- Added a regression test that signs in as `alice`, funds `github:alice`, and verifies `/me` shows the account and claimable balance.

## Validation

- `uv run --extra dev python -m pytest tests/test_wallet_api.py::test_me_page_shows_signed_in_github_claim_balance -q` -> 1 passed
- `uv run --extra dev python -m pytest tests/test_wallet_api.py -q` -> 16 passed
- `uv run --extra dev python -m pytest -q` -> 80 passed
- `uv run --extra dev ruff format --check app/main.py tests/test_wallet_api.py` -> 2 files already formatted
- `uv run --extra dev ruff check app/main.py tests/test_wallet_api.py` -> All checks passed
- `uv run --extra dev mypy app` -> Success
- `git diff --check -- app/main.py app/templates/me.html tests/test_wallet_api.py` -> no whitespace errors

No private keys, secrets, deployment changes, price claims, or CI coverage reductions included.
