### PR TITLE
Validate internal account paths

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -285,9 +285,24 @@ def _normalized_account(account: str) -> str:
     if re.search(r"[\x00-\x1f\x7f]", account):
         raise HTTPException(status_code=400, detail="account must not contain control characters")
     clean = account.strip()
-    if clean.lower().startswith("mrwk1"):
+    lower = clean.lower()
+    if lower == TREASURY_ACCOUNT:
+        return TREASURY_ACCOUNT
+    if lower.startswith("treasury:"):
+        raise HTTPException(status_code=400, detail="treasury account must be treasury:mrwk")
+    if lower.startswith("reserve:"):
+        reserve_prefix = "reserve:bounty:"
+        if not lower.startswith(reserve_prefix):
+            raise HTTPException(
+                status_code=400, detail="reserve account must use reserve:bounty:<id>"
+            )
+        bounty_id = lower.removeprefix(reserve_prefix)
+        if not bounty_id.isdigit() or int(bounty_id) <= 0:
+            raise HTTPException(status_code=400, detail="reserve bounty id must be positive")
+        return f"{reserve_prefix}{int(bounty_id)}"
+    if lower.startswith("mrwk1"):
         return clean.lower()
-    if clean.lower().startswith("github:"):
+    if lower.startswith("github:"):
         login = clean.split(":", 1)[1].lower()
         if not GITHUB_LOGIN_RE.fullmatch(login):
             raise HTTPException(status_code=400, detail="github login must be valid")

--- a/tests/test_account_validation.py
+++ b/tests/test_account_validation.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
-from app.ledger.service import ensure_genesis
+from app.ledger.service import create_bounty, ensure_genesis
 from app.main import create_app
 
 
@@ -110,3 +111,115 @@ def test_account_page_rejects_empty_github_login(sqlite_url: str) -> None:
     client = _setup_app(sqlite_url)
     resp = client.get("/accounts/github:%20")
     assert resp.status_code == 400
+
+
+def test_account_views_normalize_treasury_account(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+
+    api_resp = client.get("/api/v1/accounts/Treasury:MRWK")
+    page_resp = client.get("/accounts/Treasury:MRWK")
+    mcp_resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": {"name": "get_balance", "arguments": {"account": "Treasury:MRWK"}},
+        },
+    )
+
+    assert api_resp.status_code == 200
+    assert api_resp.json()["account"] == "treasury:mrwk"
+    assert api_resp.json()["exists"] is True
+    assert page_resp.status_code == 200
+    assert mcp_resp.status_code == 200
+    assert mcp_resp.json()["result"]["content"][0]["text"].startswith("treasury:mrwk: ")
+
+
+@pytest.mark.parametrize("account", ["treasury:", "treasury:ops"])
+def test_account_views_reject_malformed_treasury_accounts(sqlite_url: str, account: str) -> None:
+    client = _setup_app(sqlite_url)
+
+    api_resp = client.get(f"/api/v1/accounts/{account}")
+    page_resp = client.get(f"/accounts/{account}")
+    mcp_resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": {"name": "get_balance", "arguments": {"account": account}},
+        },
+    )
+
+    assert api_resp.status_code == 400
+    assert page_resp.status_code == 400
+    assert mcp_resp.status_code == 200
+    assert mcp_resp.json()["error"]["code"] == -32602
+
+
+def test_account_views_accept_valid_reserve_bounty_account(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=122,
+            issue_url="https://github.com/ramimbo/mergework/issues/122",
+            title="Useful small fixes",
+            reward_mrwk="50",
+            acceptance="Accepted focused fix.",
+        )
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    api_resp = client.get("/api/v1/accounts/reserve:bounty:1")
+    page_resp = client.get("/accounts/reserve:bounty:1")
+    mcp_resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": {"name": "get_balance", "arguments": {"account": "Reserve:Bounty:001"}},
+        },
+    )
+
+    assert api_resp.status_code == 200
+    assert api_resp.json()["account"] == "reserve:bounty:1"
+    assert api_resp.json()["exists"] is True
+    assert page_resp.status_code == 200
+    assert mcp_resp.status_code == 200
+    assert mcp_resp.json()["result"]["content"][0]["text"] == "reserve:bounty:1: 50 MRWK"
+
+
+@pytest.mark.parametrize(
+    "account",
+    [
+        "reserve:",
+        "reserve:wallet:1",
+        "reserve:bounty:",
+        "reserve:bounty:0",
+        "reserve:bounty:-1",
+        "reserve:bounty:not-a-number",
+    ],
+)
+def test_account_views_reject_malformed_reserve_accounts(sqlite_url: str, account: str) -> None:
+    client = _setup_app(sqlite_url)
+
+    api_resp = client.get(f"/api/v1/accounts/{account}")
+    page_resp = client.get(f"/accounts/{account}")
+    mcp_resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": {"name": "get_balance", "arguments": {"account": account}},
+        },
+    )
+
+    assert api_resp.status_code == 400
+    assert page_resp.status_code == 400
+    assert mcp_resp.status_code == 200
+    assert mcp_resp.json()["error"]["code"] == -32602


### PR DESCRIPTION
## Summary

Bounty #122

This PR tightens public account normalization for internal MergeWork ledger accounts.

- Normalize `treasury:mrwk` across API, HTML account pages, and MCP `get_balance` while rejecting malformed `treasury:*` paths.
- Require reserve accounts to use the generated `reserve:bounty:<positive id>` shape before balance lookup, with case and leading-zero normalization.
- Add regression coverage for valid and malformed internal account paths through `/api/v1/accounts/{account}`, `/accounts/{account}`, and MCP `get_balance`.

## Concrete before/after

Before this change, malformed values such as `reserve:`, `reserve:wallet:1`, `reserve:bounty:0`, or `reserve:bounty:not-a-number` could be treated as ordinary zero-balance public accounts in account views or MCP balance lookup.

After this change, malformed treasury/reserve internal account paths fail with `400` on HTTP surfaces and JSON-RPC `-32602` through MCP, while valid generated accounts like `reserve:bounty:1` continue to work.

## Verification

- `uv run --python 3.12 --extra dev pytest tests/test_account_validation.py tests/test_api_mcp.py tests/test_bounty_pages.py -q` -> 61 passed, 1 warning.
- `uv run --python 3.12 --extra dev pytest -q` -> 181 passed, 2 warnings.
- `uv run --python 3.12 --extra dev ruff format --check app/main.py tests/test_account_validation.py` -> passed.
- `uv run --python 3.12 --extra dev ruff check app/main.py tests/test_account_validation.py` -> passed.
- `uv run --python 3.12 --extra dev mypy app` -> success.
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `uv run --python 3.12 --extra dev python scripts/check_agents.py` -> AGENTS.md ok.
- `git diff --check` -> no output.

## AI disclosure

This PR was prepared with AI assistance from Codex. I selected the scope, checked current open PRs for overlap, made a focused code/test change, and ran the verification above locally. No secrets, private keys, wallet material, private deployment values, private vulnerability details, or MRWK price claims are included.
