### PR TITLE
Reject self wallet transfers

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -429,6 +429,8 @@ def submit_wallet_transfer(
     ensure_genesis(session)
     sender = _wallet_for_update(session, from_address)
     receiver = _wallet_for_update(session, to_address)
+    if sender.address == receiver.address:
+        raise LedgerError("sender and receiver must be different")
     amount = parse_mrwk_amount(amount_mrwk)
     clean_memo = memo.strip()
     if len(clean_memo) > 240:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -8,8 +8,11 @@ from fastapi.testclient import TestClient
 from app.db import create_schema, session_scope
 from app.ledger.service import (
     TREASURY_ACCOUNT,
+    LedgerError,
     add_ledger_entry,
     ensure_genesis,
+    register_wallet,
+    submit_wallet_transfer,
     wallet_claim_payload,
     wallet_link_payload,
 )
@@ -375,3 +378,28 @@ def test_wallet_pages_do_not_require_manual_nonce(sqlite_url: str, monkeypatch) 
     assert "Transaction number is handled automatically" in me
     assert "different key will be rejected" in me
     assert "GitHub account is linked to the wallet" in me
+
+
+def test_reject_self_transfer(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    _, public_hex, address = _keypair()
+
+    with session_scope(sqlite_url) as session:
+        register_wallet(session, public_key_hex=public_hex)
+
+    with (
+        pytest.raises(LedgerError, match="sender and receiver must be different"),
+        session_scope(sqlite_url) as session,
+    ):
+        submit_wallet_transfer(
+            session,
+            from_address=address,
+            to_address=address,
+            amount_mrwk="1",
+            nonce=1,
+            memo="",
+            signature_hex="a" * 128,
+        )


### PR DESCRIPTION
Refs #50\n\n## Summary\n- reject wallet transfers where sender and receiver resolve to the same MRWK address\n- add regression coverage for the self-transfer edge case\n\n## Bug evidence\nBefore this change, a signed transfer from a wallet to itself could create a ledger entry, increment the wallet nonce, and store a WalletTransfer row while producing no balance change. That allowed meaningless ledger spam.\n\n## Tests\n- Ran on DeerFlow Windows sandbox via Docker: `docker run --rm -v C:\\bounty-sandbox\\mergework:/work -w /work python:3.12 bash -lc 'pip install -q -e . pytest && pytest tests/test_wallet_api.py -q'`\n- Result: `16 passed in 6.95s`