### PR TITLE
Validate deploy GitHub login settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ipaddress
 import os
+import re
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
@@ -28,6 +29,7 @@ WEAK_SECRET_VALUES = {
     "admin",
     "mergework",
 }
+GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 
 
 def _csv_env(name: str, default: str = "") -> tuple[str, ...]:
@@ -44,6 +46,10 @@ def _secret_errors(name: str, value: str) -> list[str]:
     if len(set(value)) < 12:
         return [f"{name} must look randomly generated"]
     return []
+
+
+def _invalid_github_logins(logins: tuple[str, ...]) -> list[str]:
+    return sorted({login for login in logins if not GITHUB_LOGIN_RE.fullmatch(login)})
 
 
 def validate_deploy_settings(settings: Settings) -> list[str]:
@@ -67,8 +73,12 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
         errors.append("MERGEWORK_GITHUB_OAUTH_CLIENT_ID is required")
     if not settings.admin_logins:
         errors.append("MERGEWORK_ADMIN_LOGINS must list admin GitHub logins")
+    elif _invalid_github_logins(settings.admin_logins):
+        errors.append("MERGEWORK_ADMIN_LOGINS must contain valid GitHub logins")
     if not settings.github_accepted_labelers:
         errors.append("MERGEWORK_GITHUB_ACCEPTED_LABELERS must list maintainer logins")
+    elif _invalid_github_logins(settings.github_accepted_labelers):
+        errors.append("MERGEWORK_GITHUB_ACCEPTED_LABELERS must contain valid GitHub logins")
     if settings.admin_logins and settings.github_accepted_labelers:
         non_admin_labelers = sorted(
             set(settings.github_accepted_labelers) - set(settings.admin_logins)

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -89,6 +89,18 @@ def test_deploy_readiness_rejects_non_admin_accepted_labelers() -> None:
     assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS must be included in MERGEWORK_ADMIN_LOGINS" in errors
 
 
+def test_deploy_readiness_rejects_invalid_admin_or_labeler_logins() -> None:
+    errors = validate_deploy_settings(
+        _settings(
+            admin_logins=("bad_login",),
+            github_accepted_labelers=("bad_login",),
+        )
+    )
+
+    assert "MERGEWORK_ADMIN_LOGINS must contain valid GitHub logins" in errors
+    assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS must contain valid GitHub logins" in errors
+
+
 def test_deploy_readiness_rejects_public_base_url_path_query_or_fragment() -> None:
     path_errors = validate_deploy_settings(
         _settings(public_base_url="https://mrwk.example.test/app")


### PR DESCRIPTION
## Summary

- Add deploy-readiness validation for invalid GitHub login syntax in `MERGEWORK_ADMIN_LOGINS` and `MERGEWORK_GITHUB_ACCEPTED_LABELERS`.
- Add regression coverage so operator typos like underscores are rejected before deploy.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: deploy readiness currently accepts malformed admin/accepted-labeler logins that can never match GitHub webhook/admin identity checks, so an operator typo can pass readiness and only fail during review or admin use.

## Test Evidence

- [ ] `ruff format --check .`
- [ ] `ruff check .`
- [ ] `mypy app`
- [ ] `pytest`
- [x] `python scripts/docs_smoke.py` (docs, template, example, or onboarding changes)

Additional local validation on this machine:
- `python3 -m py_compile app/config.py tests/test_deploy_readiness.py` -> passed
- Strong dummy deploy env + `python3 scripts/check_deploy_ready.py` -> `Deploy readiness check passed.`
- Direct `validate_deploy_settings(...)` probe with `bad_login` in admin and accepted-labeler settings returned both expected validation errors.
- `python3 scripts/docs_smoke.py` -> `docs smoke ok`
- `git diff --check` -> passed

I did not run local pytest/ruff/mypy because this machine only has Python 3.9.6 and the project requires Python >=3.12; hosted PR CI should cover the full gate.

## MRWK

Bounty #104