### PR TITLE
Add accepted work activity dashboard

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -137,6 +137,84 @@ def ledger_to_dict(entry: LedgerEntry, proof_hash: str | None = None) -> dict[st
     }
 
 
+def _activity_row(entry: LedgerEntry, proof: Proof) -> dict[str, Any] | None:
+    data = json.loads(proof.public_json)
+    if not isinstance(data, dict) or data.get("kind") != "bounty_payment":
+        return None
+    submission_url = str(data.get("submission_url") or entry.reference)
+    return {
+        "ledger_sequence": entry.sequence,
+        "account": entry.to_account,
+        "amount_mrwk": format_mrwk(entry.amount_microunits),
+        "amount_microunits": entry.amount_microunits,
+        "submission_url": submission_url,
+        "proof_hash": proof.hash,
+        "proof_url": f"/proofs/{proof.hash}",
+        "bounty_id": proof.bounty_id,
+        "bounty_issue_number": data.get("issue_number"),
+        "created_at": entry.created_at.isoformat(),
+    }
+
+
+def activity_to_dict(session: Session) -> dict[str, Any]:
+    rows = session.execute(
+        select(LedgerEntry, Proof)
+        .join(Proof, Proof.ledger_sequence == LedgerEntry.sequence)
+        .where(LedgerEntry.entry_type == "bounty_payment", Proof.kind == "bounty_payment")
+        .order_by(LedgerEntry.sequence.desc())
+    ).all()
+    recent: list[dict[str, Any]] = []
+    seen_sequences: set[int] = set()
+    for entry, proof in rows:
+        if entry.sequence in seen_sequences:
+            continue
+        row = _activity_row(entry, proof)
+        if row is None or row["account"] is None:
+            continue
+        seen_sequences.add(entry.sequence)
+        recent.append(row)
+
+    by_account: dict[str, dict[str, Any]] = {}
+    for row in recent:
+        account = str(row["account"])
+        contributor = by_account.setdefault(
+            account,
+            {
+                "account": account,
+                "accepted_awards": 0,
+                "accepted_microunits": 0,
+                "accepted_mrwk": "0",
+                "latest_submission_url": row["submission_url"],
+                "latest_proof_hash": row["proof_hash"],
+                "latest_proof_url": row["proof_url"],
+            },
+        )
+        contributor["accepted_awards"] += 1
+        contributor["accepted_microunits"] += int(row["amount_microunits"])
+        contributor["accepted_mrwk"] = format_mrwk(contributor["accepted_microunits"])
+
+    contributors = sorted(
+        by_account.values(),
+        key=lambda item: (-int(item["accepted_microunits"]), str(item["account"])),
+    )
+    for contributor in contributors:
+        del contributor["accepted_microunits"]
+
+    total_microunits = sum(int(row["amount_microunits"]) for row in recent)
+    for row in recent:
+        del row["amount_microunits"]
+
+    return {
+        "totals": {
+            "accepted_awards": len(recent),
+            "accepted_mrwk": format_mrwk(total_microunits),
+            "contributors": len(contributors),
+        },
+        "contributors": contributors,
+        "recent": recent[:100],
+    }
+
+
 def _wallet_timestamp(value: datetime) -> str:
     if value.tzinfo is not None:
         value = value.replace(tzinfo=None)
@@ -680,6 +758,11 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 raise HTTPException(status_code=500, detail="invalid proof payload")
             return data
 
+    @app.get("/api/v1/activity")
+    def api_activity() -> dict[str, Any]:
+        with session_scope(db_url) as session:
+            return activity_to_dict(session)
+
     @app.post("/webhooks/github")
     async def github_webhook(request: Request) -> JSONResponse:
         body = await request.body()
@@ -858,6 +941,10 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         return templates.TemplateResponse(
             request, "ledger_entry.html", {"entry": api_ledger_entry(sequence)}
         )
