### PR TITLE
Show accepted awards on bounty detail pages

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -122,6 +122,34 @@ def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
     }
 
 
+def bounty_awards_to_dict(session: Session, bounty_id: int) -> list[dict[str, Any]]:
+    proofs = session.scalars(
+        select(Proof)
+        .where(Proof.bounty_id == bounty_id, Proof.kind == "bounty_payment")
+        .order_by(Proof.ledger_sequence.desc())
+    ).all()
+    awards: list[dict[str, Any]] = []
+    for proof in proofs:
+        data = json.loads(proof.public_json)
+        if not isinstance(data, dict) or data.get("kind") != "bounty_payment":
+            continue
+        proof_hash = str(proof.hash)
+        awards.append(
+            {
+                "proof_hash": proof_hash,
+                "proof_url": f"/proofs/{proof_hash}",
+                "ledger_sequence": proof.ledger_sequence,
+                "ledger_url": f"/ledger/{proof.ledger_sequence}",
+                "account": data.get("to_account"),
+                "amount_mrwk": data.get("amount_mrwk"),
+                "submission_url": data.get("submission_url"),
+                "accepted_by": data.get("accepted_by"),
+                "created_at": proof.created_at.isoformat(),
+            }
+        )
+    return awards
+
+
 def ledger_to_dict(entry: LedgerEntry, proof_hash: str | None = None) -> dict[str, Any]:
     return {
         "sequence": entry.sequence,
@@ -550,7 +578,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             bounty = session.get(Bounty, bounty_id)
             if bounty is None:
                 raise HTTPException(status_code=404, detail="bounty not found")
-            return bounty_to_dict(bounty)
+            result = bounty_to_dict(bounty)
+            result["accepted_awards"] = bounty_awards_to_dict(session, bounty.id)
+            return result
 
     @app.post("/api/v1/bounties/{bounty_id}/pay")
     async def api_pay_bounty(

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -42,4 +42,49 @@
     <p>{{ bounty.acceptance }}</p>
   </section>
 </section>
+
+<section>
+  <div class="section-head">
+    <h2>Accepted work</h2>
+    <p>{{ bounty.awards_paid }}/{{ bounty.max_awards }} awards paid{% if bounty.awards_remaining %}; {{ bounty.awards_remaining }} still open{% endif %}.</p>
+  </div>
+  {% if bounty.accepted_awards %}
+  <div class="ledger-list">
+    {% for award in bounty.accepted_awards %}
+    <article class="ledger-row ledger-row--bounty-payment">
+      <div class="ledger-entry-card">
+        <div class="ledger-card-head">
+          <div class="ledger-card-title">
+            <a class="ledger-entry-link" href="{{ award.ledger_url }}">#{{ award.ledger_sequence }}</a>
+            <span class="ledger-type ledger-type--bounty-payment">Accepted</span>
+          </div>
+          <strong class="ledger-amount">{{ award.amount_mrwk }} MRWK</strong>
+        </div>
+        <dl class="ledger-card-grid">
+          <div class="ledger-field ledger-field--to">
+            <dt>Paid to</dt>
+            <dd>{% if award.account %}<a href="/accounts/{{ award.account }}">{{ award.account }}</a>{% else %}-{% endif %}</dd>
+          </div>
+          <div class="ledger-field ledger-field--reference reference-cell">
+            <dt>Submission</dt>
+            {% set submission_url = safe_public_url(award.submission_url) %}
+            <dd>{% if submission_url %}<a href="{{ submission_url }}">{{ award.submission_url | replace("https://github.com/", "") }}</a>{% elif award.submission_url %}<code>{{ award.submission_url }}</code>{% else %}-{% endif %}</dd>
+          </div>
+          <div class="ledger-field ledger-field--proof">
+            <dt>Proof</dt>
+            <dd><a href="{{ award.proof_url }}">{{ award.proof_hash[:12] }}</a></dd>
+          </div>
+          <div class="ledger-field">
+            <dt>Accepted by</dt>
+            <dd>{{ award.accepted_by or "-" }}</dd>
+          </div>
+        </dl>
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+  {% else %}
+  <p>No accepted work has been paid for this bounty yet.</p>
+  {% endif %}
+</section>
 {% endblock %}

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -89,6 +89,61 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert "Focused PR improves status, reward, issue link, and acceptance text." in response.text
 
 
+def test_bounty_detail_shows_accepted_award_history(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=164,
+            issue_url="https://github.com/ramimbo/mergework/issues/164",
+            title="Improve bounty discovery pages",
+            reward_mrwk="100",
+            max_awards=3,
+            acceptance="Bounty detail pages should show accepted work and proofs.",
+        )
+        first_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/201",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        second_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:bob",
+            submission_url="https://github.com/ramimbo/mergework/pull/202",
+            accepted_by="reviewer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    api_detail = client.get(f"/api/v1/bounties/{bounty_id}").json()
+    page = client.get(f"/bounties/{bounty_id}")
+
+    assert [award["proof_hash"] for award in api_detail["accepted_awards"]] == [
+        second_proof.hash,
+        first_proof.hash,
+    ]
+    assert api_detail["accepted_awards"][0]["account"] == "github:bob"
+    assert api_detail["accepted_awards"][0]["submission_url"] == (
+        "https://github.com/ramimbo/mergework/pull/202"
+    )
+    assert page.status_code == 200
+    assert "Accepted work" in page.text
+    assert "2/3 awards paid" in page.text
+    assert "1 still open" in page.text
+    assert 'href="https://github.com/ramimbo/mergework/pull/202"' in page.text
+    assert f'href="/proofs/{second_proof.hash}"' in page.text
+    assert f'href="/ledger/{second_proof.ledger_sequence}"' in page.text
+    assert "/accounts/github:bob" in page.text
+
+
 def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Refs #164.

## Summary
- add proof-backed accepted_awards to the bounty detail API response
- show accepted work, ledger entry, proof link, recipient, submit URL, accepted-by, and remaining award count on public bounty detail pages
- cover the API ordering and rendered page links with regression coverage

## Validation
- uv run --python 3.12 --extra dev pytest tests/test_bounty_pages.py::test_bounty_detail_shows_accepted_award_history -q
- uv run --python 3.12 --extra dev pytest tests/test_bounty_pages.py tests/test_activity.py tests/test_api_mcp.py -q
- uv run --python 3.12 --extra dev pytest -q
- uv run --python 3.12 --extra dev ruff check app/main.py tests/test_bounty_pages.py
- uv run --python 3.12 --extra dev ruff format --check app/main.py tests/test_bounty_pages.py
- uv run --python 3.12 --extra dev mypy app
- python3 scripts/check_agents.py
- python3 scripts/docs_smoke.py
- git diff --check

No secrets, wallet material, private context, deployment values, or MRWK price claims are included.