### PR TITLE
Prompt docs smoke evidence in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,12 +2,17 @@
 
 - 
 
+## Evidence
+
+- Confusion, missing step, stale example, or bug this addresses:
+
 ## Test Evidence
 
 - [ ] `ruff format --check .`
 - [ ] `ruff check .`
 - [ ] `mypy app`
 - [ ] `pytest`
+- [ ] `python scripts/docs_smoke.py` (docs, template, example, or onboarding changes)
 
 ## MRWK
 


### PR DESCRIPTION
Bounty #114

## Summary
- add an Evidence prompt to the public PR template so contributors describe the confusion, missing step, stale example, or bug being fixed
- add `python scripts/docs_smoke.py` to the template's Test Evidence checklist for docs, template, example, and onboarding changes

## Evidence
- Confusion fixed: #114 requires docs smoke for docs/template/onboarding submissions, but the current PR template only prompts for Ruff, mypy, and pytest.
- Missing step fixed: contributors making docs or template changes now see the docs-smoke command before opening the PR.

## Test Evidence
- [x] `ruff format --check .`
- [x] `ruff check .`
- [x] `mypy app`
- [x] `pytest`
- [x] `python scripts/docs_smoke.py`
- [x] `python scripts/check_agents.py`

## MRWK

Bounty #114
