### PR TITLE
Reject boolean bounty identifiers

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -149,6 +149,14 @@ def _clean_required_text(value: str, field: str, max_length: int) -> str:
     return clean
 
 
+def _positive_int(value: int, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise LedgerError(f"{field} must be an integer")
+    if value <= 0:
+        raise LedgerError(f"{field} must be positive")
+    return value
+
+
 def _clean_proof_metadata(verifier_result: dict[str, Any]) -> dict[str, Any]:
     clean = dict(verifier_result)
     for key, value in clean.items():
@@ -381,15 +389,13 @@ def create_bounty(
 ) -> Bounty:
     ensure_genesis(session)
     reward = parse_mrwk_amount(reward_mrwk)
-    if issue_number <= 0:
-        raise LedgerError("issue_number must be positive")
-    if max_awards <= 0:
-        raise LedgerError("max_awards must be positive")
-    if max_awards > 1_000:
+    clean_issue_number = _positive_int(issue_number, "issue_number")
+    clean_max_awards = _positive_int(max_awards, "max_awards")
+    if clean_max_awards > 1_000:
         raise LedgerError("max_awards is too large")
-    reserved = reward * max_awards
+    reserved = reward * clean_max_awards
     clean_repo = _clean_required_text(repo, "repo", 200)
-    existing_bounty = find_bounty_by_issue(session, clean_repo, issue_number)
+    existing_bounty = find_bounty_by_issue(session, clean_repo, clean_issue_number)
     if existing_bounty is not None:
         raise LedgerError("bounty already exists for issue")
     clean_issue_url = validate_public_url(issue_url)
@@ -399,12 +405,12 @@ def create_bounty(
         raise LedgerError("treasury balance too low")
     bounty = Bounty(
         repo=clean_repo,
-        issue_number=issue_number,
+        issue_number=clean_issue_number,
         issue_url=clean_issue_url,
         title=clean_title,
         reward_microunits=reward,
         reserved_microunits=reserved,
-        max_awards=max_awards,
+        max_awards=clean_max_awards,
         awards_paid=0,
         status="open",
         acceptance=clean_acceptance,
@@ -423,8 +429,11 @@ def create_bounty(
 
 
 def find_bounty_by_issue(session: Session, repo: str, issue_number: int) -> Bounty | None:
+    clean_issue_number = _positive_int(issue_number, "issue_number")
     return session.scalar(
-        select(Bounty).where(Bounty.repo == repo, Bounty.issue_number == issue_number).limit(1)
+        select(Bounty)
+        .where(Bounty.repo == repo, Bounty.issue_number == clean_issue_number)
+        .limit(1)
     )
 
 
@@ -572,6 +581,7 @@ def pay_bounty(
     verifier_result: dict[str, Any],
 ) -> Proof:
     ensure_genesis(session)
+    bounty_id = _positive_int(bounty_id, "bounty_id")
     bounty = session.get(Bounty, bounty_id)
     if bounty is None:
         raise LedgerError("bounty not found")
@@ -667,6 +677,7 @@ def close_bounty(
     reference: str | None = None,
 ) -> LedgerEntry | None:
     ensure_genesis(session)
+    bounty_id = _positive_int(bounty_id, "bounty_id")
     bounty = session.get(Bounty, bounty_id)
     if bounty is None:
         raise LedgerError("bounty not found")

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -112,6 +112,35 @@ def test_create_bounty_rejects_non_positive_issue_number(sqlite_url: str) -> Non
                 )
 
 
+def test_create_bounty_rejects_boolean_issue_number_or_awards(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        with pytest.raises(LedgerError, match="issue_number must be an integer"):
+            create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=True,
+                issue_url="https://github.com/ramimbo/mergework/issues/1",
+                title="Boolean issue number",
+                reward_mrwk="1",
+                acceptance="Should not be created",
+            )
+
+        with pytest.raises(LedgerError, match="max_awards must be an integer"):
+            create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=12,
+                issue_url="https://github.com/ramimbo/mergework/issues/12",
+                title="Boolean max awards",
+                reward_mrwk="1",
+                max_awards=True,
+                acceptance="Should not be created",
+            )
+
+
 def test_create_bounty_rejects_duplicate_repo_issue(sqlite_url: str) -> None:
     create_schema(sqlite_url)
 
@@ -301,6 +330,45 @@ def test_close_bounty_releases_unpaid_awards(sqlite_url: str) -> None:
             )
         assert verify_hash_chain(session) is True
         assert verify_supply_conservation(session) is True
+
+
+def test_bounty_mutations_reject_boolean_bounty_id(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=14,
+            issue_url="https://github.com/ramimbo/mergework/issues/14",
+            title="Boolean bounty id guard",
+            reward_mrwk="10",
+            max_awards=2,
+            acceptance="Boolean ids must not alias bounty 1.",
+        )
+
+        with pytest.raises(LedgerError, match="bounty_id must be an integer"):
+            pay_bounty(
+                session,
+                bounty_id=True,
+                to_account="github:alice",
+                submission_url="https://github.com/ramimbo/mergework/pull/14",
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted"},
+            )
+
+        with pytest.raises(LedgerError, match="bounty_id must be an integer"):
+            close_bounty(
+                session,
+                bounty_id=True,
+                closed_by="maintainer",
+                reference="https://github.com/ramimbo/mergework/issues/14#close",
+            )
+
+        assert bounty.status == "open"
+        assert bounty.awards_paid == 0
+        assert get_balance(session, "github:alice") == 0
 
 
 def test_payout_is_idempotent_for_same_bounty(sqlite_url: str) -> None:


### PR DESCRIPTION
Refs #228

## Summary
- Add a shared service-layer positive integer guard that rejects booleans before they can alias `1`.
- Apply the guard to bounty creation, bounty lookup, bounty payout, and bounty close paths.
- Add regression coverage for boolean `issue_number`, `max_awards`, and `bounty_id` values.

## Repro Before Fix
A direct service call with `issue_number=True` or `bounty_id=True` was accepted because Python treats `True` as integer `1`. That could create a bounty for issue `#1`, or pay/close bounty id `1`, instead of rejecting malformed identifiers.

## Verification
- `uv run --python 3.12 --extra dev python -m pytest tests/test_ledger.py -q` -> 18 passed
- `uv run --python 3.12 --extra dev python -m pytest -q` -> 207 passed, 2 warnings
- `uv run --python 3.12 --extra dev ruff check .` -> all checks passed
- `uv run --python 3.12 --extra dev ruff format --check .` -> 37 files already formatted
- `uv run --python 3.12 --extra dev python -m mypy app` -> success
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --python 3.12 --extra dev python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No secrets, wallet material, private vulnerability details, deployment values, payout details, PayPal details, or MRWK price claims are included.