### PR TITLE
Add activity API result limit

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -175,7 +175,9 @@ def _activity_row_matches(row: dict[str, Any], query: str) -> bool:
     return any(query in str(value or "").lower() for value in searchable_values)
 
 
-def activity_to_dict(session: Session, query: str | None = None) -> dict[str, Any]:
+def activity_to_dict(
+    session: Session, query: str | None = None, limit: int = 100
+) -> dict[str, Any]:
     search_query = _activity_search_query(query)
     rows = session.execute(
         select(LedgerEntry, Proof)
@@ -234,7 +236,7 @@ def activity_to_dict(session: Session, query: str | None = None) -> dict[str, An
         },
         "query": search_query,
         "contributors": contributors,
-        "recent": recent[:100],
+        "recent": recent[:limit],
     }
 
 
@@ -886,9 +888,11 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             return data
 
     @app.get("/api/v1/activity")
-    def api_activity(q: str | None = Query(None)) -> dict[str, Any]:
+    def api_activity(
+        q: str | None = Query(None), limit: Annotated[int, Query(ge=1, le=200)] = 100
+    ) -> dict[str, Any]:
         with session_scope(db_url) as session:
-            return activity_to_dict(session, q)
+            return activity_to_dict(session, q, limit)
 
     @app.post("/webhooks/github")
     async def github_webhook(request: Request) -> JSONResponse:

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -102,7 +102,11 @@ Read accepted-work activity summarized from proof-backed bounty payments:
 
 ```bash
 curl -s "$API_HOST/api/v1/activity"
+curl -s "$API_HOST/api/v1/activity?limit=10"
 ```
+
+Use `limit` to choose how many recent accepted-work rows to return from 1 to
+200.
 
 Inspect a proof, account, or registered wallet:
 

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -156,6 +156,51 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
     assert no_match["recent"] == []
 
 
+def test_activity_api_limits_recent_rows(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=164,
+            issue_url="https://github.com/ramimbo/mergework/issues/164",
+            title="Activity limit bounty",
+            reward_mrwk="50",
+            max_awards=3,
+            acceptance="Agents should be able to request only the newest rows.",
+        )
+        first_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/170",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        second_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:bob",
+            submission_url="https://github.com/ramimbo/mergework/pull/171",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    limited = client.get("/api/v1/activity?limit=1")
+    too_small = client.get("/api/v1/activity?limit=0")
+    too_large = client.get("/api/v1/activity?limit=201")
+
+    assert limited.status_code == 200
+    assert limited.json()["totals"]["accepted_awards"] == 2
+    assert [row["proof_hash"] for row in limited.json()["recent"]] == [second_proof.hash]
+    assert first_proof.hash not in {row["proof_hash"] for row in limited.json()["recent"]}
+    assert too_small.status_code == 422
+    assert too_large.status_code == 422
+
+
 def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))


### PR DESCRIPTION
## Summary
- Adds a bounded `limit` query parameter to `/api/v1/activity` so agents can request a smaller recent-work feed.
- Keeps totals and contributor summaries computed over the matching activity set while limiting only the returned `recent` rows.
- Documents the new public API option.

Bounty #164

## Verification
- `.\.venv\Scripts\python.exe -m pytest tests\test_activity.py -q` -> 4 passed.
- `.\.venv\Scripts\python.exe -m ruff check app\main.py tests\test_activity.py` -> passed.
- `.\.venv\Scripts\python.exe -m ruff format --check app\main.py tests\test_activity.py` -> passed.
