### PR TITLE
Preserve HTTPS on forwarded slash redirects

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,7 @@ import secrets
 import time
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
@@ -77,6 +77,27 @@ API_DOCS_CSP = (
     "worker-src 'self' blob:"
 )
 API_DOCS_PATHS = {"/api/docs", "/api/redoc"}
+
+
+def _request_was_forwarded_https(request: Request) -> bool:
+    forwarded_proto = request.headers.get("x-forwarded-proto", "")
+    if forwarded_proto:
+        return forwarded_proto.split(",", 1)[0].strip().lower() == "https"
+    return request.url.scheme == "https"
+
+
+def _preserve_forwarded_https_redirect(request: Request, response: Response) -> None:
+    if response.status_code not in {307, 308} or not _request_was_forwarded_https(request):
+        return
+    location = response.headers.get("location")
+    if not location:
+        return
+    parsed = urlsplit(location)
+    if parsed.scheme != "http" or parsed.netloc != request.url.netloc:
+        return
+    response.headers["location"] = urlunsplit(
+        ("https", parsed.netloc, parsed.path, parsed.query, parsed.fragment)
+    )
 
 
 def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
@@ -320,6 +341,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             )
         if request.url.path in API_DOCS_PATHS:
             response.headers["Content-Security-Policy"] = API_DOCS_CSP
+        _preserve_forwarded_https_redirect(request, response)
         for name, value in SECURITY_HEADERS.items():
             response.headers.setdefault(name, value)
         return response

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -61,6 +61,55 @@ def test_head_requests_match_get_routes_without_body(sqlite_url: str) -> None:
     assert post_only.headers["allow"] == "POST"
 
 
+def test_trailing_slash_redirects_keep_forwarded_https_scheme(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=103,
+            issue_url="https://github.com/ramimbo/mergework/issues/103",
+            title="Public UX bounty",
+            reward_mrwk="75",
+            acceptance="Trailing slash redirects should keep HTTPS on public hosts.",
+        )
+
+    public_client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="http://mrwk.ltclab.site",
+    )
+    api_client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="http://api.mrwk.ltclab.site",
+    )
+
+    public_page = public_client.get(
+        f"/bounties/{bounty.id}/",
+        headers={"x-forwarded-proto": "https"},
+        follow_redirects=False,
+    )
+    public_api = public_client.get(
+        f"/api/v1/bounties/{bounty.id}/",
+        headers={"x-forwarded-proto": "https"},
+        follow_redirects=False,
+    )
+    api_host = api_client.get(
+        f"/api/v1/bounties/{bounty.id}/",
+        headers={"x-forwarded-proto": "https"},
+        follow_redirects=False,
+    )
+
+    assert public_page.status_code == 307
+    assert public_page.headers["location"] == f"https://mrwk.ltclab.site/bounties/{bounty.id}"
+    assert public_api.status_code == 307
+    assert public_api.headers["location"] == f"https://mrwk.ltclab.site/api/v1/bounties/{bounty.id}"
+    assert api_host.status_code == 307
+    assert (
+        api_host.headers["location"] == f"https://api.mrwk.ltclab.site/api/v1/bounties/{bounty.id}"
+    )
+
+
 def test_account_api_rejects_empty_account_path(sqlite_url: str) -> None:
     create_schema(sqlite_url)
 


### PR DESCRIPTION
Refs #103

## Summary

Fixes HTTPS trailing-slash redirects so public requests that arrive through the HTTPS proxy do not get redirected back to `http://` on the same host.

Live repro before the fix: trailing-slash requests to `/bounties/25/`, `/api/v1/bounties/25/`, and the API host all returned `307` with `location: http://...`.

## Changes

- Preserve the forwarded HTTPS scheme for same-host `307`/`308` redirects when `x-forwarded-proto: https` is present.
- Add a regression covering the public host, public API path, and API host.

## Verification

- Red regression before implementation: `tests/test_api_mcp.py::test_trailing_slash_redirects_keep_forwarded_https_scheme` failed because the `Location` header used `http://`.
- `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_trailing_slash_redirects_keep_forwarded_https_scheme -q` -> 1 passed.
- `uv run --extra dev python -m pytest tests/test_api_mcp.py tests/test_bounty_pages.py -q` -> 31 passed, 1 warning.
- `uv run --extra dev python -m pytest -q` -> 122 passed, 2 warnings.
- `uv run --extra dev ruff format --check app/main.py tests/test_api_mcp.py` -> passed.
- `uv run --extra dev ruff check app/main.py tests/test_api_mcp.py` -> passed.
- `uv run --extra dev python -m mypy app` -> passed.
- `python -m scripts.check_deploy_ready` with CI-style required env -> passed.

No payment behavior, wallet signing, secrets, deployment settings, or price logic changed.