+
+    @app.get("/activity", response_class=HTMLResponse)
+    def activity_page(request: Request) -> HTMLResponse:
+        return templates.TemplateResponse(request, "activity.html", api_activity())
 
     @app.get("/accounts/{account}", response_class=HTMLResponse)
     def account_page(request: Request, account: str) -> HTMLResponse:

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -1,0 +1,84 @@
+{% extends "base.html" %}
+{% block title %}Accepted Work Activity{% endblock %}
+{% block content %}
+<h1>Accepted work activity</h1>
+<p class="lead">Proof-backed MRWK bounty payments, grouped by contributor account.</p>
+
+<section class="grid">
+  <article><strong>{{ totals.accepted_awards }}</strong><span>accepted awards</span></article>
+  <article><strong>{{ totals.accepted_mrwk }}</strong><span>accepted MRWK</span></article>
+  <article><strong>{{ totals.contributors }}</strong><span>contributors</span></article>
+</section>
+
+<section>
+  <h2>Contributors</h2>
+  {% if contributors %}
+  <div class="ledger-list">
+    {% for contributor in contributors %}
+    <article class="ledger-row">
+      <div class="ledger-entry-card">
+        <div class="ledger-card-head">
+          <div class="ledger-card-title">
+            <a class="ledger-entry-link" href="/accounts/{{ contributor.account }}">{{ contributor.account }}</a>
+            <span class="ledger-scan-note">{{ contributor.accepted_awards }} accepted</span>
+          </div>
+          <strong class="ledger-amount">{{ contributor.accepted_mrwk }} MRWK</strong>
+        </div>
+        <dl class="ledger-card-grid">
+          <div class="ledger-field ledger-field--reference reference-cell">
+            <dt>Latest work</dt>
+            {% set latest_submission_url = safe_public_url(contributor.latest_submission_url) %}
+            <dd>{% if latest_submission_url %}<a href="{{ latest_submission_url }}">{{ contributor.latest_submission_url | replace("https://github.com/", "") }}</a>{% else %}<code>{{ contributor.latest_submission_url }}</code>{% endif %}</dd>
+          </div>
+          <div class="ledger-field ledger-field--proof">
+            <dt>Latest proof</dt>
+            <dd><a href="{{ contributor.latest_proof_url }}">{{ contributor.latest_proof_hash[:12] }}</a></dd>
+          </div>
+        </dl>
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+  {% else %}
+  <p>No accepted bounty payments yet.</p>
+  {% endif %}
+</section>
+
+<section>
+  <h2>Recent accepted work</h2>
+  {% if recent %}
+  <div class="ledger-list">
+    {% for row in recent %}
+    <article class="ledger-row ledger-row--bounty-payment">
+      <div class="ledger-entry-card">
+        <div class="ledger-card-head">
+          <div class="ledger-card-title">
+            <a class="ledger-entry-link" href="/ledger/{{ row.ledger_sequence }}">#{{ row.ledger_sequence }}</a>
+            <span class="ledger-type ledger-type--bounty-payment">Bounty Payment</span>
+          </div>
+          <strong class="ledger-amount">{{ row.amount_mrwk }} MRWK</strong>
+        </div>
+        <dl class="ledger-card-grid">
+          <div class="ledger-field ledger-field--to">
+            <dt>Contributor</dt>
+            <dd><a href="/accounts/{{ row.account }}">{{ row.account }}</a></dd>
+          </div>
+          <div class="ledger-field ledger-field--reference reference-cell">
+            <dt>Accepted work</dt>
+            {% set submission_url = safe_public_url(row.submission_url) %}
+            <dd>{% if submission_url %}<a href="{{ submission_url }}">{{ row.submission_url | replace("https://github.com/", "") }}</a>{% else %}<code>{{ row.submission_url }}</code>{% endif %}</dd>
+          </div>
+          <div class="ledger-field ledger-field--proof">
+            <dt>Proof</dt>
+            <dd><a href="{{ row.proof_url }}">{{ row.proof_hash[:12] }}</a></dd>
+          </div>
+        </dl>
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+  {% else %}
+  <p>No proof-backed accepted work rows yet.</p>
+  {% endif %}
+</section>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -16,6 +16,7 @@
         <a href="https://github.com/ramimbo/mergework">GitHub</a>
         {% else %}
         <a href="/bounties">Bounties</a>
