### PR TITLE
Add open award slot bounty filter

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -592,7 +592,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         }
 
     def list_bounties_by_status(
-        status: str | None = None, query_text: str | None = None
+        status: str | None = None,
+        query_text: str | None = None,
+        open_awards_only: bool = False,
     ) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
             query = select(Bounty)
@@ -624,14 +626,18 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                     if issue_number is not None:
                         text_filter = or_(text_filter, Bounty.issue_number == issue_number)
                     query = query.where(text_filter)
+            if open_awards_only:
+                query = query.where(Bounty.status == "open", Bounty.max_awards > Bounty.awards_paid)
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             return [bounty_to_dict(bounty) for bounty in bounties]
 
     @app.get("/api/v1/bounties")
     def api_bounties(
-        status: str | None = Query(None), q: str | None = Query(None)
+        status: str | None = Query(None),
+        q: str | None = Query(None),
+        open_awards_only: bool = Query(False),
     ) -> list[dict[str, Any]]:
-        return list_bounties_by_status(status, q)
+        return list_bounties_by_status(status, q, open_awards_only)
 
     @app.post("/api/v1/bounties")
     async def api_create_bounty(

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -15,10 +15,12 @@ Check service status and list bounties:
 curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
 curl -s "$API_HOST/api/v1/bounties?status=open"
+curl -s "$API_HOST/api/v1/bounties?open_awards_only=true"
 ```
 
 The bounties list returns public bounty rows. `status` can be omitted or set to
-`open`, `paid`, or `closed`:
+`open`, `paid`, or `closed`. Set `open_awards_only=true` when an agent only
+wants bounties that are still open and have at least one award slot remaining:
 
 ```json
 {

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -411,6 +411,64 @@ def test_bounty_api_filters_by_status(sqlite_url: str) -> None:
     assert invalid.json()["detail"] == "status must be one of: open, paid, closed"
 
 
+def test_bounty_api_filters_to_open_award_slots(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        open_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=43,
+            issue_url="https://github.com/ramimbo/mergework/issues/43",
+            title="Open award slot bounty",
+            reward_mrwk="5",
+            max_awards=2,
+            acceptance="Available award slots should be discoverable.",
+        )
+        exhausted_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=44,
+            issue_url="https://github.com/ramimbo/mergework/issues/44",
+            title="Exhausted award slot bounty",
+            reward_mrwk="5",
+            acceptance="Paid rows should not appear in the open-slot filter.",
+        )
+        closed_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=45,
+            issue_url="https://github.com/ramimbo/mergework/issues/45",
+            title="Closed award slot bounty",
+            reward_mrwk="5",
+            acceptance="Closed rows should not appear in the open-slot filter.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=exhausted_bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/44",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        close_bounty(
+            session,
+            bounty_id=closed_bounty.id,
+            closed_by="maintainer",
+            reference="https://github.com/ramimbo/mergework/issues/45#close",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    available = client.get("/api/v1/bounties?open_awards_only=true").json()
+    search_match = client.get("/api/v1/bounties?open_awards_only=true&q=slot").json()
+    paid_with_filter = client.get("/api/v1/bounties?status=paid&open_awards_only=true").json()
+
+    assert [item["id"] for item in available] == [open_bounty.id]
+    assert [item["id"] for item in search_match] == [open_bounty.id]
+    assert paid_with_filter == []
+
+
 def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
## Summary
- Adds `open_awards_only=true` to `/api/v1/bounties` so agents can request only bounties that are open and still have award slots remaining.
- Keeps the existing `status` and `q` filters composable with the new availability filter.
- Documents the new API query option for contributors and agents.

Bounty #164

## Verification
- `.\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py -q` -> 42 passed, 1 warning.
- `.\.venv\Scripts\python.exe -m ruff check app\main.py tests\test_api_mcp.py` -> passed.
- `.\.venv\Scripts\python.exe -m ruff format --check app\main.py tests\test_api_mcp.py` -> passed.
