### PR TITLE
Reject malformed IPv4 public base URLs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -32,6 +32,7 @@ WEAK_SECRET_VALUES = {
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 
 DNS_LABEL_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
+IPV4_DOTTED_QUAD_RE = re.compile(r"\d+\.\d+\.\d+\.\d+")
 
 
 def _csv_env(name: str, default: str = "") -> tuple[str, ...]:
@@ -76,6 +77,8 @@ def _duplicate_github_logins(logins: tuple[str, ...]) -> bool:
 
 
 def _is_valid_dns_hostname(hostname: str) -> bool:
+    if IPV4_DOTTED_QUAD_RE.fullmatch(hostname):
+        return False
     if len(hostname) > 253:
         return False
     labels = hostname.lower().split(".")

--- a/app/config.py
+++ b/app/config.py
@@ -32,7 +32,7 @@ WEAK_SECRET_VALUES = {
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 
 DNS_LABEL_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
-IPV4_DOTTED_QUAD_RE = re.compile(r"\d+\.\d+\.\d+\.\d+")
+IPV4_DOTTED_QUAD_RE = re.compile(r"(?:\d{1,3}\.){3}\d{1,3}")
 
 
 def _csv_env(name: str, default: str = "") -> tuple[str, ...]:

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -463,3 +463,9 @@ def test_deploy_readiness_rejects_private_public_base_url_ip_literals() -> None:
 
 def test_deploy_readiness_allows_global_public_base_url_ip_literal() -> None:
     assert validate_deploy_settings(_settings(public_base_url="https://8.8.8.8")) == []
+
+
+def test_deploy_readiness_allows_numeric_dns_labels_longer_than_ipv4_octets() -> None:
+    errors = validate_deploy_settings(_settings(public_base_url="https://1234.5.6.7.example"))
+
+    assert errors == []

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -362,6 +362,9 @@ def test_deploy_readiness_rejects_public_base_url_userinfo() -> None:
 
 def test_deploy_readiness_rejects_malformed_public_base_url_hosts() -> None:
     empty_host_errors = validate_deploy_settings(_settings(public_base_url="https://:443"))
+    invalid_ipv4_errors = validate_deploy_settings(
+        _settings(public_base_url="https://999.999.999.999")
+    )
     invalid_port_errors = validate_deploy_settings(
         _settings(public_base_url="https://api.example:notaport")
     )
@@ -390,6 +393,7 @@ def test_deploy_readiness_rejects_malformed_public_base_url_hosts() -> None:
 
     expected = "MERGEWORK_PUBLIC_BASE_URL must include a valid host"
     assert expected in empty_host_errors
+    assert expected in invalid_ipv4_errors
     assert expected in invalid_port_errors
     assert expected in out_of_range_port_errors
     assert expected in unbracketed_ipv6_errors


### PR DESCRIPTION
Bounty #228

## Summary
- Reject malformed IPv4-looking `MERGEWORK_PUBLIC_BASE_URL` hosts such as `https://999.999.999.999` during deploy readiness validation.
- Keep valid public IP literals on the existing `ipaddress` path; this only blocks dotted-quad hostnames that are not valid IP addresses.
- Add regression coverage in the existing malformed public base URL host test.

## Repro before fix
`validate_deploy_settings(_settings(public_base_url=https://999.999.999.999))` returned `[]`, so deploy readiness accepted an invalid IPv4 literal as a DNS hostname.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_deploy_readiness.py -q` -> 24 passed
- `uv run --python 3.12 --extra dev ruff check app/config.py tests/test_deploy_readiness.py` -> all checks passed
- `uv run --python 3.12 --extra dev ruff format --check app/config.py tests/test_deploy_readiness.py` -> 2 files already formatted
- `git diff --cached --check` -> clean before commit

No secrets, wallet material, private vulnerability details, deployment credentials, PayPal details, or MRWK price claims are included.