### PR TITLE
Reject blank wallet transfer memos

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -458,13 +458,7 @@ def submit_wallet_transfer(
     if sender.address == receiver.address:
         raise LedgerError("sender and receiver must be different")
     amount = parse_mrwk_amount(amount_mrwk)
-    if CONTROL_CHAR_RE.search(memo):
-        raise LedgerError("memo must not contain control characters")
-    clean_memo = memo.strip()
-    if not clean_memo:
-        raise LedgerError("memo is required")
-    if len(clean_memo) > 240:
-        raise LedgerError("memo is too long")
+    clean_memo = _clean_required_text(memo, "memo", 240)
     if get_balance(session, sender.address) < amount:
         raise LedgerError("insufficient balance")
     payload = wallet_transfer_payload(

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -461,6 +461,8 @@ def submit_wallet_transfer(
     if CONTROL_CHAR_RE.search(memo):
         raise LedgerError("memo must not contain control characters")
     clean_memo = memo.strip()
+    if not clean_memo:
+        raise LedgerError("memo is required")
     if len(clean_memo) > 240:
         raise LedgerError("memo is too long")
     if get_balance(session, sender.address) < amount:

--- a/app/templates/transfer.html
+++ b/app/templates/transfer.html
@@ -12,7 +12,7 @@
     <label>From address <input name="from_address" placeholder="mrwk1..." required></label>
     <label>To address <input name="to_address" placeholder="mrwk1..." required></label>
     <label>Amount MRWK <input name="amount_mrwk" inputmode="decimal" placeholder="1.5" required></label>
-    <label>Memo <input name="memo" maxlength="240" placeholder="optional"></label>
+    <label>Memo <input name="memo" maxlength="240" placeholder="required" required></label>
     <label>Private key <textarea name="private_key_hex" rows="5" autocomplete="off" autocapitalize="none" spellcheck="false" required></textarea></label>
     <p class="notice">Clear this field after use. Never share your private key.</p>
     <p class="notice">If a transfer fails, check that both wallets are registered and the sender has spendable MRWK.</p>

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -55,7 +55,7 @@ Wallet addresses look like `mrwk1...` and are derived from Ed25519 public keys:
 Transfer payloads use this shape:
 
 ```json
-{"type":"mrwk_transfer_v1","from_address":"mrwk1...","to_address":"mrwk1...","amount_microunits":1000000,"nonce":1,"memo":"optional"}
+{"type":"mrwk_transfer_v1","from_address":"mrwk1...","to_address":"mrwk1...","amount_microunits":1000000,"nonce":1,"memo":"payment for issue #123"}
 ```
 
 GitHub payout accounts still exist for contributors who were paid before linking

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -105,6 +105,7 @@ def test_wallet_api_register_lookup_and_transfer(sqlite_url: str) -> None:
         ({"amount_mrwk": "1.0000001"}, {}, "MRWK supports at most 6 decimal places"),
         ({"memo": "x" * 241}, {"memo": "x" * 241}, "memo is too long"),
         ({"memo": "   "}, {"memo": ""}, "memo is required"),
+        ({"memo": None}, {"memo": ""}, "memo is required"),
     ],
 )
 def test_wallet_transfer_api_rejects_invalid_requests(

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -104,6 +104,7 @@ def test_wallet_api_register_lookup_and_transfer(sqlite_url: str) -> None:
         ({"to_address": "mrwk1" + ("0" * 40)}, {}, "wallet not found"),
         ({"amount_mrwk": "1.0000001"}, {}, "MRWK supports at most 6 decimal places"),
         ({"memo": "x" * 241}, {"memo": "x" * 241}, "memo is too long"),
+        ({"memo": "   "}, {"memo": ""}, "memo is required"),
     ],
 )
 def test_wallet_transfer_api_rejects_invalid_requests(
@@ -126,7 +127,7 @@ def test_wallet_transfer_api_rejects_invalid_requests(
         "to_address": receiver_address,
         "amount_microunits": 1_000_000,
         "nonce": 1,
-        "memo": "",
+        "memo": "test transfer",
         **payload_overrides,
     }
     body = {
@@ -134,7 +135,7 @@ def test_wallet_transfer_api_rejects_invalid_requests(
         "to_address": receiver_address,
         "amount_mrwk": "1",
         "nonce": 1,
-        "memo": "",
+        "memo": "test transfer",
         "signature_hex": _sign(sender_key, payload),
         **body_overrides,
     }
@@ -160,7 +161,7 @@ def test_wallet_transfer_api_returns_validation_error(sqlite_url: str) -> None:
             "to_address": receiver_address,
             "amount_mrwk": "1",
             "nonce": 1,
-            "memo": "",
+            "memo": "test transfer",
             "signature_hex": "00" * 64,
         },
     )


### PR DESCRIPTION
## Summary
- reject wallet transfers whose memo becomes blank after trimming
- add regression coverage for whitespace-only memo input
- keep invalid-signature/insufficient-balance coverage using a nonblank memo

## Verification
- uv run --python 3.12 --extra dev python -m pytest tests/test_wallet_api.py -q -> 25 passed
- uv run --python 3.12 --extra dev ruff check app/ledger/service.py tests/test_wallet_api.py -> passed
- git diff --check -> clean

Bounty source: https://github.com/ramimbo/mergework/issues/228

No secrets, private keys, payout credentials, deployment values, private vulnerability details, or MRWK price claims included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wallet transfers now validate the memo and reject empty or whitespace-only memos.
  * Transfer form updated to mark the memo field as required.

* **Documentation**
  * Transfer API example updated to show a concrete memo value.

* **Tests**
  * Test suite updated to treat whitespace-only and missing memos as invalid.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->