### PR TITLE
Validate proof hash lookups

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -64,6 +64,7 @@ SECURITY_HEADERS = {
     "X-Frame-Options": "DENY",
 }
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+HEX_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 API_DOCS_CSP = (
     "default-src 'self'; "
     "base-uri 'self'; "
@@ -302,6 +303,15 @@ def _github_login_from_account(account: str) -> str | None:
     if not GITHUB_LOGIN_RE.fullmatch(login):
         return None
     return login
+
+
+def _proof_hash_from_path(proof_hash: str) -> str:
+    if proof_hash != proof_hash.strip():
+        raise HTTPException(status_code=400, detail="proof hash must be 64 hex characters")
+    clean = proof_hash.lower()
+    if not HEX_HASH_RE.fullmatch(clean):
+        raise HTTPException(status_code=400, detail="proof hash must be 64 hex characters")
+    return clean
 
 
 def _signed_value(value: str, secret: str) -> str:
@@ -757,6 +767,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/api/v1/proofs/{proof_hash}")
     def api_proof(proof_hash: str) -> dict[str, Any]:
+        proof_hash = _proof_hash_from_path(proof_hash)
         with session_scope(db_url) as session:
             proof = session.get(Proof, proof_hash)
             if proof is None:
@@ -1281,7 +1292,7 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
             )
             return json.dumps(ledger_to_dict(entry, proof.hash if proof else None))
         if name == "get_proof":
-            proof = session.get(Proof, str_arg("hash"))
+            proof = session.get(Proof, _proof_hash_from_path(str_arg("hash")))
             if proof is None:
                 return "proof not found"
             public_payload = json.loads(proof.public_json)

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -702,6 +702,31 @@ def test_mcp_get_proof_reports_unknown_hash(sqlite_url: str) -> None:
     assert result["result"]["content"][0]["text"] == "proof not found"
 
 
+def test_mcp_get_proof_rejects_malformed_hash(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "get_proof", "arguments": {"hash": "not-a-proof-hash"}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
 def test_host_specific_homepages(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -146,3 +146,8 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert "Accepted bounty payment" in proof_page.text
     assert "Bounty issue" in proof_page.text
     assert f'href="/ledger/{payment_sequence}"' in proof_page.text
+
+    missing_proof = client.get(f"/api/v1/proofs/{'0' * 64}")
+    assert missing_proof.status_code == 404
+    assert client.get("/api/v1/proofs/not-a-proof-hash").status_code == 400
+    assert client.get("/proofs/not-a-proof-hash").status_code == 400


### PR DESCRIPTION
Bounty #122

## Summary
- Validate proof hash lookup inputs before REST, HTML, and MCP database lookups.
- Return `400` for malformed proof hashes on `/api/v1/proofs/{proof_hash}` and `/proofs/{proof_hash}`.
- Preserve `404` / `proof not found` for well-formed but unknown hashes.

## Validation
- `./.venv/bin/python -m pytest tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable tests/test_api_mcp.py::test_mcp_get_proof_rejects_malformed_hash tests/test_api_mcp.py::test_mcp_get_proof_reports_unknown_hash -q` -> 3 passed
- `./.venv/bin/python -m pytest tests/test_bounty_pages.py tests/test_api_mcp.py -q` -> 42 passed, 1 warning
- `./.venv/bin/python -m pytest -q` -> 172 passed, 2 warnings
- `./.venv/bin/python -m ruff format --check .` -> 36 files already formatted
- `./.venv/bin/python -m ruff check .` -> All checks passed
- `./.venv/bin/python -m mypy app` -> Success
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `./.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> passed

No secrets, wallet material, deployment values, private context, payout configuration, or MRWK price claims are included.