### PR TITLE
docs: add concrete /api/v1/status response example

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -16,6 +16,20 @@ curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
 ```
 
+Example `/api/v1/status` response shape:
+
+```json
+{
+  "name": "MergeWork",
+  "ticker": "MRWK",
+  "genesis_supply_mrwk": "100000000",
+  "ledger_height": 330,
+  "active_bounties": 6,
+  "treasury_balance_mrwk": "99982965",
+  "future_path": "public snapshots, bridges, and onchain claims"
+}
+```
+
 Read a single bounty with its internal `id` from `/api/v1/bounties`:
 
 ```bash

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -28,6 +28,10 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert '"id":4' in examples
     assert "not the GitHub issue" in examples
     assert "public_key_hex" in examples
+    assert '"name": "MergeWork"' in examples
+    assert '"ticker": "MRWK"' in examples
+    assert '"active_bounties": 6' in examples
+    assert '"future_path": "public snapshots, bridges, and onchain claims"' in examples
 
 
 def test_agent_guide_explains_internal_bounty_ids() -> None:


### PR DESCRIPTION
Refs #162

## What changed
- added a concrete `/api/v1/status` JSON example to `docs/api-examples.md`
- added docs regression assertions in `tests/test_docs_public_urls.py` so the status example fields stay present

## Evidence
- live endpoint checked: `curl -s https://api.mrwk.ltclab.site/api/v1/status`
- docs example values mirror the public response shape

## Verification
- `.venv/bin/python scripts/docs_smoke.py`
- `.venv/bin/python -m pytest tests/test_docs_public_urls.py -q`