+        <a href="/activity">Activity</a>
         <a href="/ledger">Explorer</a>
         <a href="/wallets">Wallets</a>
         <a href="/transfer">Transfer</a>

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -35,6 +35,12 @@ curl -s "$API_HOST/api/v1/ledger?limit=10"
 curl -s "$API_HOST/api/v1/ledger/<sequence>"
 ```
 
+Read accepted-work activity summarized from proof-backed bounty payments:
+
+```bash
+curl -s "$API_HOST/api/v1/activity"
+```
+
 Inspect a proof, account, or registered wallet:
 
 ```bash

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.db import create_schema, session_scope
+from app.ledger.service import add_ledger_entry, create_bounty, ensure_genesis, pay_bounty
+from app.main import create_app
+
+
+def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        first_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=10,
+            issue_url="https://github.com/ramimbo/mergework/issues/10",
+            title="First activity bounty",
+            reward_mrwk="25",
+            max_awards=2,
+            acceptance="Activity should count accepted bounty payments.",
+        )
+        second_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=11,
+            issue_url="https://github.com/ramimbo/mergework/issues/11",
+            title="Second activity bounty",
+            reward_mrwk="40",
+            acceptance="Activity should keep wallet and GitHub accounts separate.",
+        )
+        first_proof = pay_bounty(
+            session,
+            bounty_id=first_bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/10",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        second_proof = pay_bounty(
+            session,
+            bounty_id=first_bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/issues/10#issuecomment-1",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        wallet_proof = pay_bounty(
+            session,
+            bounty_id=second_bounty.id,
+            to_account="mrwk1abc",
+            submission_url="https://github.com/ramimbo/mergework/pull/11",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        add_ledger_entry(
+            session,
+            entry_type="bounty_payment",
+            from_account="reserve:bounty:999",
+            to_account="github:alice",
+            amount_microunits=999_000000,
+            reference="https://github.com/ramimbo/mergework/pull/unproved",
+        )
+        add_ledger_entry(
+            session,
+            entry_type="github_claim",
+            from_account="github:alice",
+            to_account="mrwk1abc",
+            amount_microunits=25_000000,
+            reference="claim",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/api/v1/activity")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["totals"] == {
+        "accepted_awards": 3,
+        "accepted_mrwk": "90",
+        "contributors": 2,
+    }
+    assert payload["contributors"][0] == {
+        "account": "github:alice",
+        "accepted_awards": 2,
+        "accepted_mrwk": "50",
+        "latest_submission_url": "https://github.com/ramimbo/mergework/issues/10#issuecomment-1",
+        "latest_proof_hash": second_proof.hash,
+        "latest_proof_url": f"/proofs/{second_proof.hash}",
+    }
+    assert payload["contributors"][1]["account"] == "mrwk1abc"
+    assert payload["contributors"][1]["accepted_mrwk"] == "40"
+    assert payload["contributors"][1]["latest_proof_hash"] == wallet_proof.hash
+    assert [row["proof_hash"] for row in payload["recent"]] == [
+        wallet_proof.hash,
+        second_proof.hash,
+        first_proof.hash,
+    ]
+    assert all("unproved" not in row["submission_url"] for row in payload["recent"])
+
+
+def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    empty = client.get("/activity")
+
+    assert empty.status_code == 200
+    assert "Accepted work activity" in empty.text
+    assert "No accepted bounty payments yet." in empty.text
+
+    with session_scope(sqlite_url) as session:
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=12,
+            issue_url="https://github.com/ramimbo/mergework/issues/12",
+            title="Activity page bounty",
+            reward_mrwk="75",
+            acceptance="Activity page should link accepted work proofs.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:bob",
+            submission_url="https://github.com/ramimbo/mergework/pull/12",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    paid = client.get("/activity")
+
+    assert paid.status_code == 200
+    assert "github:bob" in paid.text
+    assert "75 MRWK" in paid.text
+    assert 'href="https://github.com/ramimbo/mergework/pull/12"' in paid.text
+    assert f'href="/proofs/{proof.hash}"' in paid.text
+    assert "/accounts/github:bob" in paid.text


### PR DESCRIPTION
Refs #129

## Summary
- add `GET /api/v1/activity` for proof-backed accepted bounty-payment activity
- add `/activity` as a public dashboard grouped by contributor account
- update API examples with the new activity endpoint

## Notes
- counts only `bounty_payment` ledger rows with `bounty_payment` proofs
- excludes claims, wallet transfers, reserves, releases, and genesis rows
- keeps `github:*` and `mrwk1...` accounts separate
- uses existing ledger/proof data only; no live GitHub fetches

## Verification
- `uv run --python 3.12 --extra dev python -m pytest tests/test_activity.py -q` -> 2 passed
- `uv run --python 3.12 --extra dev python -m pytest tests/test_activity.py tests/test_bounty_pages.py tests/test_api_mcp.py tests/test_docs_public_urls.py -q` -> 46 passed, 1 warning
- `uv run --python 3.12 --extra dev python -m pytest -q` -> 144 passed, 2 warnings
- `uv run --python 3.12 --extra dev ruff format --check app/main.py tests/test_activity.py` -> passed
- `uv run --python 3.12 --extra dev ruff check app/main.py tests/test_activity.py` -> passed
- `uv run --python 3.12 --extra dev python -m mypy app` -> passed
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> `docs smoke ok`
- `uv run --python 3.12 --extra dev python scripts/check_agents.py` -> `AGENTS.md ok`
- `git diff --check origin/main...HEAD` -> passed
