### PR TITLE
Document MCP wallet transfer response

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -216,8 +216,37 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"get_proof","arguments":{"hash":"<proof_hash>"}}}'
 ```
 
-The MCP response uses JSON-RPC content blocks. The first content block is a JSON
-string with proof metadata plus the stored public proof payload:
+Call `submit_wallet_transfer` with the same signed transfer fields used by the
+REST transfer API. Sign the canonical wallet transfer payload locally; do not
+send private keys to MergeWork:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"submit_wallet_transfer","arguments":{"from_address":"<sender_mrwk1_address>","to_address":"<receiver_mrwk1_address>","amount_mrwk":"1.5","nonce":3,"memo":"agent payout consolidation","signature_hex":"<128 lowercase hex chars>"}}}'
+```
+
+Successful MCP transfer responses wrap a JSON-string transfer object in the
+first content block. Parse `result.content[0].text` to read the transfer hash,
+ledger sequence, addresses, amount, nonce, memo, and timestamp:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 6,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"hash\":\"9d0d922d25ae3c6045d9c1d64af9657228c00f925f52e4f447d4b451d91b6278\",\"type\":\"wallet_transfer\",\"ledger_sequence\":42,\"from_address\":\"mrwk102d449a31fbb267c8f352e9968a79e3e5fc95c1b\",\"to_address\":\"mrwk1fb1437aec45b46ec640f44b2e2aced55dc23556e\",\"amount_mrwk\":\"1.5\",\"nonce\":3,\"memo\":\"agent payout consolidation\",\"created_at\":\"2026-05-24T20:05:00\"}"
+      }
+    ]
+  }
+}
+```
+
+The `get_proof` MCP response uses JSON-RPC content blocks. The first content
+block is a JSON string with proof metadata plus the stored public proof payload:
 
 ```json
 {

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -129,6 +129,21 @@ def test_api_examples_document_wallet_registration_response() -> None:
     assert '"next_nonce": 1' in examples
 
 
+def test_api_examples_document_mcp_wallet_transfer_response() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert '"name":"submit_wallet_transfer"' in examples
+    assert '"from_address":"<sender_mrwk1_address>"' in examples
+    assert '"to_address":"<receiver_mrwk1_address>"' in examples
+    assert '"signature_hex":"<128 lowercase hex chars>"' in examples
+    assert "REST transfer API" in examples
+    assert "result.content[0].text" in examples
+    assert '\\"type\\":\\"wallet_transfer\\"' in examples
+    assert '\\"ledger_sequence\\":42' in examples
+    assert '\\"amount_mrwk\\":\\"1.5\\"' in examples
+    assert '\\"memo\\":\\"agent payout consolidation\\"' in examples
+
+
 def test_agent_guide_explains_internal_bounty_ids() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Refs #229

## Summary
- Document the MCP `submit_wallet_transfer` request arguments and response wrapper in `docs/api-examples.md`.
- Clarify that the wallet transfer payload is signed locally and private keys are not sent to MergeWork.
- Add docs regression coverage for the MCP tool name, signed fields, JSON-RPC `result.content[0].text` wrapper, and wallet-transfer response fields.

## Evidence
Compared against `app/main.py::_call_mcp_tool()`:
- `submit_wallet_transfer` reads `from_address`, `to_address`, `amount_mrwk`, `nonce`, optional `memo`, and `signature_hex` from `params.arguments`.
- It returns `json.dumps(wallet_transfer_to_dict(transfer))`, so the JSON-RPC response wraps the transfer object as a text content block.

Compared against `app/main.py::wallet_transfer_to_dict()` for the response fields: `hash`, `type`, `ledger_sequence`, `from_address`, `to_address`, `amount_mrwk`, `nonce`, `memo`, and `created_at`.

This is distinct from REST transfer docs and existing MCP proof/bounty examples because it covers the MCP wrapper for signed wallet transfers.

## Verification
- `uv run --python 3.12 --extra dev python -m pytest tests/test_docs_public_urls.py::test_api_examples_document_mcp_wallet_transfer_response -q` -> `1 passed`
- `uv run --python 3.12 --extra dev python -m pytest tests/test_docs_public_urls.py -q` -> `14 passed`
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> `docs smoke ok`
- `uv run --python 3.12 --extra dev ruff check docs/api-examples.md tests/test_docs_public_urls.py` -> passed
- `uv run --python 3.12 --extra dev ruff format --check --preview docs/api-examples.md tests/test_docs_public_urls.py` -> passed
- `uv run --python 3.12 --extra dev python -m pytest -q` -> `206 passed, 2 warnings`
- `git diff --check` -> clean

No private keys, wallet secrets, real signatures, payout details, PayPal details, deployment credentials, private vulnerability details, or MRWK price claims are included.