### PR TITLE
Prompt docs issue location evidence

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -3,12 +3,25 @@ description: Report missing or unclear documentation.
 title: "[docs] "
 labels: ["documentation"]
 body:
+  - type: input
+    id: location
+    attributes:
+      label: Where did you see it?
+      description: Link the page, docs file, heading, command, or UI path that was unclear.
+      placeholder: "docs/api-examples.md#public-api-examples or /api/docs"
+    validations:
+      required: true
   - type: textarea
     id: problem
     attributes:
       label: What is unclear?
     validations:
       required: true
+  - type: textarea
+    id: reader-task
+    attributes:
+      label: What should the reader be able to do?
+      description: Describe the task, decision, or command the docs should make clear.
   - type: textarea
     id: improvement
     attributes:

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -23,6 +23,7 @@ BANNED_PUBLIC_PHRASES = [
     "1 MRWK = $",
 ]
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"
 
 
 def _local_target_exists(source: Path, target: str) -> bool:
@@ -50,6 +51,18 @@ def main() -> int:
             if not _local_target_exists(path, link):
                 print(f"broken local link in {relative}: {link}")
                 ok = False
+    docs_issue_template = ROOT / DOCS_ISSUE_TEMPLATE
+    if not docs_issue_template.exists():
+        print(f"missing docs issue template: {DOCS_ISSUE_TEMPLATE}")
+        ok = False
+    else:
+        template = docs_issue_template.read_text(encoding="utf-8").lower()
+        if "id: location" not in template:
+            print("docs issue template must ask where the unclear docs were seen")
+            ok = False
+        if "link the page, docs file, heading, command, or ui path" not in template:
+            print("docs issue template location prompt must request actionable evidence")
+            ok = False
     if ok:
         print("docs smoke ok")
         return 0


### PR DESCRIPTION
Bounty #114

## Summary
- require docs issue reports to include the page, docs file, heading, command, or UI path where the confusion was seen
- add an optional reader-task prompt so maintainers can see what the docs should help someone do
- add docs-smoke coverage so the docs issue template keeps requesting actionable location evidence

## Evidence
- Confusion fixed: the docs issue template only asked what was unclear, so maintainers could receive reports without a concrete docs location to inspect.
- Missing step fixed: docs reporters now provide the URL/file/heading/command/UI path before submitting the issue.

## Test Evidence
- [x] Red check before the template change: `python scripts/docs_smoke.py` failed with the expected docs issue template location/evidence messages.
- [x] `./.venv/bin/python scripts/docs_smoke.py`
- [x] `./.venv/bin/python scripts/check_agents.py`
- [x] `./.venv/bin/python -m pytest`
- [x] `./.venv/bin/python -m ruff format --check .`
- [x] `./.venv/bin/python -m ruff check .`
- [x] `./.venv/bin/python -m mypy app`
