### PR TITLE
Reject malformed issue reference suffixes

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -16,13 +16,15 @@ from app.ledger.service import (
 from app.models import WebhookEvent
 
 ACCEPTED_LABEL = "mrwk:accepted"
+ISSUE_NUMBER_BOUNDARY = r"(?![A-Za-z0-9_-])"
 LINKED_ISSUE_RE = re.compile(
     r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?|bounty)\s+"
-    r"(?:(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(?P<repo_number>\d+)|#(?P<number>\d+))",
+    rf"(?:(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(?P<repo_number>\d+){ISSUE_NUMBER_BOUNDARY}"
+    rf"|#(?P<number>\d+){ISSUE_NUMBER_BOUNDARY})",
     re.IGNORECASE,
 )
 GITHUB_ISSUE_URL_RE = re.compile(
-    r"https://github\.com/(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/(?P<number>\d+)",
+    rf"https://github\.com/(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/(?P<number>\d+){ISSUE_NUMBER_BOUNDARY}",
     re.IGNORECASE,
 )
 

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -171,6 +171,10 @@ def test_accepted_pr_label_rejects_malformed_issue_reference_suffixes(
             "delivery-pr-malformed-url-hyphen-ref",
             "Implements https://github.com/ramimbo/mergework/issues/3-abc",
         ),
+        (
+            "delivery-pr-malformed-url-underscore-ref",
+            "Implements https://github.com/ramimbo/mergework/issues/3_abc",
+        ),
     ]
 
     with session_scope(sqlite_url) as session:

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -155,6 +155,74 @@ def test_accepted_pr_label_pays_pr_author_for_linked_bounty_issue(sqlite_url: st
         assert get_balance(session, "github:maintainer") == 0
 
 
+def test_accepted_pr_label_rejects_malformed_issue_reference_suffixes(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    cases = [
+        ("delivery-pr-malformed-shorthand-issue-ref", "Closes #3abc"),
+        ("delivery-pr-malformed-shorthand-underscore-ref", "Closes #3_abc"),
+        ("delivery-pr-malformed-shorthand-hyphen-ref", "Closes #3-abc"),
+        (
+            "delivery-pr-malformed-url-issue-ref",
+            "Implements https://github.com/ramimbo/mergework/issues/3abc",
+        ),
+        (
+            "delivery-pr-malformed-url-hyphen-ref",
+            "Implements https://github.com/ramimbo/mergework/issues/3-abc",
+        ),
+    ]
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=3,
+            issue_url="https://github.com/ramimbo/mergework/issues/3",
+            title="Wallet transfer validation tests",
+            reward_mrwk="150",
+            acceptance="PR adds focused wallet transfer failure tests.",
+        )
+
+    for delivery_id, pr_body in cases:
+        body = json.dumps(
+            {
+                "action": "labeled",
+                "label": {"name": "mrwk:accepted"},
+                "pull_request": {
+                    "number": 8,
+                    "html_url": "https://github.com/ramimbo/mergework/pull/8",
+                    "body": pr_body,
+                    "user": {"login": "contributor"},
+                },
+                "repository": {"full_name": "ramimbo/mergework"},
+                "sender": {"login": "maintainer"},
+            },
+            separators=(",", ":"),
+        ).encode()
+
+        result = handle_github_webhook(
+            sqlite_url,
+            {
+                "X-GitHub-Delivery": delivery_id,
+                "X-GitHub-Event": "pull_request",
+                "X-Hub-Signature-256": _signature("secret", body),
+            },
+            body,
+            "secret",
+        )
+
+        assert result == {"status": "missing_issue"}
+
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:contributor") == 0
+        for delivery_id, _pr_body in cases:
+            event = session.get(WebhookEvent, delivery_id)
+            assert event is not None
+            assert event.processed_status == "missing_issue"
+
+
 def test_accepted_label_requires_submitter_login(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     body = json.dumps(


### PR DESCRIPTION
/claim #228

Bounty: #228

## Summary
- Require shorthand, repo-qualified, and full GitHub issue references to stop at a valid issue-number boundary.
- Add regression coverage for malformed suffixes like `#3abc` and `https://github.com/ramimbo/mergework/issues/3abc`.

## Repro before fix
An accepted PR label payload with a PR body such as `Closes #3abc` or `https://github.com/ramimbo/mergework/issues/3abc` could be parsed as issue `#3`, which could pay the wrong bounty issue.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_webhooks.py -q`
- `uv run --python 3.12 --extra dev python -m pytest -q`
- `uv run --python 3.12 --extra dev ruff check app/webhooks/github.py tests/test_webhooks.py`
- `uv run --python 3.12 --extra dev ruff format --check app/webhooks/github.py tests/test_webhooks.py`