### PR TITLE
Add search to accepted work activity

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -156,7 +156,26 @@ def _activity_row(entry: LedgerEntry, proof: Proof) -> dict[str, Any] | None:
     }
 
 
-def activity_to_dict(session: Session) -> dict[str, Any]:
+def _activity_search_query(query: str | None) -> str:
+    return (query or "").strip().lower()
+
+
+def _activity_row_matches(row: dict[str, Any], query: str) -> bool:
+    if not query:
+        return True
+    searchable_values = (
+        row["account"],
+        row["amount_mrwk"],
+        row["submission_url"],
+        row["proof_hash"],
+        row["bounty_id"],
+        row["bounty_issue_number"],
+    )
+    return any(query in str(value or "").lower() for value in searchable_values)
+
+
+def activity_to_dict(session: Session, query: str | None = None) -> dict[str, Any]:
+    search_query = _activity_search_query(query)
     rows = session.execute(
         select(LedgerEntry, Proof)
         .join(Proof, Proof.ledger_sequence == LedgerEntry.sequence)
@@ -170,6 +189,8 @@ def activity_to_dict(session: Session) -> dict[str, Any]:
             continue
         row = _activity_row(entry, proof)
         if row is None or row["account"] is None:
+            continue
+        if not _activity_row_matches(row, search_query):
             continue
         seen_sequences.add(entry.sequence)
         recent.append(row)
@@ -210,6 +231,7 @@ def activity_to_dict(session: Session) -> dict[str, Any]:
             "accepted_mrwk": format_mrwk(total_microunits),
             "contributors": len(contributors),
         },
+        "query": search_query,
         "contributors": contributors,
         "recent": recent[:100],
     }
@@ -782,9 +804,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             return data
 
     @app.get("/api/v1/activity")
-    def api_activity() -> dict[str, Any]:
+    def api_activity(q: str | None = Query(None)) -> dict[str, Any]:
         with session_scope(db_url) as session:
-            return activity_to_dict(session)
+            return activity_to_dict(session, q)
 
     @app.post("/webhooks/github")
     async def github_webhook(request: Request) -> JSONResponse:
@@ -966,8 +988,8 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         )
 
     @app.get("/activity", response_class=HTMLResponse)
-    def activity_page(request: Request) -> HTMLResponse:
-        return templates.TemplateResponse(request, "activity.html", api_activity())
+    def activity_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:
+        return templates.TemplateResponse(request, "activity.html", api_activity(q))
 
     @app.get("/accounts/{account}", response_class=HTMLResponse)
     def account_page(request: Request, account: str) -> HTMLResponse:

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -259,10 +259,25 @@ input, textarea, button {
   font: inherit;
 }
 button { cursor: pointer; color: white; background: var(--accent); border-color: var(--accent); }
