### PR TITLE
Reject malformed deploy secret characters

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -39,6 +39,10 @@ def _csv_env(name: str, default: str = "") -> tuple[str, ...]:
 def _secret_errors(name: str, value: str) -> list[str]:
     if not value:
         return [f"{name} is required"]
+    if value != value.strip():
+        return [f"{name} must not include leading or trailing whitespace"]
+    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+        return [f"{name} must not include control characters"]
     if len(value) < 32 or value.strip().lower() in WEAK_SECRET_VALUES:
         return [f"{name} must be at least 32 characters"]
     if len(set(value)) < 12:

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -64,6 +64,27 @@ def test_deploy_readiness_rejects_reused_secret_values() -> None:
     assert "deploy secrets must use distinct values" in errors
 
 
+def test_deploy_readiness_rejects_secret_whitespace_and_control_characters() -> None:
+    errors = validate_deploy_settings(
+        _settings(
+            github_webhook_secret=" webhook-8efc3925bb8746b8a8fd3392c4c48e32",
+            github_oauth_client_secret="oauth-7818e79f9d3a4a1d82ff0e1b9f0b8e42 ",
+            admin_token="admin-14dcaab83bb245f2bfb5d5c21a9bb55b\nextra",
+            cookie_secret="cookie-27fd1c41324a4bdcb2e4014adc3a6108\x7f",
+        )
+    )
+
+    assert (
+        "MERGEWORK_GITHUB_WEBHOOK_SECRET must not include leading or trailing whitespace" in errors
+    )
+    assert (
+        "MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET must not include leading or trailing whitespace"
+        in errors
+    )
+    assert "MERGEWORK_ADMIN_TOKEN must not include control characters" in errors
+    assert "MERGEWORK_COOKIE_SECRET must not include control characters" in errors
+
+
 def test_deploy_readiness_requires_https_oauth_and_allowed_labelers() -> None:
     errors = validate_deploy_settings(
         _settings(


### PR DESCRIPTION
Bounty #104

## Summary
- Reject deploy secret values with leading or trailing whitespace.
- Reject deploy secret values containing ASCII control characters.
- Add deploy-readiness regression coverage for webhook, OAuth client, admin token, and cookie secrets.

## Why
Deploy secrets can be copied with invisible whitespace/control characters. Before this change, those values could pass deploy readiness if they were long and varied enough, even though the runtime value would not match the intended webhook, admin, or cookie secret.

## Verification
- Red before implementation: `uv run --python 3.12 --extra dev python -m pytest tests/test_deploy_readiness.py::test_deploy_readiness_rejects_secret_whitespace_and_control_characters -q` failed because no secret-whitespace/control errors were reported.
- `uv run --python 3.12 --extra dev python -m pytest tests/test_deploy_readiness.py -q` -> 13 passed
- `uv run --python 3.12 --extra dev python -m pytest -q` -> 145 passed, 2 warnings
- Ruff format/check on touched files -> passed
- `mypy app`, docs smoke, and `check_agents.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- Strong dummy deploy env with `scripts/check_deploy_ready.py` -> Deploy readiness check passed.
- Invalid env with leading whitespace in `MERGEWORK_GITHUB_WEBHOOK_SECRET` -> failed with the expected deploy-readiness error.

No private values, deployment secrets, wallet material, or MRWK price claims are included.
