### PR TITLE
Validate accepted webhook sender logins

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -112,7 +112,11 @@ def _handle_accepted_issue_label(
             database_url, delivery_id, event_type, payload_hash, "missing_submitter"
         )
     submitter = submitter_login.strip()
-    accepted_by = ((payload.get("sender") or {}).get("login") or "maintainer").strip().lower()
+    sender = payload.get("sender") or {}
+    sender_login = sender.get("login") if isinstance(sender, dict) else None
+    if not isinstance(sender_login, str) or not sender_login.strip():
+        return _record_status(database_url, delivery_id, event_type, payload_hash, "missing_sender")
+    accepted_by = sender_login.strip().lower()
     if accepted_labelers and accepted_by not in accepted_labelers:
         return _record_status(
             database_url, delivery_id, event_type, payload_hash, "unauthorized_labeler"

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -198,6 +198,50 @@ def test_accepted_label_requires_submitter_login(sqlite_url: str) -> None:
         assert event.processed_status == "missing_submitter"
 
 
+def test_accepted_label_requires_sender_login(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "labeled",
+            "label": {"name": "mrwk:accepted"},
+            "issue": {
+                "number": 45,
+                "html_url": "https://github.com/ramimbo/mergework/issues/45",
+                "user": {"login": "alice"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": 123},
+        },
+        separators=(",", ":"),
+    ).encode()
+    headers = {
+        "X-GitHub-Delivery": "delivery-missing-sender",
+        "X-GitHub-Event": "issues",
+        "X-Hub-Signature-256": _signature("secret", body),
+    }
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=45,
+            issue_url="https://github.com/ramimbo/mergework/issues/45",
+            title="Accepted issue with malformed sender",
+            reward_mrwk="25",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+
+    result = handle_github_webhook(sqlite_url, headers, body, "secret")
+
+    assert result == {"status": "missing_sender"}
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:alice") == 0
+        event = session.get(WebhookEvent, "delivery-missing-sender")
+        assert event is not None
+        assert event.processed_status == "missing_sender"
+
+
 def test_accepted_pr_labels_can_pay_multiple_awards_for_one_bounty(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     first_body = json.dumps(


### PR DESCRIPTION
/claim #122

Bounty #122

## Summary
- Validate the accepted-label webhook sender before using it as `accepted_by`.
- Record malformed or missing sender logins as `missing_sender` instead of raising during webhook handling.
- Add regression coverage proving a signed accepted-label payload with a non-string `sender.login` does not pay the submitter and records the webhook status.

## Evidence
- Before fix: a signed accepted-label payload with `sender.login` set to a non-string reached `.strip()` and could crash instead of recording a safe status.
- After fix: the same payload returns `{status:missing_sender}`, records `processed_status=missing_sender`, and leaves the submitter balance at zero.

## Verification
- `uv run --python 3.12 --extra dev python -m pytest -q` -> 196 passed, 2 warnings
- `uv run --python 3.12 --extra dev ruff format --check .` -> 37 files already formatted
- `uv run --python 3.12 --extra dev ruff check .` -> All checks passed
- `uv run --python 3.12 --extra dev python -m mypy app` -> Success: no issues found in 11 source files
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --python 3.12 --extra dev python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

AI-assisted with Codex. No secrets, wallet material, private deployment values, private vulnerability details, or MRWK price claims are included.