### PR TITLE
Validate deploy public base URL text

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -139,6 +139,7 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
             errors.append(
                 "MERGEWORK_GITHUB_ACCEPTED_LABELERS must be included in MERGEWORK_ADMIN_LOGINS"
             )
+    errors.extend(_required_env_value_errors("MERGEWORK_PUBLIC_BASE_URL", settings.public_base_url))
     try:
         parsed_base_url = urlparse(settings.public_base_url)
     except ValueError:

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -147,6 +147,25 @@ def test_deploy_readiness_requires_https_oauth_and_allowed_labelers() -> None:
     assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS must list maintainer logins" in errors
 
 
+def test_deploy_readiness_rejects_public_base_url_text_hazards() -> None:
+    whitespace_errors = validate_deploy_settings(
+        _settings(public_base_url=" https://staging.mrwk.example.test")
+    )
+    newline_errors = validate_deploy_settings(
+        _settings(public_base_url="https://staging.mrwk.example.test\n")
+    )
+    tab_errors = validate_deploy_settings(
+        _settings(public_base_url="https://staging.mrwk.example.test\t")
+    )
+
+    assert (
+        "MERGEWORK_PUBLIC_BASE_URL must not include leading or trailing whitespace"
+        in whitespace_errors
+    )
+    assert "MERGEWORK_PUBLIC_BASE_URL must not include control characters" in newline_errors
+    assert "MERGEWORK_PUBLIC_BASE_URL must not include control characters" in tab_errors
+
+
 def test_deploy_readiness_rejects_malformed_oauth_client_id() -> None:
     whitespace_errors = validate_deploy_settings(_settings(github_oauth_client_id=" client-id"))
     control_errors = validate_deploy_settings(_settings(github_oauth_client_id="client-id\nextra"))


### PR DESCRIPTION
Refs #163

## Summary
- Reject `MERGEWORK_PUBLIC_BASE_URL` values with leading/trailing whitespace during deploy readiness.
- Reject public-base URL control characters before `urlparse()` can normalize newline or tab characters away.
- Add focused deploy-readiness regressions for leading space, trailing newline, and trailing tab inputs.

## Before / After
Before this change, `MERGEWORK_PUBLIC_BASE_URL` values ending in a real newline or tab returned no public-base readiness error because URL parsing normalized those characters. After this change they return the existing whitespace/control-character deploy-readiness errors, while a clean HTTPS origin still passes.

## Evidence
- Red before fix: `uv run --extra dev python -m pytest tests/test_deploy_readiness.py::test_deploy_readiness_rejects_public_base_url_text_hazards -q` failed because a leading-space public base URL returned no error.
- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py::test_deploy_readiness_rejects_public_base_url_text_hazards -q` -> 1 passed.
- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py -q` -> 20 passed.
- `uv run --extra dev python -m pytest -q` -> 172 passed, 2 warnings.
- `uv run --extra dev ruff check app/config.py tests/test_deploy_readiness.py` and `ruff format --check` -> passed.
- `uv run --extra dev python -m mypy app` -> success.
- `uv run --extra dev python scripts/check_agents.py && uv run --extra dev python scripts/docs_smoke.py && git diff --check` -> ok.

No secrets, wallet material, private vulnerability details, deployment credentials, or MRWK price claims are included.
