### PR TITLE
Link bounty sources from activity rows

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -142,16 +142,23 @@ def _activity_row(entry: LedgerEntry, proof: Proof) -> dict[str, Any] | None:
     if not isinstance(data, dict) or data.get("kind") != "bounty_payment":
         return None
     submission_url = str(data.get("submission_url") or entry.reference)
+    repo = data.get("repo")
+    issue_number = data.get("issue_number")
+    issue_url = None
+    if isinstance(repo, str) and isinstance(issue_number, int):
+        issue_url = f"https://github.com/{repo}/issues/{issue_number}"
     return {
         "ledger_sequence": entry.sequence,
         "account": entry.to_account,
         "amount_mrwk": format_mrwk(entry.amount_microunits),
         "amount_microunits": entry.amount_microunits,
         "submission_url": submission_url,
+        "bounty_repo": repo,
+        "bounty_issue_number": issue_number,
+        "bounty_issue_url": issue_url,
         "proof_hash": proof.hash,
         "proof_url": f"/proofs/{proof.hash}",
         "bounty_id": proof.bounty_id,
-        "bounty_issue_number": data.get("issue_number"),
         "created_at": entry.created_at.isoformat(),
     }
 

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -64,6 +64,11 @@
             <dd><a href="/accounts/{{ row.account }}">{{ row.account }}</a></dd>
           </div>
           <div class="ledger-field ledger-field--reference reference-cell">
+            <dt>Bounty</dt>
+            {% set bounty_issue_url = safe_public_url(row.bounty_issue_url) %}
+            <dd>{% if bounty_issue_url %}<a href="{{ bounty_issue_url }}">{{ row.bounty_repo }} #{{ row.bounty_issue_number }}</a>{% else %}-{% endif %}</dd>
+          </div>
+          <div class="ledger-field ledger-field--reference reference-cell">
             <dt>Accepted work</dt>
             {% set submission_url = safe_public_url(row.submission_url) %}
             <dd>{% if submission_url %}<a href="{{ submission_url }}">{{ row.submission_url | replace("https://github.com/", "") }}</a>{% else %}<code>{{ row.submission_url }}</code>{% endif %}</dd>

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -98,6 +98,11 @@ def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -
         second_proof.hash,
         first_proof.hash,
     ]
+    assert payload["recent"][0]["bounty_issue_url"] == (
+        "https://github.com/ramimbo/mergework/issues/11"
+    )
+    assert payload["recent"][0]["bounty_repo"] == "ramimbo/mergework"
+    assert payload["recent"][0]["bounty_issue_number"] == 11
     assert all("unproved" not in row["submission_url"] for row in payload["recent"])
 
 
@@ -135,6 +140,7 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert paid.status_code == 200
     assert "github:bob" in paid.text
     assert "75 MRWK" in paid.text
+    assert 'href="https://github.com/ramimbo/mergework/issues/12"' in paid.text
     assert 'href="https://github.com/ramimbo/mergework/pull/12"' in paid.text
     assert f'href="/proofs/{proof.hash}"' in paid.text
     assert "/accounts/github:bob" in paid.text


### PR DESCRIPTION
Refs #164.

## Summary
- add source bounty metadata to proof-backed activity API rows
- render the source bounty issue link on recent accepted work activity rows
- keep existing contributor, submission, proof, and amount links intact

## Validation
- `uv run --python 3.12 --extra dev pytest tests/test_activity.py -q`
- `uv run --python 3.12 --extra dev pytest tests/test_api_mcp.py tests/test_activity.py -q`
- `uv run --python 3.12 --extra dev pytest -q`
- `uv run --python 3.12 --extra dev ruff check app/main.py tests/test_activity.py`
- `uv run --python 3.12 --extra dev ruff format --check app/main.py tests/test_activity.py`
- `uv run --python 3.12 --extra dev mypy app`
- `python3 scripts/check_agents.py`
- `python3 scripts/docs_smoke.py`
- `git diff --check`

No secrets, wallet material, private context, deployment values, or MRWK price claims are included.