### PR TITLE
Validate deploy database URL schemes

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -78,7 +78,15 @@ def _is_valid_dns_hostname(hostname: str) -> bool:
 
 def _sqlite_database_errors(database_url: str) -> list[str]:
     parsed = urlparse(database_url)
-    if not parsed.scheme.startswith("sqlite"):
+    is_sqlite = parsed.scheme == "sqlite" or parsed.scheme.startswith("sqlite+")
+    is_postgres = (
+        parsed.scheme in {"postgres", "postgresql"}
+        or parsed.scheme.startswith("postgres+")
+        or parsed.scheme.startswith("postgresql+")
+    )
+    if not (is_sqlite or is_postgres):
+        return ["MERGEWORK_DATABASE_URL must use sqlite, postgresql, or postgres"]
+    if not is_sqlite:
         return []
 
     sqlite_path = parsed.path

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -131,6 +131,37 @@ def test_deploy_readiness_accepts_absolute_sqlite_and_external_database_urls() -
         )
         == []
     )
+    assert (
+        validate_deploy_settings(
+            _settings(
+                database_url="postgresql+psycopg://mergework:password@db.example.test/mergework"
+            )
+        )
+        == []
+    )
+    assert (
+        validate_deploy_settings(
+            _settings(
+                database_url="postgres+psycopg://mergework:password@db.example.test/mergework"
+            )
+        )
+        == []
+    )
+
+
+def test_deploy_readiness_rejects_malformed_database_url_schemes() -> None:
+    missing_scheme_errors = validate_deploy_settings(_settings(database_url="not-a-url"))
+    unsupported_scheme_errors = validate_deploy_settings(
+        _settings(database_url="ftp://db.example.test/mergework")
+    )
+    sqlite_lookalike_errors = validate_deploy_settings(
+        _settings(database_url="sqlitefoo:////srv/mergework/data/app.sqlite3")
+    )
+
+    expected = "MERGEWORK_DATABASE_URL must use sqlite, postgresql, or postgres"
+    assert expected in missing_scheme_errors
+    assert expected in unsupported_scheme_errors
+    assert expected in sqlite_lookalike_errors
 
 
 def test_deploy_readiness_requires_https_oauth_and_allowed_labelers() -> None:


### PR DESCRIPTION
Refs #163

## Summary
- Reject malformed or unsupported `MERGEWORK_DATABASE_URL` schemes during deploy readiness.
- Preserve SQLite/Postgres driver URLs such as `sqlite+...`, `postgres+...`, and `postgresql+...`.
- Add regressions for missing schemes, unsupported schemes, and SQLite lookalike schemes.

## Before / After
Before this change, `not-a-url`, `ftp://db.example.test/mergework`, and `sqlitefoo:////srv/mergework/data/app.sqlite3` returned no database-url readiness error. After this change they return `MERGEWORK_DATABASE_URL must use sqlite, postgresql, or postgres`, while valid driver URLs still pass.

## Evidence
- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py -q` -> 20 passed.
- `uv run --extra dev python -m pytest -q` -> 172 passed, 2 warnings.
- `uv run --extra dev ruff check app/config.py tests/test_deploy_readiness.py` -> passed.
- `uv run --extra dev ruff format --check app/config.py tests/test_deploy_readiness.py` -> 2 files already formatted.
- `uv run --extra dev python -m mypy app` -> success.
- `uv run --extra dev python scripts/check_agents.py && uv run --extra dev python scripts/docs_smoke.py && git diff --check` -> ok.

No secrets, wallet material, private vulnerability details, deployment credentials, or MRWK price claims are included.
