### PR TITLE
Document wallet transfer API response

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -172,6 +172,34 @@ The registration response uses the same public wallet shape as
 }
 ```
 
+Submit a signed wallet transfer. Sign the canonical wallet transfer payload with
+the sender wallet private key and the sender wallet's `next_nonce` value; do not
+send the private key to MergeWork.
+
+```bash
+curl -s -X POST "$API_HOST/api/v1/transfers" \
+  -H "Content-Type: application/json" \
+  -d '{"from_address":"<sender_mrwk1_address>","to_address":"<receiver_mrwk1_address>","amount_mrwk":"1.5","nonce":3,"memo":"agent payout consolidation","signature_hex":"<128 lowercase hex chars>"}'
+```
+
+Successful transfer responses identify the transfer hash, the immutable ledger
+entry sequence created for the transfer, both wallet addresses, amount, nonce,
+memo, and timestamp:
+
+```json
+{
+  "hash": "9d0d922d25ae3c6045d9c1d64af9657228c00f925f52e4f447d4b451d91b6278",
+  "type": "wallet_transfer",
+  "ledger_sequence": 42,
+  "from_address": "mrwk102d449a31fbb267c8f352e9968a79e3e5fc95c1b",
+  "to_address": "mrwk1fb1437aec45b46ec640f44b2e2aced55dc23556e",
+  "amount_mrwk": "1.5",
+  "nonce": 3,
+  "memo": "agent payout consolidation",
+  "created_at": "2026-05-24T20:05:00"
+}
+```
+
 ## MCP Examples
 
 List MCP tools:

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -172,9 +172,15 @@ The registration response uses the same public wallet shape as
 }
 ```
 
-Submit a signed wallet transfer. Sign the canonical wallet transfer payload with
-the sender wallet private key and the sender wallet's `next_nonce` value; do not
-send the private key to MergeWork.
+Submit a signed wallet transfer. The example below assumes the sender wallet's
+current `next_nonce` is `3`. Sign the canonical wallet transfer payload with
+the sender wallet private key; do not send the private key to MergeWork. The
+signed payload uses `amount_microunits` converted from the public `amount_mrwk`
+string and is serialized as compact ASCII JSON with sorted keys:
+
+```json
+{"amount_microunits":1500000,"from_address":"<sender_mrwk1_address>","memo":"agent payout consolidation","nonce":3,"to_address":"<receiver_mrwk1_address>","type":"mrwk_transfer_v1"}
+```
 
 ```bash
 curl -s -X POST "$API_HOST/api/v1/transfers" \
@@ -196,7 +202,7 @@ memo, and timestamp:
   "amount_mrwk": "1.5",
   "nonce": 3,
   "memo": "agent payout consolidation",
-  "created_at": "2026-05-24T20:05:00"
+  "created_at": "2026-05-24T20:05:00+00:00"
 }
 ```
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -136,11 +136,15 @@ def test_api_examples_document_wallet_transfer_response() -> None:
     assert '"from_address":"<sender_mrwk1_address>"' in examples
     assert '"to_address":"<receiver_mrwk1_address>"' in examples
     assert '"signature_hex":"<128 lowercase hex chars>"' in examples
-    assert "sender wallet's `next_nonce` value" in examples
+    assert "current `next_nonce` is `3`" in examples
+    assert '"amount_microunits":1500000' in examples
+    assert '"type":"mrwk_transfer_v1"' in examples
+    assert "compact ASCII JSON with sorted keys" in examples
     assert '"type": "wallet_transfer"' in examples
     assert '"ledger_sequence": 42' in examples
     assert '"amount_mrwk": "1.5"' in examples
     assert '"memo": "agent payout consolidation"' in examples
+    assert '"created_at": "2026-05-24T20:05:00+00:00"' in examples
 
 
 def test_agent_guide_explains_internal_bounty_ids() -> None:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -129,6 +129,20 @@ def test_api_examples_document_wallet_registration_response() -> None:
     assert '"next_nonce": 1' in examples
 
 
+def test_api_examples_document_wallet_transfer_response() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert 'POST "$API_HOST/api/v1/transfers"' in examples
+    assert '"from_address":"<sender_mrwk1_address>"' in examples
+    assert '"to_address":"<receiver_mrwk1_address>"' in examples
+    assert '"signature_hex":"<128 lowercase hex chars>"' in examples
+    assert "sender wallet's `next_nonce` value" in examples
+    assert '"type": "wallet_transfer"' in examples
+    assert '"ledger_sequence": 42' in examples
+    assert '"amount_mrwk": "1.5"' in examples
+    assert '"memo": "agent payout consolidation"' in examples
+
+
 def test_agent_guide_explains_internal_bounty_ids() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Bounty #229

## Summary
- Document the public `POST /api/v1/transfers` wallet transfer request and response shape.
- Clarify that callers sign the canonical transfer payload with the sender wallet private key and use the sender wallet `next_nonce`.
- Add docs regression coverage for the transfer endpoint, signature placeholder, and response fields returned by `wallet_transfer_to_dict()`.

## Evidence
- Compared the documented response shape against `app/main.py::wallet_transfer_to_dict()` and `app/ledger/service.py::submit_wallet_transfer()`.
- The response includes `hash`, `type`, `ledger_sequence`, wallet addresses, `amount_mrwk`, `nonce`, `memo`, and `created_at`.
- No private keys, real signatures, wallet secrets, or payout details are included.

## Verification
- `uv run --python 3.12 --extra dev python -m pytest tests/test_docs_public_urls.py -q` -> 14 passed
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --python 3.12 --extra dev ruff check docs/api-examples.md tests/test_docs_public_urls.py` -> all checks passed
- `uv run --python 3.12 --extra dev ruff format --check --preview docs/api-examples.md tests/test_docs_public_urls.py` -> 2 files already formatted
- `git diff --check` -> clean