### PR TITLE
Add public bounty sort options

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -592,10 +592,15 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         }
 
     def list_bounties_by_status(
-        status: str | None = None, query_text: str | None = None
+        status: str | None = None, query_text: str | None = None, sort: str | None = None
     ) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
             query = select(Bounty)
+            normalized_sort = (sort or "newest").strip().lower()
+            if normalized_sort not in {"newest", "reward", "remaining"}:
+                raise HTTPException(
+                    status_code=400, detail="sort must be one of: newest, reward, remaining"
+                )
             if status is not None:
                 normalized_status = status.strip().lower()
                 if normalized_status not in {"open", "paid", "closed"}:
@@ -624,14 +629,26 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                     if issue_number is not None:
                         text_filter = or_(text_filter, Bounty.issue_number == issue_number)
                     query = query.where(text_filter)
-            bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
+            order_by: tuple[Any, ...]
+            if normalized_sort == "reward":
+                order_by = (Bounty.reward_microunits.desc(), Bounty.id.desc())
+            elif normalized_sort == "remaining":
+                order_by = (
+                    (Bounty.max_awards - Bounty.awards_paid).desc(),
+                    Bounty.id.desc(),
+                )
+            else:
+                order_by = (Bounty.id.desc(),)
+            bounties = session.scalars(query.order_by(*order_by)).all()
             return [bounty_to_dict(bounty) for bounty in bounties]
 
     @app.get("/api/v1/bounties")
     def api_bounties(
-        status: str | None = Query(None), q: str | None = Query(None)
+        status: str | None = Query(None),
+        q: str | None = Query(None),
+        sort: str | None = Query(None),
     ) -> list[dict[str, Any]]:
