### PR TITLE
Reject wallet text control characters

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -36,6 +36,7 @@ TREASURY_ACCOUNT = "treasury:mrwk"
 MICRO_UNITS = 1_000_000
 GENESIS_SUPPLY_MICRO = 100_000_000 * MICRO_UNITS
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 
 
 class LedgerError(RuntimeError):
@@ -126,6 +127,8 @@ def resolve_payout_account(session: Session, to_account: str) -> str:
 def _clean_optional_text(value: str | None, field: str, max_length: int) -> str | None:
     if value is None:
         return None
+    if CONTROL_CHAR_RE.search(value):
+        raise LedgerError(f"{field} must not contain control characters")
     clean = value.strip()
     if len(clean) > max_length:
         raise LedgerError(f"{field} is too long")
@@ -436,6 +439,8 @@ def submit_wallet_transfer(
     if sender.address == receiver.address:
         raise LedgerError("sender and receiver must be different")
     amount = parse_mrwk_amount(amount_mrwk)
+    if CONTROL_CHAR_RE.search(memo):
+        raise LedgerError("memo must not contain control characters")
     clean_memo = memo.strip()
     if len(clean_memo) > 240:
         raise LedgerError("memo is too long")

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -169,6 +169,54 @@ def test_wallet_transfer_api_returns_validation_error(sqlite_url: str) -> None:
     assert response.json()["detail"] in {"invalid signature", "insufficient balance"}
 
 
+def test_wallet_register_api_rejects_label_control_characters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    _, public_hex, _ = _keypair()
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/api/v1/wallets/register",
+        json={"public_key_hex": public_hex, "label": "Main\nWallet"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "wallet label must not contain control characters"
+
+
+def test_wallet_transfer_api_rejects_memo_control_characters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    sender_key, sender_public, sender_address = _keypair()
+    _, receiver_public, receiver_address = _keypair()
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _register_wallet(client, sender_public)
+    _register_wallet(client, receiver_public)
+    _fund_wallet(sqlite_url, sender_address)
+    memo = "line1\nline2"
+    payload = {
+        "type": "mrwk_transfer_v1",
+        "from_address": sender_address,
+        "to_address": receiver_address,
+        "amount_microunits": 1_000_000,
+        "nonce": 1,
+        "memo": memo,
+    }
+
+    response = client.post(
+        "/api/v1/transfers",
+        json={
+            "from_address": sender_address,
+            "to_address": receiver_address,
+            "amount_mrwk": "1",
+            "nonce": 1,
+            "memo": memo,
+            "signature_hex": _sign(sender_key, payload),
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "memo must not contain control characters"
+
+
 def test_wallet_api_malformed_register_requests_return_4xx(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))

--- a/tests/test_wallets.py
+++ b/tests/test_wallets.py
@@ -56,6 +56,17 @@ def test_wallet_registration_rejects_oversized_label(sqlite_url: str) -> None:
         register_wallet(session, public_key_hex=public_hex, label="x" * 161)
 
 
+def test_wallet_registration_rejects_label_control_characters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    _, public_hex, _ = _keypair()
+
+    with (
+        session_scope(sqlite_url) as session,
+        pytest.raises(LedgerError, match="wallet label must not contain control characters"),
+    ):
+        register_wallet(session, public_key_hex=public_hex, label="Main\nWallet")
+
+
 def test_signed_wallet_transfer_moves_balance_and_rejects_replay(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     sender_key, sender_public, sender_address = _keypair()
@@ -106,6 +117,44 @@ def test_signed_wallet_transfer_moves_balance_and_rejects_replay(sqlite_url: str
                 nonce=1,
                 memo="first transfer",
                 signature_hex=signature,
+            )
+
+
+def test_wallet_transfer_rejects_memo_control_characters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    sender_key, sender_public, sender_address = _keypair()
+    _, receiver_public, receiver_address = _keypair()
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        register_wallet(session, public_key_hex=sender_public)
+        register_wallet(session, public_key_hex=receiver_public)
+        add_ledger_entry(
+            session,
+            entry_type="test_funding",
+            from_account=TREASURY_ACCOUNT,
+            to_account=sender_address,
+            amount_microunits=10_000_000,
+            reference="test-funding",
+        )
+        memo = "line1\nline2"
+        payload = wallet_transfer_payload(
+            from_address=sender_address,
+            to_address=receiver_address,
+            amount_microunits=2_500_000,
+            nonce=1,
+            memo=memo,
+        )
+
+        with pytest.raises(LedgerError, match="memo must not contain control characters"):
+            submit_wallet_transfer(
+                session,
+                from_address=sender_address,
+                to_address=receiver_address,
+                amount_mrwk="2.5",
+                nonce=1,
+                memo=memo,
+                signature_hex=_sign(sender_key, payload),
             )
 
 


### PR DESCRIPTION
Refs #122

## Summary
- Reject ASCII control characters in optional wallet labels before they are stored and rendered.
- Reject ASCII control characters in signed transfer memos before they are stored in wallet transfer history.
- Add service-level and API-level regressions for wallet labels and transfer memos.

## Why
Wallet labels and transfer memos are public wallet surfaces, but they only had trimming/length checks. A newline or other ASCII control character could be accepted and stored, unlike the newer public URL and bounty text hardening. This keeps wallet-facing text fields on the same validation footing without changing normal labels or memos.

## Verification
- Direct pre-fix probe accepted `label="Main\nWallet"` and `memo="line1\nline2"`.
- `python -m pytest tests/test_wallets.py tests/test_wallet_api.py -q` -> 29 passed
- `python -m pytest -q` -> 148 passed, 2 warnings
- `ruff check app/ledger/service.py tests/test_wallets.py tests/test_wallet_api.py` -> All checks passed
- `ruff format --check app/ledger/service.py tests/test_wallets.py tests/test_wallet_api.py` -> 3 files already formatted
- `mypy app` -> Success: no issues found in 11 source files
- `scripts/docs_smoke.py` -> docs smoke ok
- `scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> passed

Duplicate check:
- Checked current open PR titles and #122 comments. Existing related PRs cover public URLs, bounty metadata, deploy secrets, account namespaces, and MCP tool names, not wallet labels or transfer memos.

No secrets, wallet material, deployment values, private context, or MRWK price claims are included.