### PR TITLE
Reject non-integer wallet nonces

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -298,6 +298,8 @@ def _verify_wallet_payload(
     nonce: int,
     signature_hex: str,
 ) -> str:
+    if isinstance(nonce, bool) or not isinstance(nonce, int):
+        raise LedgerError("nonce must be an integer")
     if nonce != wallet.nonce + 1:
         raise LedgerError("invalid nonce")
     try:

--- a/tests/test_wallets.py
+++ b/tests/test_wallets.py
@@ -197,6 +197,83 @@ def test_wallet_transfer_rejects_bad_signature(sqlite_url: str) -> None:
             )
 
 
+def test_wallet_operations_reject_boolean_nonces(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    sender_key, sender_public, sender_address = _keypair()
+    _, receiver_public, receiver_address = _keypair()
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        register_wallet(session, public_key_hex=sender_public, label="Sender")
+        register_wallet(session, public_key_hex=receiver_public, label="Receiver")
+        add_ledger_entry(
+            session,
+            entry_type="test_funding",
+            from_account=TREASURY_ACCOUNT,
+            to_account=sender_address,
+            amount_microunits=10_000_000,
+            reference="test-funding",
+        )
+
+        transfer_payload = wallet_transfer_payload(
+            from_address=sender_address,
+            to_address=receiver_address,
+            amount_microunits=1_000_000,
+            nonce=True,
+            memo="bool nonce",
+        )
+        with pytest.raises(LedgerError, match="nonce must be an integer"):
+            submit_wallet_transfer(
+                session,
+                from_address=sender_address,
+                to_address=receiver_address,
+                amount_mrwk="1",
+                nonce=True,
+                memo="bool nonce",
+                signature_hex=_sign(sender_key, transfer_payload),
+            )
+
+        link_payload = wallet_link_payload(
+            address=sender_address,
+            github_login="alice",
+            nonce=True,
+        )
+        with pytest.raises(LedgerError, match="nonce must be an integer"):
+            link_wallet_to_github(
+                session,
+                address=sender_address,
+                github_login="alice",
+                nonce=True,
+                signature_hex=_sign(sender_key, link_payload),
+            )
+
+        valid_link_payload = wallet_link_payload(
+            address=sender_address,
+            github_login="alice",
+            nonce=1,
+        )
+        link_wallet_to_github(
+            session,
+            address=sender_address,
+            github_login="alice",
+            nonce=1,
+            signature_hex=_sign(sender_key, valid_link_payload),
+        )
+        claim_payload = wallet_claim_payload(
+            address=sender_address,
+            github_login="alice",
+            nonce=True,
+        )
+        with pytest.raises(LedgerError, match="nonce must be an integer"):
+            submit_github_claim(
+                session,
+                address=sender_address,
+                github_login="alice",
+                nonce=True,
+                signature_hex=_sign(sender_key, claim_payload),
+            )
+
+
 def test_linked_wallet_can_claim_existing_github_balance(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     private_key, public_hex, address = _keypair()


### PR DESCRIPTION
Refs #228

## Summary
- Reject boolean and non-integer wallet nonces inside the shared ledger-service signature verification path.
- Apply the same service-boundary guard to signed wallet transfers, wallet-to-GitHub linking, and GitHub balance claims.
- Add regression coverage showing boolean nonces are rejected before they can be accepted as nonce `1` through Python's `bool`/`int` equality behavior.

## Repro Before Fix
A direct ledger service caller could sign a wallet payload with `nonce: true`; because `True == 1` in Python, `_verify_wallet_payload()` accepted it for a fresh wallet whose next nonce was `1`. The operation could then persist a boolean nonce value through transfer, link, or claim paths instead of requiring an integer nonce.

## Verification
- `./.venv/bin/python -m pytest tests/test_wallets.py::test_wallet_operations_reject_boolean_nonces -q` -> 1 passed
- `./.venv/bin/python -m pytest tests/test_wallets.py tests/test_wallet_api.py -q` -> 32 passed
- `./.venv/bin/python -m pytest -q` -> 206 passed, 2 warnings
- `./.venv/bin/python -m ruff format --check .` -> 37 files already formatted
- `./.venv/bin/python -m ruff check .` -> all checks passed
- `./.venv/bin/python -m mypy app` -> success
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `./.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No secrets, wallet material, private vulnerability details, deployment values, payout details, or MRWK price claims are included.
