### PR TITLE
Reject staging dry-run URL credentials

### DIFF
--- a/scripts/staging_webhook_dry_run.py
+++ b/scripts/staging_webhook_dry_run.py
@@ -55,6 +55,8 @@ def _post_webhook(
 
 def _validate_http_url(url: str) -> None:
     parsed = urlparse(url)
+    if parsed.username or parsed.password:
+        raise RuntimeError("staging dry-run URL must not include username or password")
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise RuntimeError(f"{url} must use http or https")
 

--- a/tests/test_staging_webhook_dry_run.py
+++ b/tests/test_staging_webhook_dry_run.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from scripts.staging_webhook_dry_run import _enforce_staging_target
+from scripts.staging_webhook_dry_run import _enforce_staging_target, _validate_http_url
 
 
 def test_staging_webhook_dry_run_allows_loopback_hosts() -> None:
@@ -18,3 +18,16 @@ def test_staging_webhook_dry_run_rejects_non_staging_public_hosts(
 
     with pytest.raises(RuntimeError, match="MERGEWORK_STAGING_BASE_URL"):
         _enforce_staging_target("https://mrwk.example.test")
+
+
+def test_staging_webhook_dry_run_rejects_url_credentials() -> None:
+    with pytest.raises(RuntimeError, match="must not include username or password"):
+        _validate_http_url("https://operator:secret@staging.mrwk.example.test")
+    with pytest.raises(RuntimeError, match="must not include username or password"):
+        _validate_http_url("https://operator@staging.mrwk.example.test")
+    with pytest.raises(RuntimeError, match="must not include username or password"):
+        _validate_http_url("https://:secret@staging.mrwk.example.test")
+    with pytest.raises(RuntimeError, match="must not include username or password"):
+        _validate_http_url("ftp://operator:secret@staging.mrwk.example.test")
+
+    _validate_http_url("https://staging.mrwk.example.test")


### PR DESCRIPTION
Fixes a staging dry-run safety gap for Bounty #55.

The dry-run script validates that target URLs use HTTP(S), but it currently accepts URLs with embedded username/password userinfo before sending requests through `httpx`, such as `https://operator:secret@staging...`.

What changed:
- Reject username/password userinfo in staging dry-run target URLs.
- Use a generic error message so credential-bearing URLs are not echoed into local or CI logs.
- Add regression coverage for `user:pass@host`, `user@host`, and `:pass@host`, while preserving normal staging URLs.

Verification:
- Red test before fix: `test_staging_webhook_dry_run_rejects_url_credentials` failed because credential-bearing URLs were accepted.
- `uv run --extra dev python -m pytest tests/test_staging_webhook_dry_run.py tests/test_deploy_readiness.py -q` -> 5 passed.
- `uv run --extra dev python -m pytest -q` -> 80 passed.
- Ruff format/check touched files: passed.
- Mypy app: passed.
- Docs smoke: ok.
- Diff whitespace check: passed.
- Independent review pass: no findings after the redaction fix.
