### PR TITLE
Document wallet registration response

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -139,6 +139,22 @@ curl -s -X POST "$API_HOST/api/v1/wallets/register" \
   -d '{"public_key_hex":"<64 lowercase hex chars>","label":"agent wallet"}'
 ```
 
+The registration response uses the same public wallet shape as
+`/api/v1/wallets/<address>`:
+
+```json
+{
+  "address": "mrwk102d449a31fbb267c8f352e9968a79e3e5fc95c1b",
+  "public_key_hex": "1111111111111111111111111111111111111111111111111111111111111111",
+  "label": "agent wallet",
+  "github_login": null,
+  "balance_mrwk": "0",
+  "nonce": 0,
+  "next_nonce": 1,
+  "created_at": "2026-05-24T20:00:00"
+}
+```
+
 ## MCP Examples
 
 List MCP tools:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -105,6 +105,19 @@ def test_api_examples_document_wallet_response_shape() -> None:
     assert "read-only wallet lookup" in examples
 
 
+def test_api_examples_document_wallet_registration_response() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert 'POST "$API_HOST/api/v1/wallets/register"' in examples
+    assert "same public wallet shape" in examples
+    assert '"address": "mrwk102d449a31fbb267c8f352e9968a79e3e5fc95c1b"' in examples
+    assert '"label": "agent wallet"' in examples
+    assert '"github_login": null' in examples
+    assert '"balance_mrwk": "0"' in examples
+    assert '"nonce": 0' in examples
+    assert '"next_nonce": 1' in examples
+
+
 def test_agent_guide_explains_internal_bounty_ids() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Refs #162

## What changed

- Added a concrete `POST /api/v1/wallets/register` response example to `docs/api-examples.md`.
- Clarified that wallet registration returns the same public wallet object shape as `GET /api/v1/wallets/{address}`.
- Added docs regression assertions for the registration response fields: `address`, `label`, `github_login`, `balance_mrwk`, `nonce`, and `next_nonce`.

## Evidence

- Compared the docs against `app/main.py::api_register_wallet()`, which returns `wallet_to_dict(session, wallet)` after successful registration.
- Compared the response fields against `app/main.py::wallet_to_dict()`.
- Verified the sample address by deriving it from the documented sample public key with `app.wallets.address_from_public_key_hex("1" * 64)`, which returns `mrwk102d449a31fbb267c8f352e9968a79e3e5fc95c1b`.
- Did not submit a live wallet-registration request; the docs change is based on the app code path to avoid creating public test data on the hosted service.

## Verification

- `./.venv/bin/python -m pytest tests/test_docs_public_urls.py -q` -> 7 passed.
- `./.venv/bin/python -m pytest tests/test_docs_public_urls.py tests/test_wallet_api.py -q` -> 29 passed.
- `./.venv/bin/python -m pytest -q` -> 172 passed, 2 warnings.
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok.
- `./.venv/bin/python -m ruff check docs/api-examples.md tests/test_docs_public_urls.py` -> all checks passed.
- `./.venv/bin/python -m ruff format --check tests/test_docs_public_urls.py` -> 1 file already formatted.
- `git diff --check` -> clean.

No private keys, seed material, secrets, private vulnerability details, deployment credentials, or MRWK price claims are included.
