### PR TITLE
Handle malformed bounty API JSON

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -332,19 +332,21 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     async def api_create_bounty(
         request: Request, admin_login: str = Depends(require_admin_token)
     ) -> dict[str, Any]:
-        data = await request.json()
+        data = await _json_object(request)
         with session_scope(db_url) as session:
             try:
                 bounty = create_bounty(
                     session,
-                    repo=data["repo"],
-                    issue_number=int(data["issue_number"]),
-                    issue_url=data["issue_url"],
-                    title=data["title"],
+                    repo=_required_str(data, "repo"),
+                    issue_number=_required_int(data, "issue_number"),
+                    issue_url=_required_str(data, "issue_url"),
+                    title=_required_str(data, "title"),
                     reward_mrwk=str(data["reward_mrwk"]),
                     max_awards=_optional_int(data, "max_awards", 1),
-                    acceptance=data["acceptance"],
+                    acceptance=_required_str(data, "acceptance"),
                 )
+            except KeyError as exc:
+                raise HTTPException(status_code=400, detail=f"{exc.args[0]} is required") from exc
             except LedgerError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             result = bounty_to_dict(bounty)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -113,6 +113,38 @@ def test_admin_bounty_api_requires_admin_token_not_cookie_auth(
     assert token_auth.status_code == 200
 
 
+def test_admin_bounty_api_returns_400_for_malformed_json(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+
+    non_object = client.post(
+        "/api/v1/bounties",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json=["not", "an", "object"],
+    )
+    missing_field = client.post(
+        "/api/v1/bounties",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json={
+            "issue_number": 77,
+            "issue_url": "https://github.com/ramimbo/mergework/issues/77",
+            "title": "Missing repo",
+            "reward_mrwk": "10",
+            "acceptance": "Maintainer applies mrwk:accepted",
+        },
+    )
+
+    assert non_object.status_code == 400
+    assert non_object.json()["detail"] == "json body must be an object"
+    assert missing_field.status_code == 400
+    assert missing_field.json()["detail"] == "repo is required"
+
+
 def test_admin_payout_api_requires_admin_token_not_cookie_auth(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Refs #50

## Summary

Return controlled 400 responses from the admin bounty JSON API when the request body is not an object or required fields are missing.

## Observed problem

Most JSON endpoints already use the shared request helpers, but `POST /api/v1/bounties` still parsed raw JSON and indexed fields directly. A valid admin-token request with a JSON list raised an internal `TypeError` instead of returning the same structured 400 used elsewhere.

## What changed

- Reuse `_json_object` for the bounty-create JSON body.
- Reuse `_required_str` and `_required_int` for required create-bounty fields.
- Add regression coverage for a non-object body and a missing `repo` field.

## Validation

- Red test reproduced `TypeError: list indices must be integers or slices, not str`.
- `uv run --extra dev python -m pytest tests/test_security.py::test_admin_bounty_api_returns_400_for_malformed_json tests/test_security.py::test_admin_bounty_api_accepts_multi_award_count -q` -> 2 passed
- `uv run --extra dev python -m pytest tests/test_security.py -q` -> 17 passed
- `uv run --extra dev python -m pytest -q` -> 80 passed
- `uv run --extra dev ruff format --check .` -> 30 files already formatted
- `uv run --extra dev ruff check .` -> All checks passed
- `uv run --extra dev mypy app` -> Success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check -- app/main.py tests/test_security.py` -> no whitespace errors
