### PR TITLE
Add bounty list summary cards

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ import re
 import secrets
 import time
 from datetime import datetime
+from decimal import Decimal
 from pathlib import Path
 from typing import Annotated, Any
 from urllib.parse import urlencode, urlsplit, urlunsplit
@@ -119,6 +120,20 @@ def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
         "status": bounty.status,
         "acceptance": bounty.acceptance,
         "created_at": bounty.created_at.isoformat(),
+    }
+
+
+def bounty_list_summary(bounties: list[dict[str, Any]]) -> dict[str, Any]:
+    open_awards = sum(int(bounty["awards_remaining"]) for bounty in bounties)
+    open_pool_microunits = sum(
+        int(Decimal(str(bounty["reward_mrwk"])) * Decimal(1_000_000))
+        * int(bounty["awards_remaining"])
+        for bounty in bounties
+    )
+    return {
+        "bounties_shown": len(bounties),
+        "open_awards": open_awards,
+        "open_pool_mrwk": format_mrwk(open_pool_microunits),
     }
 
 
@@ -1038,11 +1053,13 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     ) -> HTMLResponse:
         selected_status = status.strip().lower() if status is not None else None
         query_text = q.strip() if q is not None else ""
+        bounties = list_bounties_by_status(status, q)
         return templates.TemplateResponse(
             request,
             "bounties.html",
             {
-                "bounties": list_bounties_by_status(status, q),
+                "bounties": bounties,
+                "summary": bounty_list_summary(bounties),
                 "selected_status": selected_status,
                 "query_text": query_text,
             },

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -224,6 +224,28 @@ code.hash { overflow-wrap: anywhere; }
   padding: 4px 10px;
   text-transform: capitalize;
 }
+.bounty-list-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin: 24px 0;
+}
+.bounty-list-summary article {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 6px;
+  padding: 14px;
+}
+.bounty-list-summary span {
+  display: block;
+  color: var(--muted);
+  font-size: .9rem;
+  margin-bottom: 6px;
+}
+.bounty-list-summary strong {
+  display: block;
+  font-size: 1.25rem;
+}
 .acceptance-card h2 {
   margin: 0 0 10px;
 }

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -16,6 +16,20 @@
   <a href="/bounties?status=closed{% if query_text %}&q={{ query_text | urlencode }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
 </nav>
 {% if query_text %}<p>Showing matches for “{{ query_text }}”.</p>{% endif %}
+<section class="bounty-list-summary" aria-label="Bounty list summary">
+  <article>
+    <span>Bounties shown</span>
+    <strong>{{ summary.bounties_shown }}</strong>
+  </article>
+  <article>
+    <span>Awards open</span>
+    <strong>{{ summary.open_awards }}</strong>
+  </article>
+  <article>
+    <span>Open reward pool</span>
+    <strong>{{ summary.open_pool_mrwk }} MRWK</strong>
+  </article>
+</section>
 <div class="list">
   {% for bounty in bounties %}
   <article>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -50,6 +50,12 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
         in all_rows.text
     )
     assert "ramimbo/mergework #50" in all_rows.text
+    assert "Bounty list summary" in all_rows.text
+    assert "Bounties shown" in all_rows.text
+    assert "Awards open" in all_rows.text
+    assert "Open reward pool" in all_rows.text
+    assert "1</strong>" in all_rows.text
+    assert "50 MRWK</strong>" in all_rows.text
 
     paid_rows = client.get("/bounties?status=paid")
     assert paid_rows.status_code == 200
@@ -57,6 +63,7 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert "Open public bounty" not in paid_rows.text
     assert f'href="/bounties/{paid_bounty.id}"' in paid_rows.text
     assert 'href="/bounties?status=paid"' in paid_rows.text
+    assert "0 MRWK</strong>" in paid_rows.text
 
     paid_rows_uppercase = client.get("/bounties?status=PAID")
     assert paid_rows_uppercase.status_code == 200


### PR DESCRIPTION
## Summary
- Adds a compact /bounties summary showing bounties shown, open award slots, and total open MRWK pool for the active status filter.
- Keeps the existing list and status filters intact while making contributor discovery faster.

Bounty #164

## Verification
- ./.venv/bin/python -m pytest tests/test_bounty_pages.py -q
- ./.venv/bin/python -m pytest tests/test_bounty_pages.py tests/test_activity.py tests/test_api_mcp.py -q
- ./.venv/bin/python -m ruff format --check .
- ./.venv/bin/python -m ruff check .
- git diff --check