### PR TITLE
Validate MCP string arguments

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1087,6 +1087,22 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
                 return int(clean)
         raise ValueError(f"{field} must be an integer")
 
+    def str_arg(field: str, *, allow_empty: bool = False) -> str:
+        value = args[field]
+        if not isinstance(value, str):
+            raise ValueError(f"{field} must be a string")
+        if not allow_empty and value == "":
+            raise ValueError(f"{field} must not be empty")
+        return value
+
+    def optional_str_arg(field: str, default: str = "") -> str:
+        value = args.get(field, default)
+        if value is None:
+            return default
+        if not isinstance(value, str):
+            raise ValueError(f"{field} must be a string")
+        return value
+
     with session_scope(database_url) as session:
         if name == "list_bounties":
             bounties = session.scalars(
@@ -1099,29 +1115,29 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
                 return "bounty not found"
             return json.dumps(bounty_to_dict(bounty))
         if name == "get_balance":
-            account = _normalized_account(str(args["account"]))
+            account = _normalized_account(str_arg("account"))
             return f"{account}: {format_mrwk(get_balance(session, account))} MRWK"
         if name == "register_wallet":
             wallet = register_wallet(
                 session,
-                public_key_hex=str(args["public_key_hex"]),
-                label=str(args["label"]) if args.get("label") is not None else None,
+                public_key_hex=str_arg("public_key_hex"),
+                label=optional_str_arg("label") if args.get("label") is not None else None,
             )
             return json.dumps(wallet_to_dict(session, wallet))
         if name == "get_wallet":
-            wallet_row = session.get(Wallet, str(args["address"]).lower())
+            wallet_row = session.get(Wallet, str_arg("address").lower())
             if wallet_row is None:
                 return "wallet not found"
             return json.dumps(wallet_to_dict(session, wallet_row))
         if name == "submit_wallet_transfer":
             transfer = submit_wallet_transfer(
                 session,
-                from_address=str(args["from_address"]),
-                to_address=str(args["to_address"]),
-                amount_mrwk=str(args["amount_mrwk"]),
+                from_address=str_arg("from_address"),
+                to_address=str_arg("to_address"),
+                amount_mrwk=str_arg("amount_mrwk"),
                 nonce=int_arg("nonce"),
-                memo=str(args.get("memo", "")),
-                signature_hex=str(args["signature_hex"]),
+                memo=optional_str_arg("memo"),
+                signature_hex=str_arg("signature_hex"),
             )
             return json.dumps(wallet_transfer_to_dict(transfer))
         if name == "get_ledger_entry":
@@ -1133,7 +1149,7 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
             )
             return json.dumps(ledger_to_dict(entry, proof.hash if proof else None))
         if name == "get_proof":
-            proof = session.get(Proof, str(args["hash"]))
+            proof = session.get(Proof, str_arg("hash"))
             if proof is None:
                 return "proof not found"
             public_payload = json.loads(proof.public_json)

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -464,6 +464,43 @@ def test_mcp_get_bounty_rejects_fractional_id(sqlite_url: str) -> None:
     }
 
 
+@pytest.mark.parametrize(
+    ("tool_name", "arguments", "request_id"),
+    [
+        ("get_balance", {"account": True}, 13),
+        ("get_balance", {"account": 123}, 14),
+        ("get_balance", {"account": ""}, 15),
+        ("get_wallet", {"address": 123}, 16),
+        ("get_proof", {"hash": 123}, 17),
+    ],
+)
+def test_mcp_rejects_invalid_string_arguments(
+    sqlite_url: str, tool_name: str, arguments: dict[str, object], request_id: int
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
 def test_mcp_get_ledger_entry_includes_payment_proof_hash(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
## Summary

Refs #103 / Bounty #103.

Some MCP tools were coercing invalid string arguments instead of rejecting them. Live checks showed examples like `get_balance` with `account=true` returning `True: 0 MRWK`, `account=123` returning `123: 0 MRWK`, an empty account returning `: 0 MRWK`, and numeric `get_wallet` / `get_proof` arguments falling through to not-found responses.

This adds explicit MCP string argument validation so required string fields reject non-string and empty values with `invalid tool arguments`, while optional string fields still allow omitted/null values.

## Verification

- `uv run --extra dev python -m pytest tests/test_api_mcp.py -q -k invalid_string_arguments`
- `uv run --extra dev python -m pytest tests/test_api_mcp.py -q`
- `uv run --extra dev python -m pytest -q`
- `uv run --extra dev ruff format --check app/main.py tests/test_api_mcp.py`
- `uv run --extra dev ruff check app/main.py tests/test_api_mcp.py`
- `uv run --extra dev python -m mypy app`
- `MERGEWORK_DATABASE_URL='sqlite:////srv/mergework/data/mergework.sqlite3' MERGEWORK_PUBLIC_BASE_URL='https://staging.mrwk.example.test' MERGEWORK_GITHUB_WEBHOOK_SECRET='webhook-8efc3925bb8746b8a8fd3392c4c48e32' MERGEWORK_GITHUB_OAUTH_CLIENT_ID='client-id' MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET='oauth-7818e79f9d3a4a1d82ff0e1b9f0b8e42' MERGEWORK_ADMIN_LOGINS='alice' MERGEWORK_ADMIN_TOKEN='admin-14dcaab83bb245f2bfb5d5c21a9bb55b' MERGEWORK_COOKIE_SECRET='cookie-27fd1c41324a4bdcb2e4014adc3a6108' MERGEWORK_GITHUB_ACCEPTED_LABELERS='alice' uv run --extra dev python -m scripts.check_deploy_ready`
- Runtime probe confirmed the invalid string cases now return `invalid tool arguments` and valid `get_balance(account="treasury:mrwk")` still works.
