### PR TITLE
Document docs smoke for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ small, verifiable, and easy for maintainers to review.
 - Use clear names and simple code.
 - Add or update tests for changed behavior.
 - Update docs for public behavior changes.
+- Run `python scripts/docs_smoke.py` when changing docs, templates, examples, or onboarding.
 - Do not submit generated noise, duplicate reports, or unrelated rewrites.
 - Do not claim payout, acceptance, or ledger status that has not happened.
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -29,3 +29,10 @@ def test_api_examples_document_internal_bounty_ids() -> None:
 
 def test_docs_smoke_covers_public_api_examples() -> None:
     assert "docs/api-examples.md" in REQUIRED
+
+
+def test_contributing_names_docs_smoke_for_public_docs_changes() -> None:
+    contributing = Path("CONTRIBUTING.md").read_text(encoding="utf-8")
+
+    assert "python scripts/docs_smoke.py" in contributing
+    assert "docs, templates, examples, or onboarding" in contributing


### PR DESCRIPTION
Bounty #114

## Summary
- add the docs-smoke command to the contributor quality expectations
- cover that guidance with a focused docs test

## Evidence
- Missing step fixed: `CONTRIBUTING.md` told contributors to update docs for public behavior changes, but did not tell docs/template/example/onboarding contributors to run `python scripts/docs_smoke.py`.
- This is separate from the PR template reminder in #117 because it updates the public contributor guide that people may read before opening a PR.

## Test Evidence
- [x] Red check: `uv run --extra dev python -m pytest tests/test_docs_public_urls.py::test_contributing_names_docs_smoke_for_public_docs_changes -q` failed before the docs change because `CONTRIBUTING.md` lacked `python scripts/docs_smoke.py`.
- [x] `uv run --extra dev python scripts/docs_smoke.py`
- [x] `uv run --extra dev python scripts/check_agents.py`
- [x] `uv run --extra dev python -m pytest -q`
- [x] `uv run --extra dev ruff format --check .`
- [x] `uv run --extra dev ruff check .`
- [x] `uv run --extra dev python -m mypy app`
