### PR TITLE
Ignore PR issue label webhook events

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -111,6 +111,14 @@ def _handle_accepted_issue_label(
         return {"status": "ignored"}
     if not repo or not labeled_item:
         return _record_status(database_url, delivery_id, event_type, payload_hash, "missing_issue")
+    if event_type == "issues" and "pull_request" in issue:
+        return _record_status(
+            database_url,
+            delivery_id,
+            event_type,
+            payload_hash,
+            "ignored_pull_request_issue",
+        )
 
     user = labeled_item.get("user") or {}
     submitter_login = user.get("login") if isinstance(user, dict) else None

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -155,6 +155,58 @@ def test_accepted_pr_label_pays_pr_author_for_linked_bounty_issue(sqlite_url: st
         assert get_balance(session, "github:maintainer") == 0
 
 
+def test_accepted_issue_event_for_pull_request_does_not_pay_matching_bounty(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "labeled",
+            "label": {"name": "mrwk:accepted"},
+            "issue": {
+                "number": 3,
+                "html_url": "https://github.com/ramimbo/mergework/pull/3",
+                "pull_request": {
+                    "html_url": "https://github.com/ramimbo/mergework/pull/3",
+                    "url": "https://api.github.com/repos/ramimbo/mergework/pulls/3",
+                },
+                "user": {"login": "contributor"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "maintainer"},
+        },
+        separators=(",", ":"),
+    ).encode()
+    headers = {
+        "X-GitHub-Delivery": "delivery-pr-issue-event",
+        "X-GitHub-Event": "issues",
+        "X-Hub-Signature-256": _signature("secret", body),
+    }
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=3,
+            issue_url="https://github.com/ramimbo/mergework/issues/3",
+            title="Real bounty issue with matching PR number",
+            reward_mrwk="150",
+            acceptance="Maintainer applies mrwk:accepted to the accepted work.",
+        )
+
+    result = handle_github_webhook(
+        sqlite_url, headers, body, "secret", accepted_labelers=("maintainer",)
+    )
+
+    assert result == {"status": "ignored_pull_request_issue"}
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:contributor") == 0
+        event = session.get(WebhookEvent, "delivery-pr-issue-event")
+        assert event is not None
+        assert event.processed_status == "ignored_pull_request_issue"
+
+
 def test_accepted_label_requires_submitter_login(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     body = json.dumps(


### PR DESCRIPTION
Bounty #228

## Summary
- Ignore GitHub `issues` labeled events that are actually pull request issue objects (`issue.pull_request` is present).
- Prevent those PR issue events from being treated as accepted bounty issues when a PR number happens to match an open bounty issue number.
- Add a regression test that records `ignored_pull_request_issue` and verifies no contributor balance is paid.

## Repro before fix
A signed `issues` webhook for a labeled pull request carries an `issue` object with `pull_request` metadata. Before this guard, the handler used `issue.number` as the bounty issue number and could pay a matching bounty issue if the PR number collided with it.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_webhooks.py tests/test_security.py -q` -> 46 passed
- `uv run --python 3.12 --extra dev python -m pytest -q` -> 206 passed, 2 warnings
- `uv run --python 3.12 --extra dev ruff check app/webhooks/github.py tests/test_webhooks.py` -> all checks passed
- `uv run --python 3.12 --extra dev ruff format --check --preview app/webhooks/github.py tests/test_webhooks.py` -> 2 files already formatted
- `uv run --python 3.12 --extra dev python -m mypy app` -> success
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --python 3.12 --extra dev python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No secrets, wallet material, private vulnerability details, deployment credentials, PayPal details, or MRWK price claims are included.