### PR TITLE
Validate MCP wallet lookup addresses

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,7 @@ from app.ledger.service import (
     submit_wallet_transfer,
 )
 from app.models import Account, Bounty, LedgerEntry, Proof, Wallet, WalletTransfer
+from app.wallets import normalize_wallet_address
 from app.webhooks.github import handle_github_webhook
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -1257,7 +1258,8 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
             )
             return json.dumps(wallet_to_dict(session, wallet))
         if name == "get_wallet":
-            wallet_row = session.get(Wallet, str_arg("address").lower())
+            address = normalize_wallet_address(str_arg("address"))
+            wallet_row = session.get(Wallet, address)
             if wallet_row is None:
                 return "wallet not found"
             return json.dumps(wallet_to_dict(session, wallet_row))

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -561,6 +561,7 @@ def test_mcp_get_bounty_rejects_fractional_id(sqlite_url: str) -> None:
         ("get_balance", {"account": ""}, 15),
         ("get_wallet", {"address": 123}, 16),
         ("get_proof", {"hash": 123}, 17),
+        ("get_wallet", {"address": "not-a-wallet"}, 18),
     ],
 )
 def test_mcp_rejects_invalid_string_arguments(


### PR DESCRIPTION
## Summary
- validate MCP `get_wallet` addresses with the existing MRWK wallet normalizer
- preserve `wallet not found` for well-formed but unregistered wallets
- add regression coverage for malformed string addresses returning JSON-RPC invalid tool arguments

## Bounty
Bounty #122.

## Root Cause
`get_wallet` only lowercased the provided address before `session.get`, so malformed string addresses such as `not-a-wallet` returned a successful text result of `wallet not found` instead of the same invalid-arguments error used for other malformed MCP inputs.

## Validation
- Red before fix: `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_mcp_rejects_invalid_string_arguments -q` failed on `get_wallet` with `not-a-wallet`, returning `wallet not found`.
- `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_mcp_rejects_invalid_string_arguments -q` -> 6 passed
- `uv run --extra dev python -m pytest tests/test_api_mcp.py -q` -> 39 passed, 1 warning
- `uv run --extra dev python -m pytest -q` -> 172 passed, 2 warnings
- `uv run --extra dev ruff format --check app/main.py tests/test_api_mcp.py` -> 2 files already formatted
- `uv run --extra dev ruff check app/main.py tests/test_api_mcp.py` -> All checks passed
- `uv run --extra dev python -m mypy app` -> Success: no issues found in 11 source files
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --extra dev python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> passed

No secrets, wallet material, deployment values, private context, or MRWK price claims are included.