### PR TITLE
Document REST proof response shape

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -112,6 +112,29 @@ curl -s "$API_HOST/api/v1/accounts/treasury:mrwk"
 curl -s "$API_HOST/api/v1/wallets/<wallet_address>"
 ```
 
+The REST proof endpoint returns the stored public proof payload directly. It
+does not wrap the proof in the MCP JSON-RPC `result.content[0].text` envelope:
+
+```json
+{
+  "accepted_by": "ramimbo",
+  "amount_mrwk": "75",
+  "bounty_id": 39,
+  "issue_number": 229,
+  "kind": "bounty_payment",
+  "ledger_hash": "89296912e15fee4e3ede321ce695b0e212e8f03dc2e2dbb43fd2c45becd0a32c",
+  "ledger_sequence": 397,
+  "repo": "ramimbo/mergework",
+  "submission_url": "https://github.com/ramimbo/mergework/pull/224",
+  "to_account": "github:p3xill",
+  "verifier_result": {
+    "accepted_by": "ramimbo",
+    "note": "maintainer cleanup; claim https://github.com/ramimbo/mergework/issues/122#issuecomment-4532333835",
+    "source": "admin_api"
+  }
+}
+```
+
 The wallet endpoint is a read-only wallet lookup. It returns the registered
 address, public key, optional label and linked GitHub login, current balance,
 current nonce, next nonce to sign with, and registration timestamp:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -43,6 +43,23 @@ def test_api_examples_document_mcp_get_proof_response_shape() -> None:
     assert "proof.issue_number" in examples
 
 
+def test_api_examples_document_rest_proof_response_shape() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/proofs/<proof_hash>" in examples
+    assert "REST proof endpoint" in examples
+    assert '"kind": "bounty_payment"' in examples
+    assert '"ledger_sequence": 397' in examples
+    assert (
+        '"ledger_hash": "89296912e15fee4e3ede321ce695b0e212e8f03dc2e2dbb43fd2c45becd0a32c"'
+        in examples
+    )
+    assert '"submission_url": "https://github.com/ramimbo/mergework/pull/224"' in examples
+    assert '"verifier_result": {' in examples
+    assert '"source": "admin_api"' in examples
+    assert "does not wrap the proof" in examples
+
+
 def test_api_examples_document_account_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Bounty #229

What changed:
- Documented the public REST `GET /api/v1/proofs/<proof_hash>` response shape in `docs/api-examples.md`.
- Clarified that the REST proof endpoint returns the stored public proof payload directly, unlike the MCP `get_proof` JSON-RPC `result.content[0].text` envelope.
- Added docs regression coverage so the REST proof example stays present and includes the key proof/payment fields.

Evidence:
- Compared the example against the live unauthenticated endpoint:
  `GET https://api.mrwk.ltclab.site/api/v1/proofs/530f141494aef2af05e3a9a97ef4ec39e026ac721b47914c4dcb404eb3bb256a`
- The live response includes `kind`, `ledger_sequence`, `ledger_hash`, `submission_url`, `to_account`, and `verifier_result` directly at the top level.
- Cross-checked the handler in `app/main.py::api_proof()`, which loads `proof.public_json`, adds `ledger_hash`/`ledger_sequence`, and returns the object directly.

Verification:
- `uv run --python 3.12 --extra dev python -m pytest tests/test_docs_public_urls.py::test_api_examples_document_rest_proof_response_shape -q` -> 1 passed
- `uv run --python 3.12 --extra dev python -m pytest tests/test_docs_public_urls.py -q` -> 14 passed
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --python 3.12 --extra dev ruff check docs/api-examples.md tests/test_docs_public_urls.py` -> all checks passed
- `uv run --python 3.12 --extra dev ruff format --check --preview docs/api-examples.md tests/test_docs_public_urls.py` -> 2 files already formatted
- `uv run --python 3.12 --extra dev python -m pytest -q` -> 206 passed, 2 warnings
- `git diff --check` -> clean

No private keys, wallet secrets, real signatures, payout credentials, deployment values, private vulnerability details, or MRWK price claims are included.