### PR TITLE
Reject control characters in proof metadata

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -149,6 +149,14 @@ def _clean_required_text(value: str, field: str, max_length: int) -> str:
     return clean
 
 
+def _clean_proof_metadata(verifier_result: dict[str, Any]) -> dict[str, Any]:
+    clean = dict(verifier_result)
+    for key, value in clean.items():
+        if isinstance(value, str) and CONTROL_CHAR_RE.search(value):
+            raise LedgerError(f"verifier_result.{key} must not contain control characters")
+    return clean
+
+
 def wallet_transfer_payload(
     *,
     from_address: str,
@@ -565,6 +573,10 @@ def pay_bounty(
         raise LedgerError("bounty already paid")
     if bounty.status != "open":
         raise LedgerError("bounty is not open")
+    clean_accepted_by = _clean_required_text(accepted_by, "accepted_by", 80)
+    clean_verifier_result = _clean_proof_metadata(verifier_result)
+    if "accepted_by" in clean_verifier_result:
+        clean_verifier_result["accepted_by"] = clean_accepted_by
     clean_submission_url = validate_public_url(submission_url)
     existing_submission = session.scalar(
         select(Submission)
@@ -599,7 +611,7 @@ def pay_bounty(
         submitter_account=to_account,
         url=clean_submission_url,
         status="accepted",
-        verifier_result=canonical_json(verifier_result),
+        verifier_result=canonical_json(clean_verifier_result),
     )
     session.add(submission)
     try:
@@ -620,12 +632,12 @@ def pay_bounty(
         "repo": bounty.repo,
         "issue_number": bounty.issue_number,
         "submission_url": clean_submission_url,
-        "accepted_by": accepted_by,
+        "accepted_by": clean_accepted_by,
         "to_account": to_account,
         "amount_mrwk": format_mrwk(bounty.reward_microunits),
         "ledger_sequence": ledger_entry.sequence,
         "ledger_hash": ledger_entry.entry_hash,
-        "verifier_result": verifier_result,
+        "verifier_result": clean_verifier_result,
     }
     proof_hash = hashlib.sha256(canonical_json(proof_payload).encode()).hexdigest()
     proof = Proof(

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -501,6 +501,95 @@ def test_bounty_urls_reject_embedded_credentials(sqlite_url: str) -> None:
             )
 
 
+def test_bounty_payment_proof_rejects_control_character_metadata(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        first_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=15,
+            issue_url="https://github.com/ramimbo/mergework/issues/15",
+            title="Proof metadata",
+            reward_mrwk="1",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+        second_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=16,
+            issue_url="https://github.com/ramimbo/mergework/issues/16",
+            title="Proof verifier metadata",
+            reward_mrwk="1",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+
+        with pytest.raises(LedgerError, match="accepted_by must not contain control characters"):
+            pay_bounty(
+                session,
+                bounty_id=first_bounty.id,
+                to_account="github:alice",
+                submission_url="https://github.com/ramimbo/mergework/pull/15",
+                accepted_by="maintainer\nops",
+                verifier_result={"label": "mrwk:accepted"},
+            )
+        with pytest.raises(
+            LedgerError, match="verifier_result.note must not contain control characters"
+        ):
+            pay_bounty(
+                session,
+                bounty_id=second_bounty.id,
+                to_account="github:bob",
+                submission_url="https://github.com/ramimbo/mergework/pull/16",
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted", "note": "line1\nline2"},
+            )
+
+        assert first_bounty.awards_paid == 0
+        assert second_bounty.awards_paid == 0
+        assert get_balance(session, "github:alice") == 0
+        assert get_balance(session, "github:bob") == 0
+
+
+def test_admin_payout_api_rejects_control_character_note(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    create_schema(sqlite_url)
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=17,
+            issue_url="https://github.com/ramimbo/mergework/issues/17",
+            title="Admin proof metadata",
+            reward_mrwk="25",
+            acceptance="Maintainer verifies payout.",
+        )
+        bounty_id = bounty.id
+
+    response = client.post(
+        f"/api/v1/bounties/{bounty_id}/pay",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json={
+            "to_account": "github:alice",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/17",
+            "accepted_by": "maintainer",
+            "note": "line1\nline2",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == ("verifier_result.note must not contain control characters")
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:alice") == 0
+
+
 def test_bounty_urls_reject_control_characters(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Refs #122

## Summary
- Reject ASCII control characters in `accepted_by` before generating a public bounty payment proof.
- Reject ASCII control characters in string values inside `verifier_result` before storing the submission/proof payload.
- Normalize duplicated verifier `accepted_by` metadata to the cleaned proof value.
- Add service-level and admin payout API regressions.

## Why
Bounty payment proofs are public JSON and rendered on proof pages. Before this change, `pay_bounty(..., accepted_by="maintainer\nops")` and admin payout notes such as `"line1\nline2"` could be stored in proof metadata. That left proof text metadata behind the newer URL and public text hardening.

## Verification
- Direct pre-fix probe accepted `accepted_by="maintainer\nops"` into `proof.public_json`.
- `python -m pytest tests/test_security.py::test_bounty_payment_proof_rejects_control_character_metadata tests/test_security.py::test_admin_payout_api_rejects_control_character_note -q` -> 2 passed
- `python -m pytest tests/test_security.py tests/test_ledger.py tests/test_api_mcp.py -q` -> 76 passed, 1 warning
- `python -m pytest -q` -> 146 passed, 2 warnings
- `ruff check app/ledger/service.py tests/test_security.py` -> All checks passed
- `ruff format --check app/ledger/service.py tests/test_security.py` -> 2 files already formatted
- `mypy app` -> Success: no issues found in 11 source files
- `scripts/docs_smoke.py` -> docs smoke ok
- `scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> passed

Duplicate check:
- Checked current open PR titles and #122 comments. Existing related PRs cover public URLs, bounty metadata, wallet labels/memos, deploy secrets, account namespaces, MCP tool names, and non-string admin metadata, not control characters in proof `accepted_by`/`verifier_result` metadata.

No secrets, wallet material, deployment values, private context, or MRWK price claims are included.