### PR TITLE
Allow IPv6 loopback staging dry runs

### DIFF
--- a/scripts/staging_webhook_dry_run.py
+++ b/scripts/staging_webhook_dry_run.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import ipaddress
 import json
 import os
 import sys
@@ -61,7 +62,11 @@ def _validate_http_url(url: str) -> None:
 def _enforce_staging_target(base_url: str) -> None:
     parsed = urlparse(base_url)
     host = parsed.hostname or ""
-    if host in {"127.0.0.1", "localhost"} or "staging" in host:
+    try:
+        is_loopback = ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        is_loopback = host.lower() == "localhost"
+    if is_loopback or "staging" in host:
         return
     if os.environ.get("MERGEWORK_ALLOW_NON_STAGING_DRY_RUN") == "1":
         return

--- a/tests/test_staging_webhook_dry_run.py
+++ b/tests/test_staging_webhook_dry_run.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.staging_webhook_dry_run import _enforce_staging_target
+
+
+def test_staging_webhook_dry_run_allows_loopback_hosts() -> None:
+    _enforce_staging_target("http://localhost:8000")
+    _enforce_staging_target("http://127.0.0.1:8000")
+    _enforce_staging_target("http://[::1]:8000")
+
+
+def test_staging_webhook_dry_run_rejects_non_staging_public_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MERGEWORK_ALLOW_NON_STAGING_DRY_RUN", raising=False)
+
+    with pytest.raises(RuntimeError, match="MERGEWORK_STAGING_BASE_URL"):
+        _enforce_staging_target("https://mrwk.example.test")


### PR DESCRIPTION
Refs #55

## Summary
- Allow `scripts/staging_webhook_dry_run.py` to treat IPv6 loopback targets such as `http://[::1]:8000` as local staging targets.
- Add focused coverage for localhost, IPv4 loopback, IPv6 loopback, and non-staging public host rejection.

## Evidence
- Red test before the fix: `uv run --extra dev python -m pytest tests/test_staging_webhook_dry_run.py -q` failed because `http://[::1]:8000` raised `MERGEWORK_STAGING_BASE_URL must point at localhost...`.
- `uv run --extra dev python -m pytest tests/test_staging_webhook_dry_run.py -q` -> 2 passed
- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py tests/test_staging_webhook_dry_run.py -q` -> 6 passed
- `uv run --extra dev python -m pytest -q` -> 81 passed
- `uv run --extra dev ruff format --check scripts/staging_webhook_dry_run.py tests/test_staging_webhook_dry_run.py` -> passed
- `uv run --extra dev ruff check scripts/staging_webhook_dry_run.py tests/test_staging_webhook_dry_run.py` -> passed
- `uv run --extra dev mypy app` -> passed
- `git diff --check -- scripts/staging_webhook_dry_run.py tests/test_staging_webhook_dry_run.py` -> passed

No secrets, private keys, deployment credential values, or price claims included.