### PR TITLE
Reject duplicate bounty issue creation

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -370,6 +370,9 @@ def create_bounty(
         raise LedgerError("max_awards is too large")
     reserved = reward * max_awards
     clean_repo = _clean_required_text(repo, "repo", 200)
+    existing_bounty = find_bounty_by_issue(session, clean_repo, issue_number)
+    if existing_bounty is not None:
+        raise LedgerError("bounty already exists for issue")
     clean_issue_url = validate_public_url(issue_url)
     clean_title = _clean_required_text(title, "title", 300)
     clean_acceptance = _clean_required_text(acceptance, "acceptance", 5_000)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -98,6 +98,33 @@ def test_create_bounty_rejects_non_positive_issue_number(sqlite_url: str) -> Non
                 )
 
 
+def test_create_bounty_rejects_duplicate_repo_issue(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=7,
+            issue_url="https://github.com/ramimbo/mergework/issues/7",
+            title="Original bounty",
+            reward_mrwk="25",
+            acceptance="First bounty for this issue.",
+        )
+
+        with pytest.raises(LedgerError, match="bounty already exists for issue"):
+            create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=7,
+                issue_url="https://github.com/ramimbo/mergework/issues/7",
+                title="Duplicate bounty",
+                reward_mrwk="25",
+                acceptance="Second bounty for this issue should be rejected cleanly.",
+            )
+
+
 def test_multi_award_bounty_pays_distinct_submissions_until_exhausted(
     sqlite_url: str,
 ) -> None:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -181,6 +181,32 @@ def test_admin_bounty_api_returns_400_for_malformed_json(
     assert missing_field.json()["detail"] == "repo is required"
 
 
+def test_admin_bounty_api_rejects_duplicate_repo_issue(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    payload = _admin_bounty_form_data()
+
+    first = client.post(
+        "/api/v1/bounties",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json=payload,
+    )
+    duplicate = client.post(
+        "/api/v1/bounties",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json=payload,
+    )
+
+    assert first.status_code == 200
+    assert duplicate.status_code == 400
+    assert duplicate.json()["detail"] == "bounty already exists for issue"
+
+
 def test_admin_bounty_api_rejects_fractional_integer_fields(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Reject duplicate bounty creation for the same `(repo, issue_number)` before hitting the database unique constraint.
- Return the existing API 400 error path instead of letting a duplicate create request surface as an unhandled integrity error.
- Add service and admin API regression coverage for duplicate bounty issues.

## Bounty

Bounty #122

## Evidence

- Before this patch, `create_bounty()` only relied on the `uq_bounty_issue` database constraint for duplicates.
- That means a duplicate admin/API create could raise `IntegrityError` at `session.flush()` instead of a clean `LedgerError`, while the API only catches `LedgerError` for user-facing 400 responses.
- The patch checks `find_bounty_by_issue()` after repo normalization and returns `bounty already exists for issue` through the existing validation path.

## Validation

- `uv run --extra dev python -m pytest tests/test_ledger.py::test_create_bounty_rejects_duplicate_repo_issue tests/test_security.py::test_admin_bounty_api_rejects_duplicate_repo_issue -q` -> 2 passed
- `uv run --extra dev python -m pytest tests/test_ledger.py tests/test_security.py -q` -> 39 passed
- `uv run --extra dev python -m pytest -q` -> 146 passed, 2 warnings
- `uv run --extra dev ruff format --check --preview app/ledger/service.py tests/test_ledger.py tests/test_security.py` -> 3 files already formatted
- `uv run --extra dev ruff check app/ledger/service.py tests/test_ledger.py tests/test_security.py` -> all checks passed
- `uv run --extra dev python -m mypy app` -> success
- `python3 scripts/docs_smoke.py` -> docs smoke ok
- `python3 scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> no output

No secrets, wallet material, deployment values, private context, or MRWK price claims are included.
