### PR TITLE
Document account API response example

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -49,6 +49,24 @@ curl -s "$API_HOST/api/v1/accounts/treasury:mrwk"
 curl -s "$API_HOST/api/v1/wallets/mrwk1..."
 ```
 
+Account responses identify the normalized ledger address, optional GitHub login,
+existence, current balance, and whether the account can move funds directly:
+
+```json
+{
+  "account": "github:tatelyman",
+  "ledger_address": "github:tatelyman",
+  "github_login": "tatelyman",
+  "exists": true,
+  "balance_mrwk": "395",
+  "transfer_status": "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
+}
+```
+
+For `treasury:` and `reserve:` accounts, `github_login` is `null` and
+`transfer_status` explains that direct MRWK wallet transfers are only available
+for registered `mrwk1` addresses.
+
 Register a wallet public key. Keep the private key local; only send the public
 key to MergeWork.
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -30,6 +30,19 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "public_key_hex" in examples
 
 
+def test_api_examples_document_account_response_shape() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/accounts/treasury:mrwk" in examples
+    assert '"ledger_address": "github:tatelyman"' in examples
+    assert '"github_login": "tatelyman"' in examples
+    assert '"exists": true' in examples
+    assert '"balance_mrwk": "395"' in examples
+    assert "Claim GitHub balances from /me" in examples
+    assert "treasury:" in examples
+    assert "registered `mrwk1` addresses" in examples
+
+
 def test_agent_guide_explains_internal_bounty_ids() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Refs #162

## Summary
- Add a concrete `/api/v1/accounts/{account}` response example to `docs/api-examples.md`.
- Show the actual account fields: normalized `account`, `ledger_address`, optional `github_login`, `exists`, `balance_mrwk`, and `transfer_status`.
- Clarify that `treasury:` and `reserve:` accounts do not map to GitHub logins and cannot directly transfer MRWK like registered `mrwk1` wallet addresses.
- Add a docs regression for the account response shape.

## Evidence
Compared the docs change against `app/main.py::api_account()` and the live unauthenticated response from `GET https://api.mrwk.ltclab.site/api/v1/accounts/github:tatelyman`, which returned the documented fields with `account=github:tatelyman`, `ledger_address=github:tatelyman`, `github_login=tatelyman`, `exists=true`, `balance_mrwk=395`, and the GitHub-claim transfer guidance.

Checks:
- `uv run --python 3.12 --extra dev pytest tests/test_docs_public_urls.py -q` -> 7 passed.
- `uv run --python 3.12 --extra dev pytest -q` -> 172 passed, 2 warnings.
- `python3 scripts/docs_smoke.py` -> docs smoke ok.
- `python3 scripts/check_agents.py` -> AGENTS.md ok.
- `uv run --python 3.12 --extra dev ruff check tests/test_docs_public_urls.py` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check tests/test_docs_public_urls.py` -> 1 file already formatted.
- `uv run --python 3.12 --extra dev mypy app` -> success.
- `git diff --check` -> no output.

No private keys, seed material, secrets, private vulnerability details, deployment credentials, or price claims are included.