### PR TITLE
Handle malformed webhook submission URLs

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -134,7 +134,15 @@ def _handle_accepted_issue_label(
         )
 
     bounty_issue_numbers: list[int] = []
-    submission_url = labeled_item.get("html_url", "")
+    submission_url_value = labeled_item.get("html_url", "")
+    if submission_url_value is None:
+        submission_url = ""
+    elif isinstance(submission_url_value, str):
+        submission_url = submission_url_value
+    else:
+        return _record_status(
+            database_url, delivery_id, event_type, payload_hash, "malformed_submission_url"
+        )
     if event_type == "pull_request":
         bounty_issue_numbers = _linked_issue_numbers(str(pull_request.get("body") or ""), repo)
     elif isinstance(issue_number, int):

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -286,6 +286,21 @@ def test_accepted_label_handles_malformed_object_fields(sqlite_url: str) -> None
             },
             "missing_issue",
         ),
+        (
+            "delivery-malformed-submission-url",
+            {
+                "action": "labeled",
+                "label": {"name": "mrwk:accepted"},
+                "issue": {
+                    "number": 44,
+                    "html_url": {"href": "https://github.com/ramimbo/mergework/issues/44"},
+                    "user": {"login": "alice"},
+                },
+                "repository": {"full_name": "ramimbo/mergework"},
+                "sender": {"login": "maintainer"},
+            },
+            "malformed_submission_url",
+        ),
     ]
 
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
/claim #228

Bounty #228

## Summary
- Handle malformed signed webhook payloads where the accepted issue/PR `html_url` field is present but not a string.
- Return and record `malformed_submission_url` instead of letting the handler raise `AttributeError` before an event status is persisted.
- Preserve the existing fallback for missing/null `html_url` values, so normal accepted-label handling is unchanged.

## Repro Before Fix
A signed `issues` webhook payload with:

```json
html_url: {href:https://github.com/ramimbo/mergework/issues/44}
```

raised:

```text
AttributeError: 'dict' object has no attribute 'strip'
```

when `pay_bounty()` tried to validate the non-string submission URL.

## Verification
- `uv run --python 3.12 --extra dev python -m pytest tests/test_webhooks.py -q` -> 13 passed
- `uv run --python 3.12 --extra dev python -m pytest -q` -> 205 passed, 2 warnings
- `uv run --python 3.12 --extra dev ruff format --check .` -> 37 files already formatted
- `uv run --python 3.12 --extra dev ruff check .` -> all checks passed
- `uv run --python 3.12 --extra dev python -m mypy app` -> success
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No secrets, wallet material, private vulnerability details, deployment values, payout details, or MRWK price claims are included.