### PR TITLE
Show accepted work on account pages

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -215,6 +215,45 @@ def activity_to_dict(session: Session) -> dict[str, Any]:
     }
 
 
+def accepted_work_for_account(session: Session, account: str) -> list[dict[str, Any]]:
+    rows = session.execute(
+        select(Proof, LedgerEntry)
+        .join(LedgerEntry, LedgerEntry.sequence == Proof.ledger_sequence)
+        .where(
+            Proof.kind == "bounty_payment",
+            LedgerEntry.entry_type == "bounty_payment",
+            LedgerEntry.to_account == account,
+        )
+        .order_by(LedgerEntry.sequence.desc())
+    ).all()
+    accepted_work: list[dict[str, Any]] = []
+    for proof, entry in rows:
+        data = json.loads(proof.public_json)
+        if not isinstance(data, dict) or data.get("kind") != "bounty_payment":
+            continue
+        repo = data.get("repo")
+        issue_number = data.get("issue_number")
+        issue_url = None
+        if isinstance(repo, str) and isinstance(issue_number, int):
+            issue_url = f"https://github.com/{repo}/issues/{issue_number}"
+        accepted_work.append(
+            {
+                "ledger_sequence": entry.sequence,
+                "ledger_url": f"/ledger/{entry.sequence}",
+                "proof_hash": proof.hash,
+                "proof_url": f"/proofs/{proof.hash}",
+                "amount_mrwk": format_mrwk(entry.amount_microunits),
+                "submission_url": data.get("submission_url"),
+                "issue_url": issue_url,
+                "repo": repo,
+                "issue_number": issue_number,
+                "accepted_by": data.get("accepted_by"),
+                "created_at": entry.created_at.isoformat(),
+            }
+        )
+    return accepted_work
+
+
 def _wallet_timestamp(value: datetime) -> str:
     if value.tzinfo is not None:
         value = value.replace(tzinfo=None)
@@ -967,8 +1006,15 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             ).all()
             proofs = _proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
             transactions = [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
+            accepted_work = accepted_work_for_account(session, account)
         return templates.TemplateResponse(
-            request, "account.html", {"account": account_data, "transactions": transactions}
+            request,
+            "account.html",
+            {
+                "account": account_data,
+                "accepted_work": accepted_work,
+                "transactions": transactions,
+            },
         )
 
     @app.get("/wallets", response_class=HTMLResponse)

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -20,6 +20,52 @@
 
 <section>
   <div class="section-head">
+    <h2>Accepted work</h2>
+    <p>Proof-backed bounty payments made to this account.</p>
+  </div>
+  {% if accepted_work %}
+  <div class="ledger-list">
+    {% for work in accepted_work %}
+    <article class="ledger-row ledger-row--bounty-payment">
+      <div class="ledger-entry-card">
+        <div class="ledger-card-head">
+          <div class="ledger-card-title">
+            <a class="ledger-entry-link" href="{{ work.ledger_url }}">#{{ work.ledger_sequence }}</a>
+            <span class="ledger-type ledger-type--bounty-payment">Accepted</span>
+          </div>
+          <strong class="ledger-amount">{{ work.amount_mrwk }} MRWK</strong>
+        </div>
+        <dl class="ledger-card-grid">
+          <div class="ledger-field ledger-field--reference reference-cell">
+            <dt>Bounty</dt>
+            {% set issue_url = safe_public_url(work.issue_url) %}
+            <dd>{% if issue_url %}<a href="{{ issue_url }}">{{ work.repo }} #{{ work.issue_number }}</a>{% else %}-{% endif %}</dd>
+          </div>
+          <div class="ledger-field ledger-field--reference reference-cell">
+            <dt>Submission</dt>
+            {% set submission_url = safe_public_url(work.submission_url) %}
+            <dd>{% if submission_url %}<a href="{{ submission_url }}">{{ work.submission_url | replace("https://github.com/", "") }}</a>{% elif work.submission_url %}<code>{{ work.submission_url }}</code>{% else %}-{% endif %}</dd>
+          </div>
+          <div class="ledger-field ledger-field--proof">
+            <dt>Proof</dt>
+            <dd><a href="{{ work.proof_url }}">{{ work.proof_hash[:12] }}</a></dd>
+          </div>
+          <div class="ledger-field">
+            <dt>Accepted by</dt>
+            <dd>{{ work.accepted_by or "-" }}</dd>
+          </div>
+        </dl>
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+  {% else %}
+  <p>No proof-backed accepted work for this account yet.</p>
+  {% endif %}
+</section>
+
+<section>
+  <div class="section-head">
     <h2>Transactions</h2>
     <p>Credits and debits involving this account.</p>
   </div>

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -785,6 +785,11 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     )
     assert "Claim GitHub balances from /me" in account
     assert 'href="https://github.com/alice">@alice</a>' in account
+    assert "Accepted work" in account
+    assert "Proof-backed bounty payments made to this account." in account
+    assert 'href="https://github.com/ramimbo/mergework/issues/2"' in account
+    assert 'href="https://github.com/ramimbo/mergework/pull/3"' in account
+    assert f'href="/proofs/{proof.hash}"' in account
     assert 'href="/accounts/reserve:bounty:1"' in account
     assert 'href="/accounts/github:alice"' in account
 


### PR DESCRIPTION
Refs #164.

## Summary
- add proof-backed accepted work history to public account pages
- show bounty source issue, submit URL, proof, ledger entry, amount, and accepted-by for each paid bounty row
- keep the existing transaction table below the higher-signal accepted-work view

## Validation
- `uv run --python 3.12 --extra dev pytest tests/test_api_mcp.py::test_explorer_links_ledger_proof_and_account -q`
- `uv run --python 3.12 --extra dev pytest tests/test_api_mcp.py tests/test_activity.py -q`
- `uv run --python 3.12 --extra dev pytest -q`
- `uv run --python 3.12 --extra dev ruff check app/main.py tests/test_api_mcp.py`
- `uv run --python 3.12 --extra dev ruff format --check app/main.py tests/test_api_mcp.py`
- `uv run --python 3.12 --extra dev mypy app`
- `python3 scripts/check_agents.py`
- `python3 scripts/docs_smoke.py`
- `git diff --check`

No secrets, wallet material, private context, deployment values, or MRWK price claims are included.