### PR TITLE
Reject control characters in wallet text

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -36,6 +36,7 @@ TREASURY_ACCOUNT = "treasury:mrwk"
 MICRO_UNITS = 1_000_000
 GENESIS_SUPPLY_MICRO = 100_000_000 * MICRO_UNITS
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+CONTROL_CHARACTER_RE = re.compile(r"[\x00-\x1f\x7f]")
 
 
 class LedgerError(RuntimeError):
@@ -127,6 +128,8 @@ def _clean_optional_text(value: str | None, field: str, max_length: int) -> str 
     if value is None:
         return None
     clean = value.strip()
+    if CONTROL_CHARACTER_RE.search(clean):
+        raise LedgerError(f"{field} must not contain control characters")
     if len(clean) > max_length:
         raise LedgerError(f"{field} is too long")
     return clean or None
@@ -437,6 +440,8 @@ def submit_wallet_transfer(
         raise LedgerError("sender and receiver must be different")
     amount = parse_mrwk_amount(amount_mrwk)
     clean_memo = memo.strip()
+    if CONTROL_CHARACTER_RE.search(clean_memo):
+        raise LedgerError("memo must not contain control characters")
     if len(clean_memo) > 240:
         raise LedgerError("memo is too long")
     if get_balance(session, sender.address) < amount:

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -127,9 +127,9 @@ def resolve_payout_account(session: Session, to_account: str) -> str:
 def _clean_optional_text(value: str | None, field: str, max_length: int) -> str | None:
     if value is None:
         return None
-    clean = value.strip()
-    if CONTROL_CHARACTER_RE.search(clean):
+    if CONTROL_CHARACTER_RE.search(value):
         raise LedgerError(f"{field} must not contain control characters")
+    clean = value.strip()
     if len(clean) > max_length:
         raise LedgerError(f"{field} is too long")
     return clean or None
@@ -439,9 +439,9 @@ def submit_wallet_transfer(
     if sender.address == receiver.address:
         raise LedgerError("sender and receiver must be different")
     amount = parse_mrwk_amount(amount_mrwk)
-    clean_memo = memo.strip()
-    if CONTROL_CHARACTER_RE.search(clean_memo):
+    if CONTROL_CHARACTER_RE.search(memo):
         raise LedgerError("memo must not contain control characters")
+    clean_memo = memo.strip()
     if len(clean_memo) > 240:
         raise LedgerError("memo is too long")
     if get_balance(session, sender.address) < amount:

--- a/tests/test_wallets.py
+++ b/tests/test_wallets.py
@@ -60,11 +60,12 @@ def test_wallet_registration_rejects_control_characters_in_label(sqlite_url: str
     create_schema(sqlite_url)
     _, public_hex, _ = _keypair()
 
-    with (
-        session_scope(sqlite_url) as session,
-        pytest.raises(LedgerError, match="wallet label must not contain control characters"),
-    ):
-        register_wallet(session, public_key_hex=public_hex, label="Ops\nWallet")
+    with session_scope(sqlite_url) as session:
+        for label in ("Ops\nWallet", "\nOps", "Ops\t"):
+            with pytest.raises(
+                LedgerError, match="wallet label must not contain control characters"
+            ):
+                register_wallet(session, public_key_hex=public_hex, label=label)
 
 
 def test_signed_wallet_transfer_moves_balance_and_rejects_replay(sqlite_url: str) -> None:
@@ -138,24 +139,42 @@ def test_wallet_transfer_rejects_control_characters_in_memo(sqlite_url: str) -> 
             reference="test-funding",
         )
 
+        for memo in ("bad\tmemo", "\tbad", "bad\n"):
+            payload = wallet_transfer_payload(
+                from_address=sender_address,
+                to_address=receiver_address,
+                amount_microunits=1_000_000,
+                nonce=1,
+                memo=memo.strip(),
+            )
+            with pytest.raises(LedgerError, match="memo must not contain control characters"):
+                submit_wallet_transfer(
+                    session,
+                    from_address=sender_address,
+                    to_address=receiver_address,
+                    amount_mrwk="1",
+                    nonce=1,
+                    memo=memo,
+                    signature_hex=_sign(sender_key, payload),
+                )
+
         payload = wallet_transfer_payload(
             from_address=sender_address,
             to_address=receiver_address,
             amount_microunits=1_000_000,
             nonce=1,
-            memo="bad\tmemo",
+            memo="clean memo",
         )
-
-        with pytest.raises(LedgerError, match="memo must not contain control characters"):
-            submit_wallet_transfer(
-                session,
-                from_address=sender_address,
-                to_address=receiver_address,
-                amount_mrwk="1",
-                nonce=1,
-                memo="bad\tmemo",
-                signature_hex=_sign(sender_key, payload),
-            )
+        transfer = submit_wallet_transfer(
+            session,
+            from_address=sender_address,
+            to_address=receiver_address,
+            amount_mrwk="1",
+            nonce=1,
+            memo=" clean memo ",
+            signature_hex=_sign(sender_key, payload),
+        )
+        assert transfer.memo == "clean memo"
 
 
 def test_wallet_transfer_rejects_bad_signature(sqlite_url: str) -> None:

--- a/tests/test_wallets.py
+++ b/tests/test_wallets.py
@@ -56,6 +56,17 @@ def test_wallet_registration_rejects_oversized_label(sqlite_url: str) -> None:
         register_wallet(session, public_key_hex=public_hex, label="x" * 161)
 
 
+def test_wallet_registration_rejects_control_characters_in_label(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    _, public_hex, _ = _keypair()
+
+    with (
+        session_scope(sqlite_url) as session,
+        pytest.raises(LedgerError, match="wallet label must not contain control characters"),
+    ):
+        register_wallet(session, public_key_hex=public_hex, label="Ops\nWallet")
+
+
 def test_signed_wallet_transfer_moves_balance_and_rejects_replay(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     sender_key, sender_public, sender_address = _keypair()
@@ -106,6 +117,44 @@ def test_signed_wallet_transfer_moves_balance_and_rejects_replay(sqlite_url: str
                 nonce=1,
                 memo="first transfer",
                 signature_hex=signature,
+            )
+
+
+def test_wallet_transfer_rejects_control_characters_in_memo(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    sender_key, sender_public, sender_address = _keypair()
+    _, receiver_public, receiver_address = _keypair()
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        register_wallet(session, public_key_hex=sender_public, label="Sender")
+        register_wallet(session, public_key_hex=receiver_public, label="Receiver")
+        add_ledger_entry(
+            session,
+            entry_type="test_funding",
+            from_account=TREASURY_ACCOUNT,
+            to_account=sender_address,
+            amount_microunits=10_000_000,
+            reference="test-funding",
+        )
+
+        payload = wallet_transfer_payload(
+            from_address=sender_address,
+            to_address=receiver_address,
+            amount_microunits=1_000_000,
+            nonce=1,
+            memo="bad\tmemo",
+        )
+
+        with pytest.raises(LedgerError, match="memo must not contain control characters"):
+            submit_wallet_transfer(
+                session,
+                from_address=sender_address,
+                to_address=receiver_address,
+                amount_mrwk="1",
+                nonce=1,
+                memo="bad\tmemo",
+                signature_hex=_sign(sender_key, payload),
             )
 
 


### PR DESCRIPTION
## Summary

- Reject ASCII control characters in wallet labels before storing or rendering them.
- Reject ASCII control characters in wallet transfer memos before signing/storing the transfer.
- Add regression coverage for both public wallet text paths.

## Bounty

Bounty #122

## Evidence

- Before this patch, `register_wallet(..., label="Ops\nWallet")` accepted and stored a public wallet label containing a newline.
- Before this patch, `submit_wallet_transfer(..., memo="bad\tmemo")` accepted and stored a public transfer memo containing a tab when the signed payload matched that memo.
- The new checks reject those control characters before persistence while preserving the existing label/memo length checks.

## Validation

- `uv run --extra dev python -m pytest tests/test_wallets.py -q` -> 7 passed
- `uv run --extra dev python -m pytest tests/test_wallet_api.py tests/test_wallets.py -q` -> 27 passed
- `uv run --extra dev python -m pytest -q` -> 146 passed, 2 warnings
- `uv run --extra dev ruff format --check --preview app/ledger/service.py tests/test_wallets.py` -> 2 files already formatted
- `uv run --extra dev ruff check app/ledger/service.py tests/test_wallets.py` -> all checks passed
- `uv run --extra dev python -m mypy app` -> success
- `python3 scripts/docs_smoke.py` -> docs smoke ok
- `python3 scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> no output

No secrets, wallet private keys, deployment values, private context, or MRWK price claims are included.
