### PR TITLE
Reject malformed public base URL hosts

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ipaddress
 import os
+import re
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
@@ -29,6 +30,8 @@ WEAK_SECRET_VALUES = {
     "mergework",
 }
 
+DNS_LABEL_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
+
 
 def _csv_env(name: str, default: str = "") -> tuple[str, ...]:
     return tuple(
@@ -44,6 +47,13 @@ def _secret_errors(name: str, value: str) -> list[str]:
     if len(set(value)) < 12:
         return [f"{name} must look randomly generated"]
     return []
+
+
+def _is_valid_dns_hostname(hostname: str) -> bool:
+    if len(hostname) > 253:
+        return False
+    labels = hostname.lower().split(".")
+    return all(DNS_LABEL_RE.fullmatch(label) for label in labels)
 
 
 def validate_deploy_settings(settings: Settings) -> list[str]:
@@ -77,7 +87,13 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
             errors.append(
                 "MERGEWORK_GITHUB_ACCEPTED_LABELERS must be included in MERGEWORK_ADMIN_LOGINS"
             )
-    parsed_base_url = urlparse(settings.public_base_url)
+    try:
+        parsed_base_url = urlparse(settings.public_base_url)
+    except ValueError:
+        errors.append("MERGEWORK_PUBLIC_BASE_URL must include a valid host")
+        return errors
+    authority = parsed_base_url.netloc.rsplit("@", 1)[-1]
+    has_bracketed_host = authority.startswith("[")
     if parsed_base_url.scheme != "https":
         errors.append("MERGEWORK_PUBLIC_BASE_URL must use https")
     if not parsed_base_url.netloc:
@@ -88,10 +104,21 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
         errors.append("MERGEWORK_PUBLIC_BASE_URL must not include query or fragment")
     if parsed_base_url.username or parsed_base_url.password:
         errors.append("MERGEWORK_PUBLIC_BASE_URL must not include userinfo")
-    if parsed_base_url.hostname:
+    try:
+        has_empty_port = parsed_base_url.port is None and parsed_base_url.netloc.endswith(":")
+    except ValueError:
+        errors.append("MERGEWORK_PUBLIC_BASE_URL must include a valid host")
+    else:
+        if has_empty_port:
+            errors.append("MERGEWORK_PUBLIC_BASE_URL must include a valid host")
+    if not parsed_base_url.hostname:
+        errors.append("MERGEWORK_PUBLIC_BASE_URL must include a valid host")
+    else:
         try:
             ip_address = ipaddress.ip_address(parsed_base_url.hostname)
         except ValueError:
+            if has_bracketed_host or not _is_valid_dns_hostname(parsed_base_url.hostname):
+                errors.append("MERGEWORK_PUBLIC_BASE_URL must include a valid host")
             is_loopback = parsed_base_url.hostname.lower() == "localhost"
             is_private_or_link_local = False
         else:

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -113,6 +113,49 @@ def test_deploy_readiness_rejects_public_base_url_userinfo() -> None:
     assert "MERGEWORK_PUBLIC_BASE_URL must not include userinfo" in errors
 
 
+def test_deploy_readiness_rejects_malformed_public_base_url_hosts() -> None:
+    empty_host_errors = validate_deploy_settings(_settings(public_base_url="https://:443"))
+    invalid_port_errors = validate_deploy_settings(
+        _settings(public_base_url="https://api.example:notaport")
+    )
+    out_of_range_port_errors = validate_deploy_settings(
+        _settings(public_base_url="https://api.example:70000")
+    )
+    unbracketed_ipv6_errors = validate_deploy_settings(
+        _settings(public_base_url="https://2001:db8::1")
+    )
+    unmatched_bracket_errors = validate_deploy_settings(_settings(public_base_url="https://[::1"))
+    empty_bracket_errors = validate_deploy_settings(_settings(public_base_url="https://[]"))
+    bracketed_dns_errors = validate_deploy_settings(
+        _settings(public_base_url="https://[api.example]")
+    )
+    dot_host_errors = validate_deploy_settings(_settings(public_base_url="https://."))
+    empty_label_errors = validate_deploy_settings(_settings(public_base_url="https://api..example"))
+    leading_hyphen_errors = validate_deploy_settings(
+        _settings(public_base_url="https://-api.example")
+    )
+    trailing_hyphen_errors = validate_deploy_settings(
+        _settings(public_base_url="https://api-.example")
+    )
+    underscore_errors = validate_deploy_settings(
+        _settings(public_base_url="https://api_host.example")
+    )
+
+    expected = "MERGEWORK_PUBLIC_BASE_URL must include a valid host"
+    assert expected in empty_host_errors
+    assert expected in invalid_port_errors
+    assert expected in out_of_range_port_errors
+    assert expected in unbracketed_ipv6_errors
+    assert expected in unmatched_bracket_errors
+    assert expected in empty_bracket_errors
+    assert expected in bracketed_dns_errors
+    assert expected in dot_host_errors
+    assert expected in empty_label_errors
+    assert expected in leading_hyphen_errors
+    assert expected in trailing_hyphen_errors
+    assert expected in underscore_errors
+
+
 def test_deploy_readiness_script_runs_directly_from_source() -> None:
     env = {
         **os.environ,


### PR DESCRIPTION
Refs #104 / Bounty #104.

## Summary

- Reject malformed `MERGEWORK_PUBLIC_BASE_URL` hostnames during deploy readiness.
- Add regression coverage for empty hosts, invalid ports, unbracketed/malformed bracketed IPv6 authorities, bracketed DNS names, dot-only hosts, empty DNS labels, leading/trailing hyphen labels, and underscores.
- Preserve existing loopback, private/link-local IP, userinfo, path, query, and fragment validation.

## Evidence

Before this patch, `validate_deploy_settings(...)` accepted or crashed on malformed origins such as `https://:443`, `https://api.example:notaport`, `https://2001:db8::1`, `https://[::1`, `https://api..example`, and `https://api_host.example`. The focused regression failed before the validator change and passes after the fix.

## Verification

```bash
uv run --python 3.12 --extra dev python -m pytest tests/test_deploy_readiness.py::test_deploy_readiness_rejects_malformed_public_base_url_hosts -q
uv run --python 3.12 --extra dev python -m pytest tests/test_deploy_readiness.py -q
uv run --python 3.12 --extra dev python -m pytest -q
uv run --python 3.12 --extra dev ruff check app/config.py tests/test_deploy_readiness.py
uv run --python 3.12 --extra dev python -m mypy app
uv run --python 3.12 --extra dev python scripts/docs_smoke.py
uv run --python 3.12 --extra dev python scripts/check_agents.py
git diff --check origin/main...HEAD
```

Additional deploy-readiness smoke: a valid staging origin passed, while `MERGEWORK_PUBLIC_BASE_URL='https://[::1'` failed with `MERGEWORK_PUBLIC_BASE_URL must include a valid host`.
