### PR TITLE
Reject empty login CSV entries in deploy readiness

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -35,9 +35,10 @@ DNS_LABEL_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
 
 
 def _csv_env(name: str, default: str = "") -> tuple[str, ...]:
-    return tuple(
-        item.strip().lower() for item in os.environ.get(name, default).split(",") if item.strip()
-    )
+    raw_value = os.environ.get(name, default)
+    if not raw_value.strip():
+        return ()
+    return tuple(item.strip().lower() for item in raw_value.split(","))
 
 
 def _secret_errors(name: str, value: str) -> list[str]:
@@ -66,7 +67,12 @@ def _required_env_value_errors(name: str, value: str) -> list[str]:
 
 
 def _invalid_github_logins(logins: tuple[str, ...]) -> list[str]:
-    return sorted({login for login in logins if not GITHUB_LOGIN_RE.fullmatch(login)})
+    return sorted({login for login in logins if login and not GITHUB_LOGIN_RE.fullmatch(login)})
+
+
+def _duplicate_github_logins(logins: tuple[str, ...]) -> bool:
+    present_logins = [login for login in logins if login]
+    return len(set(present_logins)) != len(present_logins)
 
 
 def _is_valid_dns_hostname(hostname: str) -> bool:
@@ -120,21 +126,25 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
     if not settings.admin_logins:
         errors.append("MERGEWORK_ADMIN_LOGINS must list admin GitHub logins")
     else:
-        if len(set(settings.admin_logins)) != len(settings.admin_logins):
+        if "" in settings.admin_logins:
+            errors.append("MERGEWORK_ADMIN_LOGINS must not include empty entries")
+        if _duplicate_github_logins(settings.admin_logins):
             errors.append("MERGEWORK_ADMIN_LOGINS must not include duplicate logins")
         if _invalid_github_logins(settings.admin_logins):
             errors.append("MERGEWORK_ADMIN_LOGINS must contain valid GitHub logins")
     if not settings.github_accepted_labelers:
         errors.append("MERGEWORK_GITHUB_ACCEPTED_LABELERS must list maintainer logins")
     else:
-        if len(set(settings.github_accepted_labelers)) != len(settings.github_accepted_labelers):
+        if "" in settings.github_accepted_labelers:
+            errors.append("MERGEWORK_GITHUB_ACCEPTED_LABELERS must not include empty entries")
+        if _duplicate_github_logins(settings.github_accepted_labelers):
             errors.append("MERGEWORK_GITHUB_ACCEPTED_LABELERS must not include duplicate logins")
         if _invalid_github_logins(settings.github_accepted_labelers):
             errors.append("MERGEWORK_GITHUB_ACCEPTED_LABELERS must contain valid GitHub logins")
     if settings.admin_logins and settings.github_accepted_labelers:
-        non_admin_labelers = sorted(
-            set(settings.github_accepted_labelers) - set(settings.admin_logins)
-        )
+        admin_login_set = {login for login in settings.admin_logins if login}
+        accepted_labeler_set = {login for login in settings.github_accepted_labelers if login}
+        non_admin_labelers = sorted(accepted_labeler_set - admin_login_set)
         if non_admin_labelers:
             errors.append(
                 "MERGEWORK_GITHUB_ACCEPTED_LABELERS must be included in MERGEWORK_ADMIN_LOGINS"

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import sys
 
-from app.config import Settings, validate_deploy_settings
+from app.config import Settings, get_settings, validate_deploy_settings
 
 
 def _settings(**overrides: object) -> Settings:
@@ -190,6 +190,32 @@ def test_deploy_readiness_rejects_invalid_admin_or_labeler_logins() -> None:
 
     assert "MERGEWORK_ADMIN_LOGINS must contain valid GitHub logins" in errors
     assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS must contain valid GitHub logins" in errors
+
+
+def test_deploy_readiness_rejects_empty_login_csv_entries(monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_DATABASE_URL", "sqlite:////srv/mergework/data/app.sqlite3")
+    monkeypatch.setenv("MERGEWORK_PUBLIC_BASE_URL", "https://staging.mrwk.example.test")
+    monkeypatch.setenv(
+        "MERGEWORK_GITHUB_WEBHOOK_SECRET", "webhook-8efc3925bb8746b8a8fd3392c4c48e32"
+    )
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv(
+        "MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", "oauth-7818e79f9d3a4a1d82ff0e1b9f0b8e42"
+    )
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-14dcaab83bb245f2bfb5d5c21a9bb55b")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "cookie-27fd1c41324a4bdcb2e4014adc3a6108")
+    monkeypatch.setenv("MERGEWORK_ADMIN_LOGINS", "alice,")
+    monkeypatch.setenv("MERGEWORK_GITHUB_ACCEPTED_LABELERS", "alice,,")
+
+    errors = validate_deploy_settings(get_settings())
+
+    assert "MERGEWORK_ADMIN_LOGINS must not include empty entries" in errors
+    assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS must not include empty entries" in errors
+    assert "MERGEWORK_ADMIN_LOGINS must not include duplicate logins" not in errors
+    assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS must not include duplicate logins" not in errors
+    assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS must be included in MERGEWORK_ADMIN_LOGINS" not in (
+        errors
+    )
 
 
 def test_deploy_readiness_rejects_public_base_url_path_query_or_fragment() -> None:


### PR DESCRIPTION
Summary:
Reject empty GitHub login markers in deploy-readiness CSV settings.

Related bounty or issue:
Bounty #163

What changed:
- Preserve empty comma-separated entries from `MERGEWORK_ADMIN_LOGINS` and `MERGEWORK_GITHUB_ACCEPTED_LABELERS` once the env var has nonblank content.
- Report a focused deploy-readiness error when either login list contains an empty entry.
- Keep whitespace around normal entries accepted after stripping, so common values like `alice, bob` continue to work.

Concrete before/after:
- Before: `MERGEWORK_ADMIN_LOGINS=alice,` and `MERGEWORK_GITHUB_ACCEPTED_LABELERS=alice,,` were normalized to `alice` and passed deploy readiness.
- After: those values fail deploy readiness with explicit empty-entry errors, preventing an operator from shipping a malformed account list.

Validation:
- `uv run --extra dev pytest tests/test_deploy_readiness.py -q` -> 20 passed.
- `uv run --extra dev pytest -q` -> 172 passed, 2 warnings.
- `uv run --extra dev ruff check app/config.py tests/test_deploy_readiness.py` -> passed.
- `uv run --extra dev ruff format --check app/config.py tests/test_deploy_readiness.py` -> passed.
- `uv run --extra dev mypy app` -> success.
- `python3 scripts/check_agents.py` -> AGENTS.md ok.
- `python3 scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> no output.

Notes:
No secrets, wallet material, private vulnerability details, deployment credentials, or MRWK price claims are included.
