### PR TITLE
Document auth session API response

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -53,6 +53,21 @@ API path such as `/api/v1/bounties/11`.
 
 ## Ledger, Proofs, Accounts, And Wallets
 
+Check whether the current request has an authenticated GitHub session:
+
+```bash
+curl -s "$API_HOST/api/v1/auth/me"
+```
+
+Unauthenticated requests return a public session shape with a `null` login:
+
+```json
+{
+  "authenticated": false,
+  "github_login": null
+}
+```
+
 Read recent ledger entries and inspect one entry:
 
 ```bash

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -73,6 +73,15 @@ def test_api_examples_document_ledger_response_shape() -> None:
     assert "bounty-payment ledger entries" in examples
 
 
+def test_api_examples_document_auth_me_response_shape() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/auth/me" in examples
+    assert '"authenticated": false' in examples
+    assert '"github_login": null' in examples
+    assert "Unauthenticated requests return" in examples
+
+
 def test_api_examples_document_bounty_list_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Add a public `/api/v1/auth/me` example to `docs/api-examples.md`.
- Document the unauthenticated response shape with `authenticated: false` and `github_login: null`.
- Add a docs regression so the auth-session response fields stay covered.

Refs #162

## Evidence
Compared against `app/main.py::api_auth_me()`, which returns `{authenticated: login is not None, github_login: login}`.

Live unauthenticated readback on 2026-05-25 UTC:

```powershell
Invoke-RestMethod -Uri 'https://api.mrwk.ltclab.site/api/v1/auth/me' | ConvertTo-Json -Compress
```

returned:

```json
{authenticated:false,github_login:null}
```

## Verification
- `uv run --python 3.12 --extra dev python -m pytest tests/test_docs_public_urls.py -q` -> 12 passed
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --python 3.12 --extra dev ruff check tests/test_docs_public_urls.py` -> All checks passed
- `uv run --python 3.12 --extra dev ruff format --check tests/test_docs_public_urls.py` -> 1 file already formatted
- `git diff --check` -> clean

AI-assisted with Codex. No private keys, seed material, secrets, private vulnerability details, deployment credentials, PayPal details, or MRWK price claims are included.