### PR TITLE
Document MCP get_bounty example

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -77,3 +77,12 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_bounties","arguments":{}}}'
 ```
+
+Call `get_bounty` with the internal bounty `id` returned by `list_bounties`,
+not the GitHub issue number:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_bounty","arguments":{"id":11}}}'
+```

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -23,6 +23,9 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "https://api.mrwk.ltclab.site" in examples
     assert "https://mcp.mrwk.ltclab.site" in examples
     assert "/api/v1/bounties/<bounty_id>" in examples
+    assert '"name":"get_bounty"' in examples
+    assert '"arguments":{"id":11}' in examples
+    assert '"id":4' in examples
     assert "not the GitHub issue" in examples
     assert "public_key_hex" in examples
 


### PR DESCRIPTION
Bounty #114

## Summary

- Add an MCP `get_bounty` example to the public API examples.
- Clarify that the MCP lookup uses the internal bounty `id` returned by `list_bounties`, not the GitHub issue number.
- Extend the docs URL test so this example stays covered.

## Verification

- Red check: `uv run --extra dev python -m pytest tests/test_docs_public_urls.py::test_api_examples_document_internal_bounty_ids -q` failed before the docs change because `"name":"get_bounty"` was missing.
- `uv run --extra dev python -m pytest tests/test_docs_public_urls.py::test_api_examples_document_internal_bounty_ids -q`
- `./.venv/bin/python scripts/docs_smoke.py`
- `./.venv/bin/python scripts/check_agents.py`
- `./.venv/bin/python -m pytest tests/test_docs_public_urls.py -q`
- `./.venv/bin/python -m pytest -q`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m mypy app`
- `git diff --check`
