### PR TITLE
Harden generated wallet key output

### DIFF
--- a/app/templates/wallets.html
+++ b/app/templates/wallets.html
@@ -16,7 +16,7 @@
     <label>Label <input id="wallet-label" name="label" placeholder="Main wallet"></label>
     <label>Address <input id="wallet-address" name="address" readonly></label>
     <label>Public key <textarea id="wallet-public-key" name="public_key_hex" rows="3" readonly></textarea></label>
-    <label>Private key <textarea id="wallet-private-key" name="private_key_hex" rows="5" readonly></textarea></label>
+    <label>Private key <textarea id="wallet-private-key" name="private_key_hex" rows="5" readonly autocomplete="off" autocapitalize="none" spellcheck="false"></textarea></label>
     <button type="submit">Register public key</button>
   </form>
   <p class="notice">Private key stays in this browser. Store it yourself; the server cannot recover it.</p>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -349,6 +349,11 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Generate wallet" in wallets
     assert "Private key stays in this browser" in wallets
     assert "If you lose the private key" in wallets
+    assert (
+        'id="wallet-private-key" name="private_key_hex" rows="5" readonly autocomplete="off"'
+        in wallets
+    )
+    assert 'autocapitalize="none" spellcheck="false"' in wallets
     assert address in detail
     assert "Main smoke wallet" in wallets
     assert "Main smoke wallet" in detail


### PR DESCRIPTION
Refs #45

## Observed Problem

Live `/wallets` smoke check shows the generated private key output is a readonly textarea without browser hardening attributes. The page warns that the key stays in the browser and must be stored by the user, but the key field itself still allows normal textarea browser behavior.

## Changed Behavior

- Adds `autocomplete="off"` to the generated private key output field.
- Adds `autocapitalize="none"` and `spellcheck="false"` to keep browser text helpers away from the key.
- Extends the wallet page smoke regression to cover the generated private key output attributes.

## Validation

- `uv run --extra dev python -m pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows -q` -> 1 passed
- `uv run --extra dev python -m pytest tests/test_wallet_api.py -q` -> 15 passed
- `uv run --extra dev python -m pytest -q` -> 79 passed
- `uv run --extra dev ruff format --check tests/test_wallet_api.py` -> 1 file already formatted
- `uv run --extra dev ruff check tests/test_wallet_api.py` -> All checks passed
- `uv run --extra dev mypy app` -> Success
- `git diff --check -- app/templates/wallets.html tests/test_wallet_api.py` -> no whitespace errors

No secrets, deployment changes, price claims, or CI coverage reductions included.
