### PR TITLE
docs: add MCP ledger entry example

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -92,3 +92,28 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_bounty","arguments":{"id":11}}}'
 ```
+
+Call `get_ledger_entry` with the immutable ledger `sequence`, not a proof hash
+or bounty id. The JSON-RPC response wraps a text content block; parse
+`result.content[0].text` as JSON to read the same fields returned by
+`/api/v1/ledger/<sequence>`.
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"get_ledger_entry","arguments":{"sequence":322}}}'
+```
+
+The parsed text payload includes fields such as `sequence`, `type`, `from`,
+`to`, `amount_mrwk`, `reference`, `previous_hash`, `entry_hash`, nullable
+`proof_hash`, and `created_at`.
+
+Call `submit_work_proof` only for submission guidance. It does not claim or pay
+a bounty by itself; accepted work still requires the GitHub-native bounty flow
+and maintainer acceptance.
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"submit_work_proof","arguments":{}}}'
+```

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -53,3 +53,16 @@ def test_agent_guide_documents_activity_endpoint() -> None:
 
     assert "GET /api/v1/activity" in guide
     assert "accepted-work activity" in guide
+
+
+def test_api_examples_document_mcp_ledger_and_submission_guidance() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert '"name":"get_ledger_entry"' in examples
+    assert '"arguments":{"sequence":322}' in examples
+    assert "result.content[0].text" in examples
+    assert "/api/v1/ledger/<sequence>" in examples
+    assert "not a proof hash" in examples
+    assert '"name":"submit_work_proof"' in examples
+    assert "does not claim or pay" in examples
+    assert "by itself" in examples


### PR DESCRIPTION
Bounty #162

Adds focused public API example coverage for two MCP tools that were listed but not yet shown in `docs/api-examples.md`:

- `get_ledger_entry`: documents that callers pass the immutable ledger `sequence` (not a bounty id or proof hash), and that the JSON-RPC result returns a text content block whose text parses to the same ledger fields as `/api/v1/ledger/<sequence>`.
- `submit_work_proof`: clarifies that the tool returns submission guidance only and does not claim or pay a bounty by itself.

Evidence checked against `app/main.py::_call_mcp_tool()` and live unauthenticated MCP calls:

- `get_ledger_entry` for sequence `322` returned `result.content[0].text` JSON with `sequence`, `type`, `from`, `to`, `amount_mrwk`, `reference`, `previous_hash`, `entry_hash`, `proof_hash`, and `created_at`.
- `submit_work_proof` returned the documented guidance text requiring a focused PR/issue, bounty reference, test evidence, and maintainer `mrwk:accepted`.

Verification:

- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --python 3.12 --extra dev pytest tests/test_docs_public_urls.py -q` -> 7 passed
- `uv run --python 3.12 --extra dev pytest -q` -> 172 passed, 2 warnings
- `uv run --python 3.12 --extra dev ruff format --check .` -> 36 files already formatted
- `uv run --python 3.12 --extra dev ruff check .` -> All checks passed
- `uv run --python 3.12 --extra dev mypy app` -> Success
