### PR TITLE
docs: show /api/v1/activity response shape

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -41,6 +41,13 @@ Read accepted-work activity summarized from proof-backed bounty payments:
 curl -s "$API_HOST/api/v1/activity"
 ```
 
+The activity payload includes project totals, contributor rollups, and recent
+accepted submissions backed by proofs:
+
+```json
+{"totals":{"accepted_awards":12,"accepted_mrwk":"600","contributors":5},"contributors":[{"account":"github:alice","accepted_awards":3,"accepted_mrwk":"150","latest_submission_url":"https://github.com/ramimbo/mergework/pull/42","latest_proof_hash":"<proof_hash>","latest_proof_url":"/proofs/<proof_hash>"}],"recent":[{"ledger_sequence":27,"account":"github:alice","amount_mrwk":"50","submission_url":"https://github.com/ramimbo/mergework/pull/42","proof_hash":"<proof_hash>","proof_url":"/proofs/<proof_hash>","bounty_id":11,"bounty_issue_number":22,"created_at":"2026-05-24T12:00:00"}]}
+```
+
 Inspect a proof, account, or registered wallet:
 
 ```bash

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -27,6 +27,8 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert '"arguments":{"id":11}' in examples
     assert '"id":4' in examples
     assert "not the GitHub issue" in examples
+    assert "accepted_awards" in examples
+    assert "latest_submission_url" in examples
     assert "public_key_hex" in examples
 
 


### PR DESCRIPTION
## Summary
- Add a sample `/api/v1/activity` payload to the public API examples.
- Clarify contributor rollups, recent rows, and internal bounty id fields.

## Evidence
- The docs page already linked `/api/v1/activity`, but the example file did not show the response shape.
- This change reduces guesswork for agents/docs readers using the public API.

## Test Evidence
- `./.venv/bin/python scripts/docs_smoke.py`
- `./.venv/bin/python -m pytest tests/test_docs_public_urls.py -q`

## MRWK
- Refs #114