### PR TITLE
Clarify GitHub account claim status

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -438,7 +438,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 "exists": account_row is not None,
                 "balance_mrwk": format_mrwk(get_balance(session, account)),
                 "transfer_status": (
-                    "MRWK wallet transfers are enabled for registered mrwk1 addresses."
+                    "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
+                    if account.startswith("github:")
+                    else "MRWK wallet transfers are enabled for registered mrwk1 addresses."
                 ),
             }
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -366,6 +366,7 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     ledger = client.get("/ledger").text
     entry = client.get("/ledger/3").text
     proof_page = client.get(f"/proofs/{proof.hash}").text
+    account_api = client.get("/api/v1/accounts/github:alice").json()
     account = client.get("/accounts/github:alice").text
 
     assert "/ledger/3" in ledger
@@ -381,7 +382,10 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     assert "maintainer" in proof_page
     assert "github:alice" in proof_page
     assert "Ledger address" in account
-    assert "MRWK wallet transfers are enabled" in account
+    assert account_api["transfer_status"] == (
+        "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
+    )
+    assert "Claim GitHub balances from /me" in account
     assert 'href="/accounts/reserve:bounty:1"' in account
     assert 'href="/accounts/github:alice"' in account
 


### PR DESCRIPTION
Refs #50 / Bounty #50.

This fixes the still-current `github:*` account copy papercut on `main`: public GitHub account pages showed the generic registered-wallet transfer status, which makes a bounty balance look directly spendable as a wallet account.

Change:
- `github:*` account API/page responses now say to claim GitHub balances from `/me` after linking a registered `mrwk1` wallet.
- Non-GitHub account pages keep the existing registered-wallet transfer copy.
- The explorer/account regression now checks the API `transfer_status` and rendered account page copy for `github:alice`.

Context:
- PR #52 attempted this behavior earlier, but the maintainer noted it needed a rebase before acceptance. This PR applies the focused fix against current `main`.

Verification:
- Red test first: `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_explorer_links_ledger_proof_and_account -q` failed with the generic wallet-transfer copy.
- `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_explorer_links_ledger_proof_and_account -q` -> 1 passed
- `uv run --extra dev python -m pytest tests/test_api_mcp.py -q` -> 14 passed
- `uv run --extra dev python -m pytest -q` -> 79 passed
- `uv run --extra dev ruff format --check .` -> 30 files already formatted
- `uv run --extra dev ruff check .` -> all checks passed
- `uv run --extra dev mypy app` -> success
- `git diff --check -- app/main.py tests/test_api_mcp.py` -> passed
