### PR TITLE
Deploy-readiness: reject duplicate admin/labeler logins

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -67,8 +67,12 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
         errors.append("MERGEWORK_GITHUB_OAUTH_CLIENT_ID is required")
     if not settings.admin_logins:
         errors.append("MERGEWORK_ADMIN_LOGINS must list admin GitHub logins")
+    elif len(set(settings.admin_logins)) != len(settings.admin_logins):
+        errors.append("MERGEWORK_ADMIN_LOGINS must not include duplicate logins")
     if not settings.github_accepted_labelers:
         errors.append("MERGEWORK_GITHUB_ACCEPTED_LABELERS must list maintainer logins")
+    elif len(set(settings.github_accepted_labelers)) != len(settings.github_accepted_labelers):
+        errors.append("MERGEWORK_GITHUB_ACCEPTED_LABELERS must not include duplicate logins")
     if settings.admin_logins and settings.github_accepted_labelers:
         non_admin_labelers = sorted(
             set(settings.github_accepted_labelers) - set(settings.admin_logins)

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -89,6 +89,18 @@ def test_deploy_readiness_rejects_non_admin_accepted_labelers() -> None:
     assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS must be included in MERGEWORK_ADMIN_LOGINS" in errors
 
 
+def test_deploy_readiness_rejects_duplicate_admin_or_labeler_logins() -> None:
+    errors = validate_deploy_settings(
+        _settings(
+            admin_logins=("alice", "alice"),
+            github_accepted_labelers=("alice", "alice"),
+        )
+    )
+
+    assert "MERGEWORK_ADMIN_LOGINS must not include duplicate logins" in errors
+    assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS must not include duplicate logins" in errors
+
+
 def test_deploy_readiness_rejects_public_base_url_path_query_or_fragment() -> None:
     path_errors = validate_deploy_settings(
         _settings(public_base_url="https://mrwk.example.test/app")


### PR DESCRIPTION
## Summary
- add deploy-readiness validation to reject duplicate entries in 
- add deploy-readiness validation to reject duplicate entries in 
- add focused regression test coverage in 

## Validation
- .............                                                            [100%]
13 passed in 0.06s

Refs: #104