### PR TITLE
Document status API response shape

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -18,16 +18,17 @@ curl -s "$API_HOST/api/v1/bounties?status=open"
 ```
 
 The status response reports public service metadata, current ledger height,
-active bounty count, treasury balance, and the planned future path:
+active bounty count, treasury balance, and the planned future path. The example
+below shows the response shape with illustrative values:
 
 ```json
 {
   "name": "MergeWork",
   "ticker": "MRWK",
   "genesis_supply_mrwk": "100000000",
-  "ledger_height": 410,
-  "active_bounties": 4,
-  "treasury_balance_mrwk": "99980315",
+  "ledger_height": 123,
+  "active_bounties": 2,
+  "treasury_balance_mrwk": "99990000",
   "future_path": "public snapshots, bridges, and onchain claims"
 }
 ```

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -17,6 +17,24 @@ curl -s "$API_HOST/api/v1/bounties"
 curl -s "$API_HOST/api/v1/bounties?status=open"
 ```
 
+The status response reports public service metadata, current ledger height,
+active bounty count, treasury balance, and the planned future path:
+
+```json
+{
+  "name": "MergeWork",
+  "ticker": "MRWK",
+  "genesis_supply_mrwk": "100000000",
+  "ledger_height": 410,
+  "active_bounties": 4,
+  "treasury_balance_mrwk": "99980315",
+  "future_path": "public snapshots, bridges, and onchain claims"
+}
+```
+
+Values that depend on ledger activity can change as bounties are reserved,
+paid, or closed, so refresh live examples before using exact counts.
+
 The bounties list returns public bounty rows. `status` can be omitted or set to
 `open`, `paid`, or `closed`:
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -30,6 +30,20 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "public_key_hex" in examples
 
 
+def test_api_examples_document_status_response_shape() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/status" in examples
+    assert "status response reports" in examples
+    assert '"name": "MergeWork"' in examples
+    assert '"ticker": "MRWK"' in examples
+    assert '"genesis_supply_mrwk": "100000000"' in examples
+    assert '"ledger_height": 410' in examples
+    assert '"active_bounties": 4' in examples
+    assert '"treasury_balance_mrwk": "99980315"' in examples
+    assert "Values that depend on ledger activity can change" in examples
+
+
 def test_api_examples_document_mcp_get_proof_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from scripts.docs_smoke import REQUIRED
@@ -38,9 +39,11 @@ def test_api_examples_document_status_response_shape() -> None:
     assert '"name": "MergeWork"' in examples
     assert '"ticker": "MRWK"' in examples
     assert '"genesis_supply_mrwk": "100000000"' in examples
-    assert '"ledger_height": 410' in examples
-    assert '"active_bounties": 4' in examples
-    assert '"treasury_balance_mrwk": "99980315"' in examples
+    assert re.search(r'"ledger_height": \d+', examples)
+    assert re.search(r'"active_bounties": \d+', examples)
+    assert re.search(r'"treasury_balance_mrwk": "\d+"', examples)
+    assert '"ledger_height": 410' not in examples
+    assert "illustrative values" in examples
     assert "Values that depend on ledger activity can change" in examples
 
 


### PR DESCRIPTION
Bounty #229

What changed:
- Documented the public `GET /api/v1/status` response shape in `docs/api-examples.md`.
- Clarified which fields are stable service metadata and which live values can change with ledger/bounty activity.
- Added docs regression coverage for the status example fields.

Evidence:
- Compared the example against the live unauthenticated endpoint: `GET https://api.mrwk.ltclab.site/api/v1/status`.
- The live response includes `name`, `ticker`, `genesis_supply_mrwk`, `ledger_height`, `active_bounties`, `treasury_balance_mrwk`, and `future_path`.
- Cross-checked `app/main.py::api_status()`, which returns those same keys from ledger and bounty state.

Verification:
- `uv run --python 3.12 --extra dev python -m pytest tests/test_docs_public_urls.py::test_api_examples_document_status_response_shape -q` -> 1 passed
- `uv run --python 3.12 --extra dev python -m pytest tests/test_docs_public_urls.py -q` -> 14 passed
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --python 3.12 --extra dev ruff check docs/api-examples.md tests/test_docs_public_urls.py` -> all checks passed
- `uv run --python 3.12 --extra dev ruff format --check --preview docs/api-examples.md tests/test_docs_public_urls.py` -> 2 files already formatted
- `uv run --python 3.12 --extra dev python -m pytest -q` -> 206 passed, 2 warnings
- `git diff --check` -> clean

No private keys, wallet secrets, real signatures, payout credentials, deployment values, private vulnerability details, or MRWK price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced API reference documentation with detailed examples of the `/api/v1/status` endpoint response, including sample payloads with service metadata and ledger-related information such as current ledger height, active bounty count, and treasury balance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->