### PR TITLE
Reject reused deploy secrets

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -53,6 +53,15 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
     )
     errors.extend(_secret_errors("MERGEWORK_ADMIN_TOKEN", settings.admin_token))
     errors.extend(_secret_errors("MERGEWORK_COOKIE_SECRET", settings.cookie_secret))
+    deploy_secrets = [
+        settings.github_webhook_secret,
+        settings.github_oauth_client_secret,
+        settings.admin_token,
+        settings.cookie_secret,
+    ]
+    present_secrets = [secret for secret in deploy_secrets if secret]
+    if len(set(present_secrets)) != len(present_secrets):
+        errors.append("deploy secrets must use distinct values")
     if not settings.github_oauth_client_id:
         errors.append("MERGEWORK_GITHUB_OAUTH_CLIENT_ID is required")
     if not settings.admin_logins:

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -47,6 +47,19 @@ def test_deploy_readiness_rejects_low_diversity_secrets() -> None:
     assert "MERGEWORK_GITHUB_WEBHOOK_SECRET must look randomly generated" in errors
 
 
+def test_deploy_readiness_rejects_reused_secret_values() -> None:
+    reused_secret = "shared-secret-8efc3925bb8746b8a8fd3392c4c48e32"
+
+    errors = validate_deploy_settings(
+        _settings(
+            github_webhook_secret=reused_secret,
+            cookie_secret=reused_secret,
+        )
+    )
+
+    assert "deploy secrets must use distinct values" in errors
+
+
 def test_deploy_readiness_requires_https_oauth_and_allowed_labelers() -> None:
     errors = validate_deploy_settings(
         _settings(


### PR DESCRIPTION
Refs #55

## Observed Problem

Deploy readiness already rejects weak or missing secret values, but it still accepted the same strong-looking random value reused across multiple secret roles. That can accidentally tie webhook signing, OAuth, admin access, and cookie signing to one leaked value.

## Changed Behavior

- Adds a deploy-readiness check that requires deploy secret values to be distinct.
- Keeps missing-secret errors unchanged by only comparing present secret values.
- Adds focused regression coverage for reused deploy secrets.

## Validation

- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py::test_deploy_readiness_rejects_reused_secret_values -q` -> 1 passed
- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py -q` -> 5 passed
- `uv run --extra dev python -m pytest -q` -> 80 passed
- `uv run --extra dev ruff format --check app/config.py tests/test_deploy_readiness.py` -> 2 files already formatted
- `uv run --extra dev ruff check app/config.py tests/test_deploy_readiness.py` -> All checks passed
- `uv run --extra dev mypy app` -> Success
- `MERGEWORK_... uv run --extra dev python -m scripts.check_deploy_ready` -> Deploy readiness check passed
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `docker build -t mergework:ci .` -> built successfully
- `git diff --check -- app/config.py tests/test_deploy_readiness.py` -> no whitespace errors

No secrets, deployment changes, price claims, or CI coverage reductions included.
