### PR TITLE
Document wallet GitHub link API response

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -172,6 +172,34 @@ The registration response uses the same public wallet shape as
 }
 ```
 
+Link a registered wallet to the current GitHub login. The GitHub login comes
+from the signed-in session cookie, not the request body. Sign the canonical
+wallet-link payload for the wallet's `next_nonce` with the wallet private key;
+do not send the private key to MergeWork.
+
+```bash
+curl -s -X POST "$API_HOST/api/v1/wallets/link-github" \
+  -H "Content-Type: application/json" \
+  -b "<signed GitHub session cookie>" \
+  -d '{"address":"<registered_mrwk1_address>","nonce":1,"signature_hex":"<128 lowercase hex chars>"}'
+```
+
+The link response uses the same public wallet shape as
+`/api/v1/wallets/<address>` with `github_login` set to the authenticated login:
+
+```json
+{
+  "address": "mrwk102d449a31fbb267c8f352e9968a79e3e5fc95c1b",
+  "public_key_hex": "1111111111111111111111111111111111111111111111111111111111111111",
+  "label": "agent wallet",
+  "github_login": "tatelyman",
+  "balance_mrwk": "0",
+  "nonce": 1,
+  "next_nonce": 2,
+  "created_at": "2026-05-24T20:00:00"
+}
+```
+
 ## MCP Examples
 
 List MCP tools:

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -175,7 +175,12 @@ The registration response uses the same public wallet shape as
 Link a registered wallet to the current GitHub login. The GitHub login comes
 from the signed-in session cookie, not the request body. Sign the canonical
 wallet-link payload for the wallet's `next_nonce` with the wallet private key;
-do not send the private key to MergeWork.
+do not send the private key to MergeWork. The signed payload is compact ASCII
+JSON with sorted keys and includes the authenticated GitHub login:
+
+```json
+{"address":"<registered_mrwk1_address>","github_login":"<signed_in_github_login>","nonce":1,"type":"mrwk_link_github_v1"}
+```
 
 ```bash
 curl -s -X POST "$API_HOST/api/v1/wallets/link-github" \

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -129,6 +129,20 @@ def test_api_examples_document_wallet_registration_response() -> None:
     assert '"next_nonce": 1' in examples
 
 
+def test_api_examples_document_wallet_github_link_response() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert 'POST "$API_HOST/api/v1/wallets/link-github"' in examples
+    assert "signed-in session cookie" in examples
+    assert '"address":"<registered_mrwk1_address>"' in examples
+    assert '"signature_hex":"<128 lowercase hex chars>"' in examples
+    assert "wallet-link payload" in examples
+    assert "wallet's `next_nonce`" in examples
+    assert '"github_login": "tatelyman"' in examples
+    assert '"nonce": 1' in examples
+    assert '"next_nonce": 2' in examples
+
+
 def test_agent_guide_explains_internal_bounty_ids() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -138,6 +138,9 @@ def test_api_examples_document_wallet_github_link_response() -> None:
     assert '"signature_hex":"<128 lowercase hex chars>"' in examples
     assert "wallet-link payload" in examples
     assert "wallet's `next_nonce`" in examples
+    assert '"github_login":"<signed_in_github_login>"' in examples
+    assert '"type":"mrwk_link_github_v1"' in examples
+    assert "compact ASCII" in examples
     assert '"github_login": "tatelyman"' in examples
     assert '"nonce": 1' in examples
     assert '"next_nonce": 2' in examples


### PR DESCRIPTION
/claim #229

## Summary
- Documented `POST /api/v1/wallets/link-github` in `docs/api-examples.md`.
- Clarified that the GitHub login comes from the signed session cookie while the body carries only `address`, `nonce`, and `signature_hex`.
- Added the successful response shape, matching the public wallet object returned by `wallet_to_dict()` after `github_login` is linked.
- Added regression coverage in `tests/test_docs_public_urls.py`.

## Evidence
- Request fields match `app/main.py::api_link_wallet_github()`.
- Signature guidance matches `app/ledger/service.py::wallet_link_payload()` and `link_wallet_to_github()`.
- Response fields match `app/main.py::wallet_to_dict()`.

## Verification
- `uv run --python 3.12 --extra dev python -m pytest tests/test_docs_public_urls.py -q` -> 14 passed
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --python 3.12 --extra dev ruff check docs/api-examples.md tests/test_docs_public_urls.py` -> all checks passed
- `uv run --python 3.12 --extra dev ruff format --check --preview docs/api-examples.md tests/test_docs_public_urls.py` -> 2 files already formatted
- `uv run --python 3.12 --extra dev python -m pytest -q` -> 206 passed, 2 warnings
- `git diff --check` -> clean

No private keys, wallet secrets, real signatures, payout details, PayPal details, deployment credentials, private vulnerability details, or MRWK price claims are included.
