### PR TITLE
Reject non-integer bounty fields

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -157,6 +157,19 @@ def _clean_proof_metadata(verifier_result: dict[str, Any]) -> dict[str, Any]:
     return clean
 
 
+def _required_int(value: int, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise LedgerError(f"{field} must be an integer")
+    return value
+
+
+def _required_positive_int(value: int, field: str) -> int:
+    value = _required_int(value, field)
+    if value <= 0:
+        raise LedgerError(f"{field} must be positive")
+    return value
+
+
 def wallet_transfer_payload(
     *,
     from_address: str,
@@ -381,10 +394,8 @@ def create_bounty(
 ) -> Bounty:
     ensure_genesis(session)
     reward = parse_mrwk_amount(reward_mrwk)
-    if issue_number <= 0:
-        raise LedgerError("issue_number must be positive")
-    if max_awards <= 0:
-        raise LedgerError("max_awards must be positive")
+    issue_number = _required_positive_int(issue_number, "issue_number")
+    max_awards = _required_positive_int(max_awards, "max_awards")
     if max_awards > 1_000:
         raise LedgerError("max_awards is too large")
     reserved = reward * max_awards
@@ -572,6 +583,7 @@ def pay_bounty(
     verifier_result: dict[str, Any],
 ) -> Proof:
     ensure_genesis(session)
+    bounty_id = _required_positive_int(bounty_id, "bounty_id")
     bounty = session.get(Bounty, bounty_id)
     if bounty is None:
         raise LedgerError("bounty not found")
@@ -667,6 +679,7 @@ def close_bounty(
     reference: str | None = None,
 ) -> LedgerEntry | None:
     ensure_genesis(session)
+    bounty_id = _required_positive_int(bounty_id, "bounty_id")
     bounty = session.get(Bounty, bounty_id)
     if bounty is None:
         raise LedgerError("bounty not found")

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -112,6 +112,39 @@ def test_create_bounty_rejects_non_positive_issue_number(sqlite_url: str) -> Non
                 )
 
 
+def test_create_bounty_rejects_non_integer_issue_number_and_max_awards(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        for issue_number in (True, 1.5):
+            with pytest.raises(LedgerError, match="issue_number must be an integer"):
+                create_bounty(
+                    session,
+                    repo="ramimbo/mergework",
+                    issue_number=issue_number,
+                    issue_url="https://github.com/ramimbo/mergework/issues/1",
+                    title="Invalid bounty",
+                    reward_mrwk="1",
+                    acceptance="Should not be created",
+                )
+
+        for max_awards in (True, 1.5):
+            with pytest.raises(LedgerError, match="max_awards must be an integer"):
+                create_bounty(
+                    session,
+                    repo="ramimbo/mergework",
+                    issue_number=14,
+                    issue_url="https://github.com/ramimbo/mergework/issues/14",
+                    title="Invalid award count",
+                    reward_mrwk="1",
+                    max_awards=max_awards,
+                    acceptance="Should not be created",
+                )
+
+
 def test_create_bounty_rejects_duplicate_repo_issue(sqlite_url: str) -> None:
     create_schema(sqlite_url)
 
@@ -469,6 +502,40 @@ def test_bounty_max_awards_must_be_positive(sqlite_url: str) -> None:
                 reward_mrwk="10",
                 max_awards=0,
                 acceptance="Accepted label",
+            )
+
+
+def test_bounty_mutations_reject_boolean_bounty_ids(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=13,
+            issue_url="https://github.com/ramimbo/mergework/issues/13",
+            title="Reject malformed bounty ids",
+            reward_mrwk="10",
+            acceptance="Accepted label",
+        )
+
+        with pytest.raises(LedgerError, match="bounty_id must be an integer"):
+            pay_bounty(
+                session,
+                bounty_id=True,
+                to_account="github:alice",
+                submission_url="https://github.com/ramimbo/mergework/pull/13",
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted"},
+            )
+
+        with pytest.raises(LedgerError, match="bounty_id must be an integer"):
+            close_bounty(
+                session,
+                bounty_id=True,
+                closed_by="maintainer",
+                reference="https://github.com/ramimbo/mergework/issues/13#close",
             )
 
 


### PR DESCRIPTION
Refs #228

## Summary
- Add shared ledger-service integer guards for bounty mutation fields.
- Reject boolean and non-integer `issue_number`/`max_awards` values when creating bounties.
- Reject boolean and non-integer `bounty_id` values before direct `pay_bounty()` or `close_bounty()` calls can treat `True` as bounty id `1`.

## Repro Before Fix
Direct ledger-service calls could pass values such as `issue_number=True`, `max_awards=True`, or `bounty_id=True`. Because Python booleans are integers (`True == 1`), those values could create or mutate bounty `#1`-style records instead of being rejected as malformed input.

## Verification
- `./.venv/bin/python -m pytest tests/test_ledger.py::test_create_bounty_rejects_non_integer_issue_number_and_max_awards tests/test_ledger.py::test_bounty_mutations_reject_boolean_bounty_ids -q` -> 2 passed
- `./.venv/bin/python -m pytest -q` -> 207 passed, 2 warnings
- `./.venv/bin/python -m ruff format --check .` -> 37 files already formatted
- `./.venv/bin/python -m ruff check .` -> all checks passed
- `./.venv/bin/python -m mypy app` -> success
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `./.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No secrets, wallet material, private vulnerability details, deployment values, payout details, or MRWK price claims are included.