### PR TITLE
Validate Postgres deploy database URLs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,7 +4,7 @@ import ipaddress
 import os
 import re
 from dataclasses import dataclass
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 
 @dataclass(frozen=True)
@@ -82,8 +82,16 @@ def _is_valid_dns_hostname(hostname: str) -> bool:
     return all(DNS_LABEL_RE.fullmatch(label) for label in labels)
 
 
-def _sqlite_database_errors(database_url: str) -> list[str]:
-    parsed = urlparse(database_url)
+def _postgres_query_includes_host(query: str) -> bool:
+    return any(value.strip() for value in parse_qs(query, keep_blank_values=True).get("host", ()))
+
+
+def _database_url_errors(database_url: str) -> list[str]:
+    try:
+        parsed = urlparse(database_url)
+    except ValueError:
+        return ["MERGEWORK_DATABASE_URL must include a valid database host"]
+
     is_sqlite = parsed.scheme == "sqlite" or parsed.scheme.startswith("sqlite+")
     is_postgres = (
         parsed.scheme in {"postgres", "postgresql"}
@@ -92,8 +100,28 @@ def _sqlite_database_errors(database_url: str) -> list[str]:
     )
     if not (is_sqlite or is_postgres):
         return ["MERGEWORK_DATABASE_URL must use sqlite, postgresql, or postgres"]
-    if not is_sqlite:
-        return []
+    if is_postgres:
+        errors: list[str] = []
+        try:
+            hostname = parsed.hostname
+        except ValueError:
+            errors.append("MERGEWORK_DATABASE_URL must include a valid database host")
+            hostname = None
+        if not hostname and not _postgres_query_includes_host(parsed.query):
+            errors.append("MERGEWORK_DATABASE_URL must include a database host")
+
+        authority = parsed.netloc.rsplit("@", 1)[-1]
+        try:
+            port = parsed.port
+        except ValueError:
+            errors.append("MERGEWORK_DATABASE_URL must include a valid database port")
+        else:
+            if port is None and authority.endswith(":"):
+                errors.append("MERGEWORK_DATABASE_URL must include a valid database port")
+
+        if parsed.path in ("", "/"):
+            errors.append("MERGEWORK_DATABASE_URL must include a database name")
+        return errors
 
     sqlite_path = parsed.path
     is_memory = database_url == "sqlite:///:memory:" or sqlite_path == "/:memory:"
@@ -111,7 +139,7 @@ def _sqlite_database_errors(database_url: str) -> list[str]:
 def validate_deploy_settings(settings: Settings) -> list[str]:
     errors: list[str] = []
     errors.extend(_required_env_value_errors("MERGEWORK_DATABASE_URL", settings.database_url))
-    errors.extend(_sqlite_database_errors(settings.database_url))
+    errors.extend(_database_url_errors(settings.database_url))
     errors.extend(_secret_errors("MERGEWORK_GITHUB_WEBHOOK_SECRET", settings.github_webhook_secret))
     errors.extend(
         _secret_errors("MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", settings.github_oauth_client_secret)

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -111,6 +111,40 @@ def test_deploy_readiness_rejects_non_persistent_sqlite_database_urls() -> None:
     assert "MERGEWORK_DATABASE_URL must use a persistent sqlite file" in empty_errors
 
 
+def test_deploy_readiness_rejects_malformed_postgres_database_urls() -> None:
+    missing_host_errors = validate_deploy_settings(
+        _settings(database_url="postgresql:///mergework")
+    )
+    empty_host_errors = validate_deploy_settings(
+        _settings(database_url="postgresql://:5432/mergework")
+    )
+    missing_database_errors = validate_deploy_settings(
+        _settings(database_url="postgresql://db.example.test")
+    )
+    empty_database_errors = validate_deploy_settings(
+        _settings(database_url="postgresql://db.example.test/")
+    )
+    invalid_port_errors = validate_deploy_settings(
+        _settings(database_url="postgresql://db.example.test:notaport/mergework")
+    )
+    out_of_range_port_errors = validate_deploy_settings(
+        _settings(database_url="postgresql://db.example.test:70000/mergework")
+    )
+    empty_port_errors = validate_deploy_settings(
+        _settings(database_url="postgresql://db.example.test:/mergework")
+    )
+    unmatched_bracket_errors = validate_deploy_settings(_settings(database_url="postgresql://[::1"))
+
+    assert "MERGEWORK_DATABASE_URL must include a database host" in missing_host_errors
+    assert "MERGEWORK_DATABASE_URL must include a database host" in empty_host_errors
+    assert "MERGEWORK_DATABASE_URL must include a database name" in missing_database_errors
+    assert "MERGEWORK_DATABASE_URL must include a database name" in empty_database_errors
+    assert "MERGEWORK_DATABASE_URL must include a valid database port" in invalid_port_errors
+    assert "MERGEWORK_DATABASE_URL must include a valid database port" in out_of_range_port_errors
+    assert "MERGEWORK_DATABASE_URL must include a valid database port" in empty_port_errors
+    assert "MERGEWORK_DATABASE_URL must include a valid database host" in unmatched_bracket_errors
+
+
 def test_deploy_readiness_rejects_database_url_missing_whitespace_or_control() -> None:
     missing_errors = validate_deploy_settings(_settings(database_url=""))
     blank_errors = validate_deploy_settings(_settings(database_url="   "))
@@ -130,6 +164,8 @@ def test_deploy_readiness_rejects_database_url_missing_whitespace_or_control() -
 
 
 def test_deploy_readiness_accepts_absolute_sqlite_and_external_database_urls() -> None:
+    socket_database_url = "postgresql://mergework:password@/mergework?host=/var/run/postgresql"
+
     assert (
         validate_deploy_settings(
             _settings(database_url="sqlite:////srv/mergework/data/app.sqlite3")
@@ -165,6 +201,7 @@ def test_deploy_readiness_accepts_absolute_sqlite_and_external_database_urls() -
         )
         == []
     )
+    assert validate_deploy_settings(_settings(database_url=socket_database_url)) == []
 
 
 def test_deploy_readiness_rejects_malformed_database_url_schemes() -> None:


### PR DESCRIPTION
/claim #122

## Summary
- validate Postgres deploy database URLs instead of accepting every postgres/postgresql scheme
- reject missing database host, missing database name, invalid/empty ports, and malformed hosts during deploy readiness checks
- keep valid hosted database URLs and Unix-socket URLs using `?host=...` accepted

## Verification
- `uv run --python 3.12 --extra dev python -m pytest -q`
- `uv run --python 3.12 --extra dev ruff check`
- `uv run --python 3.12 --extra dev python -m mypy app`
- `git diff --check`