### PR TITLE
docs: add MCP wallet and ledger examples

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -92,3 +92,25 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_bounty","arguments":{"id":11}}}'
 ```
+
+Register and inspect a wallet through MCP. Keep the private key local; send
+only the public key hex:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"register_wallet","arguments":{"public_key_hex":"<64 lowercase hex chars>","label":"agent wallet"}}}'
+
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"get_wallet","arguments":{"address":"mrwk1..."}}}'
+```
+
+Read one ledger entry through MCP with the numeric `sequence` from
+`/api/v1/ledger`:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"get_ledger_entry","arguments":{"sequence":1}}}'
+```

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -28,6 +28,11 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert '"id":4' in examples
     assert "not the GitHub issue" in examples
     assert "public_key_hex" in examples
+    assert '"name":"register_wallet"' in examples
+    assert '"name":"get_wallet"' in examples
+    assert '"address":"mrwk1..."' in examples
+    assert '"name":"get_ledger_entry"' in examples
+    assert '"sequence":1' in examples
 
 
 def test_agent_guide_explains_internal_bounty_ids() -> None:


### PR DESCRIPTION
## Summary
- Add MCP examples for register_wallet, get_wallet, and get_ledger_entry so docs/api-examples.md matches the live public MCP tool surface.
- Clarify that wallet registration sends only public key hex and ledger lookup uses the numeric sequence from /api/v1/ledger.
- Add docs coverage assertions for the new MCP examples.

## Evidence
- Live MCP tools/list at https://mcp.mrwk.ltclab.site/mcp includes register_wallet, get_wallet, and get_ledger_entry.
- Existing docs only showed tools/list, get_balance, list_bounties, and get_bounty examples.

## Test Evidence
- [x] ./.venv/Scripts/python.exe scripts/docs_smoke.py
- [x] ./.venv/Scripts/python.exe -m pytest tests/test_docs_public_urls.py
- [x] ./.venv/Scripts/python.exe -m ruff format --check .
- [x] ./.venv/Scripts/python.exe -m ruff check .
- [x] ./.venv/Scripts/python.exe -m mypy app
- [x] ./.venv/Scripts/python.exe -m pytest

## MRWK
Refs #162