### PR TITLE
Validate ledger entry sequences

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -304,6 +304,12 @@ def _github_login_from_account(account: str) -> str | None:
     return login
 
 
+def _positive_ledger_sequence(sequence: int) -> int:
+    if sequence <= 0:
+        raise HTTPException(status_code=400, detail="ledger sequence must be positive")
+    return sequence
+
+
 def _signed_value(value: str, secret: str) -> str:
     timestamp = str(int(time.time()))
     body = f"{value}|{timestamp}"
@@ -748,6 +754,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/api/v1/ledger/{sequence}")
     def api_ledger_entry(sequence: int) -> dict[str, Any]:
+        sequence = _positive_ledger_sequence(sequence)
         with session_scope(db_url) as session:
             entry = session.get(LedgerEntry, sequence)
             if entry is None:
@@ -1219,6 +1226,12 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
                 return int(clean)
         raise ValueError(f"{field} must be an integer")
 
+    def positive_int_arg(field: str) -> int:
+        value = int_arg(field)
+        if value <= 0:
+            raise ValueError(f"{field} must be positive")
+        return value
+
     def str_arg(field: str, *, allow_empty: bool = False) -> str:
         value = args[field]
         if not isinstance(value, str):
@@ -1273,7 +1286,7 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
             )
             return json.dumps(wallet_transfer_to_dict(transfer))
         if name == "get_ledger_entry":
-            entry = session.get(LedgerEntry, int_arg("sequence"))
+            entry = session.get(LedgerEntry, positive_int_arg("sequence"))
             if entry is None:
                 return "ledger entry not found"
             proof = session.scalar(

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -634,6 +634,31 @@ def test_mcp_get_ledger_entry_includes_payment_proof_hash(sqlite_url: str) -> No
     assert payload["proof_hash"] == proof_hash
 
 
+def test_mcp_get_ledger_entry_rejects_non_positive_sequence(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "get_ledger_entry", "arguments": {"sequence": 0}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
 def test_mcp_get_proof_returns_public_proof_details(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -139,6 +139,8 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert "Bounty Payment" in ledger_entry_page.text
     assert "Bounty scan status" in ledger_entry_page.text
     assert "Award paid" in ledger_entry_page.text
+    assert client.get("/api/v1/ledger/0").status_code == 400
+    assert client.get("/ledger/0").status_code == 400
 
     proof_page = client.get(f"/proofs/{proof_hash}")
     assert proof_page.status_code == 200


### PR DESCRIPTION
Bounty #122

## Summary
- Validate ledger entry sequence inputs before REST, HTML, and MCP lookups.
- Return `400` for `/api/v1/ledger/0` and `/ledger/0` instead of treating non-positive values as missing ledger entries.
- Preserve existing not-found behavior for positive but unknown ledger sequences.

## Validation
- `./.venv/bin/python -m pytest tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable tests/test_api_mcp.py::test_mcp_get_ledger_entry_rejects_non_positive_sequence tests/test_api_mcp.py::test_mcp_get_ledger_entry_includes_payment_proof_hash -q` -> 3 passed
- `./.venv/bin/python -m pytest -q` -> 172 passed, 2 warnings
- `./.venv/bin/python -m ruff format --check .` -> 36 files already formatted
- `./.venv/bin/python -m ruff check .` -> All checks passed
- `./.venv/bin/python -m mypy app` -> Success
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `./.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> passed

No secrets, wallet material, deployment values, private context, payout configuration, or MRWK price claims are included.