### PR TITLE
Make deploy readiness script directly runnable

### DIFF
--- a/scripts/check_deploy_ready.py
+++ b/scripts/check_deploy_ready.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from app.config import get_settings, validate_deploy_settings
 
 

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
+
 from app.config import Settings, validate_deploy_settings
 
 
@@ -59,3 +63,30 @@ def test_deploy_readiness_requires_https_oauth_and_allowed_labelers() -> None:
     assert "MERGEWORK_PUBLIC_BASE_URL must use https" in errors
     assert "MERGEWORK_GITHUB_OAUTH_CLIENT_ID is required" in errors
     assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS must list maintainer logins" in errors
+
+
+def test_deploy_readiness_script_runs_directly_from_source() -> None:
+    env = {
+        **os.environ,
+        "MERGEWORK_DATABASE_URL": "sqlite:////srv/mergework/data/mergework.sqlite3",
+        "MERGEWORK_PUBLIC_BASE_URL": "https://staging.mrwk.example.test",
+        "MERGEWORK_GITHUB_WEBHOOK_SECRET": "webhook-8efc3925bb8746b8a8fd3392c4c48e32",
+        "MERGEWORK_GITHUB_OAUTH_CLIENT_ID": "client-id",
+        "MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET": "oauth-7818e79f9d3a4a1d82ff0e1b9f0b8e42",
+        "MERGEWORK_ADMIN_LOGINS": "alice",
+        "MERGEWORK_ADMIN_TOKEN": "admin-14dcaab83bb245f2bfb5d5c21a9bb55b",
+        "MERGEWORK_COOKIE_SECRET": "cookie-27fd1c41324a4bdcb2e4014adc3a6108",
+        "MERGEWORK_GITHUB_ACCEPTED_LABELERS": "alice",
+    }
+
+    result = subprocess.run(
+        [sys.executable, "-S", "scripts/check_deploy_ready.py"],
+        check=False,
+        cwd=os.getcwd(),
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "Deploy readiness check passed."


### PR DESCRIPTION
Refs #55

## Observed Problem

The CI workflow runs `python scripts/check_deploy_ready.py`, but running that script directly from source can fail before the readiness checks run because Python puts `scripts/` on `sys.path`, not the repository root:

`ModuleNotFoundError: No module named 'app'`

## Changed Behavior

- Adds the repo root to `sys.path` inside `scripts/check_deploy_ready.py` before importing `app.config`.
- Adds a regression test that runs `python -S scripts/check_deploy_ready.py` with a CI-style deploy environment, proving the script works directly from source.

## Validation

- Red test reproduced the direct-script import failure before the fix.
- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py::test_deploy_readiness_script_runs_directly_from_source -q` -> 1 passed
- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py -q` -> 5 passed
- `MERGEWORK_... uv run --extra dev python scripts/check_deploy_ready.py` -> Deploy readiness check passed.
- `MERGEWORK_... uv run --extra dev python -S scripts/check_deploy_ready.py` -> Deploy readiness check passed.
- `uv run --extra dev python -m pytest -q` -> 80 passed
- ruff format/check on touched files -> passed
- `uv run --extra dev mypy app` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `docker build -t mergework:ci .` -> built successfully
- `git diff --check -- scripts/check_deploy_ready.py tests/test_deploy_readiness.py` -> passed
