### PR TITLE
Reject credential-bearing public URLs

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -81,6 +81,8 @@ def validate_public_url(url: str) -> str:
     parsed = urlparse(clean)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise LedgerError("URL must use http or https")
+    if parsed.username or parsed.password:
+        raise LedgerError("URL must not include credentials")
     return clean
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -339,6 +339,40 @@ def test_bounty_urls_reject_unsafe_schemes(sqlite_url: str) -> None:
             )
 
 
+def test_bounty_urls_reject_embedded_credentials(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        with pytest.raises(LedgerError, match="URL must not include credentials"):
+            create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=9,
+                issue_url="https://operator:secret@github.com/ramimbo/mergework/issues/9",
+                title="Credential-bearing URL",
+                reward_mrwk="1",
+                acceptance="Maintainer applies mrwk:accepted",
+            )
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=10,
+            issue_url="https://github.com/ramimbo/mergework/issues/10",
+            title="Safe URL",
+            reward_mrwk="1",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+        with pytest.raises(LedgerError, match="URL must not include credentials"):
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:alice",
+                submission_url="https://operator:secret@github.com/ramimbo/mergework/pull/10",
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted"},
+            )
+
+
 def test_bounty_fields_reject_oversized_values(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Refs #50

## Summary

- reject credential-bearing public URLs such as `https://operator:secret@example.com/...`
- apply the guard at the shared `validate_public_url()` entry point used by bounty issue URLs and payout submission URLs
- add regression coverage for both bounty creation and bounty payout URL paths

## Evidence

Observed problem in the service layer before this patch: `validate_public_url()` accepted HTTP(S) URLs with userinfo because it only checked scheme and host. Those URLs are later persisted and rendered in bounty, ledger, and proof surfaces, so fake or accidentally copied credential-bearing URLs could become public.

## Validation

- `UV_CACHE_DIR=/private/tmp/uv-cache-mergework uv run --extra dev pytest tests/test_security.py::test_bounty_urls_reject_embedded_credentials -q` -> 1 passed
- `UV_CACHE_DIR=/private/tmp/uv-cache-mergework uv run --extra dev pytest tests/test_security.py -q` -> 19 passed
- `UV_CACHE_DIR=/private/tmp/uv-cache-mergework uv run --extra dev pytest -q` -> 99 passed, 2 existing warnings
- `UV_CACHE_DIR=/private/tmp/uv-cache-mergework uv run --extra dev ruff format --check app/ledger/service.py tests/test_security.py` -> 2 files already formatted
- `UV_CACHE_DIR=/private/tmp/uv-cache-mergework uv run --extra dev ruff check app/ledger/service.py tests/test_security.py` -> All checks passed
- `UV_CACHE_DIR=/private/tmp/uv-cache-mergework uv run --extra dev mypy app` -> Success
- `git diff --check` -> passed

No secrets, private keys, wallet signing, spending, deployment changes, private vulnerability details, or price claims included.
