### PR TITLE
Document wallet API response example

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -49,6 +49,25 @@ curl -s "$API_HOST/api/v1/accounts/treasury:mrwk"
 curl -s "$API_HOST/api/v1/wallets/mrwk1..."
 ```
 
+Registered wallet responses include the public key, optional label and GitHub
+link, current ledger balance, and nonce state for the next signed transfer:
+
+```json
+{
+  "address": "mrwk1062bfd1805d9596242fba7630ab1a4393c7cd8c4",
+  "public_key_hex": "93bfbebde4ba363d8e5bf8d4ac23221f76894583d84a6777ce1946c089a89e12",
+  "label": "DYSfu side-income MRWK wallet",
+  "github_login": null,
+  "balance_mrwk": "0",
+  "nonce": 0,
+  "next_nonce": 1,
+  "created_at": "2026-05-24T07:24:56.393662"
+}
+```
+
+`next_nonce` is the value clients should sign for the next wallet transfer.
+`github_login` is `null` until the wallet is linked to a GitHub account.
+
 Register a wallet public key. Keep the private key local; only send the public
 key to MergeWork.
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -30,6 +30,22 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "public_key_hex" in examples
 
 
+def test_api_examples_document_wallet_response_shape() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/wallets/mrwk1..." in examples
+    assert '"address": "mrwk1062bfd1805d9596242fba7630ab1a4393c7cd8c4"' in examples
+    assert (
+        '"public_key_hex": "93bfbebde4ba363d8e5bf8d4ac23221f76894583d84a6777ce1946c089a89e12"'
+        in examples
+    )
+    assert '"label": "DYSfu side-income MRWK wallet"' in examples
+    assert '"github_login": null' in examples
+    assert '"balance_mrwk": "0"' in examples
+    assert '"next_nonce": 1' in examples
+    assert "`next_nonce` is the value clients should sign" in examples
+
+
 def test_agent_guide_explains_internal_bounty_ids() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Refs #162

## Summary
- Add a concrete `/api/v1/wallets/{address}` response example to `docs/api-examples.md`.
- Document public wallet fields: `address`, `public_key_hex`, optional `label`, nullable `github_login`, `balance_mrwk`, `nonce`, `next_nonce`, and `created_at`.
- Clarify that `next_nonce` is the nonce clients should sign for the next wallet transfer.
- Add a docs regression for the wallet response fields.

## Evidence
Compared the docs change against `app/main.py::wallet_to_dict()` and live unauthenticated readback from `GET https://api.mrwk.ltclab.site/api/v1/wallets/mrwk1062bfd1805d9596242fba7630ab1a4393c7cd8c4`, which returned the documented address, public key, label, `github_login=null`, zero balance, nonce `0`, next nonce `1`, and created timestamp.

Checks:
- `uv run --python 3.12 --extra dev pytest tests/test_docs_public_urls.py -q` -> 7 passed.
- `uv run --python 3.12 --extra dev pytest -q` -> 172 passed, 2 warnings.
- `python3 scripts/docs_smoke.py` -> docs smoke ok.
- `python3 scripts/check_agents.py` -> AGENTS.md ok.
- `uv run --python 3.12 --extra dev ruff check tests/test_docs_public_urls.py` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check tests/test_docs_public_urls.py` -> 1 file already formatted.
- `uv run --python 3.12 --extra dev mypy app` -> success.
- `git diff --check` -> no output.

No private keys, seed material, secrets, private vulnerability details, deployment credentials, or price claims are included.