### PR TITLE
docs: document status API response

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -16,6 +16,20 @@ curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
 ```
 
+The status response is a compact public health and ledger summary:
+
+```json
+{
+  "name": "MergeWork",
+  "ticker": "MRWK",
+  "genesis_supply_mrwk": "100000000",
+  "ledger_height": 42,
+  "active_bounties": 3,
+  "treasury_balance_mrwk": "99999000",
+  "future_path": "public snapshots, bridges, and onchain claims"
+}
+```
+
 Read a single bounty with its internal `id` from `/api/v1/bounties`:
 
 ```bash

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -30,6 +30,16 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "public_key_hex" in examples
 
 
+def test_api_examples_document_status_response_fields() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/status" in examples
+    assert '"ledger_height": 42' in examples
+    assert '"active_bounties": 3' in examples
+    assert '"treasury_balance_mrwk": "99999000"' in examples
+    assert '"future_path": "public snapshots, bridges, and onchain claims"' in examples
+
+
 def test_agent_guide_explains_internal_bounty_ids() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Bounty #114

## What changed
- Added a concrete `/api/v1/status` JSON response example to `docs/api-examples.md`.
- Added docs coverage so the public examples keep the key status fields visible: `ledger_height`, `active_bounties`, `treasury_balance_mrwk`, and `future_path`.

## Why
The docs already showed the status curl command, but contributors and agents still had to call the endpoint to learn which fields it returns. This makes the health/ledger summary shape explicit without changing any API behavior.

## Verification
- `uv run --extra dev python -m pytest tests/test_docs_public_urls.py -q` -> 7 passed
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> passed

No secrets, wallet material, deployment values, private context, or MRWK price claims are included.