### PR TITLE
Fix public bounties status filtering

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -329,8 +329,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             "future_path": "public snapshots, bridges, and onchain claims",
         }
 
-    @app.get("/api/v1/bounties")
-    def api_bounties(status: str | None = Query(None)) -> list[dict[str, Any]]:
+    def list_bounties_by_status(status: str | None = None) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
             query = select(Bounty)
             if status is not None:
@@ -341,6 +340,10 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 query = query.where(Bounty.status == status)
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             return [bounty_to_dict(bounty) for bounty in bounties]
+
+    @app.get("/api/v1/bounties")
+    def api_bounties(status: str | None = Query(None)) -> list[dict[str, Any]]:
+        return list_bounties_by_status(status)
 
     @app.post("/api/v1/bounties")
     async def api_create_bounty(
@@ -721,8 +724,15 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         )
 
     @app.get("/bounties", response_class=HTMLResponse)
-    def bounties_page(request: Request) -> HTMLResponse:
-        return templates.TemplateResponse(request, "bounties.html", {"bounties": api_bounties()})
+    def bounties_page(request: Request, status: str | None = Query(None)) -> HTMLResponse:
+        return templates.TemplateResponse(
+            request,
+            "bounties.html",
+            {
+                "bounties": list_bounties_by_status(status),
+                "selected_status": status,
+            },
+        )
 
     @app.get("/bounties/{bounty_id}", response_class=HTMLResponse)
     def bounty_page(request: Request, bounty_id: int) -> HTMLResponse:

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -2,6 +2,12 @@
 {% block title %}MRWK Bounties{% endblock %}
 {% block content %}
 <h1>Bounties</h1>
+<nav aria-label="Bounty status filters">
+  <a href="/bounties"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
+  <a href="/bounties?status=open"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
+  <a href="/bounties?status=paid"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
+  <a href="/bounties?status=closed"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
+</nav>
 <div class="list">
   {% for bounty in bounties %}
   <article>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -7,6 +7,53 @@ from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_
 from app.main import create_app
 
 
+def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        open_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=50,
+            issue_url="https://github.com/ramimbo/mergework/issues/50",
+            title="Open public bounty",
+            reward_mrwk="50",
+            acceptance="Open bounty should appear on the public list.",
+        )
+        paid_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=51,
+            issue_url="https://github.com/ramimbo/mergework/issues/51",
+            title="Paid public bounty",
+            reward_mrwk="50",
+            acceptance="Paid bounty should appear when filtering paid rows.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=paid_bounty.id,
+            to_account="github:contributor",
+            submission_url="https://github.com/ramimbo/mergework/pull/51",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    all_rows = client.get("/bounties")
+    assert all_rows.status_code == 200
+    assert "Open public bounty" in all_rows.text
+    assert "Paid public bounty" in all_rows.text
+    assert f'href="/bounties/{open_bounty.id}"' in all_rows.text
+
+    paid_rows = client.get("/bounties?status=paid")
+    assert paid_rows.status_code == 200
+    assert "Paid public bounty" in paid_rows.text
+    assert "Open public bounty" not in paid_rows.text
+    assert f'href="/bounties/{paid_bounty.id}"' in paid_rows.text
+    assert 'href="/bounties?status=paid"' in paid_rows.text
+
+
 def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Refs #50

Observed live:

```bash
curl -sS -i https://mrwk.ltclab.site/bounties
```

returns `HTTP/2 400` with `{"detail":"status must be one of: open, paid, closed"}`.

The HTML handler was calling the API route function directly after the API status filter added `Query(None)`, so the internal call could see FastAPI's query sentinel instead of a normal `None`.

Changes:

- moved bounty list filtering into a plain helper shared by the API and HTML routes
- let `/bounties?status=open|paid|closed` render the matching public list
- added status filter links on the public bounties page
- added a regression for `/bounties` and `/bounties?status=paid`

Verification:

```bash
/Users/cameron/Documents/Codex_WorkSpace/90-scratch/paid-oss-mergework-main/.venv/bin/python -m pytest -q
/Users/cameron/Documents/Codex_WorkSpace/90-scratch/paid-oss-mergework-main/.venv/bin/ruff check app/main.py tests/test_bounty_pages.py
```

Result: `99 passed, 2 warnings`; Ruff passed on the touched Python files.
