### PR TITLE
Reject boolean webhook issue numbers

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -90,6 +90,12 @@ def _payload_object(payload: dict[str, Any], key: str) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+def _github_issue_number(value: Any) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return None
+    return value
+
+
 def _handle_accepted_issue_label(
     database_url: str,
     payload: dict[str, Any],
@@ -137,8 +143,10 @@ def _handle_accepted_issue_label(
     submission_url = labeled_item.get("html_url", "")
     if event_type == "pull_request":
         bounty_issue_numbers = _linked_issue_numbers(str(pull_request.get("body") or ""), repo)
-    elif isinstance(issue_number, int):
-        bounty_issue_numbers = [issue_number]
+    else:
+        issue_number = _github_issue_number(issue_number)
+        if issue_number is not None:
+            bounty_issue_numbers = [issue_number]
     if not bounty_issue_numbers:
         return _record_status(database_url, delivery_id, event_type, payload_hash, "missing_issue")
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -198,6 +198,52 @@ def test_accepted_label_requires_submitter_login(sqlite_url: str) -> None:
         assert event.processed_status == "missing_submitter"
 
 
+def test_accepted_issue_label_rejects_boolean_issue_number(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "labeled",
+            "label": {"name": "mrwk:accepted"},
+            "issue": {
+                "number": True,
+                "html_url": "https://github.com/ramimbo/mergework/issues/1",
+                "user": {"login": "alice"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "maintainer"},
+        },
+        separators=(",", ":"),
+    ).encode()
+    headers = {
+        "X-GitHub-Delivery": "delivery-boolean-issue-number",
+        "X-GitHub-Event": "issues",
+        "X-Hub-Signature-256": _signature("secret", body),
+    }
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=1,
+            issue_url="https://github.com/ramimbo/mergework/issues/1",
+            title="Real issue one bounty",
+            reward_mrwk="25",
+            acceptance="Boolean issue numbers must not match this bounty.",
+        )
+
+    result = handle_github_webhook(
+        sqlite_url, headers, body, "secret", accepted_labelers=("maintainer",)
+    )
+
+    assert result == {"status": "missing_issue"}
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:alice") == 0
+        event = session.get(WebhookEvent, "delivery-boolean-issue-number")
+        assert event is not None
+        assert event.processed_status == "missing_issue"
+
+
 def test_accepted_label_requires_sender_login(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     body = json.dumps(


### PR DESCRIPTION
Bounty #228

## Summary
- Treat webhook issue numbers as valid only when they are positive integers and not booleans.
- Prevent malformed accepted-label `issues` payloads with `number: true` from matching bounty issue `#1` through Python's `bool`-is-`int` behavior.
- Add a regression test that records `missing_issue` and verifies no balance is paid for the malformed issue number.

## Repro before fix
A signed accepted-label `issues` payload with `issue.number` set to `true` could be interpreted as issue number `1`, so a repository with an open bounty on issue `#1` could be matched incorrectly.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_webhooks.py -q` -> 14 passed
- `uv run --python 3.12 --extra dev ruff check app/webhooks/github.py tests/test_webhooks.py` -> all checks passed
- `uv run --python 3.12 --extra dev ruff format --check app/webhooks/github.py tests/test_webhooks.py` -> 2 files already formatted
- `git diff --cached --check` -> clean before commit

No secrets, wallet material, private vulnerability details, deployment credentials, PayPal details, or MRWK price claims are included.