### PR TITLE
Show empty wallet state

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -173,6 +173,15 @@ code.hash { overflow-wrap: anywhere; }
   overflow-wrap: anywhere;
 }
 .lead { color: var(--muted); font-size: 1.15rem; }
+.wallet-balance {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.wallet-empty-pill {
+  color: var(--muted);
+}
 .eyebrow { color: var(--accent); font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
 .detail dl { display: grid; grid-template-columns: 160px 1fr; gap: 10px 18px; }
 .detail dt { color: var(--muted); }

--- a/app/templates/wallet_detail.html
+++ b/app/templates/wallet_detail.html
@@ -4,7 +4,12 @@
 <section class="detail">
   <p class="eyebrow">Wallet</p>
   <h1><code>{{ wallet.address }}</code></h1>
-  <p class="lead">{{ wallet.balance_mrwk }} MRWK</p>
+  <p class="lead wallet-balance">
+    {{ wallet.balance_mrwk }} MRWK
+    {% if wallet.balance_mrwk == "0" and not transactions %}
+    <span class="status-pill wallet-empty-pill">No activity yet</span>
+    {% endif %}
+  </p>
   <dl>
     {% if wallet.label %}
     <dt>Label</dt>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -338,11 +338,15 @@ def test_github_login_redirects_when_oauth_is_configured(sqlite_url: str, monkey
 def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     _, public_hex, address = _keypair()
+    _, funded_public, funded_address = _keypair()
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
     _register_wallet(client, public_hex, "Main smoke wallet")
+    _register_wallet(client, funded_public, "Funded smoke wallet")
+    _fund_wallet(sqlite_url, funded_address)
 
     wallets = client.get("/wallets").text
     detail = client.get(f"/wallets/{address}").text
+    funded_detail = client.get(f"/wallets/{funded_address}").text
     transfer = client.get("/transfer").text
     me = client.get("/me").text
 
@@ -352,6 +356,8 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert address in detail
     assert "Main smoke wallet" in wallets
     assert "Main smoke wallet" in detail
+    assert "No activity yet" in detail
+    assert "No activity yet" not in funded_detail
     assert "Signed transfer" in transfer
     assert "both wallets are registered" in transfer
     assert "/static/wallet.js" in transfer


### PR DESCRIPTION
Refs #45

## Observed Problem

An empty wallet detail page shows `0 MRWK` with the same balance treatment as funded wallets. The transaction table says there are no wallet transactions, but the balance header itself does not distinguish the empty state.

## Changed Behavior

- Adds a `No activity yet` badge beside the balance on zero-balance wallets with no transactions.
- Keeps funded wallets unchanged.
- Adds a regression check covering both an empty wallet detail page and a funded wallet detail page.

## Validation

- `uv run --extra dev python -m pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows -q` -> 1 passed
- `uv run --extra dev python -m pytest tests/test_wallet_api.py -q` -> 15 passed
- `uv run --extra dev python -m pytest -q` -> 79 passed
- `uv run --extra dev ruff format --check tests/test_wallet_api.py` -> 1 file already formatted
- `uv run --extra dev ruff check tests/test_wallet_api.py` -> All checks passed
- `uv run --extra dev mypy app` -> Success
- `git diff --check -- app/templates/wallet_detail.html app/static/style.css tests/test_wallet_api.py` -> no whitespace errors

No secrets, deployment changes, price claims, or CI coverage reductions included.
