### PR TITLE
Reject non-object proof metadata

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
 from typing import Any, cast
@@ -149,7 +150,9 @@ def _clean_required_text(value: str, field: str, max_length: int) -> str:
     return clean
 
 
-def _clean_proof_metadata(verifier_result: dict[str, Any]) -> dict[str, Any]:
+def _clean_proof_metadata(verifier_result: Any) -> dict[str, Any]:
+    if not isinstance(verifier_result, Mapping):
+        raise LedgerError("verifier_result must be an object")
     clean = dict(verifier_result)
     for key, value in clean.items():
         if isinstance(value, str) and CONTROL_CHAR_RE.search(value):

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -82,6 +82,38 @@ def test_bounty_reserve_and_payout_conserve_supply(sqlite_url: str) -> None:
         assert verify_supply_conservation(session) is True
 
 
+def test_pay_bounty_rejects_non_object_verifier_result(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=228,
+            issue_url="https://github.com/ramimbo/mergework/issues/228",
+            title="Reject malformed verifier metadata",
+            reward_mrwk="50",
+            acceptance="Accepted payouts must store object proof metadata.",
+        )
+        reserve_account = reserve_account_for_bounty(bounty.id)
+
+        with pytest.raises(LedgerError, match="verifier_result must be an object"):
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:alice",
+                submission_url="https://github.com/ramimbo/mergework/pull/228",
+                accepted_by="maintainer",
+                verifier_result=[],
+            )
+
+        assert get_balance(session, "github:alice") == 0
+        assert get_balance(session, reserve_account) == 50_000_000
+        assert session.query(Submission).count() == 0
+        assert session.query(Proof).count() == 0
+
+
 def test_resolve_payout_account_accepts_mixed_case_prefixes(sqlite_url: str) -> None:
     create_schema(sqlite_url)
 


### PR DESCRIPTION
## Summary

- Reject non-object `verifier_result` values before proof metadata is copied or serialized.
- Add a regression showing malformed verifier metadata no longer records a payout, submission, or proof.

## Why

`pay_bounty()` expects verifier metadata to be a JSON object, but `_clean_proof_metadata()` used `dict(verifier_result)` directly. That means an empty list could be accepted as `{}` and still record a bounty payout, while other non-object inputs could fail inconsistently. Accepted payout proofs should fail closed when proof metadata is not an object.

Refs #228

## Validation

- `python -m pytest tests/test_ledger.py::test_pay_bounty_rejects_non_object_verifier_result -q` -> 1 passed
- `python -m pytest tests/test_ledger.py -q` -> 17 passed
- `python -m pytest -q` -> 206 passed, 2 warnings
- `python -m ruff check app/ledger/service.py tests/test_ledger.py` -> passed
- `python -m ruff check .` -> passed, with non-fatal ruff cache write warnings from the local temp checkout
- `python -m ruff format --check app/ledger/service.py tests/test_ledger.py` -> passed
- `python -m ruff format --check .` -> 37 files already formatted
- `python -m mypy app` -> success
- `python scripts/docs_smoke.py` -> docs smoke ok
- `python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No secrets, wallet material, private vulnerability details, deployment values, payout details, or MRWK price claims are included.