### PR TITLE
Reject fractional MCP integer arguments

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1069,6 +1069,18 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
 
 def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
+    def int_arg(field: str) -> int:
+        value = args[field]
+        if isinstance(value, bool):
+            raise ValueError(f"{field} must be an integer")
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            clean = value.strip()
+            if clean and clean.lstrip("+-").isdigit():
+                return int(clean)
+        raise ValueError(f"{field} must be an integer")
+
     with session_scope(database_url) as session:
         if name == "list_bounties":
             bounties = session.scalars(
@@ -1076,7 +1088,7 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
             ).all()
             return json.dumps([bounty_to_dict(bounty) for bounty in bounties])
         if name == "get_bounty":
-            bounty = session.get(Bounty, int(args["id"]))
+            bounty = session.get(Bounty, int_arg("id"))
             if bounty is None:
                 return "bounty not found"
             return json.dumps(bounty_to_dict(bounty))
@@ -1101,13 +1113,13 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
                 from_address=str(args["from_address"]),
                 to_address=str(args["to_address"]),
                 amount_mrwk=str(args["amount_mrwk"]),
-                nonce=int(args["nonce"]),
+                nonce=int_arg("nonce"),
                 memo=str(args.get("memo", "")),
                 signature_hex=str(args["signature_hex"]),
             )
             return json.dumps(wallet_transfer_to_dict(transfer))
         if name == "get_ledger_entry":
-            entry = session.get(LedgerEntry, int(args["sequence"]))
+            entry = session.get(LedgerEntry, int_arg("sequence"))
             if entry is None:
                 return "ledger entry not found"
             proof = session.scalar(

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -429,6 +429,41 @@ def test_mcp_rejects_non_object_tool_arguments(
     }
 
 
+def test_mcp_get_bounty_rejects_fractional_id(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=103,
+            issue_url="https://github.com/ramimbo/mergework/issues/103",
+            title="MCP bounty id validation",
+            reward_mrwk="75",
+            acceptance="MCP tools should reject fractional ids.",
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/call",
+            "params": {"name": "get_bounty", "arguments": {"id": bounty_id + 0.9}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 12,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
 def test_mcp_get_ledger_entry_includes_payment_proof_hash(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Refs #103

## Summary
- reject fractional MCP integer arguments instead of letting Python truncate them with `int(...)`
- apply the same strict integer parsing to `get_bounty`, `get_ledger_entry`, and MCP wallet-transfer nonce handling
- add a regression test for `get_bounty` with a fractional JSON id

## Verification
```bash
uv run --extra dev python -m pytest tests/test_api_mcp.py::test_mcp_get_bounty_rejects_fractional_id -q
uv run --extra dev python -m pytest tests/test_api_mcp.py -q
uv run --extra dev python -m pytest -q
uv run --extra dev ruff format --check app/main.py tests/test_api_mcp.py
uv run --extra dev ruff check app/main.py tests/test_api_mcp.py
uv run --extra dev python -m mypy app
git diff --check origin/main...HEAD
```

Focused regression failed before the fix and passes after it. Full suite passes with the existing warnings.
