### PR TITLE
Reject malformed webhook PR bodies

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -136,7 +136,16 @@ def _handle_accepted_issue_label(
     bounty_issue_numbers: list[int] = []
     submission_url = labeled_item.get("html_url", "")
     if event_type == "pull_request":
-        bounty_issue_numbers = _linked_issue_numbers(str(pull_request.get("body") or ""), repo)
+        body_value = pull_request.get("body")
+        if body_value is None:
+            pull_request_body = ""
+        elif isinstance(body_value, str):
+            pull_request_body = body_value
+        else:
+            return _record_status(
+                database_url, delivery_id, event_type, payload_hash, "malformed_pull_request_body"
+            )
+        bounty_issue_numbers = _linked_issue_numbers(pull_request_body, repo)
     elif isinstance(issue_number, int):
         bounty_issue_numbers = [issue_number]
     if not bounty_issue_numbers:

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -155,6 +155,51 @@ def test_accepted_pr_label_pays_pr_author_for_linked_bounty_issue(sqlite_url: st
         assert get_balance(session, "github:maintainer") == 0
 
 
+def test_accepted_pr_label_rejects_malformed_body_objects(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "labeled",
+            "label": {"name": "mrwk:accepted"},
+            "pull_request": {
+                "number": 8,
+                "html_url": "https://github.com/ramimbo/mergework/pull/8",
+                "body": {"text": "Bounty #3"},
+                "user": {"login": "contributor"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "maintainer"},
+        },
+        separators=(",", ":"),
+    ).encode()
+    headers = {
+        "X-GitHub-Delivery": "delivery-pr-malformed-body",
+        "X-GitHub-Event": "pull_request",
+        "X-Hub-Signature-256": _signature("secret", body),
+    }
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=3,
+            issue_url="https://github.com/ramimbo/mergework/issues/3",
+            title="Wallet transfer validation tests",
+            reward_mrwk="150",
+            acceptance="PR adds focused wallet transfer failure tests.",
+        )
+
+    result = handle_github_webhook(sqlite_url, headers, body, "secret")
+
+    assert result == {"status": "malformed_pull_request_body"}
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:contributor") == 0
+        event = session.get(WebhookEvent, "delivery-pr-malformed-body")
+        assert event is not None
+        assert event.processed_status == "malformed_pull_request_body"
+
+
 def test_accepted_label_requires_submitter_login(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     body = json.dumps(


### PR DESCRIPTION
/claim #228

Bounty #228

## Summary
- Require GitHub pull request webhook `body` values to be strings before parsing bounty issue references.
- Treat non-string PR bodies as `malformed_pull_request_body` and persist that webhook status instead of parsing `str(object)` output.
- Preserve existing behavior for normal string bodies and null bodies.

## Repro Before Fix
A signed `pull_request` labeled payload with this malformed body:

```json
"body": {"text":"Bounty #3"}
```

was converted with `str(...)`, parsed as a `Bounty #3` reference, and paid the matching bounty.

## Verification
- `uv run --python 3.12 --extra dev python -m pytest tests/test_webhooks.py::test_accepted_pr_label_rejects_malformed_body_objects tests/test_webhooks.py::test_accepted_pr_label_pays_pr_author_for_linked_bounty_issue tests/test_webhooks.py::test_accepted_pr_label_can_pay_referenced_multi_award_issue tests/test_webhooks.py::test_accepted_pr_label_pays_full_github_issue_url_reference -q` -> 4 passed
- `uv run --python 3.12 --extra dev python -m pytest -q` -> 206 passed, 2 warnings
- `uv run --python 3.12 --extra dev ruff format --check .` -> 37 files already formatted
- `uv run --python 3.12 --extra dev ruff check .` -> all checks passed
- `uv run --python 3.12 --extra dev python -m mypy app` -> success
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No secrets, wallet material, private vulnerability details, deployment values, payout details, PayPal details, or MRWK price claims are included.
