### PR TITLE
docs: add concrete public activity response example

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -41,6 +41,16 @@ Read accepted-work activity summarized from proof-backed bounty payments:
 curl -s "$API_HOST/api/v1/activity"
 ```
 
+The activity payload separates overall totals from per-contributor rollups and
+recent accepted submissions:
+
+```json
+{"totals":{"accepted_awards":3,"accepted_mrwk":"15","contributors":2},"contributors":[{"account":"alice:mrwk","accepted_awards":2,"accepted_mrwk":"10","latest_submission_url":"https://github.com/ramimbo/mergework/pull/42","latest_proof_hash":"<proof_hash>","latest_proof_url":"/proofs/<proof_hash>"}],"recent":[{"ledger_sequence":27,"account":"alice:mrwk","amount_mrwk":"5","submission_url":"https://github.com/ramimbo/mergework/pull/42","proof_hash":"<proof_hash>","proof_url":"/proofs/<proof_hash>","bounty_id":11,"bounty_issue_number":22,"created_at":"2026-05-24T20:00:00"}]}
+```
+
+In that response, `bounty_id` is the internal MergeWork bounty `id`, while
+`bounty_issue_number` is the source GitHub issue number.
+
 Inspect a proof, account, or registered wallet:
 
 ```bash

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -27,6 +27,10 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert '"arguments":{"id":11}' in examples
     assert '"id":4' in examples
     assert "not the GitHub issue" in examples
+    assert '"accepted_awards":3' in examples
+    assert '"latest_submission_url"' in examples
+    assert '"bounty_issue_number":22' in examples
+    assert "recent accepted submissions" in examples
     assert "public_key_hex" in examples
 
 


### PR DESCRIPTION
Bounty #162

Adds a concrete `/api/v1/activity` response example to the public API docs so contributors can see the current `totals`, `contributors`, and `recent` shapes without guessing which fields come from activity rollups versus recent accepted submissions.

Evidence:
- Compared against `activity_to_dict()` in `app/main.py`, which currently emits `accepted_awards`, `latest_submission_url`, `latest_proof_hash`, `latest_proof_url`, `bounty_id`, and `bounty_issue_number`.
- `./.venv/bin/python scripts/docs_smoke.py`
- `./.venv/bin/python -m pytest tests/test_docs_public_urls.py -q`

No secrets or private data included.