### PR TITLE
fix: return method errors for wallet action routes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -256,6 +256,13 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     app.state.webhook_secret = secret
     app.state.settings = settings
 
+    def post_only_route() -> None:
+        raise HTTPException(
+            status_code=405,
+            detail="Method Not Allowed",
+            headers={"Allow": "POST"},
+        )
+
     @app.middleware("http")
     async def add_security_headers(request: Request, call_next: Any) -> Any:
         response = await call_next(request)
@@ -460,6 +467,14 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             except LedgerError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             return wallet_to_dict(session, wallet)
+
+    @app.get("/api/v1/wallets/register")
+    def api_register_wallet_get() -> None:
+        post_only_route()
+
+    @app.get("/api/v1/wallets/link-github")
+    def api_link_wallet_github_get() -> None:
+        post_only_route()
 
     @app.get("/api/v1/wallets/{address}")
     def api_wallet(address: str) -> dict[str, Any]:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -179,6 +179,21 @@ def test_wallet_api_malformed_register_requests_return_4xx(sqlite_url: str) -> N
     assert non_object.json()["detail"] == "json body must be an object"
 
 
+@pytest.mark.parametrize(
+    "path",
+    ["/api/v1/wallets/register", "/api/v1/wallets/link-github"],
+)
+def test_wallet_action_get_routes_report_method_not_allowed(sqlite_url: str, path: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(path)
+
+    assert response.status_code == 405
+    assert response.headers["allow"] == "POST"
+    assert response.json()["detail"] == "Method Not Allowed"
+
+
 def test_wallet_api_malformed_transfer_requests_return_4xx(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     _, sender_public, sender_address = _keypair()


### PR DESCRIPTION
## Summary
- return HTTP 405 with `Allow: POST` for GET requests to POST-only wallet action routes
- cover `/api/v1/wallets/register` and `/api/v1/wallets/link-github` with regression tests

## Validation
- `UV_CACHE_DIR=/Users/khanhnguyen/.openclaw/workspace/.cache/uv uv run --extra dev pytest tests/test_wallet_api.py -q`
- `UV_CACHE_DIR=/Users/khanhnguyen/.openclaw/workspace/.cache/uv uv run --extra dev ruff format --check app/main.py tests/test_wallet_api.py`
- `UV_CACHE_DIR=/Users/khanhnguyen/.openclaw/workspace/.cache/uv uv run --extra dev ruff check app/main.py tests/test_wallet_api.py`
- `UV_CACHE_DIR=/Users/khanhnguyen/.openclaw/workspace/.cache/uv uv run --extra dev mypy app`
- `git diff --check`

Refs #50.

Disclosure: this contribution was prepared with AI assistance.