### PR TITLE
Reject nonpersistent sqlite deploy databases

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -46,8 +46,27 @@ def _secret_errors(name: str, value: str) -> list[str]:
     return []
 
 
+def _sqlite_database_errors(database_url: str) -> list[str]:
+    if not database_url.startswith("sqlite:"):
+        return []
+
+    parsed = urlparse(database_url)
+    sqlite_path = parsed.path
+    is_memory = database_url == "sqlite:///:memory:" or sqlite_path == "/:memory:"
+    if is_memory or sqlite_path in ("", "/", "//"):
+        return ["MERGEWORK_DATABASE_URL must use a persistent sqlite file"]
+
+    is_posix_absolute = sqlite_path.startswith("//") and len(sqlite_path) > 2
+    is_windows_absolute = len(sqlite_path) > 3 and sqlite_path[0] == "/" and sqlite_path[2] == ":"
+    if not (is_posix_absolute or is_windows_absolute):
+        return ["MERGEWORK_DATABASE_URL sqlite paths must be absolute for deploys"]
+
+    return []
+
+
 def validate_deploy_settings(settings: Settings) -> list[str]:
     errors: list[str] = []
+    errors.extend(_sqlite_database_errors(settings.database_url))
     errors.extend(_secret_errors("MERGEWORK_GITHUB_WEBHOOK_SECRET", settings.github_webhook_secret))
     errors.extend(
         _secret_errors("MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", settings.github_oauth_client_secret)

--- a/app/config.py
+++ b/app/config.py
@@ -47,10 +47,10 @@ def _secret_errors(name: str, value: str) -> list[str]:
 
 
 def _sqlite_database_errors(database_url: str) -> list[str]:
-    if not database_url.startswith("sqlite:"):
+    parsed = urlparse(database_url)
+    if not parsed.scheme.startswith("sqlite"):
         return []
 
-    parsed = urlparse(database_url)
     sqlite_path = parsed.path
     is_memory = database_url == "sqlite:///:memory:" or sqlite_path == "/:memory:"
     if is_memory or sqlite_path in ("", "/", "//"):

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -64,6 +64,38 @@ def test_deploy_readiness_rejects_reused_secret_values() -> None:
     assert "deploy secrets must use distinct values" in errors
 
 
+def test_deploy_readiness_rejects_non_persistent_sqlite_database_urls() -> None:
+    memory_errors = validate_deploy_settings(_settings(database_url="sqlite:///:memory:"))
+    relative_errors = validate_deploy_settings(
+        _settings(database_url="sqlite:///mergework.sqlite3")
+    )
+    dot_relative_errors = validate_deploy_settings(
+        _settings(database_url="sqlite:///./mergework.sqlite3")
+    )
+    empty_errors = validate_deploy_settings(_settings(database_url="sqlite:////"))
+
+    assert "MERGEWORK_DATABASE_URL must use a persistent sqlite file" in memory_errors
+    assert "MERGEWORK_DATABASE_URL sqlite paths must be absolute for deploys" in relative_errors
+    assert "MERGEWORK_DATABASE_URL sqlite paths must be absolute for deploys" in dot_relative_errors
+    assert "MERGEWORK_DATABASE_URL must use a persistent sqlite file" in empty_errors
+
+
+def test_deploy_readiness_accepts_absolute_sqlite_and_external_database_urls() -> None:
+    assert (
+        validate_deploy_settings(
+            _settings(database_url="sqlite:////srv/mergework/data/app.sqlite3")
+        )
+        == []
+    )
+    assert validate_deploy_settings(_settings(database_url="sqlite:///C:/data/app.sqlite3")) == []
+    assert (
+        validate_deploy_settings(
+            _settings(database_url="postgresql://mergework:password@db.example.test/mergework")
+        )
+        == []
+    )
+
+
 def test_deploy_readiness_requires_https_oauth_and_allowed_labelers() -> None:
     errors = validate_deploy_settings(
         _settings(

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -66,8 +66,14 @@ def test_deploy_readiness_rejects_reused_secret_values() -> None:
 
 def test_deploy_readiness_rejects_non_persistent_sqlite_database_urls() -> None:
     memory_errors = validate_deploy_settings(_settings(database_url="sqlite:///:memory:"))
+    driver_memory_errors = validate_deploy_settings(
+        _settings(database_url="sqlite+pysqlite:///:memory:")
+    )
     relative_errors = validate_deploy_settings(
         _settings(database_url="sqlite:///mergework.sqlite3")
+    )
+    driver_relative_errors = validate_deploy_settings(
+        _settings(database_url="sqlite+pysqlite:///mergework.sqlite3")
     )
     dot_relative_errors = validate_deploy_settings(
         _settings(database_url="sqlite:///./mergework.sqlite3")
@@ -75,7 +81,11 @@ def test_deploy_readiness_rejects_non_persistent_sqlite_database_urls() -> None:
     empty_errors = validate_deploy_settings(_settings(database_url="sqlite:////"))
 
     assert "MERGEWORK_DATABASE_URL must use a persistent sqlite file" in memory_errors
+    assert "MERGEWORK_DATABASE_URL must use a persistent sqlite file" in driver_memory_errors
     assert "MERGEWORK_DATABASE_URL sqlite paths must be absolute for deploys" in relative_errors
+    assert (
+        "MERGEWORK_DATABASE_URL sqlite paths must be absolute for deploys" in driver_relative_errors
+    )
     assert "MERGEWORK_DATABASE_URL sqlite paths must be absolute for deploys" in dot_relative_errors
     assert "MERGEWORK_DATABASE_URL must use a persistent sqlite file" in empty_errors
 
@@ -84,6 +94,12 @@ def test_deploy_readiness_accepts_absolute_sqlite_and_external_database_urls() -
     assert (
         validate_deploy_settings(
             _settings(database_url="sqlite:////srv/mergework/data/app.sqlite3")
+        )
+        == []
+    )
+    assert (
+        validate_deploy_settings(
+            _settings(database_url="sqlite+pysqlite:////srv/mergework/data/app.sqlite3")
         )
         == []
     )


### PR DESCRIPTION
## Summary

Refs #104.

This adds deploy-readiness validation for SQLite database URLs so production deploys do not accidentally pass with an in-memory, empty, or relative SQLite database path.

## Why

`MERGEWORK_DATABASE_URL` currently defaults to a local relative SQLite path for development. That is fine for local use, but deploy readiness should fail closed if an operator runs with `sqlite:///:memory:`, `sqlite:///mergework.sqlite3`, or `sqlite:///./mergework.sqlite3`; those can lose state or depend on the current working directory. Absolute SQLite file paths and external SQLAlchemy database URLs remain accepted.

## Validation

- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py -q` -> 14 passed
- `uv run --extra dev python -m pytest -q` -> 146 passed, 2 warnings
- `uv run --extra dev ruff format --check --preview app/config.py tests/test_deploy_readiness.py` -> passed after formatting
- `uv run --extra dev ruff check --preview app/config.py tests/test_deploy_readiness.py` -> all checks passed
- `uv run --extra dev python -m mypy app` -> success
- `python3 scripts/docs_smoke.py` -> docs smoke ok
- `python3 scripts/check_agents.py` -> AGENTS.md ok
- strong dummy deploy env + `python3 -S scripts/check_deploy_ready.py` -> deploy readiness passed
- relative SQLite deploy env + `python3 -S scripts/check_deploy_ready.py` -> failed with `MERGEWORK_DATABASE_URL sqlite paths must be absolute for deploys`
- `git diff --check` -> no output

No secrets, wallet material, deployment values, private context, or MRWK price claims are included.
