### PR TITLE
Fix stale API examples and add missing MCP tool docs

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -18,30 +18,32 @@ curl -s "$API_HOST/api/v1/bounties?status=open"
 ```
 
 The bounties list returns public bounty rows. `status` can be omitted or set to
-`open`, `paid`, or `closed`:
+`open`, `paid`, or `closed`.
+
+Each bounty row includes these fields:
 
 ```json
 {
-  "id": 36,
+  "id": 39,
   "repo": "ramimbo/mergework",
-  "issue_number": 164,
-  "issue_url": "https://github.com/ramimbo/mergework/issues/164",
-  "title": "MRWK bounty: contributor activity and bounty discovery improvements",
-  "reward_mrwk": "100",
-  "reserved_mrwk": "500",
-  "max_awards": 5,
-  "awards_paid": 4,
-  "awards_remaining": 1,
+  "issue_number": 229,
+  "issue_url": "https://github.com/ramimbo/mergework/issues/229",
+  "title": "MRWK bounty: public API examples accuracy, round 2",
+  "reward_mrwk": "75",
+  "reserved_mrwk": "450",
+  "max_awards": 6,
+  "awards_paid": 2,
+  "awards_remaining": 4,
   "status": "open",
-  "acceptance": "Focused public-facing enhancements that help contributors find bounties, inspect accepted work, or understand proof/account activity, with tests. Duplicate, marketing-only, docs-only, broad redesign, or unrelated changes do not qualify.",
-  "created_at": "2026-05-24T20:44:00.015953"
+  "acceptance": "Focused public documentation PRs that make API or MCP examples match actual MergeWork response shapes, with evidence and docs/tests. Duplicate, invented, stale, style-only, or unrelated changes do not qualify.",
+  "created_at": "2026-05-25T08:15:18.624552"
 }
 ```
 
 Use `id` for the single-bounty API path. Use `issue_number` and `issue_url` when
-linking back to the source GitHub issue. Award counters can change as accepted
-work is paid; refresh concrete examples against the live API before relying on
-available slot counts.
+linking back to the source GitHub issue. Award counters (`awards_paid`,
+`awards_remaining`) change as accepted work is paid; refresh concrete examples
+against the live API before relying on available slot counts.
 
 Read a single bounty with its internal `id` from `/api/v1/bounties`:
 
@@ -78,20 +80,23 @@ curl -s "$API_HOST/api/v1/ledger/<sequence>"
 ```
 
 Ledger entries use the internal immutable sequence number as the API path key.
-Recent-list and single-entry responses share the same shape:
+The `sequence` value increments monotonically as new entries are appended.
+Recent-list and single-entry responses share the same shape.
+
+Bounty-reserve entries record the initial reserve when a bounty is created:
 
 ```json
 {
-  "sequence": 329,
+  "sequence": 392,
   "type": "bounty_reserve",
   "from": "treasury:mrwk",
-  "to": "reserve:bounty:36",
-  "amount_mrwk": "500",
-  "reference": "https://github.com/ramimbo/mergework/issues/164",
-  "previous_hash": "25c9c46690780ffc5fe49a71c29c9d6343fe4ecbf9d0b98b56ce9dc5c94dd58a",
-  "entry_hash": "248e1e38f90ac42897486a2b52a938ad51f31849250c4a979358e9721ec7c64e",
+  "to": "reserve:bounty:39",
+  "amount_mrwk": "450",
+  "reference": "https://github.com/ramimbo/mergework/issues/229",
+  "previous_hash": "db0c7dbf2c10fe173c4364bb382cf75723401ea5515cab25838385b511390720",
+  "entry_hash": "d5cc60f7b8359a12a752471577e91560509019299abc15d4ad9e63b5fd6089bb",
   "proof_hash": null,
-  "created_at": "2026-05-24T20:44:00.019706"
+  "created_at": "2026-05-25T08:15:18.628621"
 }
 ```
 
