### PR TITLE
Validate MCP tool arguments payloads

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -657,9 +657,15 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 "error": {"code": -32602, "message": "invalid params"},
             }
         name = params.get("name")
-        args = params.get("arguments") or {}
-        if not isinstance(args, dict):
+        args = params.get("arguments", {})
+        if args is None:
             args = {}
+        if not isinstance(args, dict):
+            return {
+                "jsonrpc": "2.0",
+                "id": response_id,
+                "error": {"code": -32602, "message": "invalid params"},
+            }
         if not isinstance(name, str):
             return {
                 "jsonrpc": "2.0",

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -341,6 +341,22 @@ def test_mcp_rejects_malformed_requests_without_500(sqlite_url: str) -> None:
         "error": {"code": -32602, "message": "invalid params"},
     }
 
+    bad_arguments = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": {"name": "list_bounties", "arguments": []},
+        },
+    )
+    assert bad_arguments.status_code == 200
+    assert bad_arguments.json() == {
+        "jsonrpc": "2.0",
+        "id": 8,
+        "error": {"code": -32602, "message": "invalid params"},
+    }
+
 
 def test_mcp_get_ledger_entry_includes_payment_proof_hash(sqlite_url: str) -> None:
     create_schema(sqlite_url)

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
@@ -341,19 +342,35 @@ def test_mcp_rejects_malformed_requests_without_500(sqlite_url: str) -> None:
         "error": {"code": -32602, "message": "invalid params"},
     }
 
-    bad_arguments = client.post(
+
+@pytest.mark.parametrize(
+    ("arguments", "request_id"),
+    [
+        ([], 8),
+        ("", 9),
+        (0, 10),
+        (False, 11),
+    ],
+    ids=["array", "empty-string", "zero", "false"],
+)
+def test_mcp_rejects_non_object_tool_arguments(
+    sqlite_url: str, arguments: object, request_id: int
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
         "/mcp",
         json={
             "jsonrpc": "2.0",
-            "id": 8,
+            "id": request_id,
             "method": "tools/call",
-            "params": {"name": "list_bounties", "arguments": []},
+            "params": {"name": "list_bounties", "arguments": arguments},
         },
     )
-    assert bad_arguments.status_code == 200
-    assert bad_arguments.json() == {
+    assert response.status_code == 200
+    assert response.json() == {
         "jsonrpc": "2.0",
-        "id": 8,
+        "id": request_id,
         "error": {"code": -32602, "message": "invalid params"},
     }
 


### PR DESCRIPTION
## Summary
- reject non-object `params.arguments` in MCP `tools/call` requests with JSON-RPC `-32602 invalid params`
- keep omitted or null `arguments` as an empty object for no-arg tools
- add regression coverage using `list_bounties`, which previously accepted `arguments: []` and returned a successful result

Bounty #50

## Evidence
Live repro before the patch:

```bash
curl -sS -X POST https://mcp.mrwk.ltclab.site/mcp \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":31,"method":"tools/call","params":{"name":"list_bounties","arguments":[]}}'\n```\n\nObserved: HTTP 200 JSON-RPC success with a `result` payload, even though `arguments` was an array instead of an object.\n\n## Validation\n- `uv run --extra dev pytest tests/test_api_mcp.py::test_mcp_rejects_malformed_requests_without_500 -q` -> 1 passed\n- `uv run --extra dev pytest tests/test_api_mcp.py -q` -> 18 passed\n- `uv run --extra dev pytest -q` -> 98 passed\n- `uv run --extra dev ruff format --check .` -> 33 files already formatted\n- `uv run --extra dev ruff check .` -> All checks passed\n- `uv run --extra dev mypy app` -> Success\n- `git diff --check -- app/main.py tests/test_api_mcp.py` -> passed\n\nNo secrets, private keys, wallet signing, spending, deployment changes, security exploit details, or price claims included.\n