### PR TITLE
Exclude env variants from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@
 .ruff_cache
 .venv
 .env
+.env.*
+!.env.example
 backups
 deploy/ssh
 *.sqlite3

--- a/tests/test_dockerignore.py
+++ b/tests/test_dockerignore.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_dockerignore_excludes_local_env_variants() -> None:
+    dockerignore = Path(".dockerignore").read_text(encoding="utf-8").splitlines()
+
+    assert ".env" in dockerignore
+    assert ".env.*" in dockerignore
+    assert "!.env.example" in dockerignore


### PR DESCRIPTION
## Issue
Bounty #122

## Summary
Exclude local environment-file variants such as .env.local and .env.production from the Docker build context while keeping .env.example available as a safe template.

## Acceptance criteria
- [x] Keep the change focused on a distinct small fix for Bounty #122.
- [x] Add regression coverage for the Docker ignore policy.
- [x] Keep project checks passing.

## Verification
- uv run --extra dev pytest tests\\test_dockerignore.py -q -> 1 passed
- uv run --extra dev pytest -q -> 172 passed, 2 warnings
- uv run --extra dev ruff format --check tests\\test_dockerignore.py -> passed
- uv run --extra dev ruff check tests\\test_dockerignore.py -> passed
- uv run --extra dev mypy app -> passed
- uv run --extra dev python scripts\\docs_smoke.py -> docs smoke ok
- uv run --extra dev python scripts\\check_agents.py -> AGENTS.md ok
- git diff --check -> no whitespace errors

/claim

No secrets, private deployment values, private vulnerability details, wallet material, payout configuration, or MRWK price claims are included.