### PR TITLE
Reject whitespace-padded deploy URL settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -96,6 +96,8 @@ def _sqlite_database_errors(database_url: str) -> list[str]:
 
 def validate_deploy_settings(settings: Settings) -> list[str]:
     errors: list[str] = []
+    errors.extend(_required_env_value_errors("MERGEWORK_DATABASE_URL", settings.database_url))
+    errors.extend(_required_env_value_errors("MERGEWORK_PUBLIC_BASE_URL", settings.public_base_url))
     errors.extend(_sqlite_database_errors(settings.database_url))
     errors.extend(_secret_errors("MERGEWORK_GITHUB_WEBHOOK_SECRET", settings.github_webhook_secret))
     errors.extend(

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -133,6 +133,20 @@ def test_deploy_readiness_accepts_absolute_sqlite_and_external_database_urls() -
     )
 
 
+def test_deploy_readiness_rejects_database_url_whitespace_and_control_characters() -> None:
+    whitespace_errors = validate_deploy_settings(
+        _settings(database_url=" sqlite:////srv/mergework/data/app.sqlite3")
+    )
+    control_errors = validate_deploy_settings(
+        _settings(database_url="sqlite:////srv/mergework/data/app.sqlite3\nextra")
+    )
+
+    assert "MERGEWORK_DATABASE_URL must not include leading or trailing whitespace" in (
+        whitespace_errors
+    )
+    assert "MERGEWORK_DATABASE_URL must not include control characters" in control_errors
+
+
 def test_deploy_readiness_requires_https_oauth_and_allowed_labelers() -> None:
     errors = validate_deploy_settings(
         _settings(
@@ -155,6 +169,20 @@ def test_deploy_readiness_rejects_malformed_oauth_client_id() -> None:
         whitespace_errors
     )
     assert "MERGEWORK_GITHUB_OAUTH_CLIENT_ID must not include control characters" in control_errors
+
+
+def test_deploy_readiness_rejects_public_base_url_whitespace_and_control_characters() -> None:
+    whitespace_errors = validate_deploy_settings(
+        _settings(public_base_url=" https://mrwk.example.test")
+    )
+    control_errors = validate_deploy_settings(
+        _settings(public_base_url="https://mrwk.example.test\n")
+    )
+
+    assert "MERGEWORK_PUBLIC_BASE_URL must not include leading or trailing whitespace" in (
+        whitespace_errors
+    )
+    assert "MERGEWORK_PUBLIC_BASE_URL must not include control characters" in control_errors
 
 
 def test_deploy_readiness_rejects_non_admin_accepted_labelers() -> None:


### PR DESCRIPTION
Bounty #163

## What's fixed
- reject leading/trailing whitespace and control characters in `MERGEWORK_DATABASE_URL`
- reject leading/trailing whitespace and control characters in `MERGEWORK_PUBLIC_BASE_URL`
- add regression tests for both deploy config gaps

## Why
Python's URL parsing accepts some whitespace-padded URLs, so an operator typo like ` https://mrwk.example.test` could incorrectly pass deploy readiness. This tightens validation before deploys.

## Verification
- `uv run --extra dev pytest tests/test_deploy_readiness.py tests/test_docs_public_urls.py`