### PR TITLE
Normalize GitHub account casing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -176,6 +176,8 @@ def _safe_next_path(next_path: str | None) -> str:
 def _normalized_account(account: str) -> str:
     if account.lower().startswith("mrwk1"):
         return account.lower()
+    if account.startswith("github:"):
+        return f"github:{account.removeprefix('github:').lower()}"
     return account
 
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -714,6 +714,52 @@ def test_wallet_account_views_normalize_mixed_case_addresses(sqlite_url: str) ->
     assert f"{wallet_address}: 50 MRWK" in balance["result"]["content"][0]["text"]
 
 
+def test_github_account_views_normalize_mixed_case_logins(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        proof = pay_bounty(
+            session,
+            bounty_id=create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=103,
+                issue_url="https://github.com/ramimbo/mergework/issues/103",
+                title="Normalize GitHub account links",
+                reward_mrwk="50",
+                acceptance="GitHub account views normalize login casing.",
+            ).id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/103",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    mixed_case_account = "github:Alice"
+
+    account_api = client.get(f"/api/v1/accounts/{mixed_case_account}").json()
+    account = client.get(f"/accounts/{mixed_case_account}").text
+    balance = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "get_balance", "arguments": {"account": mixed_case_account}},
+        },
+    ).json()
+
+    assert account_api["account"] == "github:alice"
+    assert account_api["github_login"] == "alice"
+    assert account_api["exists"] is True
+    assert account_api["balance_mrwk"] == "50"
+    assert "50 MRWK" in account
+    assert f"/proofs/{proof.hash}" in account
+    assert 'href="https://github.com/alice">@alice</a>' in account
+    assert "github:alice: 50 MRWK" in balance["result"]["content"][0]["text"]
+
+
 def test_ledger_page_highlights_bounty_payment_and_release(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Bounty #103

## Summary
- normalize `github:<login>` account lookups to lowercase at the shared account boundary
- keep API account pages, public account pages, and MCP `get_balance` aligned with payout account behavior
- add regression coverage for a mixed-case GitHub account with existing ledger activity

## Repro
Live account lookup currently treats mixed-case GitHub logins as separate empty accounts:

```bash
curl -s 'https://mrwk.ltclab.site/api/v1/accounts/github:ckeplinger199'
# exists=true, balance_mrwk=2455

curl -s 'https://mrwk.ltclab.site/api/v1/accounts/github:Ckeplinger199'
# exists=false, balance_mrwk=0
```

MCP `get_balance` shows the same split between `github:ckeplinger199` and `github:Ckeplinger199`.

## Validation
- `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_github_account_views_normalize_mixed_case_logins -q` -> 1 passed
- `uv run --extra dev python -m pytest tests/test_api_mcp.py tests/test_wallet_api.py tests/test_webhooks.py -q` -> 58 passed, 1 warning
- `uv run --extra dev python -m pytest -q` -> 122 passed, 2 warnings
- `uv run --extra dev ruff format --check app/main.py tests/test_api_mcp.py`
- `uv run --extra dev ruff check app/main.py tests/test_api_mcp.py`
- `uv run --extra dev python -m mypy app`
- `git diff --check`
