### PR TITLE
Reject non-public hosts in public URLs

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -96,7 +96,7 @@ def validate_public_url(url: str) -> str:
         except ValueError:
             pass
         else:
-            if ip_address.is_loopback or ip_address.is_private or ip_address.is_link_local:
+            if ip_address.is_multicast or not ip_address.is_global:
                 raise LedgerError("URL must use a public host")
     return clean
 

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import ipaddress
 import json
 import re
 from datetime import UTC, datetime
@@ -86,6 +87,17 @@ def validate_public_url(url: str) -> str:
         raise LedgerError("URL must use http or https")
     if parsed.username or parsed.password:
         raise LedgerError("URL must not include credentials")
+    hostname = parsed.hostname
+    if hostname and hostname.lower() == "localhost":
+        raise LedgerError("URL must use a public host")
+    if hostname:
+        try:
+            ip_address = ipaddress.ip_address(hostname)
+        except ValueError:
+            pass
+        else:
+            if ip_address.is_loopback or ip_address.is_private or ip_address.is_link_local:
+                raise LedgerError("URL must use a public host")
     return clean
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -536,7 +536,9 @@ def test_bounty_urls_reject_non_public_hosts(sqlite_url: str) -> None:
                 "https://localhost/ramimbo/mergework/issues/21",
                 "https://127.0.0.1/ramimbo/mergework/issues/21",
                 "https://10.0.0.5/ramimbo/mergework/issues/21",
+                "https://100.64.0.1/ramimbo/mergework/issues/21",
                 "https://169.254.10.20/ramimbo/mergework/issues/21",
+                "https://224.0.0.1/ramimbo/mergework/issues/21",
                 "https://[::1]/ramimbo/mergework/issues/21",
                 "https://[fd00::1]/ramimbo/mergework/issues/21",
             ),
@@ -722,6 +724,12 @@ def test_close_bounty_rejects_control_character_reference(sqlite_url: str) -> No
 def test_public_url_or_none_omits_control_character_urls() -> None:
     assert public_url_or_none("https://github.com/ramimbo/mergework/issues/14\nextra") is None
     assert public_url_or_none("https://127.0.0.1/ramimbo/mergework/issues/14") is None
+    assert public_url_or_none("https://100.64.0.1/ramimbo/mergework/issues/14") is None
+    assert public_url_or_none("https://224.0.0.1/ramimbo/mergework/issues/14") is None
+    assert (
+        public_url_or_none("https://8.8.8.8/ramimbo/mergework/issues/14")
+        == "https://8.8.8.8/ramimbo/mergework/issues/14"
+    )
     assert (
         public_url_or_none(" https://github.com/ramimbo/mergework/issues/14 ")
         == "https://github.com/ramimbo/mergework/issues/14"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -527,6 +527,52 @@ def test_bounty_urls_reject_embedded_credentials(sqlite_url: str) -> None:
             )
 
 
+def test_bounty_urls_reject_non_public_hosts(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        for issue_number, issue_url in enumerate(
+            (
+                "https://localhost/ramimbo/mergework/issues/21",
+                "https://127.0.0.1/ramimbo/mergework/issues/21",
+                "https://10.0.0.5/ramimbo/mergework/issues/21",
+                "https://169.254.10.20/ramimbo/mergework/issues/21",
+                "https://[::1]/ramimbo/mergework/issues/21",
+                "https://[fd00::1]/ramimbo/mergework/issues/21",
+            ),
+            start=21,
+        ):
+            with pytest.raises(LedgerError, match="URL must use a public host"):
+                create_bounty(
+                    session,
+                    repo="ramimbo/mergework",
+                    issue_number=issue_number,
+                    issue_url=issue_url,
+                    title="Non-public URL",
+                    reward_mrwk="1",
+                    acceptance="Maintainer applies mrwk:accepted",
+                )
+
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=27,
+            issue_url="https://github.com/ramimbo/mergework/issues/27",
+            title="Safe URL",
+            reward_mrwk="1",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+        with pytest.raises(LedgerError, match="URL must use a public host"):
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:alice",
+                submission_url="https://192.168.1.20/ramimbo/mergework/pull/27",
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted"},
+            )
+
+
 def test_bounty_payment_proof_rejects_control_character_metadata(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -675,6 +721,7 @@ def test_close_bounty_rejects_control_character_reference(sqlite_url: str) -> No
 
 def test_public_url_or_none_omits_control_character_urls() -> None:
     assert public_url_or_none("https://github.com/ramimbo/mergework/issues/14\nextra") is None
+    assert public_url_or_none("https://127.0.0.1/ramimbo/mergework/issues/14") is None
     assert (
         public_url_or_none(" https://github.com/ramimbo/mergework/issues/14 ")
         == "https://github.com/ramimbo/mergework/issues/14"


### PR DESCRIPTION
Refs #122

## What changed

- Reject loopback, private-network, and link-local hosts in the shared `validate_public_url()` guard.
- Make `public_url_or_none()` omit non-public hosts instead of returning them for optional rendered links.
- Add focused regression coverage for bounty issue URLs, bounty payout submission URLs, and optional public-link rendering.

## Concrete before/after

- Before: `create_bounty(..., issue_url="https://localhost/...")` and `public_url_or_none("https://127.0.0.1/...")` accepted/returned URLs that are not publicly reachable.
- After: those inputs fail with `URL must use a public host`, and optional rendered links are omitted.

## Evidence

- `./.venv/bin/python -m pytest tests/test_security.py::test_bounty_urls_reject_non_public_hosts tests/test_security.py::test_public_url_or_none_omits_control_character_urls -q` -> 2 passed.
- `./.venv/bin/python -m pytest tests/test_security.py tests/test_ledger.py tests/test_bounty_pages.py -q` -> 51 passed.
- `./.venv/bin/python -m pytest -q` -> 172 passed, 2 warnings.
- `./.venv/bin/python -m ruff check app/ledger/service.py tests/test_security.py` -> all checks passed.
- `./.venv/bin/python -m ruff format --check app/ledger/service.py tests/test_security.py` -> 2 files already formatted.
- `./.venv/bin/python -m mypy app` -> success.
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok.
- `./.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok.
- `git diff --check` -> no output.

No secrets, wallet material, private deployment values, private vulnerability details, or MRWK price claims are included.
