### PR TITLE
Validate ledger API limit bounds

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,7 @@ import re
 import secrets
 import time
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 from urllib.parse import urlencode
 
 import httpx
@@ -615,8 +615,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             return wallet_transfer_to_dict(transfer)
 
     @app.get("/api/v1/ledger")
-    def api_ledger(limit: int = 50) -> list[dict[str, Any]]:
-        limit = max(1, min(limit, 200))
+    def api_ledger(limit: Annotated[int, Query(ge=1, le=200)] = 50) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
             entries = session.scalars(
                 select(LedgerEntry).order_by(LedgerEntry.sequence.desc()).limit(limit)

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -35,6 +35,19 @@ def test_health_status_and_bounty_api(sqlite_url: str) -> None:
     assert bounties[0]["title"] == "First bounty"
 
 
+@pytest.mark.parametrize("limit", ["0", "-1", "201"])
+def test_ledger_api_rejects_out_of_range_limits(sqlite_url: str, limit: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(f"/api/v1/ledger?limit={limit}")
+
+    assert response.status_code == 422
+
+
 def test_head_requests_match_get_routes_without_body(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
## Summary

Refs #103 / Bounty #103.

`/api/v1/ledger` silently clamped out-of-range `limit` values. Live smoke checks showed `limit=0`, `limit=-1`, and `limit=201` all returned `200 OK` with a clamped result, while malformed integer input already returned `422`.

This changes the ledger API limit parameter to FastAPI bounds validation (`1..200`) so invalid ranges are rejected consistently and documented in OpenAPI.

## Verification

- `uv run --extra dev python -m pytest tests/test_api_mcp.py -q`
- `uv run --extra dev python -m pytest -q`
- `uv run --extra dev ruff format --check app/main.py tests/test_api_mcp.py`
- `uv run --extra dev ruff check app/main.py tests/test_api_mcp.py`
- `uv run --extra dev python -m mypy app`
- `MERGEWORK_DATABASE_URL='sqlite:////srv/mergework/data/mergework.sqlite3' MERGEWORK_PUBLIC_BASE_URL='https://staging.mrwk.example.test' MERGEWORK_GITHUB_WEBHOOK_SECRET='webhook-8efc3925bb8746b8a8fd3392c4c48e32' MERGEWORK_GITHUB_OAUTH_CLIENT_ID='client-id' MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET='oauth-7818e79f9d3a4a1d82ff0e1b9f0b8e42' MERGEWORK_ADMIN_LOGINS='alice' MERGEWORK_ADMIN_TOKEN='admin-14dcaab83bb245f2bfb5d5c21a9bb55b' MERGEWORK_COOKIE_SECRET='cookie-27fd1c41324a4bdcb2e4014adc3a6108' MERGEWORK_GITHUB_ACCEPTED_LABELERS='alice' uv run --extra dev python -m scripts.check_deploy_ready`
- Runtime probe: `limit=0`, `limit=-1`, and `limit=201` now return `422`; `/ledger` still returns `200`; OpenAPI exposes `minimum: 1`, `maximum: 200`, `default: 50`.
