### PR TITLE
Validate webhook submitter logins

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -105,7 +105,13 @@ def _handle_accepted_issue_label(
     if not repo or not isinstance(labeled_item, dict):
         return _record_status(database_url, delivery_id, event_type, payload_hash, "missing_issue")
 
-    submitter = ((labeled_item.get("user") or {}).get("login") or "unknown").strip()
+    user = labeled_item.get("user") or {}
+    submitter_login = user.get("login") if isinstance(user, dict) else None
+    if not isinstance(submitter_login, str) or not submitter_login.strip():
+        return _record_status(
+            database_url, delivery_id, event_type, payload_hash, "missing_submitter"
+        )
+    submitter = submitter_login.strip()
     accepted_by = ((payload.get("sender") or {}).get("login") or "maintainer").strip().lower()
     if accepted_labelers and accepted_by not in accepted_labelers:
         return _record_status(

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -155,6 +155,49 @@ def test_accepted_pr_label_pays_pr_author_for_linked_bounty_issue(sqlite_url: st
         assert get_balance(session, "github:maintainer") == 0
 
 
+def test_accepted_label_requires_submitter_login(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "labeled",
+            "label": {"name": "mrwk:accepted"},
+            "issue": {
+                "number": 44,
+                "html_url": "https://github.com/ramimbo/mergework/issues/44",
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "maintainer"},
+        },
+        separators=(",", ":"),
+    ).encode()
+    headers = {
+        "X-GitHub-Delivery": "delivery-missing-submitter",
+        "X-GitHub-Event": "issues",
+        "X-Hub-Signature-256": _signature("secret", body),
+    }
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=44,
+            issue_url="https://github.com/ramimbo/mergework/issues/44",
+            title="Accepted issue",
+            reward_mrwk="25",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+
+    result = handle_github_webhook(sqlite_url, headers, body, "secret")
+
+    assert result == {"status": "missing_submitter"}
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:unknown") == 0
+        event = session.get(WebhookEvent, "delivery-missing-submitter")
+        assert event is not None
+        assert event.processed_status == "missing_submitter"
+
+
 def test_accepted_pr_labels_can_pay_multiple_awards_for_one_bounty(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     first_body = json.dumps(


### PR DESCRIPTION
Refs #122.\n\n## Summary\n- Stop accepted-label webhooks from falling back to a synthetic `github:unknown` payout account when the labeled issue or PR payload has no submitter login.\n- Record `missing_submitter` as the webhook event status instead.\n- Add regression coverage proving no MRWK is credited to `github:unknown` for a malformed accepted-label payload.\n\n## Evidence\n- Before patch direct probe: an accepted issue-label payload with no `issue.user.login` returned `paid` and credited 25 MRWK to `github:unknown`.\n- `uv run --extra dev pytest tests/test_webhooks.py::test_accepted_label_requires_submitter_login tests/test_webhooks.py::test_accepted_label_pays_bounty_once tests/test_webhooks.py::test_accepted_pr_label_pays_pr_author_for_linked_bounty_issue -q` -> 3 passed.\n- `uv run --extra dev pytest tests/test_webhooks.py tests/test_ledger.py tests/test_api_mcp.py -q` -> 65 passed, 1 warning.\n- `uv run --extra dev pytest -q` -> 172 passed, 2 warnings.\n- `uv run --extra dev ruff check app/webhooks/github.py tests/test_webhooks.py` -> all checks passed.\n- `uv run --extra dev ruff format --check app/webhooks/github.py tests/test_webhooks.py` -> 2 files already formatted.\n- `uv run --extra dev mypy app` -> success.\n- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.\n- `uv run --extra dev python scripts/check_agents.py` -> AGENTS.md ok.\n- `git diff --check` -> passed.\n\nNo secrets, wallet material, private deployment values, or MRWK price claims are included.