### PR TITLE
Clarify public API example wording

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -1,6 +1,6 @@
 # Public API Examples
 
-MergeWork exposes read-only API and MCP hosts for contributors and agents:
+MergeWork exposes public API and MCP hosts for contributors and agents:
 
 ```bash
 API_HOST=https://api.mrwk.ltclab.site

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -53,3 +53,10 @@ def test_agent_guide_documents_activity_endpoint() -> None:
 
     assert "GET /api/v1/activity" in guide
     assert "accepted-work activity" in guide
+
+
+def test_api_examples_do_not_mislabel_write_endpoints_as_read_only() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "exposes public API and MCP hosts" in examples
+    assert "read-only API and MCP hosts" not in examples


### PR DESCRIPTION
Bounty #162

## What's fixed
- clarify that `docs/api-examples.md` covers public API/MCP hosts, not strictly read-only hosts
- add a regression test so write-capable examples are not mislabeled again

## Why
`docs/api-examples.md` includes `POST /api/v1/wallets/register`, so calling the host section "read-only" is inaccurate and confusing for contributors following the examples.

## Verification
- `python3 scripts/docs_smoke.py`
- `uv run --extra dev pytest tests/test_docs_public_urls.py`