### PR TITLE
Ensure prelinked wallet registrations create GitHub accounts

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -256,6 +256,7 @@ def register_wallet(
             existing.label = clean_label
         if normalized_login is not None:
             existing.github_login = normalized_login
+            ensure_account(session, f"github:{normalized_login}")
         ensure_account(session, address)
         return existing
     wallet = Wallet(
@@ -267,6 +268,8 @@ def register_wallet(
     )
     session.add(wallet)
     ensure_account(session, address)
+    if normalized_login is not None:
+        ensure_account(session, f"github:{normalized_login}")
     session.flush()
     return wallet
 

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -540,3 +540,18 @@ def test_me_page_prefills_claim_address_for_linked_wallet(sqlite_url: str, monke
 
     assert f'value="{address}"' in me
     assert "Claim form is prefilled with your linked wallet." in me
+
+
+def test_prelinked_wallet_creates_github_account_row(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    _, public_hex, _ = _keypair()
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        register_wallet(session, public_key_hex=public_hex, github_login="alice")
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    account = client.get("/api/v1/accounts/github:alice")
+
+    assert account.status_code == 200
+    assert account.json()["exists"] is True


### PR DESCRIPTION
## Summary

This fixes a small ledger consistency gap in service-level wallet registration. When a wallet is registered with a GitHub login before the normal web claim flow, the wallet row was linked to that login, but the corresponding `github:<login>` account row was not created. That made the public account endpoint report the linked GitHub account as missing.

The change keeps the existing wallet address account creation in place and also ensures the GitHub account row is created whenever `register_wallet(..., github_login=...)` stores or updates a linked login.

## Verification

- Added `test_prelinked_wallet_creates_github_account_row` for the original behavior.
- Red check before the fix: the new focused test failed because `/api/v1/accounts/github:alice` returned `exists: false`.
- Windows:
  - `python -m pytest -q` -> 172 passed, 2 warnings
  - `python -m ruff format --check .` -> 36 files already formatted
  - `python -m ruff check .` -> All checks passed
  - `python -m mypy app` -> Success, no issues found in 11 source files
  - `python scripts/check_agents.py` -> AGENTS.md ok
  - `python scripts/docs_smoke.py` -> docs smoke ok
  - `git diff --check` -> no whitespace errors

I also attempted the requested WSL verification, but this machine currently does not list an installed WSL distro (`wsl -l -q` returned no distributions), and `wsl --list --online` failed with `Wsl/WININET_E_CANNOT_CONNECT`. I did not mark Linux verification as passing without a reachable distro.

Refs #122