### PR TITLE
Validate deploy database URL value

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -96,6 +96,7 @@ def _sqlite_database_errors(database_url: str) -> list[str]:
 
 def validate_deploy_settings(settings: Settings) -> list[str]:
     errors: list[str] = []
+    errors.extend(_required_env_value_errors("MERGEWORK_DATABASE_URL", settings.database_url))
     errors.extend(_sqlite_database_errors(settings.database_url))
     errors.extend(_secret_errors("MERGEWORK_GITHUB_WEBHOOK_SECRET", settings.github_webhook_secret))
     errors.extend(

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -111,6 +111,24 @@ def test_deploy_readiness_rejects_non_persistent_sqlite_database_urls() -> None:
     assert "MERGEWORK_DATABASE_URL must use a persistent sqlite file" in empty_errors
 
 
+def test_deploy_readiness_rejects_database_url_missing_whitespace_or_control() -> None:
+    missing_errors = validate_deploy_settings(_settings(database_url=""))
+    blank_errors = validate_deploy_settings(_settings(database_url="   "))
+    whitespace_errors = validate_deploy_settings(
+        _settings(database_url=" postgresql://mergework:password@db.example.test/mergework")
+    )
+    control_errors = validate_deploy_settings(
+        _settings(database_url="postgresql://mergework:password@db.example.test/mergework\nextra")
+    )
+
+    assert "MERGEWORK_DATABASE_URL is required" in missing_errors
+    assert "MERGEWORK_DATABASE_URL is required" in blank_errors
+    assert "MERGEWORK_DATABASE_URL must not include leading or trailing whitespace" in (
+        whitespace_errors
+    )
+    assert "MERGEWORK_DATABASE_URL must not include control characters" in control_errors
+
+
 def test_deploy_readiness_accepts_absolute_sqlite_and_external_database_urls() -> None:
     assert (
         validate_deploy_settings(


### PR DESCRIPTION
Refs #163

## Summary
- Reject missing or blank `MERGEWORK_DATABASE_URL` during deploy readiness.
- Reject leading/trailing whitespace and control characters in `MERGEWORK_DATABASE_URL` before URL-specific validation.
- Add focused deploy-readiness regressions for empty, blank, whitespace-padded, and newline-containing database URL values.

## Before / After
Before this change, these deploy settings passed readiness with no database-url error:
- `MERGEWORK_DATABASE_URL=`
- `MERGEWORK_DATABASE_URL="   "`
- `MERGEWORK_DATABASE_URL=" postgresql://mergework:password@db.example.test/mergework"`
- `MERGEWORK_DATABASE_URL="postgresql://mergework:password@db.example.test/mergework\nextra"`

After this change they return the existing required-value, whitespace, or control-character deploy-readiness errors.

## Evidence
- `uv run --python 3.12 --extra dev pytest tests/test_deploy_readiness.py -q` -> 20 passed.
- `uv run --python 3.12 --extra dev pytest -q` -> 172 passed, 2 warnings.
- `uv run --python 3.12 --extra dev ruff check app/config.py tests/test_deploy_readiness.py` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check app/config.py tests/test_deploy_readiness.py` -> 2 files already formatted.
- `uv run --python 3.12 --extra dev mypy app` -> success.
- `python3 scripts/check_agents.py` -> AGENTS.md ok.
- `python3 scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> no output.

No secrets, wallet material, private vulnerability details, deployment credentials, or MRWK price claims are included.