### PR TITLE
Document bounties API response example

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -14,7 +14,32 @@ Check service status and list bounties:
 ```bash
 curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
+curl -s "$API_HOST/api/v1/bounties?status=open"
 ```
+
+The bounties list returns public bounty rows. `status` can be omitted or set to
+`open`, `paid`, or `closed`:
+
+```json
+{
+  "id": 36,
+  "repo": "ramimbo/mergework",
+  "issue_number": 164,
+  "issue_url": "https://github.com/ramimbo/mergework/issues/164",
+  "title": "MRWK bounty: contributor activity and bounty discovery improvements",
+  "reward_mrwk": "100",
+  "reserved_mrwk": "500",
+  "max_awards": 5,
+  "awards_paid": 0,
+  "awards_remaining": 5,
+  "status": "open",
+  "acceptance": "Focused public-facing enhancements that help contributors find bounties, inspect accepted work, or understand proof/account activity, with tests. Duplicate, marketing-only, docs-only, broad redesign, or unrelated changes do not qualify.",
+  "created_at": "2026-05-24T20:44:00.015953"
+}
+```
+
+Use `id` for the single-bounty API path. Use `issue_number` and `issue_url` when
+linking back to the source GitHub issue.
 
 Read a single bounty with its internal `id` from `/api/v1/bounties`:
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -30,6 +30,20 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "public_key_hex" in examples
 
 
+def test_api_examples_document_bounty_list_response_shape() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/bounties?status=open" in examples
+    assert "status` can be omitted or set to" in examples
+    assert '"id": 36' in examples
+    assert '"repo": "ramimbo/mergework"' in examples
+    assert '"issue_number": 164' in examples
+    assert '"reward_mrwk": "100"' in examples
+    assert '"reserved_mrwk": "500"' in examples
+    assert '"awards_remaining": 5' in examples
+    assert "Use `id` for the single-bounty API path" in examples
+
+
 def test_agent_guide_explains_internal_bounty_ids() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Refs #162

## Summary
- Add a concrete `/api/v1/bounties?status=open` response example to `docs/api-examples.md`.
- Document the allowed `status` filter values.
- Clarify which field is the internal API `id` versus source GitHub `issue_number` / `issue_url`.
- Add a docs regression for the bounty-list response fields.

## Evidence
Compared the docs change against `app/main.py::bounty_to_dict()` and live unauthenticated readback from `GET https://api.mrwk.ltclab.site/api/v1/bounties?status=open`. The first row returned the documented Bounty #164 row with id `36`, repo `ramimbo/mergework`, issue number `164`, reward `100`, reserved `500`, `5` max/open awards, `status=open`, and the documented acceptance text.

Checks:
- `uv run --python 3.12 --extra dev pytest tests/test_docs_public_urls.py -q` -> 7 passed.
- `uv run --python 3.12 --extra dev pytest -q` -> 172 passed, 2 warnings.
- `python3 scripts/docs_smoke.py` -> docs smoke ok.
- `python3 scripts/check_agents.py` -> AGENTS.md ok.
- `uv run --python 3.12 --extra dev ruff check tests/test_docs_public_urls.py` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check tests/test_docs_public_urls.py` -> 1 file already formatted.
- `uv run --python 3.12 --extra dev mypy app` -> success.
- `git diff --check` -> no output.

No private keys, seed material, secrets, private vulnerability details, deployment credentials, or price claims are included.