### PR TITLE
Reject empty URL credential markers

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -84,7 +84,7 @@ def validate_public_url(url: str) -> str:
     parsed = urlparse(clean)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise LedgerError("URL must use http or https")
-    if parsed.username or parsed.password:
+    if parsed.username is not None or parsed.password is not None:
         raise LedgerError("URL must not include credentials")
     return clean
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -23,6 +23,7 @@ from app.ledger.service import (
     pay_bounty,
     public_url_or_none,
     register_wallet,
+    validate_public_url,
 )
 from app.main import _signed_value, create_app
 from app.models import LedgerEntry, WebhookEvent
@@ -494,6 +495,10 @@ def test_bounty_urls_reject_unsafe_schemes(sqlite_url: str) -> None:
 
 
 def test_bounty_urls_reject_embedded_credentials(sqlite_url: str) -> None:
+    with pytest.raises(LedgerError, match="URL must not include credentials"):
+        validate_public_url("https://@github.com/ramimbo/mergework/issues/9")
+    assert public_url_or_none("https://@github.com/ramimbo/mergework/issues/9") is None
+
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
         ensure_genesis(session)


### PR DESCRIPTION
Refs #122.

## Summary
- reject public URLs that contain an empty userinfo marker such as `https://@example.com/path`
- keep the existing credential error path while preserving ordinary public HTTP(S) URLs
- add regression coverage for direct validation and `public_url_or_none()`

## Validation
- `uv run --python 3.12 --extra dev pytest tests/test_security.py::test_bounty_urls_reject_embedded_credentials tests/test_security.py::test_bounty_urls_reject_unsafe_schemes -q`
- `uv run --python 3.12 --extra dev pytest tests/test_security.py tests/test_ledger.py tests/test_api_mcp.py tests/test_bounty_pages.py -q`
- `uv run --python 3.12 --extra dev pytest -q`
- `uv run --python 3.12 --extra dev ruff check app/ledger/service.py tests/test_security.py`
- `uv run --python 3.12 --extra dev ruff format --check app/ledger/service.py tests/test_security.py`
- `uv run --python 3.12 --extra dev mypy app`
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py`
- `uv run --python 3.12 --extra dev python scripts/check_agents.py`

No secrets, wallet material, private context, deployment values, or MRWK price claims are included.