### PR TITLE
feat: add bounty search filters

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -502,7 +502,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             "future_path": "public snapshots, bridges, and onchain claims",
         }
 
-    def list_bounties_by_status(status: str | None = None) -> list[dict[str, Any]]:
+    def list_bounties_by_status(
+        status: str | None = None, query_text: str | None = None
+    ) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
             query = select(Bounty)
             if status is not None:
@@ -512,12 +514,29 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                         status_code=400, detail="status must be one of: open, paid, closed"
                     )
                 query = query.where(Bounty.status == normalized_status)
+            if query_text is not None:
+                normalized_query = query_text.strip()
+                if normalized_query:
+                    like_query = f"%{normalized_query.lower()}%"
+                    issue_number = None
+                    if normalized_query.isdigit():
+                        issue_number = int(normalized_query)
+                    text_filter = or_(
+                        func.lower(Bounty.repo).like(like_query),
+                        func.lower(Bounty.title).like(like_query),
+                        func.lower(Bounty.acceptance).like(like_query),
+                    )
+                    if issue_number is not None:
+                        text_filter = or_(text_filter, Bounty.issue_number == issue_number)
+                    query = query.where(text_filter)
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             return [bounty_to_dict(bounty) for bounty in bounties]
 
     @app.get("/api/v1/bounties")
-    def api_bounties(status: str | None = Query(None)) -> list[dict[str, Any]]:
-        return list_bounties_by_status(status)
+    def api_bounties(
+        status: str | None = Query(None), q: str | None = Query(None)
+    ) -> list[dict[str, Any]]:
+        return list_bounties_by_status(status, q)
 
     @app.post("/api/v1/bounties")
     async def api_create_bounty(
@@ -923,14 +942,18 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         )
 
     @app.get("/bounties", response_class=HTMLResponse)
-    def bounties_page(request: Request, status: str | None = Query(None)) -> HTMLResponse:
+    def bounties_page(
+        request: Request, status: str | None = Query(None), q: str | None = Query(None)
+    ) -> HTMLResponse:
         selected_status = status.strip().lower() if status is not None else None
+        query_text = q.strip() if q is not None else ""
         return templates.TemplateResponse(
             request,
             "bounties.html",
             {
-                "bounties": list_bounties_by_status(status),
+                "bounties": list_bounties_by_status(status, q),
                 "selected_status": selected_status,
+                "query_text": query_text,
             },
         )
 

--- a/app/main.py
+++ b/app/main.py
@@ -517,14 +517,20 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             if query_text is not None:
                 normalized_query = query_text.strip()
                 if normalized_query:
-                    like_query = f"%{normalized_query.lower()}%"
+                    escaped_query = (
+                        normalized_query.lower()
+                        .replace("\\", "\\\\")
+                        .replace("%", "\\%")
+                        .replace("_", "\\_")
+                    )
+                    like_query = f"%{escaped_query}%"
                     issue_number = None
                     if normalized_query.isdigit():
                         issue_number = int(normalized_query)
                     text_filter = or_(
-                        func.lower(Bounty.repo).like(like_query),
-                        func.lower(Bounty.title).like(like_query),
-                        func.lower(Bounty.acceptance).like(like_query),
+                        func.lower(Bounty.repo).like(like_query, escape="\\"),
+                        func.lower(Bounty.title).like(like_query, escape="\\"),
+                        func.lower(Bounty.acceptance).like(like_query, escape="\\"),
                     )
                     if issue_number is not None:
                         text_filter = or_(text_filter, Bounty.issue_number == issue_number)

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -2,12 +2,20 @@
 {% block title %}MRWK Bounties{% endblock %}
 {% block content %}
 <h1>Bounties</h1>
+<form method="get" action="/bounties" aria-label="Search bounties">
+  {% if selected_status %}<input type="hidden" name="status" value="{{ selected_status }}">{% endif %}
+  <label for="bounty-search">Search bounties</label>
+  <input id="bounty-search" name="q" type="search" value="{{ query_text }}" placeholder="repo, title, issue number, or acceptance text">
+  <button type="submit">Search</button>
+  {% if query_text %}<a href="/bounties{% if selected_status %}?status={{ selected_status }}{% endif %}">Clear search</a>{% endif %}
+</form>
 <nav aria-label="Bounty status filters">
