### PR TITLE
Normalize GitHub account lookup inputs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -206,11 +206,12 @@ def _normalized_account(account: str) -> str:
         raise HTTPException(status_code=400, detail="account must not be empty")
     if re.search(r"[\x00-\x1f\x7f]", account):
         raise HTTPException(status_code=400, detail="account must not contain control characters")
-    if account.lower().startswith("mrwk1"):
-        return account.lower()
-    if account.startswith("github:"):
-        return f"github:{account.removeprefix('github:').lower()}"
-    return account
+    clean = account.strip()
+    if clean.lower().startswith("mrwk1"):
+        return clean.lower()
+    if clean.lower().startswith("github:"):
+        return f"github:{clean.split(':', 1)[1].lower()}"
+    return clean
 
 
 def _github_login_from_account(account: str) -> str | None:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -841,28 +841,32 @@ def test_github_account_views_normalize_mixed_case_logins(sqlite_url: str) -> No
         )
 
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
-    mixed_case_account = "github:Alice"
+    account_cases = (
+        ("github:Alice", "/api/v1/accounts/github:Alice", "/accounts/github:Alice"),
+        ("GitHub:Alice", "/api/v1/accounts/GitHub:Alice", "/accounts/GitHub:Alice"),
+        (" GitHub:Alice ", "/api/v1/accounts/%20GitHub:Alice%20", "/accounts/%20GitHub:Alice%20"),
+    )
+    for mcp_account, api_path, page_path in account_cases:
+        account_api = client.get(api_path).json()
+        account = client.get(page_path).text
+        balance = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "get_balance", "arguments": {"account": mcp_account}},
+            },
+        ).json()
 
-    account_api = client.get(f"/api/v1/accounts/{mixed_case_account}").json()
-    account = client.get(f"/accounts/{mixed_case_account}").text
-    balance = client.post(
-        "/mcp",
-        json={
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "tools/call",
-            "params": {"name": "get_balance", "arguments": {"account": mixed_case_account}},
-        },
-    ).json()
-
-    assert account_api["account"] == "github:alice"
-    assert account_api["github_login"] == "alice"
-    assert account_api["exists"] is True
-    assert account_api["balance_mrwk"] == "50"
-    assert "50 MRWK" in account
-    assert f"/proofs/{proof.hash}" in account
-    assert 'href="https://github.com/alice">@alice</a>' in account
-    assert "github:alice: 50 MRWK" in balance["result"]["content"][0]["text"]
+        assert account_api["account"] == "github:alice"
+        assert account_api["github_login"] == "alice"
+        assert account_api["exists"] is True
+        assert account_api["balance_mrwk"] == "50"
+        assert "50 MRWK" in account
+        assert f"/proofs/{proof.hash}" in account
+        assert 'href="https://github.com/alice">@alice</a>' in account
+        assert "github:alice: 50 MRWK" in balance["result"]["content"][0]["text"]
 
 
 def test_ledger_page_highlights_bounty_payment_and_release(sqlite_url: str) -> None:


### PR DESCRIPTION
Refs #122

## Summary

- normalize account lookups after rejecting empty/control-character input
- canonicalize mixed-case `GitHub:` prefixes and surrounding-space GitHub account inputs to `github:<login>`
- extend API, account page, and MCP `get_balance` coverage for the canonical account path

## Verification

- Red check before fix: `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_github_account_views_normalize_mixed_case_logins -q` failed for `GitHub:Alice`
- Red check before final strip change failed for surrounding-space ` GitHub:Alice `
- `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_github_account_views_normalize_mixed_case_logins tests/test_account_validation.py -q` -> 8 passed
- `uv run --extra dev python -m pytest tests/test_api_mcp.py tests/test_account_validation.py -q` -> 44 passed, 1 warning
- `uv run --extra dev python -m pytest -q` -> 142 passed, 2 warnings
- `uv run --extra dev ruff format --check app/main.py tests/test_api_mcp.py` -> 2 files already formatted
- `uv run --extra dev ruff check app/main.py tests/test_api_mcp.py` -> all checks passed
- `uv run --extra dev python -m mypy app` -> no issues found in 11 source files
- `git diff --check` -> passed
