### PR TITLE
Clarify agent guide bounty ids

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -36,10 +36,13 @@ curl -s "$API_HOST/api/v1/bounties"
 Inspect one bounty, a ledger page, and a proof:
 
 ```bash
-curl -s "$API_HOST/api/v1/bounties/11"
+curl -s "$API_HOST/api/v1/bounties/<bounty_id>"
 curl -s "$API_HOST/api/v1/ledger?limit=10"
 curl -s "$API_HOST/api/v1/proofs/<proof_hash>"
 ```
+
+The `<bounty_id>` value is the internal MergeWork bounty id returned by
+`/api/v1/bounties`, not the GitHub issue number.
 
 Inspect an account or registered wallet:
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -30,6 +30,13 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "public_key_hex" in examples
 
 
+def test_agent_guide_explains_internal_bounty_ids() -> None:
+    guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/bounties/<bounty_id>" in guide
+    assert "not the GitHub issue number" in guide
+
+
 def test_docs_smoke_covers_public_api_examples() -> None:
     assert "docs/api-examples.md" in REQUIRED
 


### PR DESCRIPTION
Bounty #114

## Summary
- Clarify that `/api/v1/bounties/<bounty_id>` uses the internal MergeWork bounty id returned by `/api/v1/bounties`, not the GitHub issue number.
- Update the agent guide example to use the same placeholder shape as the public API examples.
- Add docs coverage so the agent guide keeps this distinction explicit.

## Confusion fixed
The agent guide previously showed `/api/v1/bounties/11` without explaining where `11` comes from. That can send contributors to the wrong endpoint if they reuse a GitHub issue number instead of the MergeWork bounty id.

## Verification
- Red check before docs update: `tests/test_docs_public_urls.py::test_agent_guide_explains_internal_bounty_ids` failed because the guide did not mention internal bounty ids.
- `.\.venv\Scripts\python.exe -m pytest tests/test_docs_public_urls.py -q` -> 5 passed
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `.\.venv\Scripts\python.exe scripts\check_agents.py` -> AGENTS.md ok
- `.\.venv\Scripts\python.exe -m pytest -q` -> 143 passed, 2 warnings
- `.\.venv\Scripts\python.exe -m ruff format --check .` -> 35 files already formatted
- `.\.venv\Scripts\python.exe -m ruff check .` -> All checks passed
- `.\.venv\Scripts\python.exe -m mypy app` -> Success: no issues found in 11 source files
- Docker Linux fallback with `python:3.12-slim`: full pytest, ruff format/check, ruff check, mypy, and docs smoke passed
- `git diff --check` -> passed, with Git's normal CRLF warning for `docs/agent-guide.md` on Windows

No secrets, wallet material, deployment values, private context, or MRWK price claims are included.