### PR TITLE
Reject non-string payout metadata

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -259,9 +259,11 @@ async def _json_object(request: Request) -> dict[str, Any]:
 
 
 def _required_str(data: dict[str, Any], field: str) -> str:
-    value = data.get(field)
-    if not isinstance(value, str):
+    if field not in data or data[field] is None:
         raise HTTPException(status_code=400, detail=f"{field} is required")
+    value = data[field]
+    if not isinstance(value, str):
+        raise HTTPException(status_code=400, detail=f"{field} must be a string")
     return value
 
 
@@ -477,19 +479,22 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     ) -> dict[str, Any]:
         data = await _json_object(request)
         try:
-            requested_account = str(data["to_account"])
-            submission_url = str(data["submission_url"])
-        except KeyError as exc:
-            raise HTTPException(
-                status_code=400, detail=f"missing required field: {exc.args[0]}"
-            ) from exc
-        accepted_by = str(data.get("accepted_by") or admin_login)
+            requested_account = _required_str(data, "to_account")
+            submission_url = _required_str(data, "submission_url")
+        except HTTPException as exc:
+            if str(exc.detail).endswith(" is required"):
+                field = str(exc.detail).removesuffix(" is required")
+                raise HTTPException(
+                    status_code=400, detail=f"missing required field: {field}"
+                ) from exc
+            raise
+        accepted_by = _optional_str(data, "accepted_by", admin_login) or admin_login
         verifier_result = {
             "source": "admin_api",
             "accepted_by": accepted_by,
         }
         if data.get("note") is not None:
-            verifier_result["note"] = str(data["note"])[:240]
+            verifier_result["note"] = _optional_str(data, "note")[:240]
         with session_scope(db_url) as session:
             try:
                 to_account = resolve_payout_account(session, requested_account)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -298,6 +298,61 @@ def test_admin_payout_api_returns_400_for_malformed_json(
     assert invalid_json.json()["detail"] == "invalid json body"
 
 
+def test_admin_payout_api_rejects_non_string_metadata_fields(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    create_schema(sqlite_url)
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        accepted_by_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=122,
+            issue_url="https://github.com/ramimbo/mergework/issues/122",
+            title="Strict payout accepted_by metadata",
+            reward_mrwk="25",
+            acceptance="Maintainer verifies payout metadata.",
+        )
+        note_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=123,
+            issue_url="https://github.com/ramimbo/mergework/issues/123",
+            title="Strict payout note metadata",
+            reward_mrwk="25",
+            acceptance="Maintainer verifies payout metadata.",
+        )
+
+    accepted_by = client.post(
+        f"/api/v1/bounties/{accepted_by_bounty.id}/pay",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json={
+            "to_account": "github:alice",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/122",
+            "accepted_by": 123,
+        },
+    )
+    note = client.post(
+        f"/api/v1/bounties/{note_bounty.id}/pay",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json={
+            "to_account": "github:bob",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/123",
+            "note": ["not", "text"],
+        },
+    )
+
+    assert accepted_by.status_code == 400
+    assert accepted_by.json()["detail"] == "accepted_by must be a string"
+    assert note.status_code == 400
+    assert note.json()["detail"] == "note must be a string"
+
+
 def test_admin_close_bounty_api_releases_remaining_reserve(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Bounty #122

## Summary
- Reject non-string `accepted_by` and `note` values in the admin bounty payout API instead of coercing them into proof metadata.
- Keep missing `to_account` and `submission_url` errors compatible with the existing API response shape.
- Add regression coverage for both metadata fields.

## Verification
- `.\.venv\Scripts\python.exe -m pytest tests/test_security.py::test_admin_payout_api_rejects_non_string_metadata_fields -q` -> 1 passed
- `.\.venv\Scripts\python.exe -m pytest tests/test_security.py tests/test_api_mcp.py tests/test_bounty_pages.py -q` -> 64 passed, 1 warning
- `.\.venv\Scripts\python.exe -m pytest -q` -> 143 passed, 2 warnings
- `.\.venv\Scripts\python.exe -m ruff format --check .` -> 35 files already formatted
- `.\.venv\Scripts\python.exe -m ruff check .` -> All checks passed
- `.\.venv\Scripts\python.exe -m mypy app` -> Success: no issues found in 11 source files
- Docker Linux fallback, `python:3.12-slim`: full pytest, ruff format/check, ruff check, and mypy all passed
- `git diff --check` -> passed

Note: local WSL lists no installed distro on this workstation, so the Linux run above used Docker rather than WSL. No secrets, wallet material, private context, deployment values, or MRWK price claims are included.