### PR TITLE
Validate wallet lookup addresses

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,7 @@ from app.ledger.service import (
     submit_wallet_transfer,
 )
 from app.models import Account, Bounty, LedgerEntry, Proof, Wallet, WalletTransfer
+from app.wallets import WalletError, normalize_wallet_address
 from app.webhooks.github import handle_github_webhook
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -383,6 +384,13 @@ def _positive_ledger_sequence(sequence: int) -> int:
     if sequence <= 0:
         raise HTTPException(status_code=400, detail="ledger sequence must be positive")
     return sequence
+
+
+def _normalized_wallet_address(address: str) -> str:
+    try:
+        return normalize_wallet_address(address)
+    except WalletError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 def _signed_value(value: str, secret: str) -> str:
@@ -786,8 +794,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/api/v1/wallets/{address}")
     def api_wallet(address: str) -> dict[str, Any]:
+        address = _normalized_wallet_address(address)
         with session_scope(db_url) as session:
-            wallet = session.get(Wallet, address.lower())
+            wallet = session.get(Wallet, address)
             if wallet is None:
                 raise HTTPException(status_code=404, detail="wallet not found")
             return wallet_to_dict(session, wallet)
@@ -1103,8 +1112,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/wallets/{address}", response_class=HTMLResponse)
     def wallet_page(request: Request, address: str) -> HTMLResponse:
+        address = _normalized_wallet_address(address)
         with session_scope(db_url) as session:
-            wallet = session.get(Wallet, address.lower())
+            wallet = session.get(Wallet, address)
             if wallet is None:
                 raise HTTPException(status_code=404, detail="wallet not found")
             wallet_data = wallet_to_dict(session, wallet)

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -230,6 +230,22 @@ def test_wallet_api_malformed_register_requests_return_4xx(sqlite_url: str) -> N
     assert non_object.json()["detail"] == "json body must be an object"
 
 
+def test_wallet_lookup_rejects_invalid_addresses_before_lookup(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    api_response = client.get("/api/v1/wallets/not-a-wallet")
+    page_response = client.get("/wallets/%20%20%20")
+    unknown_wallet = client.get("/api/v1/wallets/mrwk1" + ("0" * 40))
+
+    assert api_response.status_code == 400
+    assert api_response.json()["detail"] == "invalid MRWK wallet address"
+    assert page_response.status_code == 400
+    assert "invalid MRWK wallet address" in page_response.text
+    assert unknown_wallet.status_code == 404
+    assert unknown_wallet.json()["detail"] == "wallet not found"
+
+
 @pytest.mark.parametrize(
     "path",
     ["/api/v1/wallets/register", "/api/v1/wallets/link-github"],


### PR DESCRIPTION
/claim #122

Bounty #122

## Summary
- Validate wallet addresses before API and HTML wallet-detail lookups.
- Return `400 invalid MRWK wallet address` for malformed lookup paths instead of treating them as missing wallets.
- Preserve `404 wallet not found` for syntactically valid but unregistered `mrwk1` addresses.

## Evidence
- Before fix: `GET /api/v1/wallets/{address}` and `/wallets/{address}` lowercased the path and queried the database directly, so malformed addresses were indistinguishable from unknown wallets.
- After fix: both lookup routes use the existing `normalize_wallet_address` validator used by wallet mutation flows.
- Regression coverage checks invalid API/page lookups and valid-but-unregistered lookup behavior.

## Verification
- `uv run --python 3.12 --extra dev python -m pytest tests/test_wallet_api.py::test_wallet_lookup_rejects_invalid_addresses_before_lookup -q` -> 1 passed
- `uv run --python 3.12 --extra dev python -m pytest -q` -> 201 passed, 2 warnings
- `uv run --python 3.12 --extra dev ruff check .` -> All checks passed
- `uv run --python 3.12 --extra dev ruff format --check .` -> 37 files already formatted
- `uv run --python 3.12 --extra dev python -m mypy app` -> Success: no issues found in 11 source files
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok

AI-assisted with Codex. No secrets, wallet material, private vulnerability details, deployment credentials, or MRWK price claims are included.