### PR TITLE
Handle malformed MCP requests without 500s

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -17,6 +17,8 @@ def _ensure_sqlite_parent(database_url: str) -> None:
         return
     parsed = urlparse(database_url)
     raw_path = unquote(parsed.path)
+    if len(raw_path) > 2 and raw_path[0] == "/" and raw_path[2] == ":":
+        raw_path = raw_path[1:]
     if raw_path:
         Path(raw_path).parent.mkdir(parents=True, exist_ok=True)
 

--- a/app/main.py
+++ b/app/main.py
@@ -569,8 +569,27 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         return JSONResponse(result, status_code=code)
 
     @app.post("/mcp")
-    async def mcp(request: Request) -> dict[str, Any]:
-        payload = await request.json()
+    async def mcp(request: Request) -> Any:
+        try:
+            payload = await request.json()
+        except ValueError:
+            return JSONResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {"code": -32700, "message": "parse error"},
+                },
+                status_code=400,
+            )
+        if not isinstance(payload, dict):
+            return JSONResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {"code": -32600, "message": "invalid request"},
+                },
+                status_code=400,
+            )
         response_id = payload.get("id")
         method = payload.get("method")
         if method == "tools/list":
@@ -606,7 +625,15 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 "id": response_id,
                 "error": {"code": -32601, "message": "unknown method"},
             }
-        params = payload.get("params") or {}
+        params = payload.get("params")
+        if params is None:
+            params = {}
+        if not isinstance(params, dict):
+            return {
+                "jsonrpc": "2.0",
+                "id": response_id,
+                "error": {"code": -32602, "message": "invalid params"},
+            }
         name = params.get("name")
         args = params.get("arguments") or {}
         if not isinstance(args, dict):

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -238,6 +238,37 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert "100000000" in balance["result"]["content"][0]["text"]
 
 
+def test_mcp_rejects_malformed_requests_without_500(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    malformed = client.post("/mcp", data="not-json", headers={"content-type": "application/json"})
+    assert malformed.status_code == 400
+    assert malformed.json() == {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {"code": -32700, "message": "parse error"},
+    }
+
+    non_object = client.post("/mcp", json=[])
+    assert non_object.status_code == 400
+    assert non_object.json() == {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {"code": -32600, "message": "invalid request"},
+    }
+
+    bad_params = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 7, "method": "tools/call", "params": []},
+    )
+    assert bad_params.status_code == 200
+    assert bad_params.json() == {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "error": {"code": -32602, "message": "invalid params"},
+    }
+
+
 def test_mcp_get_proof_returns_public_proof_details(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -38,6 +38,18 @@ def test_genesis_creates_fixed_supply_once(sqlite_url: str) -> None:
         assert verify_supply_conservation(session) is True
 
 
+def test_make_engine_accepts_windows_absolute_sqlite_url(tmp_path) -> None:
+    database_path = tmp_path / "nested" / "mergework.sqlite3"
+    engine = make_engine(f"sqlite:///{database_path}")
+    try:
+        with engine.begin() as connection:
+            connection.exec_driver_sql("SELECT 1")
+    finally:
+        engine.dispose()
+
+    assert database_path.parent.exists()
+
+
 def test_bounty_reserve_and_payout_conserve_supply(sqlite_url: str) -> None:
     create_schema(sqlite_url)
 


### PR DESCRIPTION
## Summary
- return JSON-RPC parse/invalid-request errors for malformed `/mcp` request bodies instead of 500s
- validate `tools/call.params` before reading tool names
- normalize Windows absolute SQLite paths so the test fixture can create temp DB parents on Windows

## Evidence
- Live repro before fix: `POST https://mcp.mrwk.ltclab.site/mcp` with `not-json` returned HTTP 500 `Internal Server Error`.
- `uv run --extra dev --python 3.12 pytest tests\test_api_mcp.py tests\test_ledger.py::test_make_engine_accepts_windows_absolute_sqlite_url -q` -> 16 passed
- `uv run --extra dev --python 3.12 ruff check app\main.py app\db.py tests\test_api_mcp.py tests\test_ledger.py` -> passed

Bounty #50 candidate: focused public API/MCP papercut fix with regression coverage.