### PR TITLE
docs: show current public API response shapes

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -16,10 +16,44 @@ curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
 ```
 
+Current `/api/v1/status` shape:
+
+```json
+{
+  "name": "MergeWork",
+  "ticker": "MRWK",
+  "genesis_supply_mrwk": "100000000",
+  "ledger_height": 330,
+  "active_bounties": 6,
+  "treasury_balance_mrwk": "99982965",
+  "future_path": "public snapshots, bridges, and onchain claims"
+}
+```
+
 Read a single bounty with its internal `id` from `/api/v1/bounties`:
 
 ```bash
 curl -s "$API_HOST/api/v1/bounties/<bounty_id>"
+```
+
+Current bounty item fields returned by `/api/v1/bounties`:
+
+```json
+{
+  "id": 36,
+  "repo": "ramimbo/mergework",
+  "issue_number": 164,
+  "issue_url": "https://github.com/ramimbo/mergework/issues/164",
+  "title": "MRWK bounty: contributor activity and bounty discovery improvements",
+  "reward_mrwk": "100",
+  "reserved_mrwk": "500",
+  "max_awards": 5,
+  "awards_paid": 0,
+  "awards_remaining": 5,
+  "status": "open",
+  "acceptance": "<acceptance text>",
+  "created_at": "2026-05-24T20:44:00.015953"
+}
 ```
 
 The `<bounty_id>` value is the MergeWork bounty `id`, not the GitHub issue
@@ -35,10 +69,49 @@ curl -s "$API_HOST/api/v1/ledger?limit=10"
 curl -s "$API_HOST/api/v1/ledger/<sequence>"
 ```
 
+Current ledger entry fields:
+
+```json
+{
+  "sequence": 330,
+  "type": "github_claim",
+  "from": "github:tolga-tom-nook",
+  "to": "mrwk111651088541ed7a8b33bed7a0207afd8d36eee4f",
+  "amount_mrwk": "115",
+  "reference": "github-claim:tolga-tom-nook:mrwk111651088541ed7a8b33bed7a0207afd8d36eee4f:2",
+  "previous_hash": "248e1e38...",
+  "entry_hash": "705301d6...",
+  "proof_hash": null,
+  "created_at": "2026-05-24T22:06:29.950575"
+}
+```
+
 Read accepted-work activity summarized from proof-backed bounty payments:
 
 ```bash
 curl -s "$API_HOST/api/v1/activity"
+```
+
+Current `/api/v1/activity` summary keys:
+
+```json
+{
+  "totals": {
+    "accepted_awards": 279,
+    "accepted_mrwk": "14545",
+    "contributors": 50
+  },
+  "contributors": [
+    {
+      "account": "github:ckeplinger199",
+      "accepted_awards": 87,
+      "accepted_mrwk": "4875",
+      "latest_submission_url": "https://github.com/ramimbo/mergework/pull/155#pullrequestreview-4353350771",
+      "latest_proof_hash": "385ee38b...",
+      "latest_proof_url": "/proofs/385ee38b..."
+    }
+  ]
+}
 ```
 
 Inspect a proof, account, or registered wallet:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -28,6 +28,13 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert '"id":4' in examples
     assert "not the GitHub issue" in examples
     assert "public_key_hex" in examples
+    assert '"ledger_height"' in examples
+    assert '"active_bounties"' in examples
+    assert '"issue_number"' in examples
+    assert '"awards_remaining"' in examples
+    assert '"proof_hash"' in examples
+    assert '"accepted_awards"' in examples
+    assert '"latest_proof_hash"' in examples
 
 
 def test_agent_guide_explains_internal_bounty_ids() -> None:


### PR DESCRIPTION
Bounty #162

## What's changed
- add concrete current response-shape examples for `/status`, `/bounties`, `/ledger`, and `/activity`
- keep the docs explicit about internal bounty ids vs GitHub issue numbers
- extend the docs test to guard the key public response fields mentioned in the examples

## Why
Issue #162 asks for public API examples that match the live public response shapes and avoid invented or ambiguous fields.

## Evidence
- `python3 scripts/docs_smoke.py`
- local pytest not available in this checkout (`python3 -m pytest -q tests/test_docs_public_urls.py` -> `No module named pytest`)}