@@ -104,6 +109,48 @@ Read accepted-work activity summarized from proof-backed bounty payments:
 curl -s "$API_HOST/api/v1/activity"
 ```
 
+The activity response contains `totals`, `query`, `contributors`, and `recent`
+keys. `totals` summarizes overall activity. `contributors` lists each account
+with their accepted award count and latest proof. `recent` lists individual
+bounty-payment entries:
+
+```json
+{
+  "totals": {
+    "accepted_awards": 354,
+    "accepted_mrwk": "18185",
+    "contributors": 66
+  },
+  "query": "",
+  "contributors": [
+    {
+      "account": "github:ckeplinger199",
+      "accepted_awards": 92,
+      "accepted_mrwk": "5115",
+      "latest_submission_url": "https://github.com/ramimbo/mergework/pull/174",
+      "latest_proof_hash": "21f286c7dd51b5b81a5a1d1fe066a3914f3e1c864a47458d6e0333bc180796f4",
+      "latest_proof_url": "/proofs/21f286c7dd51b5b81a5a1d1fe066a3914f3e1c864a47458d6e0333bc180796f4"
+    }
+  ],
+  "recent": [
+    {
+      "ledger_sequence": 408,
+      "account": "github:szw9999",
+      "amount_mrwk": "40",
+      "submission_url": "https://github.com/ramimbo/mergework/pull/225#pullrequestreview-4355217854",
+      "proof_hash": "28952563edf452119ae6d0d878555f784c7bf4235fd180237af30af16ca7d621",
+      "proof_url": "/proofs/28952563edf452119ae6d0d878555f784c7bf4235fd180237af30af16ca7d621",
+      "bounty_id": 37,
+      "bounty_issue_number": 219,
+      "created_at": "2026-05-25T08:26:49.212157"
+    }
+  ]
+}
+```
+
+Totals, contributor rankings, and recent entries change as new awards are paid.
+Refresh against the live endpoint for current counts.
+
 Inspect a proof, account, or registered wallet:
 
 ```bash
@@ -114,7 +161,9 @@ curl -s "$API_HOST/api/v1/wallets/<wallet_address>"
 
 The wallet endpoint is a read-only wallet lookup. It returns the registered
 address, public key, optional label and linked GitHub login, current balance,
-current nonce, next nonce to sign with, and registration timestamp:
+current nonce, next nonce to sign with, and registration timestamp.
+`balance_mrwk` and `nonce` reflect the current on-ledger state and change as
+transfers are processed:
 
 ```json
 {
@@ -122,7 +171,7 @@ current nonce, next nonce to sign with, and registration timestamp:
   "public_key_hex": "d88d3edf935ba932ee2737ee5500c795f21caeb4a2fdeacb55a4ff63c52c9d51",
   "label": null,
   "github_login": "prettyboyvic",
-  "balance_mrwk": "50",
+  "balance_mrwk": "175",
   "nonce": 2,
   "next_nonce": 3,
   "created_at": "2026-05-24T17:50:56.118158"
@@ -130,7 +179,7 @@ current nonce, next nonce to sign with, and registration timestamp:
 ```
 
 Account responses identify the normalized ledger address, optional GitHub login,
-existence, current balance, and whether the account can move funds directly:
+existence, current balance, and a `transfer_status` hint:
 
 ```json
 {
@@ -138,7 +187,7 @@ existence, current balance, and whether the account can move funds directly:
   "ledger_address": "github:tatelyman",
   "github_login": "tatelyman",
   "exists": true,
-  "balance_mrwk": "395",
+  "balance_mrwk": "1290",
   "transfer_status": "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
 }
 ```
@@ -182,12 +231,33 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
 
+The current tool set includes `list_bounties`, `get_bounty`, `get_balance`,
+`register_wallet`, `get_wallet`, `submit_wallet_transfer`, `get_ledger_entry`,
+`get_proof`, and `submit_work_proof`.
+
 Call `get_balance`:
 
 ```bash
 curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_balance","arguments":{"account":"treasury:mrwk"}}}'
+```
+
+The response is a plain-text balance string:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "treasury:mrwk: 99980315 MRWK"
+      }
+    ]
+  }
+}
 ```
 
 Call `list_bounties`:
@@ -237,3 +307,53 @@ string with proof metadata plus the stored public proof payload:
 In that MCP payload, `bounty_id` is the internal MergeWork bounty id. The
 `proof.issue_number` value is the source GitHub issue number when the proof was
 created from a GitHub bounty claim.
+
+Call `get_wallet` with a registered `mrwk1` address:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"get_wallet","arguments":{"address":"mrwk1fb1437aec45b46ec640f44b2e2aced55dc23556e"}}}'
+```
+
+The response returns a JSON-string wallet object inside a content block:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"address\":\"mrwk1fb1437aec45b46ec640f44b2e2aced55dc23556e\",\"public_key_hex\":\"d88d3edf935ba932ee2737ee5500c795f21caeb4a2fdeacb55a4ff63c52c9d51\",\"label\":null,\"github_login\":\"prettyboyvic\",\"balance_mrwk\":\"175\",\"nonce\":2,\"next_nonce\":3,\"created_at\":\"2026-05-24T17:50:56.118158\"}"
+      }
+    ]
+  }
+}
+```
+
+Call `submit_work_proof` to get instructions for submitting bounty work:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"submit_work_proof","arguments":{}}}'
+```
+
+The response contains a plain-text instruction string:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Open a focused PR or issue, reference the MRWK bounty, include test evidence, and wait for a maintainer to apply mrwk:accepted."
+      }
+    ]
+  }
+}
+```

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -50,7 +50,7 @@ def test_api_examples_document_account_response_shape() -> None:
     assert '"ledger_address": "github:tatelyman"' in examples
     assert '"github_login": "tatelyman"' in examples
     assert '"exists": true' in examples
-    assert '"balance_mrwk": "395"' in examples
+    assert '"balance_mrwk": "1290"' in examples
     assert "Claim GitHub balances from /me" in examples
     assert "treasury:" in examples
     assert "registered `mrwk1` addresses" in examples
@@ -61,12 +61,12 @@ def test_api_examples_document_ledger_response_shape() -> None:
 
     assert "/api/v1/ledger?limit=10" in examples
     assert "/api/v1/ledger/<sequence>" in examples
-    assert '"sequence": 329' in examples
+    assert '"sequence": 392' in examples
     assert '"type": "bounty_reserve"' in examples
     assert '"from": "treasury:mrwk"' in examples
-    assert '"to": "reserve:bounty:36"' in examples
+    assert '"to": "reserve:bounty:39"' in examples
     assert (
-        '"entry_hash": "248e1e38f90ac42897486a2b52a938ad51f31849250c4a979358e9721ec7c64e"'
+        '"entry_hash": "d5cc60f7b8359a12a752471577e91560509019299abc15d4ad9e63b5fd6089bb"'
         in examples
     )
     assert '"proof_hash": null' in examples
@@ -87,14 +87,14 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
 
     assert "/api/v1/bounties?status=open" in examples
     assert "status` can be omitted or set to" in examples
