### PR TITLE
Clarify internal account transfer status

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -444,6 +444,13 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/api/v1/accounts/{account}")
     def api_account(account: str) -> dict[str, Any]:
+        if account.startswith(("treasury:", "reserve:")):
+            transfer_status = (
+                "Internal ledger account. MRWK wallet transfers are only available "
+                "for registered mrwk1 addresses."
+            )
+        else:
+            transfer_status = "MRWK wallet transfers are enabled for registered mrwk1 addresses."
         with session_scope(db_url) as session:
             account_row = session.get(Account, account)
             return {
@@ -451,9 +458,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 "ledger_address": account,
                 "exists": account_row is not None,
                 "balance_mrwk": format_mrwk(get_balance(session, account)),
-                "transfer_status": (
-                    "MRWK wallet transfers are enabled for registered mrwk1 addresses."
-                ),
+                "transfer_status": transfer_status,
             }
 
     @app.get("/api/v1/auth/me")

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -45,6 +45,34 @@ def test_account_api_rejects_empty_account_path(sqlite_url: str) -> None:
     assert account.json()["account"] == "github:alice"
 
 
+def test_account_api_reports_internal_ledger_account_transfer_status(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=1,
+            issue_url="https://github.com/ramimbo/mergework/issues/1",
+            title="First bounty",
+            reward_mrwk="75",
+            acceptance="Accepted label",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    treasury = client.get("/api/v1/accounts/treasury:mrwk").json()
+    reserve = client.get("/api/v1/accounts/reserve:bounty:1").json()
+
+    assert treasury["exists"] is True
+    assert reserve["exists"] is True
+    assert treasury["transfer_status"] == (
+        "Internal ledger account. MRWK wallet transfers are only available "
+        "for registered mrwk1 addresses."
+    )
+    assert reserve["transfer_status"] == treasury["transfer_status"]
+
+
 def test_bounty_api_reports_multi_award_capacity(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Refs #50

## Summary

- Updates account API transfer copy for internal ledger accounts (`treasury:*` and `reserve:*`) so they no longer advertise registered `mrwk1` wallet transfers.
- Adds a regression test covering both `treasury:mrwk` and a bounty reserve account.

## Evidence

Live repro before patch:

```bash
curl -fsS https://api.mrwk.ltclab.site/api/v1/accounts/treasury:mrwk
curl -fsS https://api.mrwk.ltclab.site/api/v1/accounts/reserve:bounty:21
```

Both responses returned:

```text
MRWK wallet transfers are enabled for registered mrwk1 addresses.
```

Those accounts are internal ledger accounts, not registered `mrwk1` wallet addresses.

## Validation

- Red regression before fix: `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_account_api_reports_internal_ledger_account_transfer_status -q` failed because `treasury:mrwk` returned the generic wallet-transfer copy.
- Focused regression after fix: `1 passed`.
- `uv run --extra dev python -m pytest tests/test_api_mcp.py -q` -> `19 passed, 1 warning`.
- `uv run --extra dev python -m pytest -q` -> `99 passed, 2 warnings`.
- `uv run --extra dev ruff format --check app/main.py tests/test_api_mcp.py` -> passed.
- `uv run --extra dev ruff check app/main.py tests/test_api_mcp.py` -> passed.
- `uv run --extra dev mypy app` -> passed.
- `git diff --check` -> passed.

No secrets, private keys, wallet signing, spending, deployment changes, security exploit details, or price claims included.
