### PR TITLE
Link proof pages to bounty details

### DIFF
--- a/app/templates/proof.html
+++ b/app/templates/proof.html
@@ -13,6 +13,10 @@
       <strong>{% if issue_card_url %}<a href="{{ issue_card_url }}">{{ proof.repo }} #{{ proof.issue_number }}</a>{% else %}{{ proof.repo }} #{{ proof.issue_number }}{% endif %}</strong>
     </article>
     <article>
+      <span>MergeWork bounty</span>
+      <strong><a href="/bounties/{{ proof.bounty_id }}">#{{ proof.bounty_id }}</a></strong>
+    </article>
+    <article>
       <span>Ledger entry</span>
       <strong><a href="/ledger/{{ proof.ledger_sequence }}">#{{ proof.ledger_sequence }}</a></strong>
     </article>
@@ -30,6 +34,8 @@
     <dt>Issue</dt>
     {% set issue_url = safe_public_url("https://github.com/" ~ proof.repo ~ "/issues/" ~ proof.issue_number) %}
     <dd>{% if issue_url %}<a href="{{ issue_url }}">{{ proof.repo }} #{{ proof.issue_number }}</a>{% else %}{{ proof.repo }} #{{ proof.issue_number }}{% endif %}</dd>
+    <dt>MergeWork bounty</dt>
+    <dd><a href="/bounties/{{ proof.bounty_id }}">#{{ proof.bounty_id }}</a></dd>
     <dt>Accepted by</dt>
     <dd>{{ proof.accepted_by }}</dd>
     <dt>Paid to</dt>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -145,4 +145,6 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert "Bounty payment proof" in proof_page.text
     assert "Accepted bounty payment" in proof_page.text
     assert "Bounty issue" in proof_page.text
+    assert "MergeWork bounty" in proof_page.text
+    assert f'href="/bounties/{bounty.id}"' in proof_page.text
     assert f'href="/ledger/{payment_sequence}"' in proof_page.text


### PR DESCRIPTION
Refs #164

## Summary
- add an internal MergeWork bounty-detail link to bounty payment proof pages
- keep the existing GitHub issue and ledger links intact
- cover the proof-page link in the existing bounty/ledger/proof page regression

## Verification
- `uv run --extra dev python -m pytest tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable -q`
- `uv run --extra dev python -m pytest tests/test_bounty_pages.py tests/test_activity.py -q`
- `uv run --extra dev python -m pytest -q`
- `uv run --extra dev ruff format --check tests/test_bounty_pages.py`
- `uv run --extra dev ruff check tests/test_bounty_pages.py`
- `uv run --extra dev python -m mypy app`
- `uv run --extra dev python scripts/docs_smoke.py`
- `uv run --extra dev python scripts/check_agents.py`
- `git diff --check`

No secrets, wallet material, private deployment values, or MRWK price claims are included.