### PR TITLE
feat(bounty): show available MRWK on bounty list page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -106,6 +106,7 @@ def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
     awards_remaining = max(0, bounty.max_awards - bounty.awards_paid)
     if bounty.status != "open":
         awards_remaining = 0
+    available_microunits = awards_remaining * bounty.reward_microunits
     return {
         "id": bounty.id,
         "repo": bounty.repo,
@@ -114,6 +115,7 @@ def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
         "title": bounty.title,
         "reward_mrwk": format_mrwk(bounty.reward_microunits),
         "reserved_mrwk": format_mrwk(bounty.reserved_microunits),
+        "available_mrwk": format_mrwk(available_microunits),
         "max_awards": bounty.max_awards,
         "awards_paid": bounty.awards_paid,
         "awards_remaining": awards_remaining,

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -28,6 +28,7 @@
       {{ bounty.repo }} #{{ bounty.issue_number }} ·
       {% endif %}
       {{ bounty.reward_mrwk }} MRWK per award ·
+      {{ bounty.available_mrwk }} MRWK available ·
       {{ bounty.awards_remaining }}/{{ bounty.max_awards }} awards open ·
       {{ bounty.status }}
     </p>

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -29,6 +29,7 @@ The bounties list returns public bounty rows. `status` can be omitted or set to
   "title": "MRWK bounty: contributor activity and bounty discovery improvements",
   "reward_mrwk": "100",
   "reserved_mrwk": "500",
+  "available_mrwk": "100",
   "max_awards": 5,
   "awards_paid": 4,
   "awards_remaining": 1,

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -217,3 +217,85 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert "Accepted bounty payment" in proof_page.text
     assert "Bounty issue" in proof_page.text
     assert f'href="/ledger/{payment_sequence}"' in proof_page.text
+
+
+def test_bounty_api_available_mrwk_is_correctly_computed(sqlite_url: str) -> None:
+    """Regression: available_mrwk = awards_remaining * reward_mrwk."""
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        # Open bounty with 3 max_awards, 75 MRWK each
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=248,
+            issue_url="https://github.com/ramimbo/mergework/issues/164",
+            title="Available MRWK regression test",
+            reward_mrwk="75",
+            max_awards=3,
+            acceptance="Test available_mrwk computation.",
+        )
+        open_id = bounty.id
+
+        # Pay 1 award: awards_remaining=2, available_mrwk=150
+        pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/248a",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        partial_id = bounty.id
+
+        # Pay second award: awards_remaining=1, available_mrwk=75
+        pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:bob",
+            submission_url="https://github.com/ramimbo/mergework/pull/248b",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        paid_bounty_id = bounty.id
+
+        # Closed bounty: available_mrwk=0
+        closed_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=249,
+            issue_url="https://github.com/ramimbo/mergework/issues/249",
+            title="Closed available MRWK test",
+            reward_mrwk="50",
+            acceptance="Closed bounty has 0 available.",
+        )
+        close_bounty(
+            session,
+            bounty_id=closed_bounty.id,
+            closed_by="maintainer",
+            reference="https://github.com/ramimbo/mergework/issues/249",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    # Open bounty with 0 paid: 3*75 = 225 available
+    open_row = client.get("/api/v1/bounties").json()[0]
+    assert open_row["available_mrwk"] == "225", f"Expected 225, got {open_row['available_mrwk']}"
+    assert open_row["awards_remaining"] == 3
+    assert open_row["reward_mrwk"] == "75"
+
+    # 1 paid: 2*75 = 150 available
+    partial = client.get(f"/api/v1/bounties/{partial_id}").json()
+    assert partial["available_mrwk"] == "150", f"Expected 150, got {partial['available_mrwk']}"
+    assert partial["awards_remaining"] == 2
+
+    # 2 paid: 1*75 = 75 available
+    paid = client.get(f"/api/v1/bounties/{paid_bounty_id}").json()
+    assert paid["available_mrwk"] == "75", f"Expected 75, got {paid['available_mrwk']}"
+    assert paid["awards_remaining"] == 1
+
+    # Closed: 0 available
+    closed = client.get(f"/api/v1/bounties/{closed_bounty.id}").json()
+    assert closed["available_mrwk"] == "0", f"Expected 0, got {closed['available_mrwk']}"
+    assert closed["awards_remaining"] == 0
+    assert closed["status"] == "closed"


### PR DESCRIPTION
Refs #164

## Summary

- Added `available_mrwk` to public bounty API: `awards_remaining * reward_mrwk`
- Shows remaining MRWK value on each bounty list card so contributors see total available value at a glance
- Updated `docs/api-examples.md`

## Evidence

Existing tests cover the bounty page rendering. No new tests needed — `bounty_to_dict` is already tested through `test_bounty_pages.py`.

## MRWK

Bounty #164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bounties now display available MRWK amounts, calculated from remaining awards and reward values.

* **Documentation**
  * Updated API documentation with the new available MRWK field.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->