### PR TITLE
Reject non-integer ledger entry amounts

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -330,6 +330,8 @@ def add_ledger_entry(
     amount_microunits: int,
     reference: str,
 ) -> LedgerEntry:
+    if isinstance(amount_microunits, bool) or not isinstance(amount_microunits, int):
+        raise LedgerError("amount_microunits must be an integer")
     if amount_microunits < 0:
         raise LedgerError("ledger amount cannot be negative")
     if from_account:

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -11,6 +11,7 @@ from app.ledger.service import (
     GENESIS_SUPPLY_MICRO,
     TREASURY_ACCOUNT,
     LedgerError,
+    add_ledger_entry,
     canonical_json,
     close_bounty,
     create_bounty,
@@ -50,6 +51,26 @@ def test_make_engine_accepts_windows_absolute_sqlite_url(tmp_path) -> None:
         engine.dispose()
 
     assert database_path.parent.exists()
+
+
+@pytest.mark.parametrize("amount_microunits", [True, 1.5, "1"])
+def test_add_ledger_entry_rejects_non_integer_amounts(
+    sqlite_url: str, amount_microunits: object
+) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+        with pytest.raises(LedgerError, match="amount_microunits must be an integer"):
+            add_ledger_entry(
+                session,
+                entry_type="bad_amount",
+                from_account=TREASURY_ACCOUNT,
+                to_account="github:alice",
+                amount_microunits=amount_microunits,  # type: ignore[arg-type]
+                reference="test-bad-amount",
+            )
 
 
 def test_bounty_reserve_and_payout_conserve_supply(sqlite_url: str) -> None:


### PR DESCRIPTION
Refs #228

## Summary
- Reject boolean and non-integer `amount_microunits` values at the shared `add_ledger_entry()` boundary.
- Add regression coverage for `True`, `1.5`, and string `1` direct service inputs.

## Evidence
Before this change, a direct service caller could pass `amount_microunits=True` and Python would treat it as integer `1`; non-integer values could either persist loosely under SQLite or fail with a raw comparison/type error before MergeWork returned a clear `LedgerError`.

This is distinct from the open nonce and bounty-id validation PRs: it protects the ledger-entry amount field used by genesis, bounty reserve/release/payment, GitHub claims, and wallet-transfer ledger writes.

## Verification
- `uv run --python 3.12 --extra dev python -m pytest tests/test_ledger.py::test_add_ledger_entry_rejects_non_integer_amounts tests/test_ledger.py::test_bounty_reserve_and_payout_conserve_supply -q` -> `4 passed`
- `uv run --python 3.12 --extra dev python -m pytest tests/test_ledger.py -q` -> `19 passed`
- `uv run --python 3.12 --extra dev python -m pytest -q` -> `208 passed, 2 warnings`
- `uv run --python 3.12 --extra dev ruff check app/ledger/service.py tests/test_ledger.py` -> passed
- `uv run --python 3.12 --extra dev ruff format --check app/ledger/service.py tests/test_ledger.py` -> passed
- `git diff --check` -> clean

No secrets, wallet material, private vulnerability details, deployment values, payout details, PayPal details, or MRWK price claims are included.