### PR TITLE
Reject non-global public base URL IPs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -228,13 +228,17 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
                 errors.append("MERGEWORK_PUBLIC_BASE_URL must include a valid host")
             is_loopback = parsed_base_url.hostname.lower() == "localhost"
             is_private_or_link_local = False
+            is_non_global = False
         else:
             is_loopback = ip_address.is_loopback
             is_private_or_link_local = ip_address.is_private or ip_address.is_link_local
+            is_non_global = ip_address.is_multicast or not ip_address.is_global
         if is_loopback:
             errors.append("MERGEWORK_PUBLIC_BASE_URL must not use a loopback host")
         elif is_private_or_link_local:
             errors.append("MERGEWORK_PUBLIC_BASE_URL must not use a private or link-local host")
+        elif is_non_global:
+            errors.append("MERGEWORK_PUBLIC_BASE_URL must use a globally routable host")
     return errors
 
 

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -457,5 +457,16 @@ def test_deploy_readiness_rejects_private_public_base_url_ip_literals() -> None:
     assert expected in private_ipv6_errors
 
 
+def test_deploy_readiness_rejects_non_global_public_base_url_ip_literals() -> None:
+    cgnat_errors = validate_deploy_settings(_settings(public_base_url="https://100.64.0.1"))
+    multicast_errors = validate_deploy_settings(_settings(public_base_url="https://224.0.0.1"))
+    multicast_ipv6_errors = validate_deploy_settings(_settings(public_base_url="https://[ff02::1]"))
+
+    expected = "MERGEWORK_PUBLIC_BASE_URL must use a globally routable host"
+    assert expected in cgnat_errors
+    assert expected in multicast_errors
+    assert expected in multicast_ipv6_errors
+
+
 def test_deploy_readiness_allows_global_public_base_url_ip_literal() -> None:
     assert validate_deploy_settings(_settings(public_base_url="https://8.8.8.8")) == []


### PR DESCRIPTION
/claim #228

Bounty: #228

## Summary
- Reject `MERGEWORK_PUBLIC_BASE_URL` IP literals that are not globally routable, including CGNAT and multicast ranges.
- Preserve the existing loopback/private/link-local error paths and keep valid global public IP literals accepted.
- Add regression coverage for IPv4 CGNAT, IPv4 multicast, and IPv6 multicast public base URL values.

## Repro before fix
`validate_deploy_settings()` returned no errors for these deployment origins even though they are not suitable public base URLs:

```text
https://100.64.0.1 -> []
https://224.0.0.1 -> []
```

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_deploy_readiness.py -q` -> `25 passed`
- `uv run --python 3.12 --extra dev python -m pytest -q` -> `206 passed, 2 warnings`
- `uv run --python 3.12 --extra dev ruff check app/config.py tests/test_deploy_readiness.py` -> passed
- `uv run --python 3.12 --extra dev ruff format --check app/config.py tests/test_deploy_readiness.py` -> passed after formatting
- `git diff --check` -> clean

No secrets, wallet material, private vulnerability details, deployment credentials, PayPal details, or MRWK price claims are included.