### PR TITLE
Allow API docs assets under CSP

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -60,6 +60,18 @@ SECURITY_HEADERS = {
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
 }
+API_DOCS_CSP = (
+    "default-src 'self'; "
+    "base-uri 'self'; "
+    "frame-ancestors 'none'; "
+    "form-action 'self'; "
+    "connect-src 'self'; "
+    "img-src 'self' data: https://fastapi.tiangolo.com; "
+    "object-src 'none'; "
+    "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net"
+)
+API_DOCS_PATHS = {"/api/docs", "/api/redoc"}
 
 
 def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
@@ -259,6 +271,8 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     @app.middleware("http")
     async def add_security_headers(request: Request, call_next: Any) -> Any:
         response = await call_next(request)
+        if request.url.path in API_DOCS_PATHS:
+            response.headers["Content-Security-Policy"] = API_DOCS_CSP
         for name, value in SECURITY_HEADERS.items():
             response.headers.setdefault(name, value)
         return response

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -59,13 +59,22 @@ def test_browser_responses_set_security_headers(sqlite_url: str) -> None:
     assert "frame-ancestors 'none'" in response.headers["content-security-policy"]
 
 
-def test_api_docs_allow_swagger_ui_assets_under_csp(sqlite_url: str) -> None:
+@pytest.mark.parametrize(
+    ("path", "expected_asset_url"),
+    (
+        ("/api/docs", "https://cdn.jsdelivr.net/npm/swagger-ui-dist"),
+        ("/api/redoc", "https://cdn.jsdelivr.net/npm/redoc"),
+    ),
+)
+def test_api_docs_allow_external_assets_under_csp(
+    sqlite_url: str, path: str, expected_asset_url: str
+) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
-    response = client.get("/api/docs")
+    response = client.get(path)
 
     assert response.status_code == 200
-    assert "https://cdn.jsdelivr.net/npm/swagger-ui-dist" in response.text
+    assert expected_asset_url in response.text
     csp = response.headers["content-security-policy"]
     assert "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net" in csp
     assert "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net" in csp

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -59,6 +59,29 @@ def test_browser_responses_set_security_headers(sqlite_url: str) -> None:
     assert "frame-ancestors 'none'" in response.headers["content-security-policy"]
 
 
+def test_api_docs_allow_swagger_ui_assets_under_csp(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/api/docs")
+
+    assert response.status_code == 200
+    assert "https://cdn.jsdelivr.net/npm/swagger-ui-dist" in response.text
+    csp = response.headers["content-security-policy"]
+    assert "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net" in csp
+    assert "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net" in csp
+    assert "img-src 'self' data: https://fastapi.tiangolo.com" in csp
+
+
+def test_regular_pages_keep_strict_csp(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/")
+
+    csp = response.headers["content-security-policy"]
+    assert "https://cdn.jsdelivr.net" not in csp
+    assert "'unsafe-inline'" not in csp
+
+
 def test_admin_bounty_form_requires_csrf_for_cookie_auth(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- use a docs-specific CSP for `/api/docs` and `/api/redoc` so FastAPI Swagger/ReDoc CDN assets can load
- keep the stricter default CSP for normal app pages
- add regression coverage for docs CSP and regular-page CSP separation

Bounty #45
Refs #50

## Validation
- `uv run --extra dev pytest tests/test_security.py -q` -> 18 passed
- `uv run --extra dev pytest -q` -> 81 passed
- `uv run --extra dev ruff check app/main.py tests/test_security.py` -> passed
- `uv run --extra dev ruff format --check app/main.py tests/test_security.py` -> already formatted

Disclosure: this contribution was prepared with AI assistance.
