### PR TITLE
docs: add public /health response example

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -12,8 +12,15 @@ MCP_HOST=https://mcp.mrwk.ltclab.site
 Check service status and list bounties:
 
 ```bash
+curl -s "$API_HOST/health"
 curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
+```
+
+Expected public health response shape:
+
+```json
+{"ok":true,"service":"mergework","ticker":"MRWK","ledger_height":330}
 ```
 
 Read a single bounty with its internal `id` from `/api/v1/bounties`:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -20,6 +20,9 @@ def test_readme_lists_live_ltclab_urls() -> None:
 def test_api_examples_document_internal_bounty_ids() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 
+    assert "$API_HOST/health" in examples
+    assert '"ok":true' in examples
+    assert '"service":"mergework"' in examples
     assert "https://api.mrwk.ltclab.site" in examples
     assert "https://mcp.mrwk.ltclab.site" in examples
     assert "/api/v1/bounties/<bounty_id>" in examples


### PR DESCRIPTION
Refs #162

Adds a concrete public health endpoint example to `docs/api-examples.md`.

## What changed
- Added `curl -s "$API_HOST/health"` to the status/bounty quickstart commands.
- Added a concrete JSON response shape for the health endpoint:
  - `ok`
  - `service`
  - `ticker`
  - `ledger_height`
- Extended docs regression checks in `tests/test_docs_public_urls.py`.

## Verification
- `uv run --extra dev python -m pytest tests/test_docs_public_urls.py -q` -> 6 passed
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
