### PR TITLE
Reject non-decimal MRWK amount notation

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -37,6 +37,7 @@ MICRO_UNITS = 1_000_000
 GENESIS_SUPPLY_MICRO = 100_000_000 * MICRO_UNITS
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
+MRWK_AMOUNT_RE = re.compile(r"^-?\d+(?:\.\d+)?$")
 
 
 class LedgerError(RuntimeError):
@@ -44,8 +45,11 @@ class LedgerError(RuntimeError):
 
 
 def parse_mrwk_amount(amount: str | int | Decimal) -> int:
+    amount_text = str(amount).strip()
+    if not MRWK_AMOUNT_RE.fullmatch(amount_text):
+        raise LedgerError("invalid MRWK amount")
     try:
-        value = Decimal(str(amount))
+        value = Decimal(amount_text)
     except (InvalidOperation, ValueError) as exc:
         raise LedgerError("invalid MRWK amount") from exc
     if not value.is_finite():

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -428,6 +428,16 @@ def test_amount_parser_rejects_non_finite_values() -> None:
             parse_mrwk_amount(amount)
 
 
+def test_amount_parser_rejects_non_decimal_notation() -> None:
+    for amount in ("1e3", "1E-3", "+1"):
+        with pytest.raises(LedgerError, match="invalid MRWK amount"):
+            parse_mrwk_amount(amount)
+
+    assert parse_mrwk_amount("1.5") == 1_500_000
+    with pytest.raises(LedgerError, match="amount must be positive"):
+        parse_mrwk_amount("-1")
+
+
 def test_amount_parser_rejects_values_above_fixed_supply() -> None:
     with pytest.raises(LedgerError, match="amount exceeds fixed supply"):
         parse_mrwk_amount("100000001")


### PR DESCRIPTION
Refs #122.

## Summary
- require MRWK amount inputs to use plain decimal notation before Decimal parsing
- reject scientific notation such as `1e3` / `1E-3` and leading plus notation such as `+1`
- preserve existing behavior for normal decimal amounts, over-precision errors, and negative amounts reporting `amount must be positive`

## Repro before fix
On current `origin/main`, `parse_mrwk_amount()` accepted non-decimal-looking amount strings:

```text
'1e3' => 1000
'1E-3' => 0.001
'1e-6' => 0.000001
'+1' => 1
'1.5' => 1.5
'0.000001' => 0.000001
'1.0000001' ERR MRWK supports at most 6 decimal places
```

Those values can flow through admin bounty creation and wallet transfer APIs because both call the shared parser.

## Validation
- `python -m pytest tests/test_security.py::test_amount_parser_rejects_non_finite_values tests/test_security.py::test_amount_parser_rejects_non_decimal_notation tests/test_security.py::test_amount_parser_rejects_values_above_fixed_supply tests/test_wallet_api.py::test_wallet_transfer_api_rejects_invalid_requests -q` -> 7 passed
- `python -m pytest tests/test_security.py tests/test_ledger.py tests/test_wallet_api.py tests/test_wallets.py -q` -> 73 passed
- `python -m pytest -q` -> 168 passed, 2 warnings
- `ruff check app/ledger/service.py tests/test_security.py`
- `ruff format --check app/ledger/service.py tests/test_security.py`
- `mypy app`
- `python scripts/docs_smoke.py`
- `python scripts/check_agents.py`
- `git diff --check`

No secrets, wallet material, deployment values, private context, or MRWK price claims are included.
