### PR TITLE
Add bounty search to public discovery pages

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -502,7 +502,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             "future_path": "public snapshots, bridges, and onchain claims",
         }
 
-    def list_bounties_by_status(status: str | None = None) -> list[dict[str, Any]]:
+    def list_bounties_by_status(
+        status: str | None = None, search: str | None = None
+    ) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
             query = select(Bounty)
             if status is not None:
@@ -512,12 +514,26 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                         status_code=400, detail="status must be one of: open, paid, closed"
                     )
                 query = query.where(Bounty.status == normalized_status)
-            bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
-            return [bounty_to_dict(bounty) for bounty in bounties]
+            bounties = [
+                bounty_to_dict(bounty)
+                for bounty in session.scalars(query.order_by(Bounty.id.desc())).all()
+            ]
+            normalized_search = search.strip().lower() if search is not None else ""
+            if not normalized_search:
+                return bounties
+            return [
+                bounty
+                for bounty in bounties
+                if normalized_search in bounty["title"].lower()
+                or normalized_search in bounty["repo"].lower()
+                or normalized_search in str(bounty["issue_number"])
+            ]
 
     @app.get("/api/v1/bounties")
-    def api_bounties(status: str | None = Query(None)) -> list[dict[str, Any]]:
-        return list_bounties_by_status(status)
+    def api_bounties(
+        status: str | None = Query(None), q: str | None = Query(None)
+    ) -> list[dict[str, Any]]:
+        return list_bounties_by_status(status, q)
 
     @app.post("/api/v1/bounties")
     async def api_create_bounty(
@@ -923,14 +939,18 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         )
 
     @app.get("/bounties", response_class=HTMLResponse)
-    def bounties_page(request: Request, status: str | None = Query(None)) -> HTMLResponse:
+    def bounties_page(
+        request: Request, status: str | None = Query(None), q: str | None = Query(None)
+    ) -> HTMLResponse:
         selected_status = status.strip().lower() if status is not None else None
+        search_query = q.strip() if q is not None else ""
         return templates.TemplateResponse(
             request,
             "bounties.html",
             {
-                "bounties": list_bounties_by_status(status),
+                "bounties": list_bounties_by_status(status, q),
                 "selected_status": selected_status,
+                "search_query": search_query,
             },
         )
 

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -8,6 +8,14 @@
   <a href="/bounties?status=paid"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
   <a href="/bounties?status=closed"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
 </nav>
+<form method="get" action="/bounties" class="search-bar">
+  {% if selected_status %}
+  <input type="hidden" name="status" value="{{ selected_status }}" />
+  {% endif %}
+  <label for="bounty-search">Search</label>
+  <input id="bounty-search" name="q" value="{{ search_query }}" placeholder="title, repo, or issue #" />
+  <button type="submit">Filter</button>
+</form>
 <div class="list">
   {% for bounty in bounties %}
   <article>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -58,6 +58,49 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert "Paid public bounty" in paid_rows_uppercase.text
     assert "Open public bounty" not in paid_rows_uppercase.text
     assert 'href="/bounties?status=paid" aria-current="page"' in paid_rows_uppercase.text
+    assert 'name="q"' in paid_rows_uppercase.text
+
+
+def test_bounties_page_searches_title_repo_and_issue_number(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=87,
+            issue_url="https://github.com/ramimbo/mergework/issues/87",
+            title="Activity feed polish",
+            reward_mrwk="50",
+            acceptance="Search should find activity-related work.",
+        )
+        create_bounty(
+            session,
+            repo="octo/docs",
+            issue_number=13,
+            issue_url="https://github.com/octo/docs/issues/13",
+            title="Docs typo cleanup",
+            reward_mrwk="25",
+            acceptance="Search should also match repo and issue number.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    title_rows = client.get("/bounties?q=activity")
+    assert title_rows.status_code == 200
+    assert "Activity feed polish" in title_rows.text
+    assert "Docs typo cleanup" not in title_rows.text
+    assert 'value="activity"' in title_rows.text
+
+    repo_rows = client.get("/bounties?q=octo/docs")
+    assert repo_rows.status_code == 200
+    assert "Docs typo cleanup" in repo_rows.text
+    assert "Activity feed polish" not in repo_rows.text
+
+    issue_rows = client.get("/bounties?q=87")
+    assert issue_rows.status_code == 200
+    assert "Activity feed polish" in issue_rows.text
+    assert "Docs typo cleanup" not in issue_rows.text
 
 
 def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #164

## Before
The public bounty list could be filtered by status only, making it harder to find a specific repo, title, or issue number quickly.

## After
- Add a public search field to `/bounties` and `/api/v1/bounties` via `q`.
- Filter by title, repo, or issue number while preserving the existing status filters.
- Cover the new search behavior with regression tests.

## Verification
- `.venv/bin/python -m pytest tests/test_bounty_pages.py -q`
- `.venv/bin/python -m pytest tests/test_bounty_pages.py tests/test_api_mcp.py -q`