+.search-form {
+  margin: 28px 0;
+}
+.search-row {
+  align-items: center;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+}
+.search-row a {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 10px 14px;
+}
 .inline-form { margin-top: 18px; max-width: 180px; }
 .wallet-tool form + h2 { margin-top: 34px; }
 @media (max-width: 640px) {
   header { align-items: flex-start; flex-direction: column; }
+  .search-row { grid-template-columns: 1fr; }
   .detail dl { grid-template-columns: 1fr; }
   .bounty-summary { grid-template-columns: 1fr; }
   .ledger-card-head { grid-template-columns: 1fr; }

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -4,6 +4,15 @@
 <h1>Accepted work activity</h1>
 <p class="lead">Proof-backed MRWK bounty payments, grouped by contributor account.</p>
 
+<form class="search-form" method="get" action="/activity" role="search">
+  <label for="activity-q">Search accepted work</label>
+  <div class="search-row">
+    <input id="activity-q" name="q" value="{{ query }}" placeholder="account, PR, proof, issue, bounty">
+    <button type="submit">Search</button>
+    {% if query %}<a href="/activity">Clear</a>{% endif %}
+  </div>
+</form>
+
 <section class="grid">
   <article><strong>{{ totals.accepted_awards }}</strong><span>accepted awards</span></article>
   <article><strong>{{ totals.accepted_mrwk }}</strong><span>accepted MRWK</span></article>

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -101,6 +101,61 @@ def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -
     assert all("unproved" not in row["submission_url"] for row in payload["recent"])
 
 
+def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=164,
+            issue_url="https://github.com/ramimbo/mergework/issues/164",
+            title="Activity search bounty",
+            reward_mrwk="100",
+            max_awards=2,
+            acceptance="Activity search should find accepted work quickly.",
+        )
+        alice_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/164",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:bob",
+            submission_url="https://github.com/ramimbo/mergework/pull/165",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    by_account = client.get("/api/v1/activity?q=ALICE").json()
+    by_proof = client.get(f"/api/v1/activity?q={alice_proof.hash[:12]}").json()
+    no_match = client.get("/api/v1/activity?q=carol").json()
+
+    assert by_account["query"] == "alice"
+    assert by_account["totals"] == {
+        "accepted_awards": 1,
+        "accepted_mrwk": "100",
+        "contributors": 1,
+    }
+    assert by_account["contributors"][0]["account"] == "github:alice"
+    assert by_account["recent"][0]["submission_url"].endswith("/pull/164")
+    assert by_proof["recent"][0]["proof_hash"] == alice_proof.hash
+    assert no_match["totals"] == {
+        "accepted_awards": 0,
+        "accepted_mrwk": "0",
+        "contributors": 0,
+    }
+    assert no_match["contributors"] == []
+    assert no_match["recent"] == []
+
+
 def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
@@ -135,6 +190,14 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert paid.status_code == 200
     assert "github:bob" in paid.text
     assert "75 MRWK" in paid.text
+    assert 'role="search"' in paid.text
+    assert 'name="q"' in paid.text
     assert 'href="https://github.com/ramimbo/mergework/pull/12"' in paid.text
     assert f'href="/proofs/{proof.hash}"' in paid.text
     assert "/accounts/github:bob" in paid.text
+
+    filtered = client.get("/activity?q=bob")
+
+    assert filtered.status_code == 200
+    assert 'value="bob"' in filtered.text
+    assert 'href="/activity">Clear</a>' in filtered.text


### PR DESCRIPTION
Summary:
Add a `q` search filter to the public accepted-work activity API and page.

Related bounty or issue:
Bounty #164

What changed:
- `/api/v1/activity?q=...` filters proof-backed accepted work by contributor account, amount, submission URL, proof hash, internal bounty id, or GitHub issue number.
- `/activity?q=...` adds a compact search form and clear link while keeping existing contributor and recent-work cards.
- Matching totals, contributor summaries, and recent accepted-work rows now reflect the active query.
- Added regression coverage for account, proof-hash, and no-result searches plus page rendering.

Validation:
- `uv run --extra dev pytest tests/test_activity.py -q` -> 3 passed.
- `uv run --extra dev pytest tests/test_activity.py tests/test_api_mcp.py::test_docs_page_lists_live_ltclab_urls -q` -> 4 passed.
- `uv run --extra dev pytest tests/test_activity.py tests/test_bounty_pages.py -q` -> 6 passed.
- `uv run --extra dev pytest -q` -> 193 passed, 2 warnings.
- `uv run --extra dev ruff format --check .` -> 37 files already formatted.
- `uv run --extra dev ruff check .` -> all checks passed.
- `uv run --extra dev mypy app` -> success.
- `python3 scripts/docs_smoke.py` -> docs smoke ok.
- `python3 scripts/check_agents.py` -> AGENTS.md ok.
- `git diff --check` -> no output.

Notes:
No secrets, wallet material, private deployment values, private vulnerability details, deployment changes, or MRWK price claims are included.