### PR TITLE
Document wallet API response example

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -46,7 +46,24 @@ Inspect a proof, account, or registered wallet:
 ```bash
 curl -s "$API_HOST/api/v1/proofs/<proof_hash>"
 curl -s "$API_HOST/api/v1/accounts/treasury:mrwk"
-curl -s "$API_HOST/api/v1/wallets/mrwk1..."
+curl -s "$API_HOST/api/v1/wallets/<wallet_address>"
+```
+
+The wallet endpoint is a read-only wallet lookup. It returns the registered
+address, public key, optional label and linked GitHub login, current balance,
+current nonce, next nonce to sign with, and registration timestamp:
+
+```json
+{
+  "address": "mrwk1fb1437aec45b46ec640f44b2e2aced55dc23556e",
+  "public_key_hex": "d88d3edf935ba932ee2737ee5500c795f21caeb4a2fdeacb55a4ff63c52c9d51",
+  "label": null,
+  "github_login": "prettyboyvic",
+  "balance_mrwk": "50",
+  "nonce": 2,
+  "next_nonce": 3,
+  "created_at": "2026-05-24T17:50:56.118158"
+}
 ```
 
 Register a wallet public key. Keep the private key local; only send the public

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -30,6 +30,24 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "public_key_hex" in examples
 
 
+def test_api_examples_document_wallet_response_shape() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/wallets/<wallet_address>" in examples
+    assert '"address": "mrwk1fb1437aec45b46ec640f44b2e2aced55dc23556e"' in examples
+    assert (
+        '"public_key_hex": "d88d3edf935ba932ee2737ee5500c795f21caeb4a2fdeacb55a4ff63c52c9d51"'
+        in examples
+    )
+    assert '"label": null' in examples
+    assert '"github_login": "prettyboyvic"' in examples
+    assert '"balance_mrwk": "50"' in examples
+    assert '"nonce": 2' in examples
+    assert '"next_nonce": 3' in examples
+    assert '"created_at": "2026-05-24T17:50:56.118158"' in examples
+    assert "read-only wallet lookup" in examples
+
+
 def test_agent_guide_explains_internal_bounty_ids() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Refs #162

This adds a concrete read-only `/api/v1/wallets/{wallet_address}` example to `docs/api-examples.md`.

The documented response shape matches `app/main.py::wallet_to_dict()` and a live unauthenticated readback from `GET https://api.mrwk.ltclab.site/api/v1/wallets/mrwk1fb1437aec45b46ec640f44b2e2aced55dc23556e`: address, public key, nullable label, nullable linked GitHub login, balance, current nonce, next nonce, and creation timestamp.

This is separate from the current #162 docs work I found: #175 covers MCP `get_proof`, #178 covers accounts, and #181 covers ledger entries.

Verification:
- Windows: `python -m pytest tests\test_docs_public_urls.py -q` -> 7 passed
- Windows: `python -m pytest -q` -> 172 passed, 2 warnings
- Windows: `python -m ruff format --check tests\test_docs_public_urls.py` -> 1 file already formatted
- Windows: `python -m ruff check .` -> All checks passed
- Windows: `python -m mypy app` -> Success
- Windows: `python scripts\check_agents.py` -> AGENTS.md ok
- Windows: `python scripts\docs_smoke.py` -> docs smoke ok
- Windows: `git diff --check` -> no output
- Linux Docker fallback (`python:3.12-slim`, clean clone with this patch): pytest, ruff format/check, mypy, AGENTS, docs smoke, and `git diff --check` passed

No private keys, seed material, secrets, private vulnerability details, deployment credentials, or price claims are included.