### PR TITLE
Hide wallet method boundary shims from OpenAPI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -667,11 +667,11 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             return wallet_to_dict(session, wallet)
 
-    @app.get("/api/v1/wallets/register")
+    @app.get("/api/v1/wallets/register", include_in_schema=False)
     def api_register_wallet_get() -> None:
         post_only_route()
 
-    @app.get("/api/v1/wallets/link-github")
+    @app.get("/api/v1/wallets/link-github", include_in_schema=False)
     def api_link_wallet_github_get() -> None:
         post_only_route()
 

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -245,6 +245,17 @@ def test_wallet_action_get_routes_report_method_not_allowed(sqlite_url: str, pat
     assert response.json()["detail"] == "Method Not Allowed"
 
 
+def test_wallet_method_boundary_routes_are_hidden_from_openapi(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    paths = client.get("/openapi.json").json()["paths"]
+
+    assert "post" in paths["/api/v1/wallets/register"]
+    assert "get" not in paths["/api/v1/wallets/register"]
+    assert "post" in paths["/api/v1/wallets/link-github"]
+    assert "get" not in paths["/api/v1/wallets/link-github"]
+
+
 def test_wallet_api_malformed_transfer_requests_return_4xx(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     _, sender_public, sender_address = _keypair()


### PR DESCRIPTION
Bounty #122

## Summary
- Hide the GET-only wallet method-boundary helper routes from OpenAPI.
- Preserve the live GET behavior: the shims still return `405 Method Not Allowed` with `Allow: POST` for callers that hit the wrong method.
- Add regression coverage so OpenAPI advertises only the real POST operations for wallet registration and GitHub linking.

## Repro before fix
Live OpenAPI currently advertises these method-boundary shims as real GET operations:

```bash
curl -s https://api.mrwk.ltclab.site/openapi.json \
  | jq '.paths["/api/v1/wallets/register"] | keys, .paths["/api/v1/wallets/link-github"] | keys'
```

Observed before patch: both paths include `get` and `post`, even though GET is only the explicit 405 boundary route.

## Verification
- `uv run --python 3.12 --extra dev pytest tests/test_wallet_api.py::test_wallet_action_get_routes_report_method_not_allowed tests/test_wallet_api.py::test_wallet_method_boundary_routes_are_hidden_from_openapi -q` -> 3 passed
- `uv run --python 3.12 --extra dev pytest tests/test_wallet_api.py -q` -> 23 passed
- `uv run --python 3.12 --extra dev pytest -q` -> 172 passed, 2 warnings
- `uv run --python 3.12 --extra dev ruff check app/main.py tests/test_wallet_api.py` -> passed
- `uv run --python 3.12 --extra dev ruff format --check app/main.py tests/test_wallet_api.py` -> passed
- `uv run --python 3.12 --extra dev mypy app` -> success
- `uv run --python 3.12 --extra dev python scripts/check_agents.py` -> ok
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> passed

No secrets, wallet material, deployment values, private context, or MRWK price claims are included.
