### PR TITLE
Reject unknown MCP tool names

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1208,7 +1208,7 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
                 "Open a focused PR or issue, reference the MRWK bounty, include test evidence, "
                 "and wait for a maintainer to apply mrwk:accepted."
             )
-    return "unknown tool"
+    raise ValueError("unknown tool")
 
 
 app = create_app()

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -497,6 +497,27 @@ def test_mcp_rejects_non_object_tool_arguments(
     }
 
 
+def test_mcp_rejects_unknown_tool_name(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/call",
+            "params": {"name": "definitely_unknown", "arguments": {}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 12,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
 def test_mcp_get_bounty_rejects_fractional_id(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Bounty #122

## Summary
- Return a JSON-RPC error for unknown MCP `tools/call` names instead of a successful `"unknown tool"` content result.
- Add regression coverage for an unknown MCP tool name.

## Evidence
- Before the patch, `tools/call` with `name="definitely_unknown"` returned HTTP 200 with a successful result containing `"unknown tool"`.
- After the patch, the same request returns JSON-RPC error code `-32602` with message `invalid tool arguments`.

## Verification
- `python -m pytest tests/test_api_mcp.py::test_mcp_rejects_unknown_tool_name -q` -> 1 passed
- `python -m pytest tests/test_api_mcp.py -q` -> 38 passed, 1 warning
- `python -m pytest tests/test_api_mcp.py tests/test_security.py -q` -> 61 passed, 1 warning
- `python -m pytest -q` -> 143 passed, 2 warnings
- `python -m ruff format --check app/main.py tests/test_api_mcp.py` -> 2 files already formatted
- `python -m ruff check app/main.py tests/test_api_mcp.py` -> All checks passed
- `python -m mypy app` -> Success
- `python scripts/docs_smoke.py` -> docs smoke ok
- `python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> passed
