### PR TITLE
fix(docs_smoke): verify PR template exists during docs smoke check

### DIFF
--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -25,7 +25,13 @@ BANNED_PUBLIC_PHRASES = [
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"
 PR_TEMPLATE = ".github/pull_request_template.md"
-ISSUE_TEMPLATES = {".github/ISSUE_TEMPLATE/bounty.yml", ".github/ISSUE_TEMPLATE/bug.yml", ".github/ISSUE_TEMPLATE/security-report.yml", ".github/ISSUE_TEMPLATE/docs.yml", DOCS_ISSUE_TEMPLATE}
+ISSUE_TEMPLATES = {
+    ".github/ISSUE_TEMPLATE/bounty.yml",
+    ".github/ISSUE_TEMPLATE/bug.yml",
+    ".github/ISSUE_TEMPLATE/security-report.yml",
+    ".github/ISSUE_TEMPLATE/docs.yml",
+    DOCS_ISSUE_TEMPLATE,
+}
 
 
 def _local_target_exists(source: Path, target: str) -> bool:

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -24,6 +24,8 @@ BANNED_PUBLIC_PHRASES = [
 ]
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"
+PR_TEMPLATE = ".github/pull_request_template.md"
+ISSUE_TEMPLATES = {".github/ISSUE_TEMPLATE/bounty.yml", ".github/ISSUE_TEMPLATE/bug.yml", ".github/ISSUE_TEMPLATE/security-report.yml", ".github/ISSUE_TEMPLATE/docs.yml", DOCS_ISSUE_TEMPLATE}
 
 
 def _local_target_exists(source: Path, target: str) -> bool:
@@ -63,6 +65,10 @@ def main() -> int:
         if "link the page, docs file, heading, command, or ui path" not in template:
             print("docs issue template location prompt must request actionable evidence")
             ok = False
+    pr_template = ROOT / PR_TEMPLATE
+    if not pr_template.exists():
+        print(f"missing PR template: {PR_TEMPLATE}")
+        ok = False
     if ok:
         print("docs smoke ok")
         return 0


### PR DESCRIPTION
Refs #228

## Summary

- Added `.github/pull_request_template.md` to the REQUIRED document set checked by `scripts/docs_smoke.py`
- If the PR template is missing, the smoke check reports it

## Test Evidence

```
python -m pytest tests/test_docs_public_urls.py -v
```

## MRWK

Bounty #228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal validation checks for repository configuration integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->