### PR TITLE
Document activity API response shape

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -102,7 +102,52 @@ Read accepted-work activity summarized from proof-backed bounty payments:
 
 ```bash
 curl -s "$API_HOST/api/v1/activity"
+curl -s "$API_HOST/api/v1/activity?q=p3xill"
 ```
+
+The optional `q` parameter filters activity rows by account, amount, submission
+URL, proof hash, internal bounty id, or GitHub issue number. The response groups
+matching proof-backed bounty payments into `totals`, contributor rollups, and
+the most recent payment rows:
+
+```json
+{
+  "totals": {
+    "accepted_awards": 2,
+    "accepted_mrwk": "115",
+    "contributors": 1
+  },
+  "query": "p3xill",
+  "contributors": [
+    {
+      "account": "github:p3xill",
+      "accepted_awards": 2,
+      "accepted_mrwk": "115",
+      "latest_submission_url": "https://github.com/ramimbo/mergework/pull/226#pullrequestreview-4354910919",
+      "latest_proof_hash": "99f78d41b9a493ba2e6136cba0b0762f013a913c9d90c562976282e93d00b81f",
+      "latest_proof_url": "/proofs/99f78d41b9a493ba2e6136cba0b0762f013a913c9d90c562976282e93d00b81f"
+    }
+  ],
+  "recent": [
+    {
+      "ledger_sequence": 399,
+      "account": "github:p3xill",
+      "amount_mrwk": "40",
+      "submission_url": "https://github.com/ramimbo/mergework/pull/226#pullrequestreview-4354910919",
+      "proof_hash": "99f78d41b9a493ba2e6136cba0b0762f013a913c9d90c562976282e93d00b81f",
+      "proof_url": "/proofs/99f78d41b9a493ba2e6136cba0b0762f013a913c9d90c562976282e93d00b81f",
+      "bounty_id": 37,
+      "bounty_issue_number": 219,
+      "created_at": "2026-05-25T08:25:28.316705"
+    }
+  ]
+}
+```
+
+`contributors` is sorted by accepted MRWK amount, while `recent` is sorted by
+newest ledger sequence and capped to the latest 100 matching rows. Use
+`proof_hash` with `/api/v1/proofs/<proof_hash>` to inspect the public proof
+payload for a payment.
 
 Inspect a proof, account, or registered wallet:
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -152,3 +152,24 @@ def test_agent_guide_documents_activity_endpoint() -> None:
 
     assert "GET /api/v1/activity" in guide
     assert "accepted-work activity" in guide
+
+
+def test_api_examples_document_activity_response_shape() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/activity?q=p3xill" in examples
+    assert '"totals": {' in examples
+    assert '"accepted_awards": 2' in examples
+    assert '"accepted_mrwk": "115"' in examples
+    assert '"contributors": [' in examples
+    assert '"account": "github:p3xill"' in examples
+    assert (
+        '"latest_submission_url": "https://github.com/ramimbo/mergework/pull/226#pullrequestreview-4354910919"'
+        in examples
+    )
+    assert '"recent": [' in examples
+    assert '"ledger_sequence": 399' in examples
+    assert '"bounty_id": 37' in examples
+    assert '"bounty_issue_number": 219' in examples
+    assert "newest ledger sequence" in examples
+    assert "/api/v1/proofs/<proof_hash>" in examples


### PR DESCRIPTION
## Summary
- Document the `/api/v1/activity?q=...` filter and response shape in public API examples
- Add a focused docs regression test for activity totals, contributor rollups, recent payment rows, and proof links
- Evidence: compared against `app/main.py::activity_to_dict()` / `api_activity()` and the live unauthenticated endpoint `https://api.mrwk.ltclab.site/api/v1/activity?q=p3xill`

## Test Plan
- `python3 scripts/docs_smoke.py`
- `/opt/hermes/.venv/bin/python -m pytest tests/test_docs_public_urls.py -q`

Refs #229
Bounty #229
/claim #229
