### PR TITLE
Reject private public base URL IP literals

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -82,11 +82,17 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
         errors.append("MERGEWORK_PUBLIC_BASE_URL must not include userinfo")
     if parsed_base_url.hostname:
         try:
-            is_loopback = ipaddress.ip_address(parsed_base_url.hostname).is_loopback
+            ip_address = ipaddress.ip_address(parsed_base_url.hostname)
         except ValueError:
             is_loopback = parsed_base_url.hostname.lower() == "localhost"
+            is_private_or_link_local = False
+        else:
+            is_loopback = ip_address.is_loopback
+            is_private_or_link_local = ip_address.is_private or ip_address.is_link_local
         if is_loopback:
             errors.append("MERGEWORK_PUBLIC_BASE_URL must not use a loopback host")
+        elif is_private_or_link_local:
+            errors.append("MERGEWORK_PUBLIC_BASE_URL must not use a private or link-local host")
     return errors
 
 

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -137,3 +137,24 @@ def test_deploy_readiness_rejects_loopback_public_base_url() -> None:
     assert "MERGEWORK_PUBLIC_BASE_URL must not use a loopback host" in localhost_errors
     assert "MERGEWORK_PUBLIC_BASE_URL must not use a loopback host" in ipv4_errors
     assert "MERGEWORK_PUBLIC_BASE_URL must not use a loopback host" in ipv6_errors
+
+
+def test_deploy_readiness_rejects_private_public_base_url_ip_literals() -> None:
+    private_ipv4_errors = validate_deploy_settings(_settings(public_base_url="https://10.0.0.5"))
+    rfc1918_errors = validate_deploy_settings(_settings(public_base_url="https://192.168.1.20"))
+    rfc1918_midblock_errors = validate_deploy_settings(
+        _settings(public_base_url="https://172.16.2.3")
+    )
+    link_local_errors = validate_deploy_settings(_settings(public_base_url="https://169.254.10.20"))
+    private_ipv6_errors = validate_deploy_settings(_settings(public_base_url="https://[fd00::1]"))
+
+    expected = "MERGEWORK_PUBLIC_BASE_URL must not use a private or link-local host"
+    assert expected in private_ipv4_errors
+    assert expected in rfc1918_errors
+    assert expected in rfc1918_midblock_errors
+    assert expected in link_local_errors
+    assert expected in private_ipv6_errors
+
+
+def test_deploy_readiness_allows_global_public_base_url_ip_literal() -> None:
+    assert validate_deploy_settings(_settings(public_base_url="https://8.8.8.8")) == []


### PR DESCRIPTION
Refs #104

## Summary
- reject private and link-local IP literal hosts in `MERGEWORK_PUBLIC_BASE_URL`
- keep the existing loopback-host rejection intact
- add deploy-readiness coverage for RFC1918 IPv4, link-local IPv4, private IPv6, and a global IP-literal boundary case

## Verification
```bash
uv run --extra dev python -m pytest tests/test_deploy_readiness.py::test_deploy_readiness_rejects_private_public_base_url_ip_literals -q
uv run --extra dev python -m pytest tests/test_deploy_readiness.py -q
uv run --extra dev python -m pytest -q
uv run --extra dev ruff format --check app/config.py tests/test_deploy_readiness.py
uv run --extra dev ruff check app/config.py tests/test_deploy_readiness.py
uv run --extra dev python -m mypy app
MERGEWORK_DATABASE_URL='sqlite:////srv/mergework/data/mergework.sqlite3' \
MERGEWORK_PUBLIC_BASE_URL='https://staging.mrwk.example.test' \
MERGEWORK_GITHUB_WEBHOOK_SECRET='webhook-8efc3925bb8746b8a8fd3392c4c48e32' \
MERGEWORK_GITHUB_OAUTH_CLIENT_ID='client-id' \
MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET='oauth-7818e79f9d3a4a1d82ff0e1b9f0b8e42' \
MERGEWORK_ADMIN_LOGINS='alice' \
MERGEWORK_ADMIN_TOKEN='admin-14dcaab83bb245f2bfb5d5c21a9bb55b' \
MERGEWORK_COOKIE_SECRET='cookie-27fd1c41324a4bdcb2e4014adc3a6108' \
MERGEWORK_GITHUB_ACCEPTED_LABELERS='alice' \
python -m scripts.check_deploy_ready
git diff --check origin/main...HEAD
```

The focused regression failed before the fix because private IP literal origins returned no deploy-readiness errors. It passes after the fix. `tests/test_deploy_readiness.py` passes (`11 passed`), and the full suite passes (`123 passed, 2 warnings`).
