### PR TITLE
docs: link accepted activity surfaces from docs hub

### DIFF
--- a/app/templates/docs.html
+++ b/app/templates/docs.html
@@ -17,6 +17,8 @@
     <li><a href="/api/v1/status">API status</a></li>
     <li><a href="/api/docs">OpenAPI docs</a></li>
     <li><a href="/api/v1/bounties">Bounty API</a></li>
+    <li><a href="/activity">Activity dashboard</a></li>
+    <li><a href="/api/v1/activity">Activity API</a></li>
     <li><a href="/api/v1/ledger">Ledger API</a></li>
     <li><a href="/wallets">Wallets</a></li>
     <li><a href="/transfer">Transfer UI</a></li>

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -711,6 +711,8 @@ def test_docs_page_lists_live_ltclab_urls(sqlite_url: str) -> None:
     assert "docs/paid-bounties.md" in docs
     assert "docs/api-examples.md" in docs
     assert "OpenAPI docs" in docs
+    assert 'href="/activity"' in docs
+    assert 'href="/api/v1/activity"' in docs
     assert "SwaggerUIBundle" in api_docs
 
 


### PR DESCRIPTION
Bounty #114

## Summary
- Add the accepted-work activity dashboard and activity API to the public docs hub.
- Extend docs-page coverage so those new activity surfaces stay discoverable from `/docs`.

## Verification
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python -m pytest tests/test_api_mcp.py::test_docs_page_lists_live_ltclab_urls tests/test_activity.py -q` -> 3 passed
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python -m pytest tests/test_docs_public_urls.py -q` -> 4 passed
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python -m pytest -q` -> 144 passed, 2 warnings
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python -m ruff check tests/test_api_mcp.py` -> All checks passed
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python -m ruff format --check tests/test_api_mcp.py` -> 1 file already formatted
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python -m mypy app` -> Success: no issues found in 11 source files
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok

No secrets, wallet material, deployment values, private context, or MRWK price claims are included.
