### PR TITLE
Validate deploy public base URL text

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -139,6 +139,7 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
             errors.append(
                 "MERGEWORK_GITHUB_ACCEPTED_LABELERS must be included in MERGEWORK_ADMIN_LOGINS"
             )
+    errors.extend(_required_env_value_errors("MERGEWORK_PUBLIC_BASE_URL", settings.public_base_url))
     try:
         parsed_base_url = urlparse(settings.public_base_url)
     except ValueError:

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -157,6 +157,30 @@ def test_deploy_readiness_rejects_malformed_oauth_client_id() -> None:
     assert "MERGEWORK_GITHUB_OAUTH_CLIENT_ID must not include control characters" in control_errors
 
 
+def test_deploy_readiness_rejects_public_base_url_text_errors() -> None:
+    empty_errors = validate_deploy_settings(_settings(public_base_url=""))
+    whitespace_errors = validate_deploy_settings(
+        _settings(public_base_url=" https://staging.mrwk.example.test")
+    )
+    trailing_whitespace_errors = validate_deploy_settings(
+        _settings(public_base_url="https://staging.mrwk.example.test ")
+    )
+    control_errors = validate_deploy_settings(
+        _settings(public_base_url="https://staging.mrwk.example.test\nextra")
+    )
+
+    assert "MERGEWORK_PUBLIC_BASE_URL is required" in empty_errors
+    assert (
+        "MERGEWORK_PUBLIC_BASE_URL must not include leading or trailing whitespace"
+        in whitespace_errors
+    )
+    assert (
+        "MERGEWORK_PUBLIC_BASE_URL must not include leading or trailing whitespace"
+        in trailing_whitespace_errors
+    )
+    assert "MERGEWORK_PUBLIC_BASE_URL must not include control characters" in control_errors
+
+
 def test_deploy_readiness_rejects_non_admin_accepted_labelers() -> None:
     errors = validate_deploy_settings(
         _settings(


### PR DESCRIPTION
Refs #163

This tightens deploy readiness around `MERGEWORK_PUBLIC_BASE_URL` text before the URL-shape checks run.

Before this change, a value like `" https://staging.mrwk.example.test"` or `"https://staging.mrwk.example.test\nextra"` could pass deploy readiness, and a trailing-space value only surfaced as a generic host error. The check now reuses the existing required-env validation path so empty values, leading/trailing whitespace, and control characters are reported directly for `MERGEWORK_PUBLIC_BASE_URL`.

Added a focused regression covering empty, leading whitespace, trailing whitespace, and newline-bearing public base URL values.

Verification:
- Windows: `python -m pytest tests\test_deploy_readiness.py -q` -> 20 passed
- Windows: `python -m pytest -q` -> 172 passed, 2 warnings
- Windows: `python -m ruff format --check .` -> 36 files already formatted
- Windows: `python -m ruff check .` -> All checks passed
- Windows: `python -m mypy app` -> Success
- Windows: `python scripts\check_agents.py` -> AGENTS.md ok
- Windows: `python scripts\docs_smoke.py` -> docs smoke ok
- Windows: `git diff --check` -> no output
- Linux Docker fallback (`python:3.12-slim`, clean clone with this patch): pytest, ruff format/check, mypy, AGENTS, docs smoke, and `git diff --check` passed

No secrets, deployment values, private context, or MRWK price claims are included.