### PR TITLE
Add bounty search filters

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -502,7 +502,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             "future_path": "public snapshots, bridges, and onchain claims",
         }
 
-    def list_bounties_by_status(status: str | None = None) -> list[dict[str, Any]]:
+    def list_bounties_by_status(
+        status: str | None = None, search: str | None = None
+    ) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
             query = select(Bounty)
             if status is not None:
@@ -512,12 +514,25 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                         status_code=400, detail="status must be one of: open, paid, closed"
                     )
                 query = query.where(Bounty.status == normalized_status)
+            if search is not None and search.strip():
+                clean_search = search.strip().lower()
+                pattern = f"%{clean_search}%"
+                search_filters: list[Any] = [
+                    func.lower(Bounty.repo).like(pattern),
+                    func.lower(Bounty.title).like(pattern),
+                    func.lower(Bounty.acceptance).like(pattern),
+                ]
+                if clean_search.isdigit():
+                    search_filters.append(Bounty.issue_number == int(clean_search))
+                query = query.where(or_(*search_filters))
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             return [bounty_to_dict(bounty) for bounty in bounties]
 
     @app.get("/api/v1/bounties")
-    def api_bounties(status: str | None = Query(None)) -> list[dict[str, Any]]:
-        return list_bounties_by_status(status)
+    def api_bounties(
+        status: str | None = Query(None), q: str | None = Query(None)
+    ) -> list[dict[str, Any]]:
+        return list_bounties_by_status(status, q)
 
     @app.post("/api/v1/bounties")
     async def api_create_bounty(
@@ -923,14 +938,18 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         )
 
     @app.get("/bounties", response_class=HTMLResponse)
-    def bounties_page(request: Request, status: str | None = Query(None)) -> HTMLResponse:
+    def bounties_page(
+        request: Request, status: str | None = Query(None), q: str | None = Query(None)
+    ) -> HTMLResponse:
         selected_status = status.strip().lower() if status is not None else None
+        search_query = q.strip() if q is not None else ""
         return templates.TemplateResponse(
             request,
             "bounties.html",
             {
-                "bounties": list_bounties_by_status(status),
+                "bounties": list_bounties_by_status(status, search_query),
                 "selected_status": selected_status,
+                "search_query": search_query,
             },
         )
 

--- a/app/main.py
+++ b/app/main.py
@@ -516,11 +516,14 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 query = query.where(Bounty.status == normalized_status)
             if search is not None and search.strip():
                 clean_search = search.strip().lower()
-                pattern = f"%{clean_search}%"
+                escaped_search = (
+                    clean_search.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+                )
+                pattern = f"%{escaped_search}%"
                 search_filters: list[Any] = [
-                    func.lower(Bounty.repo).like(pattern),
-                    func.lower(Bounty.title).like(pattern),
-                    func.lower(Bounty.acceptance).like(pattern),
+                    func.lower(Bounty.repo).like(pattern, escape="\\"),
+                    func.lower(Bounty.title).like(pattern, escape="\\"),
+                    func.lower(Bounty.acceptance).like(pattern, escape="\\"),
                 ]
                 if clean_search.isdigit():
                     search_filters.append(Bounty.issue_number == int(clean_search))

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -238,6 +238,22 @@ code.hash { overflow-wrap: anywhere; }
 .section-head h2 { margin-bottom: 0; }
 .project-list article { min-height: 190px; }
 .doc-list { line-height: 1.9; }
+.search-form {
+  align-items: end;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(220px, 1fr) auto auto;
+  margin: 0 0 18px;
+  max-width: none;
+}
+.search-form button,
+.search-form a {
+  min-height: 46px;
+}
+.search-form a {
+  align-items: center;
+  display: inline-flex;
+}
 pre {
   overflow: auto;
   border: 1px solid var(--line);
@@ -271,4 +287,5 @@ button { cursor: pointer; color: white; background: var(--accent); border-color:
   .ledger-card-grid { grid-template-columns: 1fr; }
   .ledger-field--reference,
   .ledger-field--hash { grid-column: auto; }
+  .search-form { grid-template-columns: 1fr; }
 }

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -2,12 +2,28 @@
 {% block title %}MRWK Bounties{% endblock %}
 {% block content %}
 <h1>Bounties</h1>
+<form class="search-form" method="get" action="/bounties" role="search" aria-label="Search bounties">
+  {% if selected_status %}
+  <input type="hidden" name="status" value="{{ selected_status }}">
+  {% endif %}
+  <label>
+    <span>Search bounties</span>
+    <input name="q" value="{{ search_query }}" placeholder="Repo, title, issue number, or acceptance text">
+  </label>
+  <button type="submit">Search</button>
+  {% if search_query %}
+  <a href="/bounties{% if selected_status %}?status={{ selected_status }}{% endif %}">Clear search</a>
+  {% endif %}
+</form>
 <nav aria-label="Bounty status filters">
-  <a href="/bounties"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
-  <a href="/bounties?status=open"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
-  <a href="/bounties?status=paid"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
-  <a href="/bounties?status=closed"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
+  <a href="/bounties{% if search_query %}?q={{ search_query | urlencode }}{% endif %}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
+  <a href="/bounties?status=open{% if search_query %}&q={{ search_query | urlencode }}{% endif %}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
+  <a href="/bounties?status=paid{% if search_query %}&q={{ search_query | urlencode }}{% endif %}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
+  <a href="/bounties?status=closed{% if search_query %}&q={{ search_query | urlencode }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
 </nav>
+{% if search_query %}
+<p class="notice">Showing matches for <strong>{{ search_query }}</strong>.</p>
+{% endif %}
 <div class="list">
   {% for bounty in bounties %}
   <article>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -82,16 +82,28 @@ def test_bounties_page_searches_public_bounties(sqlite_url: str) -> None:
             reward_mrwk="25",
             acceptance="Improve wallet transfer copy.",
         )
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=201,
+            issue_url="https://github.com/ramimbo/mergework/issues/201",
+            title="Literal 100% docs example",
+            reward_mrwk="25",
+            acceptance="Underscore literal is release_note cleanup.",
+        )
 
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
     page = client.get("/bounties?q=proof")
     api = client.get("/api/v1/bounties?q=164")
     status_page = client.get("/bounties?status=open&q=activity")
