### PR TITLE
Harden deploy-readiness for accepted labeler admin scope

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -69,6 +69,14 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
         errors.append("MERGEWORK_ADMIN_LOGINS must list admin GitHub logins")
     if not settings.github_accepted_labelers:
         errors.append("MERGEWORK_GITHUB_ACCEPTED_LABELERS must list maintainer logins")
+    if settings.admin_logins and settings.github_accepted_labelers:
+        non_admin_labelers = sorted(
+            set(settings.github_accepted_labelers) - set(settings.admin_logins)
+        )
+        if non_admin_labelers:
+            errors.append(
+                "MERGEWORK_GITHUB_ACCEPTED_LABELERS must be included in MERGEWORK_ADMIN_LOGINS"
+            )
     parsed_base_url = urlparse(settings.public_base_url)
     if parsed_base_url.scheme != "https":
         errors.append("MERGEWORK_PUBLIC_BASE_URL must use https")

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -78,6 +78,17 @@ def test_deploy_readiness_requires_https_oauth_and_allowed_labelers() -> None:
     assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS must list maintainer logins" in errors
 
 
+def test_deploy_readiness_rejects_non_admin_accepted_labelers() -> None:
+    errors = validate_deploy_settings(
+        _settings(
+            admin_logins=("alice",),
+            github_accepted_labelers=("alice", "bob"),
+        )
+    )
+
+    assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS must be included in MERGEWORK_ADMIN_LOGINS" in errors
+
+
 def test_deploy_readiness_rejects_public_base_url_path_query_or_fragment() -> None:
     path_errors = validate_deploy_settings(
         _settings(public_base_url="https://mrwk.example.test/app")


### PR DESCRIPTION
Refs #104

## Summary
- enforce deploy-readiness rule that every `MERGEWORK_GITHUB_ACCEPTED_LABELERS` login must also be present in `MERGEWORK_ADMIN_LOGINS`
- add regression test covering non-admin accepted labeler configuration

## Why
A misconfigured accepted-labeler list can allow non-admin identities to pass acceptance gating logic. This check fails fast during deploy-readiness and prevents unsafe operator config drift.

## Validation
- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py -q`
- `uv run --extra dev python -m pytest -q`
- `uv run --extra dev ruff check .`
- `uv run --extra dev python -m mypy app`
