### PR TITLE
Use fallback security headers in Caddy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -5,11 +5,11 @@
 ltclab.site, www.ltclab.site, mrwk.ltclab.site, api.mrwk.ltclab.site, mcp.mrwk.ltclab.site {
 	encode zstd gzip
 	header {
-		Content-Security-Policy "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; connect-src 'self'; img-src 'self' data:; object-src 'none'; script-src 'self'; style-src 'self'"
-		Strict-Transport-Security "max-age=31536000; includeSubDomains"
-		X-Content-Type-Options nosniff
-		X-Frame-Options DENY
-		Referrer-Policy no-referrer
+		?Content-Security-Policy "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; connect-src 'self'; img-src 'self' data:; object-src 'none'; script-src 'self'; style-src 'self'"
+		?Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		?X-Content-Type-Options nosniff
+		?X-Frame-Options DENY
+		?Referrer-Policy no-referrer
 	}
 	reverse_proxy app:8000
 }

--- a/tests/test_caddyfile.py
+++ b/tests/test_caddyfile.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+APP_MANAGED_SECURITY_HEADERS = (
+    "Content-Security-Policy",
+    "Strict-Transport-Security",
+    "X-Content-Type-Options",
+    "X-Frame-Options",
+    "Referrer-Policy",
+)
+
+
+def test_caddy_security_headers_are_fallback_defaults() -> None:
+    caddyfile = Path("Caddyfile").read_text(encoding="utf-8")
+
+    for header in APP_MANAGED_SECURITY_HEADERS:
+        assert f"?{header}" in caddyfile
+        assert f"\n\t\t{header}" not in caddyfile


### PR DESCRIPTION
Bounty #55

## Summary

- Change Caddy security headers to use default-header fallback syntax (`?Header-Name`) instead of setting headers unconditionally.
- Keep the FastAPI app as the primary source for browser/API security headers while letting Caddy fill them only when upstream does not set them.
- Add a Caddyfile regression test so these app-managed security headers are not configured as duplicate unconditional headers again.

## Evidence

Public responses currently include duplicate security headers because both the app and Caddy set them:

```bash
curl -sS -D - -o /dev/null https://api.mrwk.ltclab.site/api/v1/status | awk 'BEGIN{IGNORECASE=1} /^content-security-policy:|^referrer-policy:|^strict-transport-security:|^x-content-type-options:|^x-frame-options:/ {print}'
```

Observed duplicate headers:

- `Content-Security-Policy`
- `Strict-Transport-Security`
- `Referrer-Policy`
- `X-Content-Type-Options`
- `X-Frame-Options`

I also observed the same duplicate-header pattern on `https://mrwk.ltclab.site/bounties` and `https://mcp.mrwk.ltclab.site/mcp`.

## Why this shape

Caddy documents the `?` header prefix as setting a default value only when the field does not already exist. That preserves a reverse-proxy fallback without duplicating headers already set by the upstream app.

## Validation

```bash
uv run --extra dev pytest tests/test_caddyfile.py tests/test_security.py::test_browser_responses_set_security_headers -q
uv run --extra dev pytest -q
uv run --extra dev ruff format --check .
uv run --extra dev ruff check .
uv run --extra dev mypy app
git diff --check -- Caddyfile tests/test_caddyfile.py
```

Results:

- `2 passed`
- `80 passed`
- `31 files already formatted`
- `All checks passed`
- `Success: no issues found in 11 source files`
- `git diff --check` clean