### PR TITLE
Harden wallet signing fields

### DIFF
--- a/app/templates/me.html
+++ b/app/templates/me.html
@@ -23,8 +23,8 @@
   <h2>Link a wallet</h2>
   <form data-action="link-github">
     <label>Wallet address <input name="address" placeholder="mrwk1..." required></label>
-    <label>Private key <textarea name="private_key_hex" rows="5" required></textarea></label>
-    <p class="notice">Use the private key for this wallet address; a different key will be rejected.</p>
+    <label>Private key <textarea name="private_key_hex" rows="5" autocomplete="off" autocapitalize="none" spellcheck="false" required></textarea></label>
+    <p class="notice">Use the private key for this wallet address; a different key will be rejected. Clear this field after use. Never share your private key.</p>
     <p class="notice" data-link-nonce-status>Transaction number is handled automatically.</p>
     <button type="submit">Sign and link</button>
   </form>
@@ -33,8 +33,8 @@
   <h2>Claim GitHub balance</h2>
   <form data-action="claim-github">
     <label>Wallet address <input name="address" placeholder="mrwk1..." required></label>
-    <label>Private key <textarea name="private_key_hex" rows="5" required></textarea></label>
-    <p class="notice">Claim works only after this GitHub account is linked to the wallet.</p>
+    <label>Private key <textarea name="private_key_hex" rows="5" autocomplete="off" autocapitalize="none" spellcheck="false" required></textarea></label>
+    <p class="notice">Claim works only after this GitHub account is linked to the wallet. Clear this field after use. Never share your private key.</p>
     <p class="notice" data-claim-nonce-status>Transaction number is handled automatically.</p>
     <button type="submit">Sign and claim</button>
   </form>

--- a/app/templates/transfer.html
+++ b/app/templates/transfer.html
@@ -13,7 +13,8 @@
     <label>To address <input name="to_address" placeholder="mrwk1..." required></label>
     <label>Amount MRWK <input name="amount_mrwk" inputmode="decimal" placeholder="1.5" required></label>
     <label>Memo <input name="memo" maxlength="240" placeholder="optional"></label>
-    <label>Private key <textarea name="private_key_hex" rows="5" required></textarea></label>
+    <label>Private key <textarea name="private_key_hex" rows="5" autocomplete="off" autocapitalize="none" spellcheck="false" required></textarea></label>
+    <p class="notice">Clear this field after use. Never share your private key.</p>
     <p class="notice">If a transfer fails, check that both wallets are registered and the sender has spendable MRWK.</p>
     <p class="notice" data-transfer-nonce-status>Transaction number is handled automatically.</p>
     <button type="submit">Sign and send</button>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -393,6 +393,10 @@ def test_wallet_pages_do_not_require_manual_nonce(sqlite_url: str, monkeypatch) 
     assert "Transaction number is handled automatically" in me
     assert "different key will be rejected" in me
     assert "GitHub account is linked to the wallet" in me
+    assert 'name="private_key_hex" rows="5" autocomplete="off"' in transfer
+    assert me.count('name="private_key_hex" rows="5" autocomplete="off"') == 2
+    assert "Clear this field after use. Never share your private key." in transfer
+    assert "Clear this field after use. Never share your private key." in me
 
 
 def test_reject_self_transfer(sqlite_url: str) -> None:


### PR DESCRIPTION
Refs #45

## Observed Problem

The transfer, GitHub-link, and GitHub-claim forms ask contributors to paste a wallet signing key into a textarea. Those fields did not explicitly disable browser autocomplete, and the pages did not tell contributors to clear the field after use.

## Changed Behavior

- Adds `autocomplete="off"`, `autocapitalize="none"`, and `spellcheck="false"` to wallet signing key textareas.
- Adds a short warning beside transfer, link, and claim forms: clear the field after use and never share the key.
- Extends the wallet page regression test to cover the autocomplete attribute and warning copy on `/transfer` and signed-in `/me`.

## Validation

- `uv run --extra dev python -m pytest tests/test_wallet_api.py::test_wallet_pages_do_not_require_manual_nonce -q` -> 1 passed
- `uv run --extra dev python -m pytest tests/test_wallet_api.py -q` -> 15 passed
- `uv run --extra dev python -m pytest -q` -> 79 passed
- `uv run --extra dev ruff format --check tests/test_wallet_api.py` -> 1 file already formatted
- `uv run --extra dev ruff check tests/test_wallet_api.py` -> All checks passed
- `uv run --extra dev mypy app` -> Success
- `git diff --check -- app/templates/me.html app/templates/transfer.html tests/test_wallet_api.py` -> no whitespace errors

No secrets, deployment changes, price claims, or CI coverage reductions included.
