### PR TITLE
Normalize bounty repo names

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -427,7 +427,7 @@ def find_bounty_by_issue(session: Session, repo: str, issue_number: int) -> Boun
     clean_repo = _normalize_repo_name(repo)
     return session.scalar(
         select(Bounty)
-        .where(Bounty.repo == clean_repo, Bounty.issue_number == issue_number)
+        .where(func.lower(Bounty.repo) == clean_repo, Bounty.issue_number == issue_number)
         .limit(1)
     )
 

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -149,6 +149,10 @@ def _clean_required_text(value: str, field: str, max_length: int) -> str:
     return clean
 
 
+def _normalize_repo_name(repo: str) -> str:
+    return _clean_required_text(repo, "repo", 200).lower()
+
+
 def _clean_proof_metadata(verifier_result: dict[str, Any]) -> dict[str, Any]:
     clean = dict(verifier_result)
     for key, value in clean.items():
@@ -385,7 +389,7 @@ def create_bounty(
     if max_awards > 1_000:
         raise LedgerError("max_awards is too large")
     reserved = reward * max_awards
-    clean_repo = _clean_required_text(repo, "repo", 200)
+    clean_repo = _normalize_repo_name(repo)
     existing_bounty = find_bounty_by_issue(session, clean_repo, issue_number)
     if existing_bounty is not None:
         raise LedgerError("bounty already exists for issue")
@@ -420,8 +424,11 @@ def create_bounty(
 
 
 def find_bounty_by_issue(session: Session, repo: str, issue_number: int) -> Bounty | None:
+    clean_repo = _normalize_repo_name(repo)
     return session.scalar(
-        select(Bounty).where(Bounty.repo == repo, Bounty.issue_number == issue_number).limit(1)
+        select(Bounty)
+        .where(Bounty.repo == clean_repo, Bounty.issue_number == issue_number)
+        .limit(1)
     )
 
 

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -142,6 +142,30 @@ def test_create_bounty_rejects_duplicate_repo_issue(sqlite_url: str) -> None:
             )
 
 
+def test_find_bounty_by_issue_matches_legacy_mixed_case_repo(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = Bounty(
+            repo="Ramimbo/MergeWork",
+            issue_number=77,
+            issue_url="https://github.com/ramimbo/mergework/issues/77",
+            title="Legacy mixed-case bounty",
+            reward_microunits=25_000_000,
+            reserved_microunits=25_000_000,
+            max_awards=1,
+            awards_paid=0,
+            status="open",
+            acceptance="Legacy rows should still match GitHub repo identity.",
+        )
+        session.add(bounty)
+        session.flush()
+
+        assert find_bounty_by_issue(session, "ramimbo/mergework", 77) == bounty
+        assert find_bounty_by_issue(session, "RAMIMBO/MERGEWORK", 77) == bounty
+
+
 def test_multi_award_bounty_pays_distinct_submissions_until_exhausted(
     sqlite_url: str,
 ) -> None:

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -15,6 +15,7 @@ from app.ledger.service import (
     close_bounty,
     create_bounty,
     ensure_genesis,
+    find_bounty_by_issue,
     get_balance,
     pay_bounty,
     register_wallet,
@@ -117,15 +118,17 @@ def test_create_bounty_rejects_duplicate_repo_issue(sqlite_url: str) -> None:
 
     with session_scope(sqlite_url) as session:
         ensure_genesis(session)
-        create_bounty(
+        bounty = create_bounty(
             session,
-            repo="ramimbo/mergework",
+            repo="Ramimbo/MergeWork",
             issue_number=7,
             issue_url="https://github.com/ramimbo/mergework/issues/7",
             title="Original bounty",
             reward_mrwk="25",
             acceptance="First bounty for this issue.",
         )
+        assert bounty.repo == "ramimbo/mergework"
+        assert find_bounty_by_issue(session, "RAMIMBO/MERGEWORK", 7) == bounty
 
         with pytest.raises(LedgerError, match="bounty already exists for issue"):
             create_bounty(


### PR DESCRIPTION
Refs #122

## What changed

- Normalize bounty repository names to lowercase when bounties are created.
- Normalize repository names in `find_bounty_by_issue()` so webhook lookups and manual lookups match GitHub's case-insensitive repository identity.
- Extend the duplicate repo/issue regression to cover mixed-case input and mixed-case lookup.

## Concrete before/after

- Before: an operator could create a bounty for `Ramimbo/MergeWork#7` and another for `ramimbo/mergework#7`, or create a mixed-case bounty that a lower-case webhook lookup would not find.
- After: bounty creation stores `ramimbo/mergework`, duplicate checks are case-insensitive, and `find_bounty_by_issue(..., "RAMIMBO/MERGEWORK", 7)` finds the stored bounty.

## Evidence

- `./.venv/bin/python -m pytest tests/test_ledger.py::test_create_bounty_rejects_duplicate_repo_issue tests/test_webhooks.py::test_accepted_pr_label_pays_repo_qualified_multi_award_issue -q` -> 2 passed.
- `./.venv/bin/python -m pytest tests/test_ledger.py tests/test_webhooks.py tests/test_security.py -q` -> 57 passed.
- `./.venv/bin/python -m pytest -q` -> 171 passed, 2 warnings.
- `./.venv/bin/python -m ruff check app/ledger/service.py tests/test_ledger.py` -> all checks passed.
- `./.venv/bin/python -m ruff format --check app/ledger/service.py tests/test_ledger.py` -> 2 files already formatted.
- `./.venv/bin/python -m mypy app` -> success.
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok.
- `./.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok.
- `git diff --check` -> no output.

No secrets, wallet material, private deployment values, private vulnerability details, or MRWK price claims are included.
