### PR TITLE
Reject non-string proof metadata keys

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -152,9 +152,18 @@ def _clean_required_text(value: str, field: str, max_length: int) -> str:
 def _clean_proof_metadata(verifier_result: dict[str, Any]) -> dict[str, Any]:
     clean = dict(verifier_result)
     for key, value in clean.items():
+        if not isinstance(key, str):
+            raise LedgerError("verifier_result keys must be strings")
         if isinstance(value, str) and CONTROL_CHAR_RE.search(value):
             raise LedgerError(f"verifier_result.{key} must not contain control characters")
     return clean
+
+
+def _ensure_json_serializable(value: dict[str, Any], field: str) -> None:
+    try:
+        canonical_json(value)
+    except (TypeError, ValueError) as exc:
+        raise LedgerError(f"{field} must be JSON serializable") from exc
 
 
 def wallet_transfer_payload(
@@ -583,6 +592,7 @@ def pay_bounty(
     clean_verifier_result = _clean_proof_metadata(verifier_result)
     if "accepted_by" in clean_verifier_result:
         clean_verifier_result["accepted_by"] = clean_accepted_by
+    _ensure_json_serializable(clean_verifier_result, "verifier_result")
     clean_submission_url = validate_public_url(submission_url)
     existing_submission = session.scalar(
         select(Submission)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -604,6 +604,64 @@ def test_bounty_payment_proof_rejects_control_character_metadata(sqlite_url: str
         assert get_balance(session, "github:bob") == 0
 
 
+def test_bounty_payment_proof_rejects_non_string_metadata_keys(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=18,
+            issue_url="https://github.com/ramimbo/mergework/issues/18",
+            title="Proof metadata key validation",
+            reward_mrwk="1",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+        verifier_result = {"label": "mrwk:accepted"}
+        verifier_result[1] = "numeric key"
+
+        with pytest.raises(LedgerError, match="verifier_result keys must be strings"):
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:alice",
+                submission_url="https://github.com/ramimbo/mergework/pull/18",
+                accepted_by="maintainer",
+                verifier_result=verifier_result,
+            )
+
+        assert bounty.awards_paid == 0
+        assert get_balance(session, "github:alice") == 0
+
+
+def test_bounty_payment_proof_rejects_unserializable_metadata_values(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=19,
+            issue_url="https://github.com/ramimbo/mergework/issues/19",
+            title="Proof metadata value validation",
+            reward_mrwk="1",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+
+        with pytest.raises(LedgerError, match="verifier_result must be JSON serializable"):
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:alice",
+                submission_url="https://github.com/ramimbo/mergework/pull/19",
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted", "raw": object()},
+            )
+
+        assert bounty.awards_paid == 0
+        assert get_balance(session, "github:alice") == 0
+
+
 def test_admin_payout_api_rejects_control_character_note(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- validate proof verifier metadata keys before canonical JSON serialization
- add a regression test that non-string metadata keys raise `LedgerError` without changing payout state

## Why

`pay_bounty()` copies `verifier_result` and later serializes it through canonical JSON with sorted keys. If a service caller passes a metadata dict with non-string keys, serialization can raise a raw `TypeError` instead of returning a controlled ledger validation error.

## Validation

- `.\.venv\Scripts\python.exe -m pytest -q` (`206 passed, 2 warnings`)
- `.\.venv\Scripts\python.exe -m ruff check app\ledger\service.py tests\test_security.py`
- `.\.venv\Scripts\python.exe -m ruff format --check app\ledger\service.py tests\test_security.py`

Bounty #228