### PR TITLE
Validate MCP bounty ids

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1219,6 +1219,12 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
                 return int(clean)
         raise ValueError(f"{field} must be an integer")
 
+    def positive_int_arg(field: str) -> int:
+        value = int_arg(field)
+        if value <= 0:
+            raise ValueError(f"{field} must be positive")
+        return value
+
     def str_arg(field: str, *, allow_empty: bool = False) -> str:
         value = args[field]
         if not isinstance(value, str):
@@ -1242,7 +1248,7 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
             ).all()
             return json.dumps([bounty_to_dict(bounty) for bounty in bounties])
         if name == "get_bounty":
-            bounty = session.get(Bounty, int_arg("id"))
+            bounty = session.get(Bounty, positive_int_arg("id"))
             if bounty is None:
                 return "bounty not found"
             return json.dumps(bounty_to_dict(bounty))

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -553,6 +553,32 @@ def test_mcp_get_bounty_rejects_fractional_id(sqlite_url: str) -> None:
     }
 
 
+@pytest.mark.parametrize("bounty_id", [0, -1])
+def test_mcp_get_bounty_rejects_non_positive_id(sqlite_url: str, bounty_id: int) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/call",
+            "params": {"name": "get_bounty", "arguments": {"id": bounty_id}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 12,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
 @pytest.mark.parametrize(
     ("tool_name", "arguments", "request_id"),
     [


### PR DESCRIPTION
Refs #122.\n\n## Summary\n- Reject non-positive ids for the MCP `get_bounty` tool before database lookup.\n- Preserve the existing positive missing-id behavior as `bounty not found`.\n- Add regression coverage for `id=0` and negative ids returning MCP invalid-arguments errors.\n\n## Evidence\n- Before patch direct probe: MCP `get_bounty` with `id=0` and `id=-1` returned a successful result containing `bounty not found`.\n- `uv run --extra dev pytest tests/test_api_mcp.py::test_mcp_get_bounty_rejects_fractional_id tests/test_api_mcp.py::test_mcp_get_bounty_rejects_non_positive_id -q` -> 3 passed.\n- `uv run --extra dev pytest tests/test_api_mcp.py tests/test_bounty_pages.py tests/test_security.py -q` -> 74 passed, 1 warning.\n- `uv run --extra dev pytest -q` -> 173 passed, 2 warnings.\n- `uv run --extra dev ruff check app/main.py tests/test_api_mcp.py` -> all checks passed.\n- `uv run --extra dev ruff format --check app/main.py tests/test_api_mcp.py` -> 2 files already formatted.\n- `uv run --extra dev mypy app` -> success.\n- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.\n- `uv run --extra dev python scripts/check_agents.py` -> AGENTS.md ok.\n- `git diff --check` -> passed.\n\nNo secrets, wallet material, private deployment values, or MRWK price claims are included.