### PR TITLE
Harden webhook object payload fields

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -85,6 +85,11 @@ def _record_status(
     return {"status": status}
 
 
+def _payload_object(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    value = payload.get(key) or {}
+    return value if isinstance(value, dict) else {}
+
+
 def _handle_accepted_issue_label(
     database_url: str,
     payload: dict[str, Any],
@@ -93,16 +98,18 @@ def _handle_accepted_issue_label(
     payload_hash: str,
     accepted_labelers: tuple[str, ...] = (),
 ) -> dict[str, Any]:
-    issue = payload.get("issue") or {}
-    pull_request = payload.get("pull_request") or {}
+    issue = _payload_object(payload, "issue")
+    pull_request = _payload_object(payload, "pull_request")
     labeled_item = pull_request or issue
-    repo = (payload.get("repository") or {}).get("full_name")
+    repo_name = _payload_object(payload, "repository").get("full_name")
+    repo = repo_name.strip() if isinstance(repo_name, str) else ""
     issue_number = issue.get("number")
-    label = (payload.get("label") or {}).get("name", "")
+    label_name = _payload_object(payload, "label").get("name")
+    label = label_name if isinstance(label_name, str) else ""
     if payload.get("action") != "labeled" or label.lower() != ACCEPTED_LABEL:
         _record_event(database_url, delivery_id, event_type, payload_hash, "ignored")
         return {"status": "ignored"}
-    if not repo or not isinstance(labeled_item, dict):
+    if not repo or not labeled_item:
         return _record_status(database_url, delivery_id, event_type, payload_hash, "missing_issue")
 
     user = labeled_item.get("user") or {}

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -242,6 +242,87 @@ def test_accepted_label_requires_sender_login(sqlite_url: str) -> None:
         assert event.processed_status == "missing_sender"
 
 
+def test_accepted_label_handles_malformed_object_fields(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    cases = [
+        (
+            "delivery-malformed-label",
+            {
+                "action": "labeled",
+                "label": "mrwk:accepted",
+                "issue": {
+                    "number": 44,
+                    "html_url": "https://github.com/ramimbo/mergework/issues/44",
+                    "user": {"login": "alice"},
+                },
+                "repository": {"full_name": "ramimbo/mergework"},
+                "sender": {"login": "maintainer"},
+            },
+            "ignored",
+        ),
+        (
+            "delivery-malformed-repo",
+            {
+                "action": "labeled",
+                "label": {"name": "mrwk:accepted"},
+                "issue": {
+                    "number": 44,
+                    "html_url": "https://github.com/ramimbo/mergework/issues/44",
+                    "user": {"login": "alice"},
+                },
+                "repository": "ramimbo/mergework",
+                "sender": {"login": "maintainer"},
+            },
+            "missing_issue",
+        ),
+        (
+            "delivery-malformed-issue",
+            {
+                "action": "labeled",
+                "label": {"name": "mrwk:accepted"},
+                "issue": "ramimbo/mergework#44",
+                "repository": {"full_name": "ramimbo/mergework"},
+                "sender": {"login": "maintainer"},
+            },
+            "missing_issue",
+        ),
+    ]
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=44,
+            issue_url="https://github.com/ramimbo/mergework/issues/44",
+            title="Accepted issue",
+            reward_mrwk="25",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+
+    for delivery_id, payload, expected_status in cases:
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        result = handle_github_webhook(
+            sqlite_url,
+            {
+                "X-GitHub-Delivery": delivery_id,
+                "X-GitHub-Event": "issues",
+                "X-Hub-Signature-256": _signature("secret", body),
+            },
+            body,
+            "secret",
+        )
+
+        assert result == {"status": expected_status}
+
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:alice") == 0
+        for delivery_id, _payload, expected_status in cases:
+            event = session.get(WebhookEvent, delivery_id)
+            assert event is not None
+            assert event.processed_status == expected_status
+
+
 def test_accepted_pr_labels_can_pay_multiple_awards_for_one_bounty(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     first_body = json.dumps(


### PR DESCRIPTION
/claim #122

Bounty #122

## Summary
- Treat webhook payload fields that should be objects as empty objects when they arrive malformed.
- Avoid attribute errors while processing accepted-label events with malformed `label`, `repository`, or `issue` fields.
- Add regression coverage proving malformed object fields are recorded as ignored or missing issue and do not pay the submitter.

## Evidence
- Before fix: accepted-label handling assumed several payload fields were dictionaries before reading nested values.
- After fix: `_payload_object` gates nested field reads, malformed labels are ignored, malformed issue/repository payloads record `missing_issue`, and the submitter balance stays zero.
- Rebased after PR #221 merged and kept the existing `missing_sender` coverage alongside this new malformed-object coverage.

## Verification
- `uv run --python 3.12 --extra dev python -m pytest tests/test_webhooks.py -q` -> 13 passed
- `uv run --python 3.12 --extra dev python -m pytest -q` -> 201 passed, 2 warnings
- `uv run --python 3.12 --extra dev ruff format --check .` -> 37 files already formatted
- `uv run --python 3.12 --extra dev ruff check .` -> All checks passed
- `uv run --python 3.12 --extra dev python -m mypy app` -> Success: no issues found in 11 source files
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --python 3.12 --extra dev python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean
- GitHub CI `Quality, readiness, docs, and image checks` -> success

AI-assisted with Codex. No secrets, wallet material, private vulnerability details, deployment credentials, or MRWK price claims are included.