### PR TITLE
Document ledger API response example

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -35,6 +35,27 @@ curl -s "$API_HOST/api/v1/ledger?limit=10"
 curl -s "$API_HOST/api/v1/ledger/<sequence>"
 ```
 
+Ledger entries use the internal immutable sequence number as the API path key.
+Recent-list and single-entry responses share the same shape:
+
+```json
+{
+  "sequence": 329,
+  "type": "bounty_reserve",
+  "from": "treasury:mrwk",
+  "to": "reserve:bounty:36",
+  "amount_mrwk": "500",
+  "reference": "https://github.com/ramimbo/mergework/issues/164",
+  "previous_hash": "25c9c46690780ffc5fe49a71c29c9d6343fe4ecbf9d0b98b56ce9dc5c94dd58a",
+  "entry_hash": "248e1e38f90ac42897486a2b52a938ad51f31849250c4a979358e9721ec7c64e",
+  "proof_hash": null,
+  "created_at": "2026-05-24T20:44:00.019706"
+}
+```
+
+`proof_hash` is `null` for non-proof ledger entries such as bounty reserves. It
+contains a proof hash for bounty-payment ledger entries that have a public proof.
+
 Read accepted-work activity summarized from proof-backed bounty payments:
 
 ```bash

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -30,6 +30,23 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "public_key_hex" in examples
 
 
+def test_api_examples_document_ledger_response_shape() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/ledger?limit=10" in examples
+    assert "/api/v1/ledger/<sequence>" in examples
+    assert '"sequence": 329' in examples
+    assert '"type": "bounty_reserve"' in examples
+    assert '"from": "treasury:mrwk"' in examples
+    assert '"to": "reserve:bounty:36"' in examples
+    assert (
+        '"entry_hash": "248e1e38f90ac42897486a2b52a938ad51f31849250c4a979358e9721ec7c64e"'
+        in examples
+    )
+    assert '"proof_hash": null' in examples
+    assert "bounty-payment ledger entries" in examples
+
+
 def test_agent_guide_explains_internal_bounty_ids() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Refs #162

## Summary
- Add a concrete `/api/v1/ledger` response example to `docs/api-examples.md`.
- Clarify that ledger APIs use the immutable internal `sequence` as the single-entry path key.
- Document the shared recent-list/single-entry shape, including `previous_hash`, `entry_hash`, nullable `proof_hash`, and reserve-entry behavior.
- Add a docs regression for the ledger response fields.

## Evidence
Compared the docs change against `app/main.py::ledger_to_dict()` and a live unauthenticated readback from `GET https://api.mrwk.ltclab.site/api/v1/ledger?limit=1`, which returned sequence `329`, type `bounty_reserve`, `from=treasury:mrwk`, `to=reserve:bounty:36`, amount `500`, reference to issue `#164`, the documented hashes, `proof_hash=null`, and `created_at`.

Checks:
- `uv run --python 3.12 --extra dev pytest tests/test_docs_public_urls.py -q` -> 7 passed.
- `uv run --python 3.12 --extra dev pytest -q` -> 172 passed, 2 warnings.
- `python3 scripts/docs_smoke.py` -> docs smoke ok.
- `python3 scripts/check_agents.py` -> AGENTS.md ok.
- `uv run --python 3.12 --extra dev ruff check tests/test_docs_public_urls.py` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check tests/test_docs_public_urls.py` -> 1 file already formatted.
- `uv run --python 3.12 --extra dev mypy app` -> success.
- `git diff --check` -> no output.

No private keys, seed material, secrets, private vulnerability details, deployment credentials, or price claims are included.