-        return list_bounties_by_status(status, q)
+        return list_bounties_by_status(status, q, sort)
 
     @app.post("/api/v1/bounties")
     async def api_create_bounty(
@@ -1043,17 +1060,22 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/bounties", response_class=HTMLResponse)
     def bounties_page(
-        request: Request, status: str | None = Query(None), q: str | None = Query(None)
+        request: Request,
+        status: str | None = Query(None),
+        q: str | None = Query(None),
+        sort: str | None = Query(None),
     ) -> HTMLResponse:
         selected_status = status.strip().lower() if status is not None else None
         query_text = q.strip() if q is not None else ""
+        selected_sort = (sort or "newest").strip().lower()
         return templates.TemplateResponse(
             request,
             "bounties.html",
             {
-                "bounties": list_bounties_by_status(status, q),
+                "bounties": list_bounties_by_status(status, q, sort),
                 "selected_status": selected_status,
                 "query_text": query_text,
+                "selected_sort": selected_sort,
             },
         )
 

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -4,16 +4,22 @@
 <h1>Bounties</h1>
 <form method="get" action="/bounties" aria-label="Search bounties">
   {% if selected_status %}<input type="hidden" name="status" value="{{ selected_status }}">{% endif %}
+  {% if selected_sort != "newest" %}<input type="hidden" name="sort" value="{{ selected_sort }}">{% endif %}
   <label for="bounty-search">Search bounties</label>
   <input id="bounty-search" name="q" type="search" value="{{ query_text }}" placeholder="repo, title, issue number, or acceptance text">
   <button type="submit">Search</button>
-  {% if query_text %}<a href="/bounties{% if selected_status %}?status={{ selected_status }}{% endif %}">Clear search</a>{% endif %}
+  {% if query_text %}<a href="/bounties{% if selected_status or selected_sort != "newest" %}?{% if selected_status %}status={{ selected_status }}{% endif %}{% if selected_status and selected_sort != "newest" %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% endif %}">Clear search</a>{% endif %}
 </form>
 <nav aria-label="Bounty status filters">
-  <a href="/bounties{% if query_text %}?q={{ query_text | urlencode }}{% endif %}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
-  <a href="/bounties?status=open{% if query_text %}&q={{ query_text | urlencode }}{% endif %}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
-  <a href="/bounties?status=paid{% if query_text %}&q={{ query_text | urlencode }}{% endif %}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
-  <a href="/bounties?status=closed{% if query_text %}&q={{ query_text | urlencode }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
+  <a href="/bounties{% if query_text or selected_sort != "newest" %}?{% if query_text %}q={{ query_text | urlencode }}{% endif %}{% if query_text and selected_sort != "newest" %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% endif %}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
+  <a href="/bounties?status=open{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
+  <a href="/bounties?status=paid{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
+  <a href="/bounties?status=closed{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
+</nav>
+<nav aria-label="Bounty sort options">
+  <a href="/bounties{% if selected_status or query_text %}?{% if selected_status %}status={{ selected_status }}{% endif %}{% if selected_status and query_text %}&{% endif %}{% if query_text %}q={{ query_text | urlencode }}{% endif %}{% endif %}"{% if selected_sort == "newest" %} aria-current="page"{% endif %}>Newest</a>
+  <a href="/bounties?sort=reward{% if selected_status %}&status={{ selected_status }}{% endif %}{% if query_text %}&q={{ query_text | urlencode }}{% endif %}"{% if selected_sort == "reward" %} aria-current="page"{% endif %}>Reward</a>
+  <a href="/bounties?sort=remaining{% if selected_status %}&status={{ selected_status }}{% endif %}{% if query_text %}&q={{ query_text | urlencode }}{% endif %}"{% if selected_sort == "remaining" %} aria-current="page"{% endif %}>Remaining awards</a>
 </nav>
 {% if query_text %}<p>Showing matches for “{{ query_text }}”.</p>{% endif %}
 <div class="list">

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -124,6 +124,72 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     assert [row["issue_number"] for row in backslash_search.json()] == [66]
 
 
+def test_bounties_page_and_api_sort_public_bounties(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        small = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=70,
+            issue_url="https://github.com/ramimbo/mergework/issues/70",
+            title="Small bounty",
+            reward_mrwk="25",
+            max_awards=1,
+            acceptance="Small public discovery task.",
+        )
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=71,
+            issue_url="https://github.com/ramimbo/mergework/issues/71",
+            title="Large bounty",
+            reward_mrwk="125",
+            max_awards=1,
+            acceptance="Large public discovery task.",
+        )
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=72,
+            issue_url="https://github.com/ramimbo/mergework/issues/72",
+            title="Multi-award bounty",
+            reward_mrwk="50",
+            max_awards=4,
+            acceptance="Multi-award public discovery task.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=small.id,
+            to_account="github:contributor",
+            submission_url="https://github.com/ramimbo/mergework/pull/70",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    reward_sorted = client.get("/api/v1/bounties?sort=reward")
+    assert reward_sorted.status_code == 200
+    assert [row["issue_number"] for row in reward_sorted.json()] == [71, 72, 70]
+
+    remaining_sorted = client.get("/api/v1/bounties?sort=remaining")
+    assert remaining_sorted.status_code == 200
+    assert [row["issue_number"] for row in remaining_sorted.json()] == [72, 71, 70]
+
+    page = client.get("/bounties?status=open&q=discovery&sort=remaining")
+    assert page.status_code == 200
+    assert 'aria-label="Bounty sort options"' in page.text
+    assert 'href="/bounties?sort=reward&status=open&q=discovery"' in page.text
+    assert (
+        'href="/bounties?sort=remaining&status=open&q=discovery" aria-current="page"' in page.text
+    )
+    assert page.text.index("Multi-award bounty") < page.text.index("Large bounty")
+
+    bad_sort = client.get("/api/v1/bounties?sort=random")
+    assert bad_sort.status_code == 400
+
+
 def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Refs #164

What changed:
- Add a `sort` query option to the public bounty API and `/bounties` page.
- Support `newest`, `reward`, and `remaining` ordering so contributors can scan the board by newest items, highest reward, or open award slots.
- Preserve active status and search filters across the new sort links.
- Add regression coverage for API ordering, page ordering, link preservation, and invalid sort validation.

Verification:
- `python -m pytest tests/test_bounty_pages.py -q` -> 5 passed
- `python -m pytest tests/test_bounty_pages.py tests/test_api_mcp.py tests/test_activity.py -q` -> 49 passed, 1 warning
- `python -m pytest -q` -> 206 passed, 2 warnings
- `python -m ruff check app/main.py tests/test_bounty_pages.py` -> passed
- `python -m ruff format --check app/main.py tests/test_bounty_pages.py` -> passed
- `python -m mypy app` -> success
- `python scripts/docs_smoke.py` -> docs smoke ok
- `python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No secrets, wallet material, deployment values, private vulnerability details, or MRWK price claims are included.