### PR TITLE
docs: document account API response shape

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -49,6 +49,21 @@ curl -s "$API_HOST/api/v1/accounts/treasury:mrwk"
 curl -s "$API_HOST/api/v1/wallets/mrwk1..."
 ```
 
+Account responses use the same string account id in `account` and
+`ledger_address`. GitHub-backed accounts also include the login that can be
+linked from public pages:
+
+```json
+{
+  "account": "github:prettyboyvic",
+  "ledger_address": "github:prettyboyvic",
+  "github_login": "prettyboyvic",
+  "exists": true,
+  "balance_mrwk": "0",
+  "transfer_status": "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
+}
+```
+
 Register a wallet public key. Keep the private key local; only send the public
 key to MergeWork.
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -30,6 +30,19 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "public_key_hex" in examples
 
 
+def test_api_examples_document_account_response_shape() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/accounts/treasury:mrwk" in examples
+    assert "GitHub-backed accounts" in examples
+    assert '"account": "github:prettyboyvic"' in examples
+    assert '"ledger_address": "github:prettyboyvic"' in examples
+    assert '"github_login": "prettyboyvic"' in examples
+    assert '"exists": true' in examples
+    assert '"balance_mrwk": "0"' in examples
+    assert "Claim GitHub balances from /me" in examples
+
+
 def test_agent_guide_explains_internal_bounty_ids() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Bounty #162

## Summary
- document the public `/api/v1/accounts/{account}` response shape in `docs/api-examples.md`
- clarify that `account` and `ledger_address` use the same ledger account id and that GitHub-backed accounts expose `github_login`
- add a docs regression test so the documented account fields stay covered

## Evidence
Compared the example against the live unauthenticated endpoint:

`GET https://api.mrwk.ltclab.site/api/v1/accounts/github:prettyboyvic`

Observed keys: `account`, `ledger_address`, `github_login`, `exists`, `balance_mrwk`, and `transfer_status`.

## Checks
- `python scripts/docs_smoke.py` -> `docs smoke ok`
- `python -m pytest` -> `172 passed`
- `python -m ruff format --check .` -> `36 files already formatted`
- `python -m ruff check .` -> `All checks passed!`
- `python -m mypy app` -> `Success: no issues found in 11 source files`