### PR TITLE
Reject empty API account path

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -428,7 +428,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 "ledger_sequence": release.sequence if release else None,
             }
 
-    @app.get("/api/v1/accounts/{account:path}")
+    @app.get("/api/v1/accounts/{account}")
     def api_account(account: str) -> dict[str, Any]:
         with session_scope(db_url) as session:
             account_row = session.get(Account, account)

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -34,6 +34,17 @@ def test_health_status_and_bounty_api(sqlite_url: str) -> None:
     assert bounties[0]["title"] == "First bounty"
 
 
+def test_account_api_rejects_empty_account_path(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    assert client.get("/api/v1/accounts/").status_code == 404
+    account = client.get("/api/v1/accounts/github:alice")
+    assert account.status_code == 200
+    assert account.json()["account"] == "github:alice"
+
+
 def test_bounty_api_reports_multi_award_capacity(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Fixes a small API account lookup edge case for Bounty #50.

`GET /api/v1/accounts/` currently matches the account route with an empty account string and returns a successful JSON payload. Sibling required-resource routes like `/api/v1/wallets/` return 404 when the path segment is missing.

What changed:
- Changed the API account route from `{account:path}` to `{account}` so the account segment is required.
- Added a regression test that keeps `/api/v1/accounts/` at 404 while preserving `/api/v1/accounts/github:alice`.

Verification:
- Live repro before patch: `curl -i https://api.mrwk.ltclab.site/api/v1/accounts/` returned HTTP 200 with `account:""`.
- Red test before fix: `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_account_api_rejects_empty_account_path -q` failed because the endpoint returned 200.
- Focused regression: 1 passed.
- `tests/test_api_mcp.py`: 15 passed.
- Full pytest: 80 passed.
- Ruff format/check touched files: passed.
- Mypy app: passed.
- Docs smoke: ok.
- Diff whitespace check: passed.
