### PR TITLE
docs: add proof response example

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -49,6 +49,12 @@ curl -s "$API_HOST/api/v1/accounts/treasury:mrwk"
 curl -s "$API_HOST/api/v1/wallets/mrwk1..."
 ```
 
+A proof response ties the payout to a public submission artifact and verifier metadata:
+
+```json
+{"proof":{"hash":"<proof_hash>","kind":"bounty_payment","bounty_id":11,"ledger_sequence":27,"accepted_by":"maintainer","submission_url":"https://github.com/ramimbo/mergework/pull/42","public":{"repo":"ramimbo/mergework","issue_number":22}}}
+```
+
 Register a wallet public key. Keep the private key local; only send the public
 key to MergeWork.
 


### PR DESCRIPTION
## Summary
- Add a concrete `/api/v1/proofs/<proof_hash>` response example.
- Clarify proof metadata that ties payouts to public submissions.

## Evidence
- The docs already referenced proof lookup, but lacked a sample response body.
- This fills the gap for agents reading the public API docs.

## Test Evidence
- `./.venv/bin/python scripts/docs_smoke.py`
- `./.venv/bin/python -m pytest tests/test_docs_public_urls.py -q`

## MRWK
- Refs #114