### PR TITLE
Reject unserializable proof metadata values

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -154,6 +154,10 @@ def _clean_proof_metadata(verifier_result: dict[str, Any]) -> dict[str, Any]:
     for key, value in clean.items():
         if isinstance(value, str) and CONTROL_CHAR_RE.search(value):
             raise LedgerError(f"verifier_result.{key} must not contain control characters")
+    try:
+        canonical_json(clean)
+    except (TypeError, ValueError) as exc:
+        raise LedgerError("verifier_result must be JSON serializable") from exc
     return clean
 
 

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -82,6 +82,42 @@ def test_bounty_reserve_and_payout_conserve_supply(sqlite_url: str) -> None:
         assert verify_supply_conservation(session) is True
 
 
+def test_pay_bounty_rejects_non_json_serializable_verifier_result_values(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=228,
+            issue_url="https://github.com/ramimbo/mergework/issues/228",
+            title="Reject unserializable verifier metadata",
+            reward_mrwk="50",
+            acceptance="Accepted payouts must store JSON proof metadata.",
+        )
+        reserve_account = reserve_account_for_bounty(bounty.id)
+
+        with pytest.raises(LedgerError, match="verifier_result must be JSON serializable"):
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:alice",
+                submission_url="https://github.com/ramimbo/mergework/pull/228",
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted", "raw": object()},
+            )
+
+        assert bounty.awards_paid == 0
+        assert bounty.status == "open"
+        assert get_balance(session, "github:alice") == 0
+        assert get_balance(session, reserve_account) == 50_000_000
+        assert session.query(Submission).count() == 0
+        assert session.query(Proof).count() == 0
+
+
 def test_resolve_payout_account_accepts_mixed_case_prefixes(sqlite_url: str) -> None:
     create_schema(sqlite_url)
 


### PR DESCRIPTION
Bounty #228

## Summary
- Reject `verifier_result` dictionaries that contain values canonical JSON cannot serialize.
- Raise a controlled `LedgerError` before payout submission/proof rows or award counters are mutated.
- Add a regression for `{"label": "mrwk:accepted", "raw": object()}` that verifies no payment state is recorded.

## Repro before fix
A direct `pay_bounty()` call with `verifier_result={"label": "mrwk:accepted", "raw": object()}` raised a raw `TypeError: Object of type object is not JSON serializable` while building proof metadata, instead of failing closed with a ledger validation error before payout state changes.

This is distinct from the existing non-string metadata-key and non-object metadata-shape PRs: this PR covers JSON-incompatible values inside an otherwise object-shaped metadata dict.

## Verification
- Red before fix: `uv run --python 3.12 --extra dev python -m pytest tests/test_ledger.py::test_pay_bounty_rejects_non_json_serializable_verifier_result_values -q` failed with the raw `TypeError`.
- `uv run --python 3.12 --extra dev python -m pytest tests/test_ledger.py::test_pay_bounty_rejects_non_json_serializable_verifier_result_values -q` -> 1 passed
- `uv run --python 3.12 --extra dev python -m pytest tests/test_ledger.py -q` -> 17 passed
- `uv run --python 3.12 --extra dev python -m pytest -q` -> 206 passed, 2 warnings
- `uv run --python 3.12 --extra dev ruff format --check .` -> 37 files already formatted
- `uv run --python 3.12 --extra dev ruff check .` -> all checks passed
- `uv run --python 3.12 --extra dev python -m mypy app` -> success
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --python 3.12 --extra dev python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No secrets, wallet material, private vulnerability details, deployment values, payout details, or MRWK price claims are included.