### PR TITLE
Reject malformed public URL hosts

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -84,11 +84,12 @@ def validate_public_url(url: str) -> str:
     try:
         parsed = urlparse(clean)
         has_empty_port = parsed.port is None and parsed.netloc.endswith(":")
+        has_host = bool(parsed.hostname)
     except ValueError as exc:
         raise LedgerError("URL must include a valid host") from exc
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise LedgerError("URL must use http or https")
-    if has_empty_port:
+    if not has_host or has_empty_port:
         raise LedgerError("URL must include a valid host")
     if parsed.username or parsed.password:
         raise LedgerError("URL must not include credentials")

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -81,9 +81,15 @@ def validate_public_url(url: str) -> str:
         raise LedgerError("URL is too long")
     if any(ord(char) < 32 or ord(char) == 127 for char in clean):
         raise LedgerError("URL must not contain control characters")
-    parsed = urlparse(clean)
+    try:
+        parsed = urlparse(clean)
+        has_empty_port = parsed.port is None and parsed.netloc.endswith(":")
+    except ValueError as exc:
+        raise LedgerError("URL must include a valid host") from exc
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise LedgerError("URL must use http or https")
+    if has_empty_port:
+        raise LedgerError("URL must include a valid host")
     if parsed.username or parsed.password:
         raise LedgerError("URL must not include credentials")
     return clean

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -23,6 +23,7 @@ from app.ledger.service import (
     pay_bounty,
     public_url_or_none,
     register_wallet,
+    validate_public_url,
 )
 from app.main import _signed_value, create_app
 from app.models import LedgerEntry, WebhookEvent
@@ -491,6 +492,14 @@ def test_bounty_urls_reject_unsafe_schemes(sqlite_url: str) -> None:
                 accepted_by="maintainer",
                 verifier_result={"label": "mrwk:accepted"},
             )
+
+
+def test_public_urls_reject_malformed_hosts_and_ports() -> None:
+    for url in ("https://[bad", "https://example.com:bad/path", "https://example.com:/path"):
+        with pytest.raises(LedgerError, match="URL must include a valid host"):
+            validate_public_url(url)
+
+    assert public_url_or_none("https://[bad") is None
 
 
 def test_bounty_urls_reject_embedded_credentials(sqlite_url: str) -> None:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -495,11 +495,17 @@ def test_bounty_urls_reject_unsafe_schemes(sqlite_url: str) -> None:
 
 
 def test_public_urls_reject_malformed_hosts_and_ports() -> None:
-    for url in ("https://[bad", "https://example.com:bad/path", "https://example.com:/path"):
+    for url in (
+        "https://[bad",
+        "https://example.com:bad/path",
+        "https://example.com:/path",
+        "https://:443/path",
+    ):
         with pytest.raises(LedgerError, match="URL must include a valid host"):
             validate_public_url(url)
 
     assert public_url_or_none("https://[bad") is None
+    assert public_url_or_none("https://:443/path") is None
 
 
 def test_bounty_urls_reject_embedded_credentials(sqlite_url: str) -> None:


### PR DESCRIPTION
Refs #122.

## Summary
- convert malformed public URL parse/port failures into `LedgerError` validation failures
- reject malformed bracketed hosts and invalid/empty ports before storing or rendering public URLs
- keep valid explicit ports accepted
- cover the direct validator and `public_url_or_none()` fallback path

## Repro before fix
On current `main`, malformed public URLs were not handled consistently:

```text
validate 'https://[bad' ValueError Invalid IPv6 URL
optional 'https://[bad' ValueError Invalid IPv6 URL
validate 'https://example.com:bad/path' => 'https://example.com:bad/path'
optional 'https://example.com:bad/path' => 'https://example.com:bad/path'
validate 'https://example.com:/path' => 'https://example.com:/path'
optional 'https://example.com:/path' => 'https://example.com:/path'
```

After this patch, those malformed host/port values fail with `URL must include a valid host`, `public_url_or_none()` returns `None`, and a valid explicit port such as `https://example.com:8443/path` is still accepted.

## Validation
- `python -m pytest tests/test_security.py::test_bounty_urls_reject_unsafe_schemes tests/test_security.py::test_public_urls_reject_malformed_hosts_and_ports tests/test_security.py::test_bounty_urls_reject_embedded_credentials -q` -> 3 passed
- `python -m pytest tests/test_security.py tests/test_ledger.py tests/test_api_mcp.py tests/test_bounty_pages.py -q` -> 89 passed, 1 warning
- `python -m pytest -q` -> 172 passed, 2 warnings
- `ruff check app/ledger/service.py tests/test_security.py`
- `ruff format --check app/ledger/service.py tests/test_security.py`
- `mypy app`
- `python scripts/docs_smoke.py`
- `python scripts/check_agents.py`

No secrets, wallet material, deployment values, private context, or MRWK price claims are included.
