### PR TITLE
[codex] Handle HEAD requests for GET routes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from urllib.parse import urlencode
 
 import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import func, or_, select
@@ -265,7 +265,21 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.middleware("http")
     async def add_security_headers(request: Request, call_next: Any) -> Any:
-        response = await call_next(request)
+        original_method = request.scope["method"]
+        if original_method == "HEAD":
+            request.scope["method"] = "GET"
+        try:
+            response = await call_next(request)
+        finally:
+            request.scope["method"] = original_method
+        if original_method == "HEAD":
+            headers = dict(response.headers)
+            headers["content-length"] = "0"
+            response = Response(
+                status_code=response.status_code,
+                headers=headers,
+                media_type=response.media_type,
+            )
         for name, value in SECURITY_HEADERS.items():
             response.headers.setdefault(name, value)
         return response

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -34,6 +34,32 @@ def test_health_status_and_bounty_api(sqlite_url: str) -> None:
     assert bounties[0]["title"] == "First bounty"
 
 
+def test_head_requests_match_get_routes_without_body(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=1,
+            issue_url="https://github.com/ramimbo/mergework/issues/1",
+            title="First bounty",
+            reward_mrwk="75",
+            acceptance="Accepted label",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    for path in ("/", "/docs", "/api/v1/status", "/api/v1/bounties"):
+        response = client.head(path)
+        assert response.status_code == 200
+        assert response.content == b""
+
+    post_only = client.head("/api/v1/bounties/1/pay")
+    assert post_only.status_code == 405
+    assert post_only.headers["allow"] == "POST"
+
+
 def test_account_api_rejects_empty_account_path(sqlite_url: str) -> None:
     create_schema(sqlite_url)
 


### PR DESCRIPTION
## Summary

- Routes `HEAD` requests through the matching `GET` handler so public read endpoints return the same status and headers without a response body.
- Preserves `405 Allow: POST` behavior for POST-only actions.
- Adds a regression test covering HTML pages, public API routes, and a POST-only route.

## Why

Live public routes that are valid for `GET` currently reject `HEAD` with `405 Allow: GET`, including `/`, `/bounties`, `/docs`, `/api/v1/status`, and `/api/v1/bounties`. That breaks normal header probes and uptime checks for public read endpoints.

Bounty #50

## Validation

- `uv run --extra dev pytest tests/test_api_mcp.py -k head -q`
- `uv run --extra dev pytest tests/test_api_mcp.py tests/test_security.py -q`
- `uv run --extra dev ruff format --check app/main.py tests/test_api_mcp.py`
- `uv run --extra dev ruff check app/main.py tests/test_api_mcp.py`
- `uv run --extra dev mypy app`
- `uv run --extra dev pytest -q`
