### PR TITLE
Reject empty GitHub account namespace

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -210,7 +210,10 @@ def _normalized_account(account: str) -> str:
     if clean.lower().startswith("mrwk1"):
         return clean.lower()
     if clean.lower().startswith("github:"):
-        return f"github:{clean.split(':', 1)[1].lower()}"
+        login = clean.split(":", 1)[1].lower()
+        if not GITHUB_LOGIN_RE.fullmatch(login):
+            raise HTTPException(status_code=400, detail="github login must be valid")
+        return f"github:{login}"
     return clean
 
 

--- a/tests/test_account_validation.py
+++ b/tests/test_account_validation.py
@@ -42,6 +42,13 @@ def test_api_account_accepts_valid(sqlite_url: str) -> None:
     assert resp.json()["account"] == "github:alice"
 
 
+def test_api_account_rejects_empty_github_login(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.get("/api/v1/accounts/github:%20")
+    assert resp.status_code == 400
+    assert "github login" in resp.json()["detail"].lower()
+
+
 def test_mcp_get_balance_rejects_empty_account(sqlite_url: str) -> None:
     client = _setup_app(sqlite_url)
     resp = client.post(
@@ -51,6 +58,23 @@ def test_mcp_get_balance_rejects_empty_account(sqlite_url: str) -> None:
             "method": "tools/call",
             "id": 1,
             "params": {"name": "get_balance", "arguments": {"account": ""}},
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == -32602
+
+
+def test_mcp_get_balance_rejects_empty_github_login(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": {"name": "get_balance", "arguments": {"account": "github: "}},
         },
     )
     assert resp.status_code == 200
@@ -79,4 +103,10 @@ def test_mcp_get_balance_rejects_null_byte_account(sqlite_url: str) -> None:
 def test_account_page_rejects_null_byte(sqlite_url: str) -> None:
     client = _setup_app(sqlite_url)
     resp = client.get("/accounts/test%00account")
+    assert resp.status_code == 400
+
+
+def test_account_page_rejects_empty_github_login(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.get("/accounts/github:%20")
     assert resp.status_code == 400


### PR DESCRIPTION
Refs #122

## Summary
- Reject `github:` account lookups when the login suffix is empty or invalid after normalization.
- Add regression coverage for the API account endpoint, public account page, and MCP `get_balance` path.

## Evidence
- Live repro before patch: `GET /api/v1/accounts/github:%20` returned `200` with `account="github:"`, `exists=false`, and GitHub claim guidance.
- Red test: `uv run --extra dev python -m pytest tests/test_account_validation.py -q` failed on the new empty GitHub login cases.
- Focused verification: `uv run --extra dev python -m pytest tests/test_account_validation.py -q` -> 10 passed.
- Adjacent verification: `uv run --extra dev python -m pytest tests/test_api_mcp.py -q` -> 37 passed, 1 warning.
- Full verification: `uv run --extra dev python -m pytest -q` -> 145 passed, 2 warnings.
- `uv run --extra dev ruff format --check app/main.py tests/test_account_validation.py` -> passed.
- `uv run --extra dev ruff check app/main.py tests/test_account_validation.py` -> passed.
- `uv run --extra dev python -m mypy app` -> passed.
- `git diff --check` -> passed.

## Notes
- This keeps existing valid normalization behavior for `github:Alice`, `GitHub:Alice`, and surrounding-space account inputs such as ` GitHub:Alice `.
- No secrets, deployment settings, wallet material, or price claims are included.
