### PR TITLE
docs: add bounty submission checklist for mrwk bounty PRs

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -154,3 +154,19 @@ Tools:
   asks for a closing reference.
 - Do not put private security details in public issues, PRs, or ledger metadata.
 - Do not claim acceptance until a maintainer applies `mrwk:accepted`.
+
+## Bounty Submission Checklist
+
+Use this checklist before opening a PR for `mrwk:bounty` issues:
+
+1. Confirm no active claim or duplicate PR already covers the same scope.
+2. Keep changes small and directly tied to one bounty issue.
+3. Include `Bounty #<issue>` or `Refs #<issue>` in PR body.
+4. Explain the exact user or maintainer pain point you fixed.
+5. Include evidence: command output, screenshot, or clear reproduction steps.
+6. Run the required checks from the issue text (for docs work, run
+   `./.venv/bin/python scripts/docs_smoke.py`).
+7. Avoid private data, secret material, and speculative price claims.
+
+Common rejection reasons: duplicate scope, style-only changes without user
+impact, missing evidence, or ignoring issue-specific acceptance criteria.


### PR DESCRIPTION
Bounty #114

## Summary
- add a focused `Bounty Submission Checklist` section to `docs/agent-guide.md`
- map checklist steps directly to current `mrwk:bounty` acceptance expectations
- document common rejection reasons to reduce duplicate/low-evidence submissions

## Problem addressed
Contributors had to infer required submission evidence from multiple docs and issue texts. This change adds one short onboarding checklist in the main agent guide, reducing avoidable `mrwk:needs-info` and rejection outcomes.

## Validation
- `./.venv/bin/python scripts/docs_smoke.py`
- output: `docs smoke ok`

## Scope
Docs-only public-facing onboarding update; no runtime behavior changes.
