### PR TITLE
fix: reject empty account page path

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -691,7 +691,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             request, "ledger_entry.html", {"entry": api_ledger_entry(sequence)}
         )
 
-    @app.get("/accounts/{account:path}", response_class=HTMLResponse)
+    @app.get("/accounts/{account}", response_class=HTMLResponse)
     def account_page(request: Request, account: str) -> HTMLResponse:
         with session_scope(db_url) as session:
             account_data = api_account(account)

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -386,6 +386,18 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     assert 'href="/accounts/github:alice"' in account
 
 
+def test_account_page_rejects_empty_account_path(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/accounts/")
+
+    assert response.status_code == 404
+
+
 def test_ledger_page_highlights_bounty_payment_and_release(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
## Summary
- make the public account page require an account path segment
- keep valid account pages such as /accounts/github:alice working
- add a regression so /accounts/ returns 404 instead of rendering a blank account page

## Context
Live repro before patch: GET https://mrwk.ltclab.site/accounts/ returned HTTP 200 and rendered an empty account page with a blank account id, blank ledger address, and 0 MRWK.

This is distinct from PR #79, which fixes the API sibling /api/v1/accounts/. This patch targets the public HTML account page route.

Refs #50.

## Validation
- UV_CACHE_DIR=/Users/khanhnguyen/.openclaw/workspace/tmp/uv-cache uv run --extra dev python -m pytest tests/test_api_mcp.py::test_account_page_rejects_empty_account_path -q -> 1 passed
- UV_CACHE_DIR=/Users/khanhnguyen/.openclaw/workspace/tmp/uv-cache uv run --extra dev python -m pytest -q -> 80 passed
- UV_CACHE_DIR=/Users/khanhnguyen/.openclaw/workspace/tmp/uv-cache uv run --extra dev ruff format --check . -> 30 files already formatted
- UV_CACHE_DIR=/Users/khanhnguyen/.openclaw/workspace/tmp/uv-cache uv run --extra dev ruff check . -> All checks passed
- UV_CACHE_DIR=/Users/khanhnguyen/.openclaw/workspace/tmp/uv-cache uv run --extra dev mypy app -> Success
- UV_CACHE_DIR=/Users/khanhnguyen/.openclaw/workspace/tmp/uv-cache uv run --extra dev python scripts/docs_smoke.py -> docs smoke ok
- git diff --check -- app/main.py tests/test_api_mcp.py -> passed

Disclosure: this contribution was prepared with AI assistance.