### PR TITLE
Clarify wallet and claim recovery copy

### DIFF
--- a/app/templates/me.html
+++ b/app/templates/me.html
@@ -25,7 +25,7 @@
   <form data-action="link-github">
     <label>Wallet address <input name="address" placeholder="mrwk1..." required></label>
     <label>Private key <textarea name="private_key_hex" rows="5" autocomplete="off" autocapitalize="none" spellcheck="false" required></textarea></label>
-    <p class="notice">Use the private key for this wallet address; a different key will be rejected. Clear this field after use. Never share your private key.</p>
+    <p class="notice">Use the private key for this wallet address; a different key will be rejected. If linking fails, confirm the wallet is registered and the key was copied from that wallet. Clear this field after use. Never share your private key.</p>
     <p class="notice" data-link-nonce-status>Transaction number is handled automatically.</p>
     <button type="submit">Sign and link</button>
   </form>
@@ -35,7 +35,7 @@
   <form data-action="claim-github">
     <label>Wallet address <input name="address" placeholder="mrwk1..." value="{{ linked_wallet_address or '' }}" required></label>
     <label>Private key <textarea name="private_key_hex" rows="5" autocomplete="off" autocapitalize="none" spellcheck="false" required></textarea></label>
-    <p class="notice">Claim works only after this GitHub account is linked to the wallet. Clear this field after use. Never share your private key.</p>
+    <p class="notice">Claim works only after this GitHub account is linked to the wallet. Use that wallet's private key. Clear this field after use. Never share your private key.</p>
     {% if linked_wallet_address %}
     <p class="notice">Claim form is prefilled with your linked wallet.</p>
     {% endif %}

--- a/app/templates/transfer.html
+++ b/app/templates/transfer.html
@@ -15,7 +15,7 @@
     <label>Memo <input name="memo" maxlength="240" placeholder="optional"></label>
     <label>Private key <textarea name="private_key_hex" rows="5" autocomplete="off" autocapitalize="none" spellcheck="false" required></textarea></label>
     <p class="notice">Clear this field after use. Never share your private key.</p>
-    <p class="notice">If a transfer fails, check that both wallets are registered and the sender has spendable MRWK.</p>
+    <p class="notice">If a transfer fails, check that both wallets are registered, the sender has spendable MRWK, and the private key belongs to the sender address.</p>
     <p class="notice" data-transfer-nonce-status>Transaction number is handled automatically.</p>
     <button type="submit">Sign and send</button>
   </form>

--- a/app/templates/wallets.html
+++ b/app/templates/wallets.html
@@ -20,7 +20,7 @@
     <button type="submit">Register public key</button>
   </form>
   <p class="notice">Private key stays in this browser. Store it yourself; the server cannot recover it.</p>
-  <p class="notice">If you lose the private key, generate a new wallet and register that public key instead.</p>
+  <p class="notice">If you lose the private key before linking GitHub, generate a new wallet and register that public key instead. If the lost key belongs to an already-linked wallet, the app cannot currently move that GitHub link or spend from that wallet.</p>
   <pre class="result" data-wallet-result></pre>
 </section>
 

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -383,7 +383,8 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
 
     assert "Generate wallet" in wallets
     assert "Private key stays in this browser" in wallets
-    assert "If you lose the private key" in wallets
+    assert "If you lose the private key before linking GitHub" in wallets
+    assert "cannot currently move that GitHub link" in wallets
     assert (
         'id="wallet-private-key" name="private_key_hex" rows="5" readonly autocomplete="off"'
         in wallets
@@ -396,7 +397,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "No activity yet" in detail
     assert "No activity yet" not in funded_detail
     assert "Signed transfer" in transfer
-    assert "both wallets are registered" in transfer
+    assert "private key belongs to the sender address" in transfer
     assert "/static/wallet.js" in transfer
     assert "Link a wallet" in me
 
@@ -444,6 +445,8 @@ def test_wallet_pages_do_not_require_manual_nonce(sqlite_url: str, monkeypatch) 
     assert "Transaction number is handled automatically" in me
     assert "different key will be rejected" in me
     assert "GitHub account is linked to the wallet" in me
+    assert "the key was copied from that wallet" in me
+    assert "Use that wallet's private key" in me
     assert 'name="private_key_hex" rows="5" autocomplete="off"' in transfer
     assert me.count('name="private_key_hex" rows="5" autocomplete="off"') == 2
     assert "Clear this field after use. Never share your private key." in transfer


### PR DESCRIPTION
## Summary
- Clarify that generated private keys cannot be recovered after leaving the wallet page.
- Add short recovery guidance for wallet linking, GitHub claims, and transfer failures.
- Keep the change copy-only; no signing, nonce, API, or ledger behavior changes.

Refs #21

## Verification
- `uv run --python 3.12 --extra dev pytest tests/test_wallet_api.py -q`
- `PYTHONPATH=. uv run --python 3.12 --extra dev pytest -q`
- `uv run --python 3.12 --extra dev ruff format --check .`
- `uv run --python 3.12 --extra dev ruff check .`
- `uv run --python 3.12 --extra dev mypy app`