### PR TITLE
Reject loopback public base URLs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ipaddress
 import os
 from dataclasses import dataclass
 from urllib.parse import urlparse
@@ -68,6 +69,13 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
         errors.append("MERGEWORK_PUBLIC_BASE_URL must be an origin without a path")
     if parsed_base_url.query or parsed_base_url.fragment:
         errors.append("MERGEWORK_PUBLIC_BASE_URL must not include query or fragment")
+    if parsed_base_url.hostname:
+        try:
+            is_loopback = ipaddress.ip_address(parsed_base_url.hostname).is_loopback
+        except ValueError:
+            is_loopback = parsed_base_url.hostname.lower() == "localhost"
+        if is_loopback:
+            errors.append("MERGEWORK_PUBLIC_BASE_URL must not use a loopback host")
     return errors
 
 

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -106,3 +106,13 @@ def test_deploy_readiness_script_runs_directly_from_source() -> None:
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "Deploy readiness check passed."
+
+
+def test_deploy_readiness_rejects_loopback_public_base_url() -> None:
+    localhost_errors = validate_deploy_settings(_settings(public_base_url="https://localhost:8000"))
+    ipv4_errors = validate_deploy_settings(_settings(public_base_url="https://127.0.0.1"))
+    ipv6_errors = validate_deploy_settings(_settings(public_base_url="https://[::1]"))
+
+    assert "MERGEWORK_PUBLIC_BASE_URL must not use a loopback host" in localhost_errors
+    assert "MERGEWORK_PUBLIC_BASE_URL must not use a loopback host" in ipv4_errors
+    assert "MERGEWORK_PUBLIC_BASE_URL must not use a loopback host" in ipv6_errors


### PR DESCRIPTION
Refs #55 / Bounty #55.

This adds one focused deploy-readiness check for a real operator mistake: setting `MERGEWORK_PUBLIC_BASE_URL` to a loopback origin such as `https://localhost:8000`, `https://127.0.0.1`, or `https://[::1]`.

Why:
- `MERGEWORK_PUBLIC_BASE_URL` is used as the public origin for externally visible app links and OAuth callback setup.
- A loopback host can pass the existing HTTPS/host checks while still producing a deployment that only works from the server itself.

Change:
- Reject loopback IP hosts and `localhost` in `validate_deploy_settings`.
- Keep normal public HTTPS hosts accepted.
- Add focused regression coverage for localhost, IPv4 loopback, and IPv6 loopback.

Verification:
- Red test first: `uv run --extra dev python -m pytest tests/test_deploy_readiness.py::test_deploy_readiness_rejects_loopback_public_base_url -q` failed before the validator change.
- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py -q` -> 5 passed
- `uv run --extra dev python -m pytest -q` -> 80 passed
- `uv run --extra dev ruff format --check .` -> 30 files already formatted
- `uv run --extra dev ruff check .` -> all checks passed
- `uv run --extra dev mypy app` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- Valid deploy env + `python -m scripts.check_deploy_ready` -> passed
- Loopback deploy env + `python -m scripts.check_deploy_ready` -> failed with the new error
- `docker build -t mergework:ci .` -> built successfully
- `git diff --check -- app/config.py tests/test_deploy_readiness.py` -> passed
