### PR TITLE
Harden public base URL deploy readiness validation

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -64,6 +64,10 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
         errors.append("MERGEWORK_PUBLIC_BASE_URL must use https")
     if not parsed_base_url.netloc:
         errors.append("MERGEWORK_PUBLIC_BASE_URL must include a host")
+    if parsed_base_url.path.endswith("/") and parsed_base_url.path != "":
+        errors.append("MERGEWORK_PUBLIC_BASE_URL must not end with a slash")
+    if parsed_base_url.query or parsed_base_url.fragment:
+        errors.append("MERGEWORK_PUBLIC_BASE_URL must not include query or fragment")
     return errors
 
 

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from app.config import Settings, validate_deploy_settings
 
 
@@ -59,3 +61,28 @@ def test_deploy_readiness_requires_https_oauth_and_allowed_labelers() -> None:
     assert "MERGEWORK_PUBLIC_BASE_URL must use https" in errors
     assert "MERGEWORK_GITHUB_OAUTH_CLIENT_ID is required" in errors
     assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS must list maintainer logins" in errors
+
+
+@pytest.mark.parametrize(
+    ("public_base_url", "expected_error"),
+    [
+        (
+            "https://staging.mrwk.example.test/",
+            "MERGEWORK_PUBLIC_BASE_URL must not end with a slash",
+        ),
+        (
+            "https://staging.mrwk.example.test?env=staging",
+            "MERGEWORK_PUBLIC_BASE_URL must not include query or fragment",
+        ),
+        (
+            "https://staging.mrwk.example.test#callback",
+            "MERGEWORK_PUBLIC_BASE_URL must not include query or fragment",
+        ),
+    ],
+)
+def test_deploy_readiness_rejects_public_base_url_suffixes(
+    public_base_url: str, expected_error: str
+) -> None:
+    errors = validate_deploy_settings(_settings(public_base_url=public_base_url))
+
+    assert expected_error in errors


### PR DESCRIPTION
Refs #55

## Summary
- reject `MERGEWORK_PUBLIC_BASE_URL` values that end with a slash
- reject query strings and fragments in the public base URL
- add deploy-readiness regression coverage for these operator mistakes

## Why
`public_base_url` is used to build the GitHub OAuth callback with a simple `/auth/github/callback` suffix. Values such as `https://staging.example/`, `https://staging.example?env=staging`, or `https://staging.example#callback` can produce invalid or surprising redirect URIs while still passing the deploy-readiness gate.

## Validation
- `./.venv/bin/python -m pytest tests/test_deploy_readiness.py -q` -> 5 passed
- `./.venv/bin/python -m pytest -q` -> 80 passed
- `./.venv/bin/python -m ruff format --check .` -> 30 files already formatted
- `./.venv/bin/python -m ruff check .` -> all checks passed
- `./.venv/bin/python -m mypy app` -> success
- `./.venv/bin/python scripts/check_agents.py` -> ok
- `./.venv/bin/python scripts/docs_smoke.py` -> ok
- deploy-readiness env smoke -> passed

Docker image build was attempted locally but Docker was not running: `Cannot connect to the Docker daemon`.

No secrets, private keys, deployment credentials, private vulnerability details, or price claims included.