### PR TITLE
Reject edge control characters in public URLs

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -76,11 +76,11 @@ def canonical_json(data: dict[str, Any]) -> str:
 
 
 def validate_public_url(url: str) -> str:
+    if any(ord(char) < 32 or ord(char) == 127 for char in url):
+        raise LedgerError("URL must not contain control characters")
     clean = url.strip()
     if len(clean) > 500:
         raise LedgerError("URL is too long")
-    if any(ord(char) < 32 or ord(char) == 127 for char in clean):
-        raise LedgerError("URL must not contain control characters")
     parsed = urlparse(clean)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise LedgerError("URL must use http or https")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -560,6 +560,8 @@ def test_close_bounty_rejects_control_character_reference(sqlite_url: str) -> No
 
 def test_public_url_or_none_omits_control_character_urls() -> None:
     assert public_url_or_none("https://github.com/ramimbo/mergework/issues/14\nextra") is None
+    assert public_url_or_none("\nhttps://github.com/ramimbo/mergework/issues/14") is None
+    assert public_url_or_none("https://github.com/ramimbo/mergework/issues/14\n") is None
     assert (
         public_url_or_none(" https://github.com/ramimbo/mergework/issues/14 ")
         == "https://github.com/ramimbo/mergework/issues/14"


### PR DESCRIPTION
Refs #122.

## Summary
- reject ASCII control characters in public URLs before trimming surrounding whitespace
- keep ordinary surrounding spaces accepted and normalized
- cover leading/trailing newline URL inputs through `public_url_or_none()` regression assertions

## Repro before fix
On current `origin/main`, `validate_public_url()` accepted control characters at the URL edges because it trimmed first:

```text
'https://example.test/path\n' => 'https://example.test/path'
'\nhttps://example.test/path' => 'https://example.test/path'
' https://example.test/path ' => 'https://example.test/path'
'https://example.test/pa\nth' ERR URL must not contain control characters
```

After this patch, the leading/trailing newline cases return `URL must not contain control characters`, while normal surrounding spaces still trim to the clean URL.

## Validation
- `python -m pytest tests/test_security.py::test_bounty_urls_reject_control_characters tests/test_security.py::test_close_bounty_rejects_control_character_reference tests/test_security.py::test_public_url_or_none_omits_control_character_urls -q` -> 3 passed
- `python -m pytest tests/test_security.py tests/test_api_mcp.py tests/test_bounty_pages.py -q` -> 69 passed, 1 warning
- `python -m pytest -q` -> 167 passed, 2 warnings
- `ruff check app/ledger/service.py tests/test_security.py`
- `ruff format --check app/ledger/service.py tests/test_security.py`
- `mypy app`
- `python scripts/docs_smoke.py`
- `python scripts/check_agents.py`
- `git diff --check`

No secrets, wallet material, deployment values, private context, or MRWK price claims are included.
