### PR TITLE
Document REST proof API response example

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -54,7 +54,7 @@ MergeWork bounty `id` as `bounty_id`; `issue_number` is the source GitHub issue
 number, and `ledger_sequence` can be opened with `/api/v1/ledger/<sequence>`.
 
 ```json
-{"kind":"bounty_payment","bounty_id":32,"repo":"ramimbo/mergework","issue_number":156,"submission_url":"https://github.com/ramimbo/mergework/pull/155#pullrequestreview-4353350771","accepted_by":"ramimbo","to_account":"github:ckeplinger199","amount_mrwk":"40","ledger_sequence":322,"ledger_hash":"ae4d68cb6fb28d4bdce303a141ddc14ff8251da2c26009dc5449be230dc9b9ff","verifier_result":{"accepted_by":"ramimbo","note":"claim https://github.com/ramimbo/mergework/issues/107#issuecomment-4529851212","source":"admin_api"}}
+{"accepted_by":"ramimbo","amount_mrwk":"50","bounty_id":30,"issue_number":122,"kind":"bounty_payment","ledger_hash":"36ba31e67edece61c176055551e904ed2663ec80705b89650cb70e5b0fd624a7","ledger_sequence":252,"repo":"ramimbo/mergework","submission_url":"https://github.com/ramimbo/mergework/pull/123","to_account":"github:ckeplinger199","verifier_result":{"bounty_issue_number":122,"delivery_id":"e15fae40-578f-11f1-8bb8-862e130231a2","event":"pull_request","label":"mrwk:accepted"}}
 ```
 
 Register a wallet public key. Keep the private key local; only send the public

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -49,6 +49,14 @@ curl -s "$API_HOST/api/v1/accounts/treasury:mrwk"
 curl -s "$API_HOST/api/v1/wallets/mrwk1..."
 ```
 
+A proof response is the public payment proof payload. It uses the internal
+MergeWork bounty `id` as `bounty_id`; `issue_number` is the source GitHub issue
+number, and `ledger_sequence` can be opened with `/api/v1/ledger/<sequence>`.
+
+```json
+{"kind":"bounty_payment","bounty_id":32,"repo":"ramimbo/mergework","issue_number":156,"submission_url":"https://github.com/ramimbo/mergework/pull/155#pullrequestreview-4353350771","accepted_by":"ramimbo","to_account":"github:ckeplinger199","amount_mrwk":"40","ledger_sequence":322,"ledger_hash":"ae4d68cb6fb28d4bdce303a141ddc14ff8251da2c26009dc5449be230dc9b9ff","verifier_result":{"accepted_by":"ramimbo","note":"claim https://github.com/ramimbo/mergework/issues/107#issuecomment-4529851212","source":"admin_api"}}
+```
+
 Register a wallet public key. Keep the private key local; only send the public
 key to MergeWork.
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -27,6 +27,12 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert '"arguments":{"id":11}' in examples
     assert '"id":4' in examples
     assert "not the GitHub issue" in examples
+    assert "/api/v1/proofs/<proof_hash>" in examples
+    assert '"kind":"bounty_payment"' in examples
+    assert '"bounty_id":32' in examples
+    assert '"issue_number":156' in examples
+    assert '"ledger_sequence":322' in examples
+    assert "source GitHub issue" in examples
     assert "public_key_hex" in examples
 
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -29,9 +29,9 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "not the GitHub issue" in examples
     assert "/api/v1/proofs/<proof_hash>" in examples
     assert '"kind":"bounty_payment"' in examples
-    assert '"bounty_id":32' in examples
-    assert '"issue_number":156' in examples
-    assert '"ledger_sequence":322' in examples
+    assert '"bounty_id":30' in examples
+    assert '"issue_number":122' in examples
+    assert '"ledger_sequence":252' in examples
     assert "source GitHub issue" in examples
     assert "public_key_hex" in examples
 


### PR DESCRIPTION
Bounty #162

## Summary

- Add a concrete REST `/api/v1/proofs/<proof_hash>` response example to `docs/api-examples.md`.
- Clarify that `bounty_id` is the internal MergeWork bounty id, while `issue_number` is the source GitHub issue number.
- Clarify that `ledger_sequence` can be opened through `/api/v1/ledger/<sequence>`.
- Add docs regression coverage so the proof response shape stays visible in public API examples.

## Evidence

Compared this docs change against:

- `app/main.py::api_proof()`, which returns the stored public proof payload.
- `app/ledger/service.py::pay_bounty()`, which builds the proof payload fields: `kind`, `bounty_id`, `repo`, `issue_number`, `submission_url`, `accepted_by`, `to_account`, `amount_mrwk`, `ledger_sequence`, `ledger_hash`, and `verifier_result`.
- Live unauthenticated readback from `GET https://api.mrwk.ltclab.site/api/v1/proofs/32574c266e1f7cdb42115072d1f3382c5ef56ab5b53a18272cb5512fc1f67088`, which returned the documented proof fields for ledger sequence `252`.
- Follow-up commit `296b327` replaced the original proof sample with this coherent proof after review feedback, so `issue_number` and `verifier_result.bounty_issue_number` both point to issue `122`.

## Verification

- `uv run --python 3.12 --extra dev pytest tests/test_docs_public_urls.py -q` -> 6 passed.
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `uv run --python 3.12 --extra dev ruff check tests/test_docs_public_urls.py` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check tests/test_docs_public_urls.py` -> 1 file already formatted.
- `uv run --python 3.12 --extra dev pytest -q` -> 171 passed, 2 warnings.
- `uv run --python 3.12 --extra dev python scripts/check_agents.py` -> AGENTS.md ok.
- `uv run --python 3.12 --extra dev mypy app` -> success.
- `git diff --check` -> no output.

No private keys, seed material, secrets, private vulnerability details, deployment credentials, or market price claims are included.
