### PR TITLE
fix: configure Alembic path separator

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,6 +1,7 @@
 [alembic]
 script_location = migrations
 prepend_sys_path = .
+path_separator = os
 sqlalchemy.url = sqlite:///mergework.sqlite3
 
 [loggers]


### PR DESCRIPTION
## Summary

Refs #228.

Alembic now recommends setting `path_separator` explicitly. Without it, the migration test emits a deprecation warning from Alembic's legacy path-splitting fallback.

This adds `path_separator = os` to `alembic.ini`, keeping the existing `prepend_sys_path = .` behavior while removing the deprecation path.

## Validation

```bash
.venv/bin/python -W error::DeprecationWarning -m pytest tests/test_migrations.py::test_alembic_upgrade_head_builds_deploy_schema -q
# 1 passed

.venv/bin/python -m pytest -q
# 205 passed, 1 warning

.venv/bin/python -m ruff check .
# All checks passed!

.venv/bin/python -m ruff format --check .
# 37 files already formatted

.venv/bin/python -m mypy app
# Success: no issues found in 11 source files
```

The remaining warning is unrelated: `httpx` deprecation warning in `tests/test_api_mcp.py::test_mcp_rejects_malformed_requests_without_500`.