### PR TITLE
Reject non-positive MCP bounty ids

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1242,7 +1242,10 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
             ).all()
             return json.dumps([bounty_to_dict(bounty) for bounty in bounties])
         if name == "get_bounty":
-            bounty = session.get(Bounty, int_arg("id"))
+            bounty_id = int_arg("id")
+            if bounty_id <= 0:
+                raise ValueError("id must be positive")
+            bounty = session.get(Bounty, bounty_id)
             if bounty is None:
                 return "bounty not found"
             return json.dumps(bounty_to_dict(bounty))

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -553,6 +553,32 @@ def test_mcp_get_bounty_rejects_fractional_id(sqlite_url: str) -> None:
     }
 
 
+@pytest.mark.parametrize("bounty_id", [0, -1, "0", "-1"])
+def test_mcp_get_bounty_rejects_non_positive_id(sqlite_url: str, bounty_id: object) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/call",
+            "params": {"name": "get_bounty", "arguments": {"id": bounty_id}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 12,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
 @pytest.mark.parametrize(
     ("tool_name", "arguments", "request_id"),
     [


### PR DESCRIPTION
## Summary
- reject non-positive `get_bounty` MCP ids before database lookup
- preserve existing `bounty not found` behavior for positive but missing ids
- add regression coverage for numeric and string zero/negative ids

## Evidence
- Before the patch, MCP `get_bounty` with `id` values `0`, `-1`, `"0"`, and `"-1"` returned a successful content result of `bounty not found`.
- After the patch, those values return JSON-RPC `-32602 invalid tool arguments`.
- Positive existing ids and positive unknown ids keep the existing behavior.

## Validation
- `uv run --python 3.12 --extra dev pytest tests/test_api_mcp.py::test_mcp_get_bounty_rejects_non_positive_id tests/test_api_mcp.py::test_mcp_get_bounty_rejects_fractional_id -q` -> 5 passed.
- `uv run --python 3.12 --extra dev pytest tests/test_api_mcp.py -q` -> 42 passed, 1 warning.
- `uv run --python 3.12 --extra dev pytest -q` -> 175 passed, 2 warnings.
- `uv run --python 3.12 --extra dev ruff check app/main.py tests/test_api_mcp.py` -> all checks passed.
- `uv run --python 3.12 --extra dev ruff format --check app/main.py tests/test_api_mcp.py` -> 2 files already formatted.
- `uv run --python 3.12 --extra dev mypy app` -> success.
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `uv run --python 3.12 --extra dev python scripts/check_agents.py` -> AGENTS.md ok.
- Trailing-whitespace scan on touched files passed.

No secrets, wallet material, private deployment values, or MRWK price claims are included.
