### PR TITLE
Link GitHub profiles from account pages

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import re
 import secrets
 import time
 from pathlib import Path
@@ -60,6 +61,7 @@ SECURITY_HEADERS = {
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
 }
+GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 
 
 def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
@@ -154,6 +156,15 @@ def _safe_next_path(next_path: str | None) -> str:
     if not next_path or not next_path.startswith("/") or next_path.startswith("//"):
         return "/me"
     return next_path
+
+
+def _github_login_from_account(account: str) -> str | None:
+    if not account.startswith("github:"):
+        return None
+    login = account.removeprefix("github:")
+    if not GITHUB_LOGIN_RE.fullmatch(login):
+        return None
+    return login
 
 
 def _signed_value(value: str, secret: str) -> str:
@@ -444,11 +455,13 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/api/v1/accounts/{account}")
     def api_account(account: str) -> dict[str, Any]:
+        github_login = _github_login_from_account(account)
         with session_scope(db_url) as session:
             account_row = session.get(Account, account)
             return {
                 "account": account,
                 "ledger_address": account,
+                "github_login": github_login,
                 "exists": account_row is not None,
                 "balance_mrwk": format_mrwk(get_balance(session, account)),
                 "transfer_status": (

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -9,6 +9,10 @@
   <dl>
     <dt>Ledger address</dt>
     <dd><code>{{ account.ledger_address }}</code></dd>
+    {% if account.github_login %}
+    <dt>GitHub profile</dt>
+    <dd><a href="https://github.com/{{ account.github_login }}">@{{ account.github_login }}</a></dd>
+    {% endif %}
     <dt>Send status</dt>
     <dd>{{ account.transfer_status }}</dd>
   </dl>

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -529,6 +529,7 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     assert "maintainer" in proof_page
     assert "github:alice" in proof_page
     assert "Ledger address" in account
+    assert 'href="https://github.com/alice">@alice</a>' in account
     assert "MRWK wallet transfers are enabled" in account
     assert 'href="/accounts/reserve:bounty:1"' in account
     assert 'href="/accounts/github:alice"' in account


### PR DESCRIPTION
Bounty #45

## Summary
- Expose a validated `github_login` field for `github:<login>` ledger accounts.
- Show a GitHub profile link on public account pages for GitHub-backed bounty accounts.
- Add regression coverage to the existing explorer/account page test.

## Observed problem
GitHub bounty balances are displayed on public account pages such as `/accounts/github:alice`, but the page only showed the ledger account string. A reader could not jump from the MergeWork account page to the corresponding GitHub profile to verify the contributor identity without manually copying the login.

## Changed behavior
`github:<login>` account pages now include a `GitHub profile` row linking to `https://github.com/<login>`. The login is only exposed when the account suffix matches the GitHub username shape, so arbitrary account paths do not create profile links.

## Validation
- `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_explorer_links_ledger_proof_and_account -q` -> `1 passed`
- `uv run --extra dev python -m pytest tests/test_api_mcp.py tests/test_bounty_pages.py -q` -> `20 passed, 1 warning`
- `uv run --extra dev python -m pytest -q` -> `98 passed, 2 warnings`
- `uv run --extra dev python -m ruff format --check app/main.py tests/test_api_mcp.py` -> passed
- `uv run --extra dev python -m ruff check app/main.py tests/test_api_mcp.py` -> passed
- `uv run --extra dev python -m mypy app` -> passed
- `git diff --check -- app/main.py app/templates/account.html tests/test_api_mcp.py` -> passed

No secrets, private keys, deployment credentials, wallet signing changes, spending changes, or price claims included.