### PR TITLE
Clarify wallet detail claim guidance

### DIFF
--- a/app/templates/wallet_detail.html
+++ b/app/templates/wallet_detail.html
@@ -25,6 +25,7 @@
     <a href="/transfer">Send MRWK</a>
     <a href="/me">Link GitHub</a>
   </div>
+  <p class="notice">To claim GitHub bounty balance, sign in and link this wallet from your contributor account.</p>
 </section>
 
 <section>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -352,6 +352,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert address in detail
     assert "Main smoke wallet" in wallets
     assert "Main smoke wallet" in detail
+    assert "To claim GitHub bounty balance" in detail
     assert "Signed transfer" in transfer
     assert "both wallets are registered" in transfer
     assert "/static/wallet.js" in transfer


### PR DESCRIPTION
Refs #21 / Bounty #21.

This is a small, non-overlapping wallet-flow copy improvement: the wallet detail page already links to transfer and GitHub linking, but it does not say why a contributor would go from a specific wallet page to the GitHub account flow.

Change:
- Adds one short notice to `/wallets/{address}`: contributors who want to claim GitHub bounty balance should sign in and link that wallet from the contributor account page.
- Adds regression coverage in the existing wallet page smoke test.

Why this is distinct from PR #28:
- PR #28 focuses on `/wallets`, `/transfer`, and `/me` recovery guidance.
- This PR only covers the wallet detail page, where users inspect a concrete wallet address before deciding whether to transfer or link it.

Verification:
- Red test first: `uv run --extra dev python -m pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows -q` failed before the copy existed.
- `uv run --extra dev python -m pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows -q` -> 1 passed
- `uv run --extra dev python -m pytest tests/test_wallet_api.py -q` -> 15 passed
- `uv run --extra dev python -m pytest -q` -> 79 passed
- `uv run --extra dev ruff format --check .` -> 30 files already formatted
- `uv run --extra dev ruff check .` -> all checks passed
- `uv run --extra dev mypy app` -> success
- `git diff --check -- app/templates/wallet_detail.html tests/test_wallet_api.py` -> passed
