### PR TITLE
Link source issues on bounty list

### DIFF
--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -13,7 +13,12 @@
   <article>
     <h2><a href="/bounties/{{ bounty.id }}">{{ bounty.title }}</a></h2>
     <p>
+      {% set issue_url = safe_public_url(bounty.issue_url) %}
+      {% if issue_url %}
+      <a href="{{ issue_url }}" rel="nofollow noopener">{{ bounty.repo }} #{{ bounty.issue_number }}</a> ·
+      {% else %}
       {{ bounty.repo }} #{{ bounty.issue_number }} ·
+      {% endif %}
       {{ bounty.reward_mrwk }} MRWK per award ·
       {{ bounty.awards_remaining }}/{{ bounty.max_awards }} awards open ·
       {{ bounty.status }}

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -45,6 +45,11 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert "Open public bounty" in all_rows.text
     assert "Paid public bounty" in all_rows.text
     assert f'href="/bounties/{open_bounty.id}"' in all_rows.text
+    assert (
+        'href="https://github.com/ramimbo/mergework/issues/50" rel="nofollow noopener"'
+        in all_rows.text
+    )
+    assert "ramimbo/mergework #50" in all_rows.text
 
     paid_rows = client.get("/bounties?status=paid")
     assert paid_rows.status_code == 200


### PR DESCRIPTION
Bounty #164

## Summary
- turn each public bounty list repo/issue reference into a safe source issue link when `issue_url` is public
- keep the internal bounty title/detail link unchanged
- cover the list page source link with a regression assertion

## Tests
- `uv run --python 3.12 --extra dev pytest tests/test_bounty_pages.py -q` -> 3 passed
- `git diff --check` -> clean

No secrets, wallet material, deployment values, private context, or MRWK price claims are included.