-    assert '"id": 36' in examples
+    assert '"id": 39' in examples
     assert '"repo": "ramimbo/mergework"' in examples
-    assert '"issue_number": 164' in examples
-    assert '"reward_mrwk": "100"' in examples
-    assert '"reserved_mrwk": "500"' in examples
-    assert '"awards_paid": 4' in examples
-    assert '"awards_remaining": 1' in examples
-    assert "Award counters can change" in examples
+    assert '"issue_number": 229' in examples
+    assert '"reward_mrwk": "75"' in examples
+    assert '"reserved_mrwk": "450"' in examples
+    assert '"awards_paid": 2' in examples
+    assert '"awards_remaining": 4' in examples
+    assert "Award counters" in examples
     assert "Use `id` for the single-bounty API path" in examples
 
 
@@ -109,7 +109,7 @@ def test_api_examples_document_wallet_response_shape() -> None:
     )
     assert '"label": null' in examples
     assert '"github_login": "prettyboyvic"' in examples
-    assert '"balance_mrwk": "50"' in examples
+    assert '"balance_mrwk": "175"' in examples
     assert '"nonce": 2' in examples
     assert '"next_nonce": 3' in examples
     assert '"created_at": "2026-05-24T17:50:56.118158"' in examples


### PR DESCRIPTION
## Problem

Several examples in `docs/api-examples.md` had drifted from live API response shapes:

- The activity endpoint had no documented response structure at all — the docs jumped straight from the curl command to proofs/accounts/wallets, missing the `totals`, `query`, `contributors`, and `recent` keys that the endpoint actually returns.
- The bounty JSON example used a now-closed bounty (id 36) with stale award counts.
- The wallet example showed `balance_mrwk: "50"` when the live value is `"175"`.
- The account example showed `balance_mrwk: "395"` when the live value is `"1290"`.
- The ledger example used an old sequence (329) and entry hash.
- The treasury account `transfer_status` wording had changed.
- Three MCP tools (`get_wallet`, `submit_work_proof`, `submit_wallet_transfer`) had no examples at all.
- The MCP tool set was not listed — contributors had to call `tools/list` to discover what was available.

## Changes

- Added full activity endpoint response documentation with `totals`, `contributors`, and `recent` shapes verified against `GET /api/v1/activity`.
- Updated bounty, wallet, account, and ledger JSON examples to match current live responses.
- Added a note that `sequence` increments monotonically and balances change over time.
- Documented all nine MCP tools and added call/response examples for `get_wallet` and `submit_work_proof`.
- Updated test assertions in `test_docs_public_urls.py` to match the corrected examples.

## Evidence

Every JSON example was compared against the live endpoint:

```
curl -s https://api.mrwk.ltclab.site/api/v1/activity
curl -s https://api.mrwk.ltclab.site/api/v1/bounties?status=open
curl -s https://api.mrwk.ltclab.site/api/v1/ledger?limit=10
curl -s https://api.mrwk.ltclab.site/api/v1/wallets/mrwk1fb1437aec45b46ec640f44b2e2aced55dc23556e
curl -s https://api.mrwk.ltclab.site/api/v1/accounts/github:tatelyman
curl -s -X POST https://mcp.mrwk.ltclab.site/mcp -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```

## Verification

```
python scripts/docs_smoke.py  # docs smoke ok
python -m pytest              # 205 passed, 2 warnings
python -m ruff format --check .  # 37 files already formatted
python -m ruff check .        # All checks passed
python -m mypy app            # Success: no issues found in 11 source files
git diff --check              # no whitespace errors
```

Refs #229