### PR TITLE
feat: summarize accepted account work

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -215,6 +215,38 @@ def activity_to_dict(session: Session) -> dict[str, Any]:
     }
 
 
+def account_accepted_summary(session: Session, account: str) -> dict[str, Any]:
+    rows = session.execute(
+        select(LedgerEntry, Proof)
+        .join(Proof, Proof.ledger_sequence == LedgerEntry.sequence)
+        .where(
+            LedgerEntry.entry_type == "bounty_payment",
+            LedgerEntry.to_account == account,
+            Proof.kind == "bounty_payment",
+        )
+        .order_by(LedgerEntry.sequence.desc())
+    ).all()
+
+    accepted: list[dict[str, Any]] = []
+    total_microunits = 0
+    for entry, proof in rows:
+        row = _activity_row(entry, proof)
+        if row is None:
+            continue
+        total_microunits += int(row["amount_microunits"])
+        accepted.append(row)
+
+    latest = accepted[0] if accepted else None
+    return {
+        "accepted_awards": len(accepted),
+        "accepted_mrwk": format_mrwk(total_microunits),
+        "latest_ledger_sequence": latest["ledger_sequence"] if latest else None,
+        "latest_submission_url": latest["submission_url"] if latest else None,
+        "latest_proof_hash": latest["proof_hash"] if latest else None,
+        "latest_proof_url": latest["proof_url"] if latest else None,
+    }
+
+
 def _wallet_timestamp(value: datetime) -> str:
     if value.tzinfo is not None:
         value = value.replace(tzinfo=None)
@@ -959,6 +991,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         account = _normalized_account(account)
         with session_scope(db_url) as session:
             account_data = api_account(account)
+            accepted_summary = account_accepted_summary(session, account)
             entries = session.scalars(
                 select(LedgerEntry)
                 .where(or_(LedgerEntry.from_account == account, LedgerEntry.to_account == account))
@@ -968,7 +1001,13 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             proofs = _proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
             transactions = [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
         return templates.TemplateResponse(
-            request, "account.html", {"account": account_data, "transactions": transactions}
+            request,
+            "account.html",
+            {
+                "account": account_data,
+                "accepted_summary": accepted_summary,
+                "transactions": transactions,
+            },
         )
 
     @app.get("/wallets", response_class=HTMLResponse)

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -18,6 +18,46 @@
   </dl>
 </section>
 
+<section aria-labelledby="accepted-work-summary">
+  <div class="section-head">
+    <h2 id="accepted-work-summary">Accepted work summary</h2>
+    <p>Proof-backed bounty payments to this account.</p>
+  </div>
+  <div class="grid">
+    <article>
+      <strong>{{ accepted_summary.accepted_awards }}</strong>
+      <span>accepted awards</span>
+    </article>
+    <article>
+      <strong>{{ accepted_summary.accepted_mrwk }} MRWK</strong>
+      <span>accepted MRWK</span>
+    </article>
+    <article>
+      {% if accepted_summary.latest_proof_hash %}
+      <strong><a href="{{ accepted_summary.latest_proof_url }}">{{ accepted_summary.latest_proof_hash[:12] }}</a></strong>
+      <span>latest proof</span>
+      {% else %}
+      <strong>-</strong>
+      <span>latest proof</span>
+      {% endif %}
+    </article>
+  </div>
+  {% if accepted_summary.latest_proof_hash %}
+  {% set latest_submission_url = safe_public_url(accepted_summary.latest_submission_url) %}
+  <p>
+    Latest accepted work:
+    {% if latest_submission_url %}
+    <a href="{{ latest_submission_url }}">{{ accepted_summary.latest_submission_url | replace("https://github.com/", "") }}</a>
+    {% else %}
+    <code>{{ accepted_summary.latest_submission_url }}</code>
+    {% endif %}
+    via <a href="/ledger/{{ accepted_summary.latest_ledger_sequence }}">#{{ accepted_summary.latest_ledger_sequence }}</a>.
+  </p>
+  {% else %}
+  <p>No proof-backed bounty payments yet.</p>
+  {% endif %}
+</section>
+
 <section>
   <div class="section-head">
     <h2>Transactions</h2>

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -785,6 +785,12 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     )
     assert "Claim GitHub balances from /me" in account
     assert 'href="https://github.com/alice">@alice</a>' in account
+    assert "Accepted work summary" in account
+    assert "1</strong>\n      <span>accepted awards</span>" in account
+    assert "25 MRWK</strong>\n      <span>accepted MRWK</span>" in account
+    assert f'href="/proofs/{proof.hash}"' in account
+    assert 'href="https://github.com/ramimbo/mergework/pull/3"' in account
+    assert 'via <a href="/ledger/3">#3</a>' in account
     assert 'href="/accounts/reserve:bounty:1"' in account
     assert 'href="/accounts/github:alice"' in account
 


### PR DESCRIPTION
Bounty #164

## Summary
- add an accepted-work summary section to public account pages
- summarize proof-backed bounty payments for the account: accepted awards, accepted MRWK, latest proof, latest accepted work, and ledger entry link
- keep the existing transaction table intact and add focused page coverage

This makes account pages more useful for inspecting contributor activity and proof history without changing ledger data or proof payloads.

## Checks
- `python -m pytest` -> `171 passed`
- `python -m ruff format --check .` -> `36 files already formatted`
- `python -m ruff check .` -> `All checks passed!`
- `python -m mypy app` -> `Success: no issues found in 11 source files`