### PR TITLE
Show available MRWK on bounty pages

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -106,6 +106,7 @@ def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
     awards_remaining = max(0, bounty.max_awards - bounty.awards_paid)
     if bounty.status != "open":
         awards_remaining = 0
+    available_microunits = bounty.reward_microunits * awards_remaining
     return {
         "id": bounty.id,
         "repo": bounty.repo,
@@ -113,6 +114,7 @@ def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
         "issue_url": bounty.issue_url,
         "title": bounty.title,
         "reward_mrwk": format_mrwk(bounty.reward_microunits),
+        "available_mrwk": format_mrwk(available_microunits),
         "reserved_mrwk": format_mrwk(bounty.reserved_microunits),
         "max_awards": bounty.max_awards,
         "awards_paid": bounty.awards_paid,

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -28,6 +28,7 @@
       {{ bounty.repo }} #{{ bounty.issue_number }} ·
       {% endif %}
       {{ bounty.reward_mrwk }} MRWK per award ·
+      {{ bounty.available_mrwk }} MRWK still available ·
       {{ bounty.awards_remaining }}/{{ bounty.max_awards }} awards open ·
       {{ bounty.status }}
     </p>

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -25,6 +25,10 @@
       <strong>{{ bounty.awards_remaining }}</strong>
     </article>
     <article>
+      <span>Available</span>
+      <strong>{{ bounty.available_mrwk }} MRWK</strong>
+    </article>
+    <article>
       <span>Issue</span>
       <strong>
         {% if issue_url %}

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -28,6 +28,7 @@ The bounties list returns public bounty rows. `status` can be omitted or set to
   "issue_url": "https://github.com/ramimbo/mergework/issues/164",
   "title": "MRWK bounty: contributor activity and bounty discovery improvements",
   "reward_mrwk": "100",
+  "available_mrwk": "100",
   "reserved_mrwk": "500",
   "max_awards": 5,
   "awards_paid": 4,

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -182,6 +182,7 @@ def test_bounty_api_reports_multi_award_capacity(sqlite_url: str) -> None:
     bounty = client.get("/api/v1/bounties").json()[0]
 
     assert bounty["reward_mrwk"] == "25"
+    assert bounty["available_mrwk"] == "100"
     assert bounty["reserved_mrwk"] == "100"
     assert bounty["max_awards"] == 4
     assert bounty["awards_paid"] == 0
@@ -228,6 +229,7 @@ def test_bounty_api_reports_paid_multi_award_as_exhausted(sqlite_url: str) -> No
     assert body["max_awards"] == 2
     assert body["awards_paid"] == 2
     assert body["awards_remaining"] == 0
+    assert body["available_mrwk"] == "0"
     assert body["reserved_mrwk"] == "30"
 
 
@@ -269,6 +271,7 @@ def test_bounty_api_reports_closed_multi_award_as_unavailable(sqlite_url: str) -
     assert body["max_awards"] == 3
     assert body["awards_paid"] == 1
     assert body["awards_remaining"] == 0
+    assert body["available_mrwk"] == "0"
     assert body["reserved_mrwk"] == "30"
 
 

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -50,6 +50,7 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
         in all_rows.text
     )
     assert "ramimbo/mergework #50" in all_rows.text
+    assert "50 MRWK still available" in all_rows.text
 
     paid_rows = client.get("/bounties?status=paid")
     assert paid_rows.status_code == 200
@@ -147,6 +148,7 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert "<span>Status</span>" in response.text
     assert "<span>Reward per award</span>" in response.text
     assert "<span>Awards</span>" in response.text
+    assert "<span>Available</span>" in response.text
     assert "<span>Issue</span>" in response.text
     assert "100 MRWK" in response.text
     assert "What has to be true" in response.text

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -91,6 +91,7 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert '"repo": "ramimbo/mergework"' in examples
     assert '"issue_number": 164' in examples
     assert '"reward_mrwk": "100"' in examples
+    assert '"available_mrwk": "100"' in examples
     assert '"reserved_mrwk": "500"' in examples
     assert '"awards_paid": 4' in examples
     assert '"awards_remaining": 1' in examples


### PR DESCRIPTION
/claim #164

Bounty #164

## Summary
- Add `available_mrwk` to public bounty API/MCP rows so contributors can see total currently claimable MRWK for each bounty.
- Show the available MRWK total on the public bounty list and bounty detail page.
- Update the public API example and regression coverage for open, paid, and closed multi-award bounties.

## Evidence
- The new value is computed from existing code-owned fields as `reward_microunits * awards_remaining` in `bounty_to_dict`.
- Open multi-award bounties now expose the total remaining award pool; paid or closed bounties keep `awards_remaining=0` and report `available_mrwk=0`.
- The public list/detail pages render the same API-backed value, helping contributors scan which bounties still have award capacity.

## Verification
- `uv run --python 3.12 --extra dev python -m pytest -q` -> 195 passed, 2 warnings
- `uv run --python 3.12 --extra dev ruff check .` -> All checks passed
- `uv run --python 3.12 --extra dev ruff format --check .` -> 37 files already formatted
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --python 3.12 --extra dev python -m mypy app` -> Success: no issues found in 11 source files

AI-assisted with Codex. No secrets, wallet material, private vulnerability details, deployment credentials, or MRWK price claims are included.