+    percent_api = client.get("/api/v1/bounties?q=%25")
+    underscore_api = client.get("/api/v1/bounties?q=_")
 
     assert page.status_code == 200
     assert "Contributor activity discovery" in page.text
     assert "Wallet transfer polish" not in page.text
+    assert "Literal 100% docs example" not in page.text
     assert "Showing matches for <strong>proof</strong>." in page.text
     assert 'href="/bounties?status=open&q=proof"' in page.text
     assert 'href="/bounties?q=proof" aria-current="page"' in page.text
@@ -100,6 +112,8 @@ def test_bounties_page_searches_public_bounties(sqlite_url: str) -> None:
     assert "Contributor activity discovery" in status_page.text
     assert 'value="activity"' in status_page.text
     assert 'href="/bounties?status=open">Clear search</a>' in status_page.text
+    assert [item["issue_number"] for item in percent_api.json()] == [201]
+    assert [item["issue_number"] for item in underscore_api.json()] == [201]
 
 
 def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -60,6 +60,48 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert 'href="/bounties?status=paid" aria-current="page"' in paid_rows_uppercase.text
 
 
+def test_bounties_page_searches_public_bounties(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=164,
+            issue_url="https://github.com/ramimbo/mergework/issues/164",
+            title="Contributor activity discovery",
+            reward_mrwk="100",
+            acceptance="Improve public bounty discovery and proof inspection.",
+        )
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=200,
+            issue_url="https://github.com/ramimbo/mergework/issues/200",
+            title="Wallet transfer polish",
+            reward_mrwk="25",
+            acceptance="Improve wallet transfer copy.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    page = client.get("/bounties?q=proof")
+    api = client.get("/api/v1/bounties?q=164")
+    status_page = client.get("/bounties?status=open&q=activity")
+
+    assert page.status_code == 200
+    assert "Contributor activity discovery" in page.text
+    assert "Wallet transfer polish" not in page.text
+    assert "Showing matches for <strong>proof</strong>." in page.text
+    assert 'href="/bounties?status=open&q=proof"' in page.text
+    assert 'href="/bounties?q=proof" aria-current="page"' in page.text
+    assert [item["issue_number"] for item in api.json()] == [164]
+    assert status_page.status_code == 200
+    assert "Contributor activity discovery" in status_page.text
+    assert 'value="activity"' in status_page.text
+    assert 'href="/bounties?status=open">Clear search</a>' in status_page.text
+
+
 def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Refs #164.

## Summary
- add a `q` search filter to the public bounties API and bounty list page
- search title, repo, acceptance text, and numeric issue number while preserving status filters
- add a responsive search form, clear-search link, and filter links that preserve the active query

## Validation
- `uv run --python 3.12 --extra dev pytest tests/test_bounty_pages.py::test_bounties_page_searches_public_bounties -q`
- `uv run --python 3.12 --extra dev pytest tests/test_bounty_pages.py tests/test_api_mcp.py -q`
- `uv run --python 3.12 --extra dev pytest -q`
- `uv run --python 3.12 --extra dev ruff check app/main.py tests/test_bounty_pages.py`
- `uv run --python 3.12 --extra dev ruff format --check app/main.py tests/test_bounty_pages.py`
- `uv run --python 3.12 --extra dev mypy app`
- `python3 scripts/check_agents.py`
- `python3 scripts/docs_smoke.py`
- `git diff --check`

No secrets, wallet material, private context, deployment values, or MRWK price claims are included.