### PR TITLE
Reject fractional JSON integer fields

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -207,24 +207,30 @@ def _optional_str(data: dict[str, Any], field: str, default: str = "") -> str:
     return value
 
 
+def _parse_int(value: Any, field: str) -> int:
+    if isinstance(value, bool):
+        raise HTTPException(status_code=400, detail=f"{field} must be an integer")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        clean = value.strip()
+        if clean and clean.lstrip("+-").isdigit():
+            return int(clean)
+    raise HTTPException(status_code=400, detail=f"{field} must be an integer")
+
+
 def _required_int(data: dict[str, Any], field: str) -> int:
     value = data.get(field)
-    if value is None or isinstance(value, bool):
+    if value is None:
         raise HTTPException(status_code=400, detail=f"{field} must be an integer")
-    try:
-        return int(value)
-    except (TypeError, ValueError) as exc:
-        raise HTTPException(status_code=400, detail=f"{field} must be an integer") from exc
+    return _parse_int(value, field)
 
 
 def _optional_int(data: dict[str, Any], field: str, default: int) -> int:
     value = data.get(field, default)
-    if value is None or isinstance(value, bool):
+    if value is None:
         raise HTTPException(status_code=400, detail=f"{field} must be an integer")
-    try:
-        return int(value)
-    except (TypeError, ValueError) as exc:
-        raise HTTPException(status_code=400, detail=f"{field} must be an integer") from exc
+    return _parse_int(value, field)
 
 
 def _csrf_token(action: str, login: str, secret: str) -> str:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -145,6 +145,41 @@ def test_admin_bounty_api_returns_400_for_malformed_json(
     assert missing_field.json()["detail"] == "repo is required"
 
 
+def test_admin_bounty_api_rejects_fractional_integer_fields(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    payload = {
+        "repo": "ramimbo/mergework",
+        "issue_number": 77,
+        "issue_url": "https://github.com/ramimbo/mergework/issues/77",
+        "title": "Strict integer validation",
+        "reward_mrwk": "10",
+        "max_awards": 1,
+        "acceptance": "Maintainer applies mrwk:accepted",
+    }
+
+    fractional_issue = client.post(
+        "/api/v1/bounties",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json={**payload, "issue_number": 77.9},
+    )
+    fractional_awards = client.post(
+        "/api/v1/bounties",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json={**payload, "max_awards": 1.5},
+    )
+
+    assert fractional_issue.status_code == 400
+    assert fractional_issue.json()["detail"] == "issue_number must be an integer"
+    assert fractional_awards.status_code == 400
+    assert fractional_awards.json()["detail"] == "max_awards must be an integer"
+
+
 def test_admin_payout_api_requires_admin_token_not_cookie_auth(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -230,6 +230,19 @@ def test_wallet_api_malformed_transfer_requests_return_4xx(sqlite_url: str) -> N
     assert malformed_nonce.status_code == 400
     assert malformed_nonce.json()["detail"] == "nonce must be an integer"
 
+    fractional_nonce = client.post(
+        "/api/v1/transfers",
+        json={
+            "from_address": sender_address,
+            "to_address": receiver_address,
+            "amount_mrwk": "1",
+            "nonce": 1.5,
+            "signature_hex": "00" * 64,
+        },
+    )
+    assert fractional_nonce.status_code == 400
+    assert fractional_nonce.json()["detail"] == "nonce must be an integer"
+
 
 def test_wallet_api_malformed_link_and_claim_requests_return_4xx(
     sqlite_url: str, monkeypatch


### PR DESCRIPTION
Bounty #50

## Summary
- reject fractional JSON numbers for integer-only API fields instead of silently truncating them with `int(...)`
- keep JSON integers and integer strings accepted for existing clients
- add regression coverage for bounty `issue_number` / `max_awards` and wallet transfer `nonce`

## Evidence
Before this change, JSON values such as `77.9`, `1.5`, or a fractional `nonce` could pass `_required_int()` / `_optional_int()` and be truncated to `77` or `1`. That makes admin bounty creation and signed wallet operations accept a different integer than the caller submitted.

## Validation
- `uv run --extra dev pytest tests/test_security.py::test_admin_bounty_api_rejects_fractional_integer_fields tests/test_wallet_api.py::test_wallet_api_malformed_transfer_requests_return_4xx -q`
- `uv run --extra dev ruff format --check app/main.py tests/test_security.py tests/test_wallet_api.py`
- `uv run --extra dev ruff check app/main.py tests/test_security.py tests/test_wallet_api.py`
- `uv run --extra dev pytest -q`
- `uv run --extra dev mypy app`
- `git diff --check`

Disclosure: this contribution was prepared with AI assistance. No secrets, private keys, wallet signing, spending, deployment changes, private vulnerability details, or price claims are included.