### PR TITLE
Reject control characters and empty strings in account names

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -174,6 +174,10 @@ def _safe_next_path(next_path: str | None) -> str:
 
 
 def _normalized_account(account: str) -> str:
+    if not account or not account.strip():
+        raise HTTPException(status_code=400, detail="account must not be empty")
+    if re.search(r"[\x00-\x1f\x7f]", account):
+        raise HTTPException(status_code=400, detail="account must not contain control characters")
     if account.lower().startswith("mrwk1"):
         return account.lower()
     return account
@@ -743,7 +747,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             }
         try:
             text = _call_mcp_tool(db_url, name, args)
-        except (KeyError, TypeError, ValueError, LedgerError):
+        except (KeyError, TypeError, ValueError, LedgerError, HTTPException):
             return {
                 "jsonrpc": "2.0",
                 "id": response_id,

--- a/tests/test_account_validation.py
+++ b/tests/test_account_validation.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.db import create_schema, session_scope
+from app.ledger.service import ensure_genesis
+from app.main import create_app
+
+
+def _setup_app(sqlite_url: str) -> TestClient:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+    return TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+
+def test_api_account_rejects_empty(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.get("/api/v1/accounts/%20%20%20")
+    assert resp.status_code == 400
+    assert "empty" in resp.json()["detail"].lower()
+
+
+def test_api_account_rejects_null_byte(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.get("/api/v1/accounts/test%00account")
+    assert resp.status_code == 400
+    assert "control character" in resp.json()["detail"].lower()
+
+
+def test_api_account_rejects_tab(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.get("/api/v1/accounts/test%09account")
+    assert resp.status_code == 400
+    assert "control character" in resp.json()["detail"].lower()
+
+
+def test_api_account_accepts_valid(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.get("/api/v1/accounts/github:alice")
+    assert resp.status_code == 200
+    assert resp.json()["account"] == "github:alice"
+
+
+def test_mcp_get_balance_rejects_empty_account(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": {"name": "get_balance", "arguments": {"account": ""}},
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == -32602
+
+
+def test_mcp_get_balance_rejects_null_byte_account(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": {"name": "get_balance", "arguments": {"account": "test\x00account"}},
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == -32602
+
+
+def test_account_page_rejects_null_byte(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.get("/accounts/test%00account")
+    assert resp.status_code == 400


### PR DESCRIPTION
Observed problem: live `GET /api/v1/accounts/test%00account` accepted null bytes and rendered them in the HTML page title (`<title>MRWK Account test\u0000account</title>`) and body. Whitespace-only accounts like `   ` were also accepted. MCP `get_balance` with an empty account returned malformed output `: 0 MRWK`.

Changed behavior: `_normalized_account` now rejects empty or whitespace-only account names and accounts containing control characters (null bytes, tabs, newlines, etc). The MCP handler catches the resulting `HTTPException` and returns a proper JSON-RPC error instead of leaking the HTTP error.

Validation:
- Focused regression: 7 new tests in `test_account_validation.py` all pass
- Full pytest: 128 passed, 2 warnings
- ruff format/check: passed
- mypy app: passed
- `git diff --check`: no whitespace errors

No secrets, private keys, wallet signing, spending, deployment changes, private vulnerability details, or price claims included.

Refs #50