### PR TITLE
Deploy readiness: reject whitespace/control chars in MERGEWORK_DATABASE_URL

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -96,6 +96,7 @@ def _sqlite_database_errors(database_url: str) -> list[str]:
 
 def validate_deploy_settings(settings: Settings) -> list[str]:
     errors: list[str] = []
+    errors.extend(_required_env_value_errors("MERGEWORK_DATABASE_URL", settings.database_url))
     errors.extend(_sqlite_database_errors(settings.database_url))
     errors.extend(_secret_errors("MERGEWORK_GITHUB_WEBHOOK_SECRET", settings.github_webhook_secret))
     errors.extend(

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -111,6 +111,15 @@ def test_deploy_readiness_rejects_non_persistent_sqlite_database_urls() -> None:
     assert "MERGEWORK_DATABASE_URL must use a persistent sqlite file" in empty_errors
 
 
+
+
+def test_deploy_readiness_rejects_malformed_database_url_whitespace_and_control_characters() -> None:
+    whitespace_errors = validate_deploy_settings(_settings(database_url=" sqlite:////srv/mergework/data/mergework.sqlite3"))
+    control_errors = validate_deploy_settings(_settings(database_url="sqlite:////srv/mergework/data/mergework.sqlite3\nextra"))
+
+    assert "MERGEWORK_DATABASE_URL must not include leading or trailing whitespace" in whitespace_errors
+    assert "MERGEWORK_DATABASE_URL must not include control characters" in control_errors
+
 def test_deploy_readiness_accepts_absolute_sqlite_and_external_database_urls() -> None:
     assert (
         validate_deploy_settings(


### PR DESCRIPTION
Bounty #163\n\n## Summary\n- add deploy-readiness validation for  formatting\n- reject leading/trailing whitespace and control characters\n- add regression tests for whitespace-padded and control-char database URL values\n\n## Before\nMalformed values like  or newline-injected values were not flagged by generic env validation for non-sqlite URLs.\n\n## After\n now applies required env value checks to  before existing sqlite/path checks.\n\n## Verification\n- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /tmp/mergework
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 20 items

tests/test_deploy_readiness.py ....................                      [100%]

============================== 20 passed in 0.11s ==============================\n- docs smoke ok