### PR TITLE
Document GitHub claim API response

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -172,6 +172,36 @@ The registration response uses the same public wallet shape as
 }
 ```
 
+Claim an authenticated GitHub account balance into a linked wallet. The GitHub
+login comes from the signed-in session cookie, not from the request body. Sign
+the canonical GitHub-claim payload with the linked wallet private key and the
+wallet's `next_nonce` value; do not send the private key to MergeWork.
+
+```bash
+curl -s -X POST "$API_HOST/api/v1/github/claim" \
+  -H "Content-Type: application/json" \
+  -b "mrwk_user=<signed-session-cookie>" \
+  -d '{"address":"<linked_mrwk1_address>","nonce":2,"signature_hex":"<128 lowercase hex chars>"}'
+```
+
+Successful claim responses use the same immutable ledger-entry shape as
+`/api/v1/ledger/<sequence>`:
+
+```json
+{
+  "sequence": 42,
+  "type": "github_claim",
+  "from": "github:tatelyman",
+  "to": "mrwk102d449a31fbb267c8f352e9968a79e3e5fc95c1b",
+  "amount_mrwk": "395",
+  "reference": "github-claim:tatelyman:mrwk102d449a31fbb267c8f352e9968a79e3e5fc95c1b:2",
+  "previous_hash": "248e1e38f90ac42897486a2b52a938ad51f31849250c4a979358e9721ec7c64e",
+  "entry_hash": "d0c0e8f63ad11f2cc6e5f10dc1f61c45f943f3ab126c45761283c0ccf04cb276",
+  "proof_hash": null,
+  "created_at": "2026-05-24T20:05:00"
+}
+```
+
 ## MCP Examples
 
 List MCP tools:

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -175,7 +175,14 @@ The registration response uses the same public wallet shape as
 Claim an authenticated GitHub account balance into a linked wallet. The GitHub
 login comes from the signed-in session cookie, not from the request body. Sign
 the canonical GitHub-claim payload with the linked wallet private key and the
-wallet's `next_nonce` value; do not send the private key to MergeWork.
+wallet's `next_nonce` value; do not send the private key to MergeWork. This
+example assumes the wallet was just linked with nonce `1`, so its next nonce is
+`2`. The signed payload is compact ASCII JSON with sorted keys and includes the
+authenticated GitHub login:
+
+```json
+{"address":"<linked_mrwk1_address>","github_login":"<signed_in_github_login>","nonce":2,"type":"mrwk_claim_github_v1"}
+```
 
 ```bash
 curl -s -X POST "$API_HOST/api/v1/github/claim" \
@@ -191,14 +198,14 @@ Successful claim responses use the same immutable ledger-entry shape as
 {
   "sequence": 42,
   "type": "github_claim",
-  "from": "github:tatelyman",
-  "to": "mrwk102d449a31fbb267c8f352e9968a79e3e5fc95c1b",
-  "amount_mrwk": "395",
-  "reference": "github-claim:tatelyman:mrwk102d449a31fbb267c8f352e9968a79e3e5fc95c1b:2",
+  "from": "github:<github_login>",
+  "to": "<linked_mrwk1_address>",
+  "amount_mrwk": "<claimed_amount_mrwk>",
+  "reference": "github-claim:<github_login>:<linked_mrwk1_address>:2",
   "previous_hash": "248e1e38f90ac42897486a2b52a938ad51f31849250c4a979358e9721ec7c64e",
   "entry_hash": "d0c0e8f63ad11f2cc6e5f10dc1f61c45f943f3ab126c45761283c0ccf04cb276",
   "proof_hash": null,
-  "created_at": "2026-05-24T20:05:00"
+  "created_at": "2026-05-24T20:05:00+00:00"
 }
 ```
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -137,9 +137,13 @@ def test_api_examples_document_github_claim_response() -> None:
     assert '"signature_hex":"<128 lowercase hex chars>"' in examples
     assert "signed-in session cookie" in examples
     assert "wallet's `next_nonce` value" in examples
+    assert "wallet was just linked with nonce `1`" in examples
+    assert '"github_login":"<signed_in_github_login>"' in examples
+    assert '"type":"mrwk_claim_github_v1"' in examples
     assert '"type": "github_claim"' in examples
-    assert '"from": "github:tatelyman"' in examples
-    assert '"amount_mrwk": "395"' in examples
+    assert '"from": "github:<github_login>"' in examples
+    assert '"amount_mrwk": "<claimed_amount_mrwk>"' in examples
+    assert '"created_at": "2026-05-24T20:05:00+00:00"' in examples
     assert '"proof_hash": null' in examples
     assert "same immutable ledger-entry shape" in examples
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -129,6 +129,21 @@ def test_api_examples_document_wallet_registration_response() -> None:
     assert '"next_nonce": 1' in examples
 
 
+def test_api_examples_document_github_claim_response() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert 'POST "$API_HOST/api/v1/github/claim"' in examples
+    assert '"address":"<linked_mrwk1_address>"' in examples
+    assert '"signature_hex":"<128 lowercase hex chars>"' in examples
+    assert "signed-in session cookie" in examples
+    assert "wallet's `next_nonce` value" in examples
+    assert '"type": "github_claim"' in examples
+    assert '"from": "github:tatelyman"' in examples
+    assert '"amount_mrwk": "395"' in examples
+    assert '"proof_hash": null' in examples
+    assert "same immutable ledger-entry shape" in examples
+
+
 def test_agent_guide_explains_internal_bounty_ids() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
/claim #229

Bounty #229

## Summary
- Document the authenticated `POST /api/v1/github/claim` request for claiming a GitHub ledger balance into a linked wallet.
- Clarify that the GitHub login comes from the signed session cookie, while the request body contains only the linked wallet address, nonce, and signature.
- Document the successful response as the same immutable ledger-entry shape returned by `/api/v1/ledger/<sequence>`.
- Add docs regression coverage for the endpoint path, signed request fields, session-cookie note, and `github_claim` ledger response fields.

## Evidence
- Compared the request fields against `app/main.py::api_github_claim()`.
- Compared the signing behavior against `app/ledger/service.py::submit_github_claim()` and `wallet_claim_payload()`.
- Compared the response shape against `app/main.py::ledger_to_dict()`.

## Verification
- `uv run --python 3.12 --extra dev python -m pytest tests/test_docs_public_urls.py -q` -> 14 passed
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --python 3.12 --extra dev ruff check docs/api-examples.md tests/test_docs_public_urls.py` -> all checks passed
- `uv run --python 3.12 --extra dev ruff format --check --preview docs/api-examples.md tests/test_docs_public_urls.py` -> 2 files already formatted
- `uv run --python 3.12 --extra dev python -m pytest -q` -> 206 passed, 2 warnings
- `git diff --check` -> clean

No private keys, wallet secrets, real signatures, payout details, PayPal details, deployment credentials, private vulnerability details, or MRWK price claims are included.
