### PR TITLE
Update API example award counters

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -30,8 +30,8 @@ The bounties list returns public bounty rows. `status` can be omitted or set to
   "reward_mrwk": "100",
   "reserved_mrwk": "500",
   "max_awards": 5,
-  "awards_paid": 0,
-  "awards_remaining": 5,
+  "awards_paid": 4,
+  "awards_remaining": 1,
   "status": "open",
   "acceptance": "Focused public-facing enhancements that help contributors find bounties, inspect accepted work, or understand proof/account activity, with tests. Duplicate, marketing-only, docs-only, broad redesign, or unrelated changes do not qualify.",
   "created_at": "2026-05-24T20:44:00.015953"
@@ -39,7 +39,9 @@ The bounties list returns public bounty rows. `status` can be omitted or set to
 ```
 
 Use `id` for the single-bounty API path. Use `issue_number` and `issue_url` when
-linking back to the source GitHub issue.
+linking back to the source GitHub issue. Award counters can change as accepted
+work is paid; refresh concrete examples against the live API before relying on
+available slot counts.
 
 Read a single bounty with its internal `id` from `/api/v1/bounties`:
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -83,7 +83,9 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert '"issue_number": 164' in examples
     assert '"reward_mrwk": "100"' in examples
     assert '"reserved_mrwk": "500"' in examples
-    assert '"awards_remaining": 5' in examples
+    assert '"awards_paid": 4' in examples
+    assert '"awards_remaining": 1' in examples
+    assert "Award counters can change" in examples
     assert "Use `id` for the single-bounty API path" in examples
 
 


### PR DESCRIPTION
## Summary
- Update the `docs/api-examples.md` sample for bounty id 36 so its award counters match the current live public API response.
- Add a note that award counters can change as accepted work is paid, so concrete examples should be refreshed before relying on available slot counts.
- Update the docs response-shape regression test to match the refreshed example and new guidance.

Refs #122
Refs #162

## Evidence
Checked on 2026-05-25 UTC:

```bash
curl -sS 'https://api.mrwk.ltclab.site/api/v1/bounties/36' | jq '{id, issue_number, awards_paid, awards_remaining, status}'
```

Live response:

```json
{
  "id": 36,
  "issue_number": 164,
  "awards_paid": 4,
  "awards_remaining": 1,
  "status": "open"
}
```

## Verification
- `python3 scripts/docs_smoke.py` -> `docs smoke ok`
- `git diff --check` -> clean
- GitHub Actions `Quality, readiness, docs, and image checks` passed: https://github.com/ramimbo/mergework/actions/runs/26388543403/job/77672498474

Note: full project test install could not run locally because this machine only has Python 3.9.6 and the project requires Python >=3.12. The GitHub Actions run covered the full suite on Python 3.12.

AI-assisted with Codex. No secrets, wallet material, private deployment values, private vulnerability details, or MRWK price claims are included.