### PR TITLE
Link source bounty issues in activity

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -143,6 +143,11 @@ def _activity_row(entry: LedgerEntry, proof: Proof) -> dict[str, Any] | None:
     if not isinstance(data, dict) or data.get("kind") != "bounty_payment":
         return None
     submission_url = str(data.get("submission_url") or entry.reference)
+    bounty_repo = data.get("repo")
+    bounty_issue_number = data.get("issue_number")
+    bounty_issue_url = None
+    if bounty_repo and bounty_issue_number:
+        bounty_issue_url = f"https://github.com/{bounty_repo}/issues/{bounty_issue_number}"
     return {
         "ledger_sequence": entry.sequence,
         "account": entry.to_account,
@@ -152,7 +157,9 @@ def _activity_row(entry: LedgerEntry, proof: Proof) -> dict[str, Any] | None:
         "proof_hash": proof.hash,
         "proof_url": f"/proofs/{proof.hash}",
         "bounty_id": proof.bounty_id,
-        "bounty_issue_number": data.get("issue_number"),
+        "bounty_repo": bounty_repo,
+        "bounty_issue_number": bounty_issue_number,
+        "bounty_issue_url": bounty_issue_url,
         "created_at": entry.created_at.isoformat(),
     }
 

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -72,6 +72,11 @@
             <dt>Contributor</dt>
             <dd><a href="/accounts/{{ row.account }}">{{ row.account }}</a></dd>
           </div>
+          <div class="ledger-field ledger-field--issue">
+            <dt>Bounty issue</dt>
+            {% set bounty_issue_url = safe_public_url(row.bounty_issue_url) %}
+            <dd>{% if bounty_issue_url %}<a href="{{ bounty_issue_url }}" rel="nofollow noopener">{{ row.bounty_repo }} #{{ row.bounty_issue_number }}</a>{% else %}-{% endif %}</dd>
+          </div>
           <div class="ledger-field ledger-field--reference reference-cell">
             <dt>Accepted work</dt>
             {% set submission_url = safe_public_url(row.submission_url) %}

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -98,6 +98,10 @@ def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -
         second_proof.hash,
         first_proof.hash,
     ]
+    assert payload["recent"][0]["bounty_repo"] == "ramimbo/mergework"
+    assert payload["recent"][0]["bounty_issue_url"] == (
+        "https://github.com/ramimbo/mergework/issues/11"
+    )
     assert all("unproved" not in row["submission_url"] for row in payload["recent"])
 
 
@@ -192,6 +196,10 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert "75 MRWK" in paid.text
     assert 'role="search"' in paid.text
     assert 'name="q"' in paid.text
+    assert "Bounty issue" in paid.text
+    assert 'href="https://github.com/ramimbo/mergework/issues/12" rel="nofollow noopener"' in (
+        paid.text
+    )
     assert 'href="https://github.com/ramimbo/mergework/pull/12"' in paid.text
     assert f'href="/proofs/{proof.hash}"' in paid.text
     assert "/accounts/github:bob" in paid.text


### PR DESCRIPTION
## Summary
- Adds source bounty issue metadata to accepted-work activity rows.
- Links the public activity page back to the originating GitHub bounty issue for each recent accepted payment.
- Keeps existing proof, account, and accepted-work links intact.

Bounty #164

## Verification
- `.\.venv\Scripts\python.exe -m pytest tests\test_activity.py -q` -> 3 passed.
- `.\.venv\Scripts\python.exe -m ruff check app\main.py tests\test_activity.py` -> passed.
- `.\.venv\Scripts\python.exe -m ruff format --check app\main.py tests\test_activity.py` -> passed.
