### PR TITLE
Prefill linked wallet on claim form

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -29,6 +29,7 @@ from app.ledger.service import (
     format_mrwk,
     get_balance,
     link_wallet_to_github,
+    linked_wallet_for_github,
     pay_bounty,
     public_url_or_none,
     register_wallet,
@@ -909,7 +910,20 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     @app.get("/me", response_class=HTMLResponse)
     def me_page(request: Request) -> HTMLResponse:
         login = github_login_from_request(request)
-        return templates.TemplateResponse(request, "me.html", {"github_login": login})
+        linked_wallet_address = ""
+        if login:
+            with session_scope(db_url) as session:
+                linked_wallet = linked_wallet_for_github(session, login)
+                if linked_wallet:
+                    linked_wallet_address = linked_wallet.address
+        return templates.TemplateResponse(
+            request,
+            "me.html",
+            {
+                "github_login": login,
+                "linked_wallet_address": linked_wallet_address,
+            },
+        )
 
     @app.post("/admin/logout")
     def admin_logout() -> RedirectResponse:

--- a/app/templates/me.html
+++ b/app/templates/me.html
@@ -32,9 +32,12 @@
 
   <h2>Claim GitHub balance</h2>
   <form data-action="claim-github">
-    <label>Wallet address <input name="address" placeholder="mrwk1..." required></label>
+    <label>Wallet address <input name="address" placeholder="mrwk1..." value="{{ linked_wallet_address or '' }}" required></label>
     <label>Private key <textarea name="private_key_hex" rows="5" required></textarea></label>
     <p class="notice">Claim works only after this GitHub account is linked to the wallet.</p>
+    {% if linked_wallet_address %}
+    <p class="notice">Claim form is prefilled with your linked wallet.</p>
+    {% endif %}
     <p class="notice" data-claim-nonce-status>Transaction number is handled automatically.</p>
     <button type="submit">Sign and claim</button>
   </form>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -418,3 +418,22 @@ def test_reject_self_transfer(sqlite_url: str) -> None:
             memo="",
             signature_hex="a" * 128,
         )
+
+
+def test_me_page_prefills_claim_address_for_linked_wallet(sqlite_url: str, monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    create_schema(sqlite_url)
+    _, public_hex, address = _keypair()
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        register_wallet(session, public_key_hex=public_hex, github_login="alice")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    client.cookies.set("mrwk_user", _signed_value("alice", "test-cookie-secret"))
+
+    me = client.get("/me").text
+
+    assert f'value="{address}"' in me
+    assert "Claim form is prefilled with your linked wallet." in me


### PR DESCRIPTION
Refs #45

## Observed Problem

After a contributor links a GitHub account to a wallet, the `/me` claim form still asks them to paste the same wallet address again. The nearby link and claim forms share the same `mrwk1...` placeholder, so it is easy to miss that the claim should usually target the linked wallet.

## Changed Behavior

- Looks up the signed-in contributor's linked wallet when rendering `/me`.
- Prefills the GitHub balance claim form with that linked wallet address.
- Shows a short notice when the claim form was prefilled.
- Adds a regression test that signs in as a linked GitHub user and verifies the claim form address.

## Validation

- `uv run --extra dev python -m pytest tests/test_wallet_api.py::test_me_page_prefills_claim_address_for_linked_wallet -q` -> 1 passed
- `uv run --extra dev python -m pytest tests/test_wallet_api.py -q` -> 16 passed
- `uv run --extra dev python -m pytest -q` -> 80 passed
- `uv run --extra dev ruff format --check app/main.py tests/test_wallet_api.py` -> 2 files already formatted
- `uv run --extra dev ruff check app/main.py tests/test_wallet_api.py` -> All checks passed
- `uv run --extra dev mypy app` -> Success
- `git diff --check -- app/main.py app/templates/me.html tests/test_wallet_api.py` -> no whitespace errors

No secrets, deployment changes, price claims, or CI coverage reductions included.
