### PR TITLE
Reject control characters in public URLs

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -78,6 +78,8 @@ def validate_public_url(url: str) -> str:
     clean = url.strip()
     if len(clean) > 500:
         raise LedgerError("URL is too long")
+    if any(ord(char) < 32 or ord(char) == 127 for char in clean):
+        raise LedgerError("URL must not contain control characters")
     parsed = urlparse(clean)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise LedgerError("URL must use http or https")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -15,11 +15,13 @@ from app.ledger.service import (
     TREASURY_ACCOUNT,
     LedgerError,
     add_ledger_entry,
+    close_bounty,
     create_bounty,
     ensure_genesis,
     get_balance,
     parse_mrwk_amount,
     pay_bounty,
+    public_url_or_none,
     register_wallet,
 )
 from app.main import _signed_value, create_app
@@ -442,6 +444,71 @@ def test_bounty_urls_reject_embedded_credentials(sqlite_url: str) -> None:
                 accepted_by="maintainer",
                 verifier_result={"label": "mrwk:accepted"},
             )
+
+
+def test_bounty_urls_reject_control_characters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        with pytest.raises(LedgerError, match="URL must not contain control characters"):
+            create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=11,
+                issue_url="https://github.com/ramimbo/mergework/issues/11\nextra",
+                title="Control URL",
+                reward_mrwk="1",
+                acceptance="Maintainer applies mrwk:accepted",
+            )
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=12,
+            issue_url="https://github.com/ramimbo/mergework/issues/12",
+            title="Safe URL",
+            reward_mrwk="1",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+        with pytest.raises(LedgerError, match="URL must not contain control characters"):
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:alice",
+                submission_url="https://github.com/ramimbo/mergework/pull/12\textra",
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted"},
+            )
+
+
+def test_close_bounty_rejects_control_character_reference(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=13,
+            issue_url="https://github.com/ramimbo/mergework/issues/13",
+            title="Close reference guard",
+            reward_mrwk="1",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+
+        with pytest.raises(LedgerError, match="URL must not contain control characters"):
+            close_bounty(
+                session,
+                bounty_id=bounty.id,
+                closed_by="maintainer",
+                reference="https://github.com/ramimbo/mergework/issues/13\x7f",
+            )
+
+
+def test_public_url_or_none_omits_control_character_urls() -> None:
+    assert public_url_or_none("https://github.com/ramimbo/mergework/issues/14\nextra") is None
+    assert (
+        public_url_or_none(" https://github.com/ramimbo/mergework/issues/14 ")
+        == "https://github.com/ramimbo/mergework/issues/14"
+    )
 
 
 def test_bounty_fields_reject_oversized_values(sqlite_url: str) -> None:


### PR DESCRIPTION
Refs #122

## Summary
- Reject ASCII control characters in public bounty/proof URLs before storage or rendering.
- Cover issue URLs, payout submission URLs, close references, and optional public-link rendering.

## Why
Before this change, `validate_public_url()` accepted URLs containing newline, tab, or DEL characters, and `public_url_or_none()` returned them as public links. Those values can make ledger/proof links ambiguous in rendered pages and API consumers.

This is a clean replacement for the withdrawn PR #138, keeping the same useful validation direction while submitting a small LF-only diff from current `main`.

## Verification
- Red before fix: a direct probe showed `validate_public_url()` accepted newline, tab, and DEL URLs, and `public_url_or_none()` returned them.
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python -m pytest tests/test_security.py::test_bounty_urls_reject_control_characters tests/test_security.py::test_close_bounty_rejects_control_character_reference tests/test_security.py::test_public_url_or_none_omits_control_character_urls -q` -> 3 passed
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python -m pytest tests/test_security.py -q` -> 26 passed
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python -m pytest tests/test_ledger.py -q` -> 14 passed
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python -m pytest -q` -> 147 passed, 2 warnings
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python -m ruff check app/ledger/service.py tests/test_security.py` -> All checks passed
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python -m ruff format --check app/ledger/service.py tests/test_security.py` -> 2 files already formatted
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python -m mypy app` -> Success: no issues found in 11 source files
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `/Users/apple/Documents/ZQtest/earn5/mergework-pr140/.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> passed

No secrets, wallet material, deployment values, private context, or MRWK price claims are included.
