### PR TITLE
Reject userinfo in public base URLs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -68,6 +68,8 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
         errors.append("MERGEWORK_PUBLIC_BASE_URL must be an origin without a path")
     if parsed_base_url.query or parsed_base_url.fragment:
         errors.append("MERGEWORK_PUBLIC_BASE_URL must not include query or fragment")
+    if parsed_base_url.username or parsed_base_url.password:
+        errors.append("MERGEWORK_PUBLIC_BASE_URL must not include userinfo")
     return errors
 
 

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -81,6 +81,14 @@ def test_deploy_readiness_rejects_public_base_url_path_query_or_fragment() -> No
     assert "MERGEWORK_PUBLIC_BASE_URL must not include query or fragment" in fragment_errors
 
 
+def test_deploy_readiness_rejects_public_base_url_userinfo() -> None:
+    errors = validate_deploy_settings(
+        _settings(public_base_url="https://operator:secret@mrwk.example.test")
+    )
+
+    assert "MERGEWORK_PUBLIC_BASE_URL must not include userinfo" in errors
+
+
 def test_deploy_readiness_script_runs_directly_from_source() -> None:
     env = {
         **os.environ,


### PR DESCRIPTION
Refs #55

## Summary

Reject deploy configurations where `MERGEWORK_PUBLIC_BASE_URL` includes URL userinfo, for example `https://operator:secret@mrwk.example.test`.

## Observed problem

The deploy-readiness gate already requires HTTPS and a host, but it still accepted a public base URL with embedded userinfo. That is not a clean public origin for externally visible links or GitHub OAuth callback construction, and it can let credential-shaped values slip into deploy configuration.

## Changed behavior

- Detect `username` or `password` components after parsing `MERGEWORK_PUBLIC_BASE_URL`.
- Return a deploy-readiness error when userinfo is present.
- Add focused regression coverage for the rejected shape.

## Validation

- Red test before the fix: `uv run --extra dev python -m pytest tests/test_deploy_readiness.py::test_deploy_readiness_rejects_public_base_url_userinfo -q` failed because the error list was empty.
- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py::test_deploy_readiness_rejects_public_base_url_userinfo -q` -> 1 passed
- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py -q` -> 5 passed
- `uv run --extra dev python -m pytest -q` -> 80 passed
- `uv run --extra dev ruff format --check app/config.py tests/test_deploy_readiness.py` -> 2 files already formatted
- `uv run --extra dev ruff check app/config.py tests/test_deploy_readiness.py` -> All checks passed
- `uv run --extra dev mypy app` -> Success
- Valid deploy env + `uv run --extra dev python scripts/check_deploy_ready.py` -> Deploy readiness check passed
- Userinfo deploy env + `uv run --extra dev python scripts/check_deploy_ready.py` -> failed with `MERGEWORK_PUBLIC_BASE_URL must not include userinfo`
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check -- app/config.py tests/test_deploy_readiness.py` -> passed
