### PR TITLE
Validate bounty route ids

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -304,6 +304,12 @@ def _github_login_from_account(account: str) -> str | None:
     return login
 
 
+def _positive_bounty_id(bounty_id: int) -> int:
+    if bounty_id <= 0:
+        raise HTTPException(status_code=400, detail="bounty id must be positive")
+    return bounty_id
+
+
 def _signed_value(value: str, secret: str) -> str:
     timestamp = str(int(time.time()))
     body = f"{value}|{timestamp}"
@@ -546,6 +552,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/api/v1/bounties/{bounty_id}")
     def api_bounty(bounty_id: int) -> dict[str, Any]:
+        bounty_id = _positive_bounty_id(bounty_id)
         with session_scope(db_url) as session:
             bounty = session.get(Bounty, bounty_id)
             if bounty is None:
@@ -558,6 +565,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         request: Request,
         admin_login: str = Depends(require_admin_token),
     ) -> dict[str, Any]:
+        bounty_id = _positive_bounty_id(bounty_id)
         data = await _json_object(request)
         try:
             requested_account = _required_str(data, "to_account")
@@ -602,6 +610,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         request: Request,
         admin_login: str = Depends(require_admin_token),
     ) -> dict[str, Any]:
+        bounty_id = _positive_bounty_id(bounty_id)
         data = await _json_object(request)
         reference = _optional_str(data, "reference") if data.get("reference") is not None else None
         closed_by = _optional_str(data, "closed_by", admin_login)

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -88,6 +88,11 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert "What has to be true" in response.text
     assert "Focused PR improves status, reward, issue link, and acceptance text." in response.text
 
+    missing_response = client.get("/api/v1/bounties/999")
+    assert missing_response.status_code == 404
+    assert client.get("/api/v1/bounties/0").status_code == 400
+    assert client.get("/bounties/0").status_code == 400
+
 
 def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) -> None:
     create_schema(sqlite_url)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -417,6 +417,33 @@ def test_admin_close_bounty_api_releases_remaining_reserve(
     assert token_auth.json()["released_mrwk"] == "50"
 
 
+def test_admin_bounty_id_routes_reject_non_positive_ids(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    create_schema(sqlite_url)
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    headers = {"x-mergework-admin-token": "admin-token-for-tests"}
+
+    payout = client.post(
+        "/api/v1/bounties/0/pay",
+        headers=headers,
+        json={
+            "to_account": "github:alice",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/1",
+        },
+    )
+    close = client.post("/api/v1/bounties/0/close", headers=headers, json={})
+
+    assert payout.status_code == 400
+    assert payout.json()["detail"] == "bounty id must be positive"
+    assert close.status_code == 400
+    assert close.json()["detail"] == "bounty id must be positive"
+
+
 def test_admin_bounty_api_accepts_multi_award_count(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Refs #122

## Summary
- reject non-positive bounty ids before public API/detail lookup
- apply the same validation before admin payout/close handlers reach ledger code
- preserve 404 behavior for positive but missing bounty ids

## Verification
- `uv run --extra dev python -m pytest tests/test_bounty_pages.py::test_bounty_detail_highlights_action_fields tests/test_security.py::test_admin_bounty_id_routes_reject_non_positive_ids -q`
- `uv run --extra dev python -m pytest tests/test_bounty_pages.py tests/test_security.py tests/test_api_mcp.py -q`
- `uv run --extra dev python -m pytest -q`
- `uv run --extra dev ruff format --check app/main.py tests/test_bounty_pages.py tests/test_security.py`
- `uv run --extra dev ruff check app/main.py tests/test_bounty_pages.py tests/test_security.py`
- `uv run --extra dev python -m mypy app`
- `uv run --extra dev python scripts/docs_smoke.py`
- `uv run --extra dev python scripts/check_agents.py`
- `git diff --check`

No secrets, wallet material, private deployment values, or MRWK price claims are included.