### PR TITLE
Reject whitespace in public URLs

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -81,6 +81,8 @@ def validate_public_url(url: str) -> str:
         raise LedgerError("URL is too long")
     if any(ord(char) < 32 or ord(char) == 127 for char in clean):
         raise LedgerError("URL must not contain control characters")
+    if any(char.isspace() for char in clean):
+        raise LedgerError("URL must not contain whitespace")
     parsed = urlparse(clean)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise LedgerError("URL must use http or https")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -23,6 +23,7 @@ from app.ledger.service import (
     pay_bounty,
     public_url_or_none,
     register_wallet,
+    validate_public_url,
 )
 from app.main import _signed_value, create_app
 from app.models import LedgerEntry, WebhookEvent
@@ -525,6 +526,19 @@ def test_bounty_urls_reject_embedded_credentials(sqlite_url: str) -> None:
                 accepted_by="maintainer",
                 verifier_result={"label": "mrwk:accepted"},
             )
+
+
+def test_public_urls_reject_whitespace() -> None:
+    for url in (
+        "https://exa mple.com/path",
+        "https://example.com/has space",
+        "https://example.com/?q=has space",
+    ):
+        with pytest.raises(LedgerError, match="URL must not contain whitespace"):
+            validate_public_url(url)
+        assert public_url_or_none(url) is None
+
+    assert validate_public_url(" https://example.com/path ") == "https://example.com/path"
 
 
 def test_bounty_payment_proof_rejects_control_character_metadata(sqlite_url: str) -> None:


### PR DESCRIPTION
Refs #122.

## Summary
- reject public URLs containing unencoded whitespace inside the canonical URL
- keep the existing convenience behavior for ordinary surrounding spaces by trimming before validation
- add regression coverage for whitespace in host, path, and query strings plus `public_url_or_none()`

## Before / After
Before this change, values such as `https://exa mple.com/path`, `https://example.com/has space`, and `https://example.com/?q=has space` were accepted and could be stored/rendered as public URLs. After this change they raise `URL must not contain whitespace`; callers should pass percent-encoded URLs instead.

## Validation
- `uv run --python 3.12 --extra dev pytest tests/test_security.py::test_public_urls_reject_whitespace tests/test_security.py::test_bounty_urls_reject_control_characters tests/test_security.py::test_bounty_urls_reject_embedded_credentials -q`
- `uv run --python 3.12 --extra dev pytest tests/test_security.py tests/test_ledger.py tests/test_api_mcp.py tests/test_bounty_pages.py -q`
- `uv run --python 3.12 --extra dev pytest -q`
- `uv run --python 3.12 --extra dev ruff check app/ledger/service.py tests/test_security.py`
- `uv run --python 3.12 --extra dev ruff format --check app/ledger/service.py tests/test_security.py`
- `uv run --python 3.12 --extra dev mypy app`
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py`
- `uv run --python 3.12 --extra dev python scripts/check_agents.py`

No secrets, wallet material, private context, deployment values, or MRWK price claims are included.