### PR TITLE
Normalize bounty status filters for API and public page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -387,11 +387,12 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         with session_scope(db_url) as session:
             query = select(Bounty)
             if status is not None:
-                if status not in {"open", "paid", "closed"}:
+                normalized_status = status.strip().lower()
+                if normalized_status not in {"open", "paid", "closed"}:
                     raise HTTPException(
                         status_code=400, detail="status must be one of: open, paid, closed"
                     )
-                query = query.where(Bounty.status == status)
+                query = query.where(Bounty.status == normalized_status)
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             return [bounty_to_dict(bounty) for bounty in bounties]
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -338,6 +338,12 @@ def test_bounty_api_filters_by_status(sqlite_url: str) -> None:
     assert [item["id"] for item in client.get("/api/v1/bounties?status=closed").json()] == [
         closed_bounty.id
     ]
+    assert [item["id"] for item in client.get("/api/v1/bounties?status=OPEN").json()] == [
+        open_bounty.id
+    ]
+    assert [item["id"] for item in client.get("/api/v1/bounties?status= Paid ").json()] == [
+        paid_bounty.id
+    ]
     invalid = client.get("/api/v1/bounties?status=bogus")
     assert invalid.status_code == 400
     assert invalid.json()["detail"] == "status must be one of: open, paid, closed"

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -53,6 +53,11 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert f'href="/bounties/{paid_bounty.id}"' in paid_rows.text
     assert 'href="/bounties?status=paid"' in paid_rows.text
 
+    paid_rows_uppercase = client.get("/bounties?status=PAID")
+    assert paid_rows_uppercase.status_code == 200
+    assert "Paid public bounty" in paid_rows_uppercase.text
+    assert "Open public bounty" not in paid_rows_uppercase.text
+
 
 def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     create_schema(sqlite_url)


### PR DESCRIPTION
Bounty #103

## Summary
- normalize `status` query values with `strip().lower()` before validation in bounty listing
- allow case-insensitive status filtering for both `/api/v1/bounties` and `/bounties`
- add regression coverage for uppercase and whitespace-padded status values

## Repro
Live API currently rejects uppercase status values:

```bash
curl -i 'https://mrwk.ltclab.site/api/v1/bounties?status=OPEN'
# HTTP/1.1 400
# {"detail":"status must be one of: open, paid, closed"}
```

## Validation
- `uv run --extra dev ruff check .`
- `uv run --extra dev python -m mypy app`
- `uv run --extra dev python -m pytest -q`
