### PR TITLE
Reject invalid mrwk1 account paths in account views

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,7 @@ from app.ledger.service import (
     submit_wallet_transfer,
 )
 from app.models import Account, Bounty, LedgerEntry, Proof, Wallet, WalletTransfer
+from app.wallets import WalletError, normalize_wallet_address
 from app.webhooks.github import handle_github_webhook
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -286,7 +287,10 @@ def _normalized_account(account: str) -> str:
         raise HTTPException(status_code=400, detail="account must not contain control characters")
     clean = account.strip()
     if clean.lower().startswith("mrwk1"):
-        return clean.lower()
+        try:
+            return normalize_wallet_address(clean)
+        except WalletError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
     if clean.lower().startswith("github:"):
         login = clean.split(":", 1)[1].lower()
         if not GITHUB_LOGIN_RE.fullmatch(login):

--- a/tests/test_account_validation.py
+++ b/tests/test_account_validation.py
@@ -48,6 +48,12 @@ def test_api_account_rejects_empty_github_login(sqlite_url: str) -> None:
     assert resp.status_code == 400
     assert "github login" in resp.json()["detail"].lower()
 
+def test_api_account_rejects_invalid_wallet_address(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.get("/api/v1/accounts/mrwk1xyz")
+    assert resp.status_code == 400
+    assert "invalid mrwk wallet address" in resp.json()["detail"].lower()
+
 
 def test_mcp_get_balance_rejects_empty_account(sqlite_url: str) -> None:
     client = _setup_app(sqlite_url)
@@ -82,6 +88,22 @@ def test_mcp_get_balance_rejects_empty_github_login(sqlite_url: str) -> None:
     assert "error" in body
     assert body["error"]["code"] == -32602
 
+def test_mcp_get_balance_rejects_invalid_wallet_account(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": {"name": "get_balance", "arguments": {"account": "mrwk1xyz"}},
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == -32602
+
 
 def test_mcp_get_balance_rejects_null_byte_account(sqlite_url: str) -> None:
     client = _setup_app(sqlite_url)
@@ -109,4 +131,9 @@ def test_account_page_rejects_null_byte(sqlite_url: str) -> None:
 def test_account_page_rejects_empty_github_login(sqlite_url: str) -> None:
     client = _setup_app(sqlite_url)
     resp = client.get("/accounts/github:%20")
+    assert resp.status_code == 400
+
+def test_account_page_rejects_invalid_wallet_address(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.get("/accounts/mrwk1xyz")
     assert resp.status_code == 400


### PR DESCRIPTION
Refs #122

This fixes an account-normalization gap where malformed `mrwk1...` strings were treated as valid account IDs.

## What changed
- Validate `mrwk1` account paths with `normalize_wallet_address()` in `_normalized_account`.
- Return HTTP 400 for malformed wallet accounts instead of rendering zero-balance account pages.
- Added regression tests for:
  - `/api/v1/accounts/mrwk1xyz`
  - `/accounts/mrwk1xyz`
  - MCP `get_balance` with `account=mrwk1xyz`

## Repro before fix
- `GET /api/v1/accounts/mrwk1xyz` returned 200 with `{"exists": false, "balance_mrwk": "0"}`.
- `GET /accounts/mrwk1xyz` returned 200 HTML.
- MCP `get_balance(account=mrwk1xyz)` returned success text `mrwk1xyz: 0 MRWK`.

## Verification
- `uv run --extra dev python -m pytest tests/test_account_validation.py -q` -> 13 passed
- `uv run --extra dev python -m pytest tests/test_api_mcp.py -q` -> 38 passed