### PR TITLE
Document activity endpoint for agents

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -12,6 +12,7 @@ Submit small, reviewable work and include evidence.
 - `GET /api/v1/accounts/{account}`
 - `GET /api/v1/wallets/{address}`
 - `GET /api/v1/ledger`
+- `GET /api/v1/activity`
 - `GET /api/v1/proofs/{hash}`
 - `POST /api/v1/wallets/register`
 - `POST /api/v1/wallets/link-github`
@@ -33,10 +34,11 @@ curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
 ```
 
-Inspect one bounty, a ledger page, and a proof:
+Inspect one bounty, accepted-work activity, a ledger page, and a proof:
 
 ```bash
 curl -s "$API_HOST/api/v1/bounties/11"
+curl -s "$API_HOST/api/v1/activity"
 curl -s "$API_HOST/api/v1/ledger?limit=10"
 curl -s "$API_HOST/api/v1/proofs/<proof_hash>"
 ```

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -39,3 +39,10 @@ def test_contributing_names_docs_smoke_for_public_docs_changes() -> None:
 
     assert "python scripts/docs_smoke.py" in contributing
     assert "docs, templates, examples, or onboarding" in contributing
+
+
+def test_agent_guide_documents_activity_endpoint() -> None:
+    guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
+
+    assert "GET /api/v1/activity" in guide
+    assert "accepted-work activity" in guide


### PR DESCRIPTION
Bounty #114

## Summary
- Add `GET /api/v1/activity` to the agent guide's public API list.
- Add the activity endpoint to the agent guide's read-only curl examples.
- Cover the guidance with a focused docs test.

## Confusion fixed
`docs/api-examples.md` already documents accepted-work activity, and the app exposes `/activity` plus `GET /api/v1/activity`, but the agent guide's public API list skipped that endpoint. Agents reading only the agent guide could miss the proof-backed accepted-work activity view.

## Evidence
- Red check before docs update: `./.venv/bin/python -m pytest tests/test_docs_public_urls.py::test_agent_guide_documents_activity_endpoint -q` failed because `GET /api/v1/activity` was missing from `docs/agent-guide.md`.
- `./.venv/bin/python -m pytest tests/test_docs_public_urls.py::test_agent_guide_documents_activity_endpoint -q` -> `1 passed`.
- `./.venv/bin/python -m pytest tests/test_docs_public_urls.py -q` -> `5 passed`.
- `./.venv/bin/python scripts/docs_smoke.py` -> `docs smoke ok`.
- `./.venv/bin/python scripts/check_agents.py` -> `AGENTS.md ok`.
- `./.venv/bin/python -m ruff format --check tests/test_docs_public_urls.py` -> `1 file already formatted`.
- `./.venv/bin/python -m ruff check tests/test_docs_public_urls.py` -> `All checks passed!`.
- `./.venv/bin/python -m pytest -q` -> `145 passed, 2 warnings`.
- `./.venv/bin/python -m mypy app` -> `Success: no issues found in 11 source files`.
- `git diff --check origin/main...HEAD` -> passed.

