### PR TITLE
Filter bounty API by status

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -323,9 +323,16 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         }
 
     @app.get("/api/v1/bounties")
-    def api_bounties() -> list[dict[str, Any]]:
+    def api_bounties(status: str | None = Query(None)) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
-            bounties = session.scalars(select(Bounty).order_by(Bounty.id.desc())).all()
+            query = select(Bounty)
+            if status is not None:
+                if status not in {"open", "paid", "closed"}:
+                    raise HTTPException(
+                        status_code=400, detail="status must be one of: open, paid, closed"
+                    )
+                query = query.where(Bounty.status == status)
+            bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             return [bounty_to_dict(bounty) for bounty in bounties]
 
     @app.post("/api/v1/bounties")

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -215,6 +215,68 @@ def test_bounty_api_keeps_terminal_multi_awards_visible_but_inactive(sqlite_url:
     assert status["active_bounties"] == 0
 
 
+def test_bounty_api_filters_by_status(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        open_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=40,
+            issue_url="https://github.com/ramimbo/mergework/issues/40",
+            title="Open status filter bounty",
+            reward_mrwk="5",
+            acceptance="Open rows should be filterable.",
+        )
+        paid_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=41,
+            issue_url="https://github.com/ramimbo/mergework/issues/41",
+            title="Paid status filter bounty",
+            reward_mrwk="5",
+            acceptance="Paid rows should be filterable.",
+        )
+        closed_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=42,
+            issue_url="https://github.com/ramimbo/mergework/issues/42",
+            title="Closed status filter bounty",
+            reward_mrwk="5",
+            acceptance="Closed rows should be filterable.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=paid_bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/41",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        close_bounty(
+            session,
+            bounty_id=closed_bounty.id,
+            closed_by="maintainer",
+            reference="https://github.com/ramimbo/mergework/issues/42#close",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    assert [item["id"] for item in client.get("/api/v1/bounties?status=open").json()] == [
+        open_bounty.id
+    ]
+    assert [item["id"] for item in client.get("/api/v1/bounties?status=paid").json()] == [
+        paid_bounty.id
+    ]
+    assert [item["id"] for item in client.get("/api/v1/bounties?status=closed").json()] == [
+        closed_bounty.id
+    ]
+    invalid = client.get("/api/v1/bounties?status=bogus")
+    assert invalid.status_code == 400
+    assert invalid.json()["detail"] == "status must be one of: open, paid, closed"
+
+
 def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Refs #50.

## Summary

Fixes `/api/v1/bounties?status=...` so the public bounty API filters by status instead of silently returning every bounty for any status query.

Live repro before the patch: `?status=open`, `?status=closed`, and `?status=paid` all returned the same open bounty list from `https://api.mrwk.ltclab.site/api/v1/bounties`.

## Changes

- Filters `/api/v1/bounties` for `open`, `paid`, and `closed`.
- Returns `400` for unsupported status values.
- Adds regression coverage for open, paid, closed, and invalid status queries.

## Validation

- Red test before fix: `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_bounty_api_filters_by_status -q` failed because `?status=open` returned `[closed, paid, open]`.
- `uv run --extra dev python -m pytest tests/test_api_mcp.py -q` -> 15 passed.
- `uv run --extra dev python -m pytest -q` -> 80 passed.
- `uv run --extra dev ruff format --check app/main.py tests/test_api_mcp.py` -> passed.
- `uv run --extra dev ruff check app/main.py tests/test_api_mcp.py` -> passed.
- `uv run --extra dev mypy app` -> passed.
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD -- app/main.py tests/test_api_mcp.py` -> passed.

No secrets, private keys, wallet signing, spending, deployment changes, or price claims included.
