### PR TITLE
test: smoke test deploy migrations

### DIFF
--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect
+
+
+def test_alembic_upgrade_head_builds_deploy_schema(tmp_path, monkeypatch) -> None:
+    database_path = tmp_path / "mergework.sqlite3"
+    monkeypatch.setenv("MERGEWORK_DATABASE_URL", f"sqlite:///{database_path}")
+
+    config = Config("alembic.ini")
+    command.upgrade(config, "head")
+
+    engine = create_engine(f"sqlite:///{database_path}")
+    inspector = inspect(engine)
+
+    assert "bounties" in inspector.get_table_names()
+    bounty_columns = {column["name"] for column in inspector.get_columns("bounties")}
+    assert {"max_awards", "awards_paid"}.issubset(bounty_columns)
+
+    submission_indexes = inspector.get_indexes("submissions")
+    assert any(index["name"] == "uq_submission_bounty_url" for index in submission_indexes)


### PR DESCRIPTION
## Summary
- Add a pytest smoke test that runs Alembic `upgrade head` against a temporary SQLite database.
- Assert the deploy migration path creates the expected multi-award bounty columns and submission uniqueness index.

## Why
The app test suite exercises the runtime schema path, but CI did not cover the actual Alembic migration path operators use during deploy. This catches broken migration imports, revision chains, or SQLite-incompatible migration changes before deployment.

Refs Bounty #55

## Test Plan
- `uv run --extra dev python -m pytest`
- `uv run --extra dev python -m ruff format --check .`
- `uv run --extra dev python -m ruff check .`
- `uv run --extra dev python -m mypy app`
- `MERGEWORK_DATABASE_URL=sqlite:////srv/mergework/data/mergework.sqlite3 MERGEWORK_PUBLIC_BASE_URL=https://staging.mrwk.example.test MERGEWORK_GITHUB_WEBHOOK_SECRET=webhook-8efc3925bb8746b8a8fd3392c4c48e32 MERGEWORK_GITHUB_OAUTH_CLIENT_ID=client-id MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET=oauth-7818e79f9d3a4a1d82ff0e1b9f0b8e42 MERGEWORK_ADMIN_TOKEN=admin-14dcaab83bb245f2bfb5d5c21a9bb55b MERGEWORK_COOKIE_SECRET=cookie-27fd1c41324a4bdcb2e4014adc3a6108 MERGEWORK_ADMIN_LOGINS=alice MERGEWORK_GITHUB_ACCEPTED_LABELERS=alice uv run --extra dev python scripts/check_deploy_ready.py`
- `uv run --extra dev python scripts/docs_smoke.py`
- `docker build -t mergework:migration-smoke .`
- `git diff --check`
