### PR TITLE
Link bounty award proofs on detail pages

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -238,6 +238,30 @@ def activity_to_dict(session: Session, query: str | None = None) -> dict[str, An
     }
 
 
+def bounty_awards_to_dict(session: Session, bounty_id: int) -> list[dict[str, Any]]:
+    rows = session.execute(
+        select(LedgerEntry, Proof)
+        .join(Proof, Proof.ledger_sequence == LedgerEntry.sequence)
+        .where(
+            LedgerEntry.entry_type == "bounty_payment",
+            Proof.kind == "bounty_payment",
+            Proof.bounty_id == bounty_id,
+        )
+        .order_by(LedgerEntry.sequence.desc())
+    ).all()
+    awards: list[dict[str, Any]] = []
+    seen_sequences: set[int] = set()
+    for entry, proof in rows:
+        if entry.sequence in seen_sequences:
+            continue
+        row = _activity_row(entry, proof)
+        if row is None:
+            continue
+        seen_sequences.add(entry.sequence)
+        awards.append(row)
+    return awards
+
+
 def account_accepted_summary(session: Session, account: str) -> dict[str, Any]:
     rows = session.execute(
         select(LedgerEntry, Proof)
@@ -1059,8 +1083,20 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/bounties/{bounty_id}", response_class=HTMLResponse)
     def bounty_page(request: Request, bounty_id: int) -> HTMLResponse:
+        bounty_id = _positive_bounty_id(bounty_id)
+        with session_scope(db_url) as session:
+            bounty = session.get(Bounty, bounty_id)
+            if bounty is None:
+                raise HTTPException(status_code=404, detail="bounty not found")
+            bounty_data = bounty_to_dict(bounty)
+            awards = bounty_awards_to_dict(session, bounty_id)
         return templates.TemplateResponse(
-            request, "bounty_detail.html", {"bounty": api_bounty(bounty_id)}
+            request,
+            "bounty_detail.html",
+            {
+                "bounty": bounty_data,
+                "awards": awards,
+            },
         )
 
     @app.get("/ledger", response_class=HTMLResponse)

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -41,5 +41,31 @@
     <h2 id="acceptance-heading">What has to be true</h2>
     <p>{{ bounty.acceptance }}</p>
   </section>
+
+  <section class="acceptance-card" aria-labelledby="award-proofs-heading">
+    <p class="eyebrow">Award proofs</p>
+    <h2 id="award-proofs-heading">Paid awards</h2>
+    {% if awards %}
+    <ul>
+      {% for award in awards %}
+      <li>
+        <a href="{{ award.proof_url }}">Proof {{ award.proof_hash[:12] }}</a>
+        paid {{ award.amount_mrwk }} MRWK to
+        <a href="/accounts/{{ award.account }}">{{ award.account }}</a>
+        via
+        {% set submission_url = safe_public_url(award.submission_url) %}
+        {% if submission_url %}
+          <a href="{{ submission_url }}" rel="nofollow noopener">submission</a>
+        {% else %}
+          submission
+        {% endif %}
+        on ledger <a href="/ledger/{{ award.ledger_sequence }}">#{{ award.ledger_sequence }}</a>.
+      </li>
+      {% endfor %}
+    </ul>
+    {% else %}
+    <p>No paid award proofs yet.</p>
+    {% endif %}
+  </section>
 </section>
 {% endblock %}

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -158,6 +158,45 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert client.get("/bounties/0").status_code == 400
 
 
+def test_bounty_detail_links_paid_award_proofs(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=46,
+            issue_url="https://github.com/ramimbo/mergework/issues/46",
+            title="Expose bounty award proofs",
+            reward_mrwk="25",
+            max_awards=2,
+            acceptance="Bounty details should link accepted award proofs.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/46",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(f"/bounties/{bounty.id}")
+
+    assert response.status_code == 200
+    assert "Award proofs" in response.text
+    assert "Paid awards" in response.text
+    assert f'href="/proofs/{proof.hash}"' in response.text
+    assert proof.hash[:12] in response.text
+    assert 'href="/accounts/github:alice"' in response.text
+    assert 'href="https://github.com/ramimbo/mergework/pull/46" rel="nofollow noopener"' in (
+        response.text
+    )
+    assert f'href="/ledger/{proof.ledger_sequence}"' in response.text
+
+
 def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
## Summary
- Adds paid award proof links to public bounty detail pages.
- Shows the proof, recipient account, source submission, amount, and ledger sequence for each paid award.
- Keeps empty bounties clear with a no-proof state.

Bounty #164

## Verification
- `.\.venv\Scripts\python.exe -m pytest tests\test_bounty_pages.py -q` -> 5 passed.
- `.\.venv\Scripts\python.exe -m ruff check app\main.py tests\test_bounty_pages.py` -> passed.
- `.\.venv\Scripts\python.exe -m ruff format --check app\main.py tests\test_bounty_pages.py` -> passed.
