### PR TITLE
Reject non-string service text inputs

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -81,7 +81,9 @@ def canonical_json(data: dict[str, Any]) -> str:
 
 
 def validate_public_url(url: str) -> str:
-    if any(ord(char) < 32 or ord(char) == 127 for char in url):
+    if not isinstance(url, str):
+        raise LedgerError("URL must be a string")
+    if CONTROL_CHAR_RE.search(url):
         raise LedgerError("URL must not contain control characters")
     clean = url.strip()
     if len(clean) > 500:
@@ -126,6 +128,8 @@ def reserve_account_for_bounty(bounty_id: int) -> str:
 
 
 def _normalize_github_login(github_login: str) -> str:
+    if not isinstance(github_login, str):
+        raise LedgerError("github login must be a string")
     normalized = github_login.strip().lower()
     if not GITHUB_LOGIN_RE.fullmatch(normalized):
         raise LedgerError("invalid github login")
@@ -153,6 +157,8 @@ def resolve_payout_account(session: Session, to_account: str) -> str:
 def _clean_optional_text(value: str | None, field: str, max_length: int) -> str | None:
     if value is None:
         return None
+    if not isinstance(value, str):
+        raise LedgerError(f"{field} must be a string")
     if CONTROL_CHAR_RE.search(value):
         raise LedgerError(f"{field} must not contain control characters")
     clean = value.strip()
@@ -162,6 +168,8 @@ def _clean_optional_text(value: str | None, field: str, max_length: int) -> str 
 
 
 def _clean_required_text(value: str, field: str, max_length: int) -> str:
+    if not isinstance(value, str):
+        raise LedgerError(f"{field} must be a string")
     if CONTROL_CHAR_RE.search(value):
         raise LedgerError(f"{field} must not contain control characters")
     clean = value.strip()
@@ -268,7 +276,10 @@ def register_wallet(
         raise LedgerError(str(exc)) from exc
     public_key = public_key_hex.strip().lower()
     existing = session.get(Wallet, address)
-    normalized_login = _normalize_github_login(github_login) if github_login else None
+    if github_login is None or github_login == "":
+        normalized_login = None
+    else:
+        normalized_login = _normalize_github_login(github_login)
     clean_label = _clean_optional_text(label, "wallet label", 160)
     if normalized_login:
         linked = session.scalar(

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -116,6 +116,67 @@ def test_resolve_payout_account_accepts_mixed_case_prefixes(sqlite_url: str) -> 
         assert resolve_payout_account(session, mixed_wallet) == wallet.address
 
 
+def test_bounty_service_rejects_non_string_text_fields(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    base_bounty = {
+        "repo": "ramimbo/mergework",
+        "issue_number": 9,
+        "issue_url": "https://github.com/ramimbo/mergework/issues/9",
+        "title": "Validate text fields",
+        "reward_mrwk": "10",
+        "acceptance": "Accepted label",
+    }
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        for field, value, message in (
+            ("repo", 123, "repo must be a string"),
+            ("issue_url", 123, "URL must be a string"),
+            ("title", 123, "title must be a string"),
+            ("acceptance", 123, "acceptance must be a string"),
+        ):
+            payload = dict(base_bounty)
+            payload[field] = value
+            with pytest.raises(LedgerError, match=message):
+                create_bounty(session, **payload)
+
+        bounty = create_bounty(session, **base_bounty)
+
+        with pytest.raises(LedgerError, match="URL must be a string"):
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:alice",
+                submission_url=123,
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted"},
+            )
+        with pytest.raises(LedgerError, match="accepted_by must be a string"):
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:alice",
+                submission_url="https://github.com/ramimbo/mergework/pull/9",
+                accepted_by=123,
+                verifier_result={"label": "mrwk:accepted"},
+            )
+        with pytest.raises(LedgerError, match="closed_by must be a string"):
+            close_bounty(
+                session,
+                bounty_id=bounty.id,
+                closed_by=123,
+                reference="https://github.com/ramimbo/mergework/issues/9#close",
+            )
+        with pytest.raises(LedgerError, match="URL must be a string"):
+            close_bounty(
+                session,
+                bounty_id=bounty.id,
+                closed_by="maintainer",
+                reference=123,
+            )
+
+
 def test_create_bounty_rejects_non_positive_issue_number(sqlite_url: str) -> None:
     create_schema(sqlite_url)
 

--- a/tests/test_wallets.py
+++ b/tests/test_wallets.py
@@ -67,6 +67,21 @@ def test_wallet_registration_rejects_label_control_characters(sqlite_url: str) -
         register_wallet(session, public_key_hex=public_hex, label="Main\nWallet")
 
 
+def test_wallet_registration_rejects_non_string_label_and_github_login(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    _, public_hex, _ = _keypair()
+
+    with session_scope(sqlite_url) as session:
+        for bad_label in (123, 0, False):
+            with pytest.raises(LedgerError, match="wallet label must be a string"):
+                register_wallet(session, public_key_hex=public_hex, label=bad_label)
+        for bad_login in (123, 0, False):
+            with pytest.raises(LedgerError, match="github login must be a string"):
+                register_wallet(session, public_key_hex=public_hex, github_login=bad_login)
+
+
 def test_signed_wallet_transfer_moves_balance_and_rejects_replay(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     sender_key, sender_public, sender_address = _keypair()


### PR DESCRIPTION
Refs #228

## Summary
- Reject non-string URL values before `validate_public_url()` calls `.strip()`.
- Reject non-string required/optional service text values before control-character checks run.
- Reject non-string GitHub login values before login normalization.
- Add regression coverage for direct service calls that previously raised raw Python type errors for malformed bounty, payout, close, wallet label, and wallet GitHub-login inputs.

## Repro Before Fix
Direct service callers could pass values such as `repo=123`, `issue_url=123`, `accepted_by=123`, `reference=123`, `label=123`, or `github_login=123`. Those paths could raise raw `TypeError`/`AttributeError` from `.strip()` or `re.search()` instead of returning explicit `LedgerError` validation messages.

## Verification
- `./.venv/bin/python -m pytest tests/test_ledger.py::test_bounty_service_rejects_non_string_text_fields tests/test_wallets.py::test_wallet_registration_rejects_non_string_label_and_github_login -q` -> 2 passed
- `./.venv/bin/python -m pytest -q` -> 207 passed, 2 warnings
- `./.venv/bin/python -m ruff format --check .` -> 37 files already formatted
- `./.venv/bin/python -m ruff check .` -> all checks passed
- `./.venv/bin/python -m mypy app` -> success
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `./.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No secrets, wallet material, private vulnerability details, deployment values, payout details, or MRWK price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter input validation: text fields and URLs must be strings with clearer error messages; empty GitHub login is now treated as unset during wallet registration.

* **Tests**
  * New tests ensure ledger and wallet services reject non-string text fields and return the expected error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->