### PR TITLE
Validate deploy database URL text

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -96,6 +96,7 @@ def _sqlite_database_errors(database_url: str) -> list[str]:
 
 def validate_deploy_settings(settings: Settings) -> list[str]:
     errors: list[str] = []
+    errors.extend(_required_env_value_errors("MERGEWORK_DATABASE_URL", settings.database_url))
     errors.extend(_sqlite_database_errors(settings.database_url))
     errors.extend(_secret_errors("MERGEWORK_GITHUB_WEBHOOK_SECRET", settings.github_webhook_secret))
     errors.extend(

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -64,6 +64,23 @@ def test_deploy_readiness_rejects_reused_secret_values() -> None:
     assert "deploy secrets must use distinct values" in errors
 
 
+def test_deploy_readiness_rejects_database_url_text_errors() -> None:
+    empty_errors = validate_deploy_settings(_settings(database_url=""))
+    whitespace_errors = validate_deploy_settings(
+        _settings(database_url=" sqlite:////srv/mergework/data/app.sqlite3")
+    )
+    control_errors = validate_deploy_settings(
+        _settings(database_url="postgresql://mergework:password@db.example.test/mergework\nextra")
+    )
+
+    assert "MERGEWORK_DATABASE_URL is required" in empty_errors
+    assert (
+        "MERGEWORK_DATABASE_URL must not include leading or trailing whitespace"
+        in whitespace_errors
+    )
+    assert "MERGEWORK_DATABASE_URL must not include control characters" in control_errors
+
+
 def test_deploy_readiness_rejects_secret_whitespace_and_control_characters() -> None:
     errors = validate_deploy_settings(
         _settings(


### PR DESCRIPTION
Refs #104.

## Summary
- validate `MERGEWORK_DATABASE_URL` with the same required text checks used for deploy secrets
- reject missing, leading/trailing whitespace, and control-character database URLs before deploy readiness passes
- cover the three database URL text failures in deploy readiness tests

## Repro before fix
`validate_deploy_settings()` returned no `MERGEWORK_DATABASE_URL` errors for:
- empty database URL
- leading-whitespace SQLite URL
- PostgreSQL URL containing a newline

## Validation
- `python -m pytest tests/test_deploy_readiness.py -q` -> 20 passed
- `python -m pytest -q` -> 168 passed, 2 warnings
- `ruff check app/config.py tests/test_deploy_readiness.py`
- `ruff format --check app/config.py tests/test_deploy_readiness.py`
- `mypy app`
- `python scripts/docs_smoke.py`
- `python scripts/check_agents.py`
