### PR TITLE
Reject whitespace-padded deploy secrets and OAuth client id

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -39,6 +39,8 @@ def _csv_env(name: str, default: str = "") -> tuple[str, ...]:
 def _secret_errors(name: str, value: str) -> list[str]:
     if not value:
         return [f"{name} is required"]
+    if value != value.strip():
+        return [f"{name} must not include surrounding whitespace"]
     if len(value) < 32 or value.strip().lower() in WEAK_SECRET_VALUES:
         return [f"{name} must be at least 32 characters"]
     if len(set(value)) < 12:
@@ -65,6 +67,8 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
         errors.append("deploy secrets must use distinct values")
     if not settings.github_oauth_client_id:
         errors.append("MERGEWORK_GITHUB_OAUTH_CLIENT_ID is required")
+    elif settings.github_oauth_client_id != settings.github_oauth_client_id.strip():
+        errors.append("MERGEWORK_GITHUB_OAUTH_CLIENT_ID must not include surrounding whitespace")
     if not settings.admin_logins:
         errors.append("MERGEWORK_ADMIN_LOGINS must list admin GitHub logins")
     if not settings.github_accepted_labelers:

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -40,6 +40,17 @@ def test_deploy_readiness_rejects_missing_or_placeholder_secrets() -> None:
     assert "MERGEWORK_ADMIN_TOKEN is required" in errors
     assert "MERGEWORK_COOKIE_SECRET must be at least 32 characters" in errors
 
+def test_deploy_readiness_rejects_whitespace_padded_secrets_and_oauth_id() -> None:
+    errors = validate_deploy_settings(
+        _settings(
+            github_webhook_secret="  webhook-8efc3925bb8746b8a8fd3392c4c48e32  ",
+            github_oauth_client_id=" client-id ",
+        )
+    )
+
+    assert "MERGEWORK_GITHUB_WEBHOOK_SECRET must not include surrounding whitespace" in errors
+    assert "MERGEWORK_GITHUB_OAUTH_CLIENT_ID must not include surrounding whitespace" in errors
+
 
 def test_deploy_readiness_rejects_low_diversity_secrets() -> None:
     errors = validate_deploy_settings(


### PR DESCRIPTION
Refs #163

Adds focused deploy-readiness validation for a concrete operator mistake: accidentally copying env values with surrounding spaces.

Changes:
- reject surrounding whitespace for deploy secrets
- reject surrounding whitespace for MERGEWORK_GITHUB_OAUTH_CLIENT_ID
- add regression test coverage

Validation:
- `uv sync --extra dev`
- `.venv/bin/pytest -q tests/test_deploy_readiness.py`
- `.venv/bin/ruff check app/config.py tests/test_deploy_readiness.py`