### PR TITLE
Handle malformed MCP JSON-RPC requests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -570,7 +570,20 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.post("/mcp")
     async def mcp(request: Request) -> dict[str, Any]:
-        payload = await request.json()
+        try:
+            payload = await request.json()
+        except ValueError:
+            return {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": "parse error"},
+            }
+        if not isinstance(payload, dict):
+            return {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32600, "message": "invalid request"},
+            }
         response_id = payload.get("id")
         method = payload.get("method")
         if method == "tools/list":

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -403,6 +403,29 @@ def test_mcp_malformed_tool_call_returns_jsonrpc_error(sqlite_url: str) -> None:
     assert response.json()["error"] == {"code": -32602, "message": "invalid tool arguments"}
 
 
+def test_mcp_malformed_jsonrpc_request_returns_error(sqlite_url: str) -> None:
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        raise_server_exceptions=False,
+    )
+
+    invalid_json = client.post("/mcp", content="{", headers={"content-type": "application/json"})
+    non_object = client.post("/mcp", json=["not", "an", "object"])
+
+    assert invalid_json.status_code == 200
+    assert invalid_json.json() == {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {"code": -32700, "message": "parse error"},
+    }
+    assert non_object.status_code == 200
+    assert non_object.json() == {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {"code": -32600, "message": "invalid request"},
+    }
+
+
 def test_pay_bounty_rejects_reentrant_duplicate_before_ledger_write(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Refs #50

## Summary

Return JSON-RPC errors from `/mcp` for malformed top-level request bodies instead of letting invalid JSON or non-object payloads become server errors.

## Observed problem

The MCP endpoint already returned a JSON-RPC `invalid tool arguments` error for malformed tool calls, but the top-level request parser still called `request.json()` directly and then assumed the parsed value had `.get()`. Invalid JSON returned HTTP 500, and a JSON list could fail before method dispatch.

## What changed

- Return JSON-RPC `parse error` for invalid JSON bodies.
- Return JSON-RPC `invalid request` for non-object JSON bodies.
- Add regression coverage beside the existing malformed MCP tool-call test.

## Validation

- Red test reproduced HTTP 500 for invalid JSON at `/mcp`.
- `uv run --extra dev python -m pytest tests/test_security.py::test_mcp_malformed_jsonrpc_request_returns_error tests/test_security.py::test_mcp_malformed_tool_call_returns_jsonrpc_error -q` -> 2 passed
- `uv run --extra dev python -m pytest tests/test_security.py -q` -> 17 passed
- `uv run --extra dev python -m pytest -q` -> 80 passed
- `uv run --extra dev ruff format --check .` -> 30 files already formatted
- `uv run --extra dev ruff check .` -> All checks passed
- `uv run --extra dev mypy app` -> Success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check -- app/main.py tests/test_security.py` -> no whitespace errors
