### PR TITLE
Reject canonical duplicate bounty submission URLs

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,7 +6,7 @@ import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
 from typing import Any, cast
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 from sqlalchemy import case, func, select, update
 from sqlalchemy.engine import CursorResult
@@ -36,6 +36,10 @@ TREASURY_ACCOUNT = "treasury:mrwk"
 MICRO_UNITS = 1_000_000
 GENESIS_SUPPLY_MICRO = 100_000_000 * MICRO_UNITS
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+GITHUB_SUBMISSION_PATH_RE = re.compile(
+    r"/(?P<owner>[^/]+)/(?P<repo>[^/]+)/(?P<kind>issues|pull)/(?P<number>\d+)/?",
+    re.IGNORECASE,
+)
 CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 
 
@@ -87,6 +91,53 @@ def validate_public_url(url: str) -> str:
     if parsed.username or parsed.password:
         raise LedgerError("URL must not include credentials")
     return clean
+
+
+def canonical_submission_url(url: str) -> str:
+    clean = validate_public_url(url)
+    parsed = urlparse(clean)
+    netloc = parsed.netloc.lower()
+    path = parsed.path or "/"
+    if parsed.hostname and parsed.hostname.lower() == "github.com" and not parsed.params:
+        match = GITHUB_SUBMISSION_PATH_RE.fullmatch(path)
+        if match:
+            path = (
+                f"/{match['owner'].lower()}/{match['repo'].lower()}/"
+                f"{match['kind'].lower()}/{match['number']}"
+            )
+    return urlunparse(
+        (
+            parsed.scheme.lower(),
+            netloc,
+            path,
+            parsed.params,
+            parsed.query,
+            parsed.fragment,
+        )
+    )
+
+
+def _canonical_submission_exists(
+    session: Session, *, bounty_id: int, clean_submission_url: str
+) -> bool:
+    exact_match = session.scalar(
+        select(Submission.id)
+        .where(Submission.bounty_id == bounty_id, Submission.url == clean_submission_url)
+        .limit(1)
+    )
+    if exact_match is not None:
+        return True
+
+    legacy_submission_urls = session.scalars(
+        select(Submission.url).where(Submission.bounty_id == bounty_id)
+    )
+    for legacy_url in legacy_submission_urls:
+        try:
+            if canonical_submission_url(legacy_url) == clean_submission_url:
+                return True
+        except LedgerError:
+            continue
+    return False
 
 
 def public_url_or_none(url: str | None) -> str | None:
@@ -583,13 +634,10 @@ def pay_bounty(
     clean_verifier_result = _clean_proof_metadata(verifier_result)
     if "accepted_by" in clean_verifier_result:
         clean_verifier_result["accepted_by"] = clean_accepted_by
-    clean_submission_url = validate_public_url(submission_url)
-    existing_submission = session.scalar(
-        select(Submission)
-        .where(Submission.bounty_id == bounty.id, Submission.url == clean_submission_url)
-        .limit(1)
-    )
-    if existing_submission is not None:
+    clean_submission_url = canonical_submission_url(submission_url)
+    if _canonical_submission_exists(
+        session, bounty_id=bounty.id, clean_submission_url=clean_submission_url
+    ):
         raise LedgerError("submission already paid")
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -251,6 +251,125 @@ def test_multi_award_bounty_rejects_duplicate_submission_url(sqlite_url: str) ->
         assert get_balance(session, "github:bob") == 0
 
 
+def test_multi_award_bounty_rejects_canonical_duplicate_submission_url(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=12,
+            issue_url="https://github.com/ramimbo/mergework/issues/12",
+            title="Canonical proof guard",
+            reward_mrwk="10",
+            max_awards=2,
+            acceptance="Equivalent submission URLs should not earn twice.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://GITHUB.com/Ramimbo/MergeWork/PULL/12/",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+        with pytest.raises(LedgerError, match="submission already paid"):
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:bob",
+                submission_url="https://github.com/ramimbo/mergework/pull/12",
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted", "delivery": "second"},
+            )
+
+        submission = session.get(Submission, proof.submission_id)
+        assert submission is not None
+        assert submission.url == "https://github.com/ramimbo/mergework/pull/12"
+        assert bounty.status == "open"
+        assert bounty.awards_paid == 1
+        assert get_balance(session, "github:bob") == 0
+
+
+def test_multi_award_bounty_rejects_legacy_canonical_duplicate_submission_url(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=13,
+            issue_url="https://github.com/ramimbo/mergework/issues/13",
+            title="Legacy canonical proof guard",
+            reward_mrwk="10",
+            max_awards=2,
+            acceptance="Legacy equivalent submission URLs should not earn twice.",
+        )
+        session.add(
+            Submission(
+                bounty_id=bounty.id,
+                submitter_account="github:alice",
+                url="https://GITHUB.com/Ramimbo/MergeWork/PULL/13/",
+                status="accepted",
+                verifier_result=canonical_json({"label": "mrwk:accepted"}),
+            )
+        )
+        bounty.awards_paid = 1
+        session.flush()
+
+        with pytest.raises(LedgerError, match="submission already paid"):
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:bob",
+                submission_url="https://github.com/ramimbo/mergework/pull/13",
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted", "delivery": "second"},
+            )
+
+        assert bounty.status == "open"
+        assert bounty.awards_paid == 1
+        assert get_balance(session, "github:bob") == 0
+
+
+def test_submission_url_canonicalization_preserves_non_github_trailing_slash(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=14,
+            issue_url="https://github.com/ramimbo/mergework/issues/14",
+            title="External proof guard",
+            reward_mrwk="10",
+            max_awards=2,
+            acceptance="External evidence URLs keep their path semantics.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://example.com/reviews/14/",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+        submission = session.get(Submission, proof.submission_id)
+        assert submission is not None
+        assert submission.url == "https://example.com/reviews/14/"
+
+
 def test_close_bounty_releases_unpaid_awards(sqlite_url: str) -> None:
     create_schema(sqlite_url)
 


### PR DESCRIPTION
Bounty #228

## Summary
- Canonicalize bounty submission URLs before duplicate checks and storage.
- Normalize GitHub issue/pull URLs for scheme, host, owner, repo, issue/pull segment casing, and trailing-slash variants.
- Compare existing legacy submission URLs through the same canonical form before allowing another bounty payment.
- Preserve query strings and fragments, and keep non-GitHub trailing slashes unchanged.

## Evidence
Before this change, a multi-award bounty could treat equivalent GitHub proof URLs such as `https://GITHUB.com/Ramimbo/MergeWork/PULL/12/` and `https://github.com/ramimbo/mergework/pull/12` as separate submissions.

## Validation
- `uv run --extra dev python -m pytest tests/test_ledger.py -q --capture=no` -> 19 passed
- `uv run --extra dev python -m pytest -q --capture=no` -> 208 passed, 2 warnings
- `uv run --extra dev ruff check app/ledger/service.py tests/test_ledger.py` -> passed
- `uv run --extra dev ruff format --check app/ledger/service.py tests/test_ledger.py` -> passed
- `uv run --extra dev python -m mypy app` -> passed
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --extra dev python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No secrets, wallet material, private vulnerability details, deployment values, payout details, or MRWK price claims are included.