### PR TITLE
Document MCP proof response example

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -92,3 +92,34 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_bounty","arguments":{"id":11}}}'
 ```
+
+Call `get_proof` with the proof hash returned by `/api/v1/ledger`,
+`/api/v1/activity`, or `get_ledger_entry`:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"get_proof","arguments":{"hash":"<proof_hash>"}}}'
+```
+
+The MCP response uses JSON-RPC content blocks. The first content block is a JSON
+string with proof metadata plus the stored public proof payload:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"hash\":\"<proof_hash>\",\"kind\":\"bounty_payment\",\"ledger_sequence\":322,\"bounty_id\":32,\"submission_id\":279,\"created_at\":\"2026-05-24T20:28:53.628707\",\"proof\":{\"kind\":\"bounty_payment\",\"repo\":\"ramimbo/mergework\",\"issue_number\":156,\"bounty_id\":32,\"submission_url\":\"https://github.com/ramimbo/mergework/pull/155#pullrequestreview-4353350771\",\"to_account\":\"github:ckeplinger199\",\"amount_mrwk\":\"40\"}}"
+      }
+    ]
+  }
+}
+```
+
+In that MCP payload, `bounty_id` is the internal MergeWork bounty id. The
+`proof.issue_number` value is the source GitHub issue number when the proof was
+created from a GitHub bounty claim.

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -30,6 +30,19 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "public_key_hex" in examples
 
 
+def test_api_examples_document_mcp_get_proof_response_shape() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert '"name":"get_proof"' in examples
+    assert '"arguments":{"hash":"<proof_hash>"}' in examples
+    assert '"result": {' in examples
+    assert '"content": [' in examples
+    assert '"type": "text"' in examples
+    assert '\\"hash\\":\\"<proof_hash>\\"' in examples
+    assert '\\"kind\\":\\"bounty_payment\\"' in examples
+    assert "proof.issue_number" in examples
+
+
 def test_agent_guide_explains_internal_bounty_ids() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Refs #162

## Summary
- Add a `get_proof` MCP example to `docs/api-examples.md`.
- Show that MCP `tools/call` returns JSON-RPC content blocks whose first text block is a JSON string.
- Clarify that top-level `bounty_id` is the internal MergeWork bounty id while `proof.issue_number` is the source GitHub issue number.
- Add a docs regression that keeps the `get_proof` command and response shape covered.

## Evidence
Compared the docs change against `app/main.py::_call_mcp_tool()` and the live unauthenticated MCP response. Live readback used `get_proof` for proof hash `385ee38b4db15ae84f36c43cf0fe40fbebb8f706e75ce85e8bd297f9e4e1e778`; the response included JSON-RPC `result.content[0].type="text"`, and the text JSON contained `hash`, `kind`, `ledger_sequence`, `bounty_id`, `submission_id`, `created_at`, and nested `proof` fields including `issue_number`.

Checks:
- `uv run --python 3.12 --extra dev pytest tests/test_docs_public_urls.py -q` -> 7 passed.
- `uv run --python 3.12 --extra dev pytest -q` -> 172 passed, 2 warnings.
- `python3 scripts/docs_smoke.py` -> docs smoke ok.
- `python3 scripts/check_agents.py` -> AGENTS.md ok.
- `uv run --python 3.12 --extra dev ruff check tests/test_docs_public_urls.py` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check tests/test_docs_public_urls.py` -> 1 file already formatted.
- `uv run --python 3.12 --extra dev mypy app` -> success.
- `git diff --check` -> no output.

No private keys, seed material, secrets, private vulnerability details, deployment credentials, or price claims are included.