-  <a href="/bounties"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
-  <a href="/bounties?status=open"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
-  <a href="/bounties?status=paid"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
-  <a href="/bounties?status=closed"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
+  <a href="/bounties{% if query_text %}?q={{ query_text | urlencode }}{% endif %}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
+  <a href="/bounties?status=open{% if query_text %}&q={{ query_text | urlencode }}{% endif %}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
+  <a href="/bounties?status=paid{% if query_text %}&q={{ query_text | urlencode }}{% endif %}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
+  <a href="/bounties?status=closed{% if query_text %}&q={{ query_text | urlencode }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
 </nav>
+{% if query_text %}<p>Showing matches for “{{ query_text }}”.</p>{% endif %}
 <div class="list">
   {% for bounty in bounties %}
   <article>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -60,6 +60,44 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert 'href="/bounties?status=paid" aria-current="page"' in paid_rows_uppercase.text
 
 
+def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=64,
+            issue_url="https://github.com/ramimbo/mergework/issues/64",
+            title="Improve public bounty discovery",
+            reward_mrwk="100",
+            acceptance="Make contributor search find award slots and proof inspection work.",
+        )
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=65,
+            issue_url="https://github.com/ramimbo/mergework/issues/65",
+            title="Internal admin cleanup",
+            reward_mrwk="100",
+            acceptance="Private admin-only cleanup.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    text_search = client.get("/bounties?q=proof+inspection")
+    assert text_search.status_code == 200
+    assert "Search bounties" in text_search.text
+    assert "Showing matches for “proof inspection”." in text_search.text
+    assert "Improve public bounty discovery" in text_search.text
+    assert "Internal admin cleanup" not in text_search.text
+    assert 'href="/bounties?status=open&q=proof%20inspection"' in text_search.text
+
+    issue_search = client.get("/api/v1/bounties?q=65")
+    assert issue_search.status_code == 200
+    assert [row["issue_number"] for row in issue_search.json()] == [65]
+
+
 def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -82,6 +82,15 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
             reward_mrwk="100",
             acceptance="Private admin-only cleanup.",
         )
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=66,
+            issue_url="https://github.com/ramimbo/mergework/issues/66",
+            title="Literal 100% release_note path",
+            reward_mrwk="100",
+            acceptance=r"Document C:\work\mergework examples.",
+        )
 
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
@@ -96,6 +105,18 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     issue_search = client.get("/api/v1/bounties?q=65")
     assert issue_search.status_code == 200
     assert [row["issue_number"] for row in issue_search.json()] == [65]
+
+    percent_search = client.get("/api/v1/bounties?q=%25")
+    assert percent_search.status_code == 200
+    assert [row["issue_number"] for row in percent_search.json()] == [66]
+
+    underscore_search = client.get("/api/v1/bounties?q=_")
+    assert underscore_search.status_code == 200
+    assert [row["issue_number"] for row in underscore_search.json()] == [66]
+
+    backslash_search = client.get("/api/v1/bounties", params={"q": "\\"})
+    assert backslash_search.status_code == 200
+    assert [row["issue_number"] for row in backslash_search.json()] == [66]
 
 
 def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- Add a public bounty search box that filters by repo, title, acceptance text, or exact issue number.
- Preserve the current status filter when searching and keep status links scoped to the current query.
- Add regression coverage for the HTML bounty page and `/api/v1/bounties?q=...` search behavior.

Refs #164
Bounty #164

## Test Plan
- `uv run --python 3.12 --extra dev pytest -q`
- `uv run --python 3.12 --extra dev ruff format --check .`
- `uv run --python 3.12 --extra dev ruff check .`
- `uv run --python 3.12 --extra dev mypy app`
- `python3 scripts/check_agents.py`
- `python3 scripts/docs_smoke.py`
- `git diff --check`

## Bounty / payout note
This PR is submitted for MergeWork bounty #164. No secrets, wallet material, deployment values, private context, or MRWK price claims are included.
