### PR TITLE
Validate wallet lookup route addresses

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,7 @@ from app.ledger.service import (
     submit_wallet_transfer,
 )
 from app.models import Account, Bounty, LedgerEntry, Proof, Wallet, WalletTransfer
+from app.wallets import WalletError, normalize_wallet_address
 from app.webhooks.github import handle_github_webhook
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -293,6 +294,15 @@ def _normalized_account(account: str) -> str:
             raise HTTPException(status_code=400, detail="github login must be valid")
         return f"github:{login}"
     return clean
+
+
+def _wallet_address_from_path(address: str) -> str:
+    if address != address.strip():
+        raise HTTPException(status_code=400, detail="invalid MRWK wallet address")
+    try:
+        return normalize_wallet_address(address)
+    except WalletError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 def _github_login_from_account(account: str) -> str | None:
@@ -677,8 +687,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/api/v1/wallets/{address}")
     def api_wallet(address: str) -> dict[str, Any]:
+        address = _wallet_address_from_path(address)
         with session_scope(db_url) as session:
-            wallet = session.get(Wallet, address.lower())
+            wallet = session.get(Wallet, address)
             if wallet is None:
                 raise HTTPException(status_code=404, detail="wallet not found")
             return wallet_to_dict(session, wallet)
@@ -982,8 +993,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/wallets/{address}", response_class=HTMLResponse)
     def wallet_page(request: Request, address: str) -> HTMLResponse:
+        address = _wallet_address_from_path(address)
         with session_scope(db_url) as session:
-            wallet = session.get(Wallet, address.lower())
+            wallet = session.get(Wallet, address)
             if wallet is None:
                 raise HTTPException(status_code=404, detail="wallet not found")
             wallet_data = wallet_to_dict(session, wallet)

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -97,6 +97,18 @@ def test_wallet_api_register_lookup_and_transfer(sqlite_url: str) -> None:
     assert client.get(f"/api/v1/wallets/{receiver_address}").json()["balance_mrwk"] == "3"
 
 
+def test_wallet_lookup_routes_reject_malformed_addresses(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    _, public_hex, address = _keypair()
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _register_wallet(client, public_hex)
+
+    assert client.get(f"/api/v1/wallets/{address.upper()}").json()["address"] == address
+    assert client.get("/api/v1/wallets/not-a-wallet").status_code == 400
+    assert client.get(f"/api/v1/wallets/%20{address}%20").status_code == 400
+    assert client.get("/wallets/not-a-wallet").status_code == 400
+
+
 @pytest.mark.parametrize(
     ("body_overrides", "payload_overrides", "expected_detail"),
     [


### PR DESCRIPTION
Bounty #122

## Summary
- Validate REST and HTML wallet lookup path parameters with the existing MRWK wallet address normalizer before database lookup.
- Return `400` for malformed or whitespace-padded wallet path values, while preserving `404` for well-formed but unregistered wallets.
- Keep mixed-case valid wallet addresses resolving to the canonical lowercase address.

## Validation
- `./.venv/bin/python -m pytest tests/test_wallet_api.py::test_wallet_lookup_routes_reject_malformed_addresses -q` -> 1 passed
- `./.venv/bin/python -m pytest tests/test_wallet_api.py tests/test_api_mcp.py -q` -> 61 passed, 1 warning
- `./.venv/bin/python -m pytest -q` -> 172 passed, 2 warnings
- `./.venv/bin/python -m ruff format --check .` -> 36 files already formatted
- `./.venv/bin/python -m ruff check .` -> All checks passed
- `./.venv/bin/python -m mypy app` -> Success
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `./.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> passed

No secrets, wallet material, deployment values, private context, payout configuration, or MRWK price claims are included.