### PR TITLE
Reject control characters in bounty text fields

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -123,9 +123,14 @@ def resolve_payout_account(session: Session, to_account: str) -> str:
     raise LedgerError("to_account must be a github:<login> account or registered mrwk1 wallet")
 
 
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
 def _clean_optional_text(value: str | None, field: str, max_length: int) -> str | None:
     if value is None:
         return None
+    if CONTROL_CHAR_RE.search(value):
+        raise LedgerError(f"{field} must not contain control characters")
     clean = value.strip()
     if len(clean) > max_length:
         raise LedgerError(f"{field} is too long")
@@ -133,6 +138,8 @@ def _clean_optional_text(value: str | None, field: str, max_length: int) -> str 
 
 
 def _clean_required_text(value: str, field: str, max_length: int) -> str:
+    if CONTROL_CHAR_RE.search(value):
+        raise LedgerError(f"{field} must not contain control characters")
     clean = value.strip()
     if not clean:
         raise LedgerError(f"{field} is required")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -460,6 +460,28 @@ def test_bounty_fields_reject_oversized_values(sqlite_url: str) -> None:
             )
 
 
+def test_bounty_text_fields_reject_control_characters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        for field, value in (
+            ("repo", "ramimbo/mergework\nmalformed"),
+            ("title", "Control\tTitle"),
+            ("acceptance", "Maintainer applies mrwk:accepted\x7f"),
+        ):
+            payload = {
+                "repo": "ramimbo/mergework",
+                "issue_number": 7,
+                "issue_url": "https://github.com/ramimbo/mergework/issues/7",
+                "title": "Control character hardening",
+                "reward_mrwk": "1",
+                "acceptance": "Maintainer applies mrwk:accepted",
+            }
+            payload[field] = value
+            with pytest.raises(LedgerError, match=f"{field} must not contain control characters"):
+                create_bounty(session, **payload)
+
+
 def test_ledger_reference_unsafe_urls_are_not_rendered_as_links(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
## Summary

Refs #122.

Reject ASCII control characters in bounty text fields before they are stored or rendered:

- `repo`
- `title`
- `acceptance`

This keeps malformed bounty metadata out of the ledger and public bounty pages while preserving the existing trimming and length checks.

## Verification

- `uv run --extra dev python -m pytest tests/test_security.py::test_bounty_text_fields_reject_control_characters -q`
- `uv run --extra dev python -m pytest -q`
- `uv run --extra dev python -m ruff format --check .`
- `uv run --extra dev python -m ruff check .`
- `uv run --extra dev python -m mypy app`
- `uv run --extra dev python scripts/docs_smoke.py`
- `uv run --extra dev python scripts/check_agents.py`
- `git diff --check`

## Notes

I checked the currently open PRs and did not find another PR covering control-character validation for bounty `repo`, `title`, or `acceptance` fields. Existing related PRs cover public URLs, deploy secret characters, and account names instead.

No secrets, wallet material, deployment values, private context, or MRWK price claims are included.
