### PR TITLE
Handle malformed payout API JSON

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -365,9 +365,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         request: Request,
         admin_login: str = Depends(require_admin_token),
     ) -> dict[str, Any]:
-        data = await request.json()
-        if not isinstance(data, dict):
-            raise HTTPException(status_code=400, detail="json body must be an object")
+        data = await _json_object(request)
         try:
             requested_account = str(data["to_account"])
             submission_url = str(data["submission_url"])

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -159,6 +159,42 @@ def test_admin_payout_api_requires_admin_token_not_cookie_auth(
         assert get_balance(session, wallet_address) == 25_000_000
 
 
+def test_admin_payout_api_returns_400_for_malformed_json(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    create_schema(sqlite_url)
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+        raise_server_exceptions=False,
+    )
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=3,
+            issue_url="https://github.com/ramimbo/mergework/issues/3",
+            title="Malformed payout JSON",
+            reward_mrwk="25",
+            acceptance="Maintainer verifies payout.",
+        )
+        bounty_id = bounty.id
+
+    invalid_json = client.post(
+        f"/api/v1/bounties/{bounty_id}/pay",
+        content="{",
+        headers={
+            "x-mergework-admin-token": "admin-token-for-tests",
+            "content-type": "application/json",
+        },
+    )
+
+    assert invalid_json.status_code == 400
+    assert invalid_json.json()["detail"] == "invalid json body"
+
+
 def test_admin_close_bounty_api_releases_remaining_reserve(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Refs #50

## Summary

Return the existing controlled 400 JSON error for invalid JSON bodies sent to the admin payout endpoint.

## Observed problem

`POST /api/v1/bounties/{bounty_id}/pay` already handled non-object JSON and missing fields, but it still parsed the body with `request.json()` directly. An admin-token request with malformed JSON returned HTTP 500 instead of the shared `invalid json body` response used by other JSON endpoints.

## What changed

- Reuse `_json_object` in the admin payout endpoint.
- Keep the existing payout request field validation and payout behavior unchanged.
- Add regression coverage for an invalid JSON payout request.

## Validation

- Red test reproduced HTTP 500 for invalid JSON at the payout endpoint.
- `uv run --extra dev python -m pytest tests/test_security.py::test_admin_payout_api_returns_400_for_malformed_json tests/test_security.py::test_admin_payout_api_requires_admin_token_not_cookie_auth -q` -> 2 passed
- `uv run --extra dev python -m pytest tests/test_security.py -q` -> 17 passed
- `uv run --extra dev python -m pytest -q` -> 80 passed
- `uv run --extra dev ruff format --check .` -> 30 files already formatted
- `uv run --extra dev ruff check .` -> All checks passed
- `uv run --extra dev mypy app` -> Success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check -- app/main.py tests/test_security.py` -> no whitespace errors
