### PR TITLE
Reject non-string wallet normalizer inputs

### DIFF
--- a/app/wallets.py
+++ b/app/wallets.py
@@ -21,35 +21,43 @@ def canonical_wallet_json(payload: dict[str, Any]) -> str:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
 
 
-def normalize_public_key_hex(public_key_hex: str) -> str:
-    normalized = public_key_hex.strip().lower()
+def _clean_string(value: object, message: str) -> str:
+    if not isinstance(value, str):
+        raise WalletError(message)
+    return value.strip().lower()
+
+
+def normalize_public_key_hex(public_key_hex: object) -> str:
+    normalized = _clean_string(
+        public_key_hex, "public key must be 32 bytes encoded as lowercase hex"
+    )
     if not PUBLIC_KEY_RE.fullmatch(normalized):
         raise WalletError("public key must be 32 bytes encoded as lowercase hex")
     return normalized
 
 
-def normalize_signature_hex(signature_hex: str) -> str:
-    normalized = signature_hex.strip().lower()
+def normalize_signature_hex(signature_hex: object) -> str:
+    normalized = _clean_string(signature_hex, "signature must be 64 bytes encoded as lowercase hex")
     if not SIGNATURE_RE.fullmatch(normalized):
         raise WalletError("signature must be 64 bytes encoded as lowercase hex")
     return normalized
 
 
-def normalize_wallet_address(address: str) -> str:
-    normalized = address.strip().lower()
+def normalize_wallet_address(address: object) -> str:
+    normalized = _clean_string(address, "invalid MRWK wallet address")
     if not ADDRESS_RE.fullmatch(normalized):
         raise WalletError("invalid MRWK wallet address")
     return normalized
 
 
-def address_from_public_key_hex(public_key_hex: str) -> str:
+def address_from_public_key_hex(public_key_hex: object) -> str:
     public_key = normalize_public_key_hex(public_key_hex)
     digest = hashlib.sha256(bytes.fromhex(public_key)).hexdigest()
     return f"mrwk1{digest[:40]}"
 
 
 def verify_wallet_signature(
-    *, public_key_hex: str, payload: dict[str, Any], signature_hex: str
+    *, public_key_hex: object, payload: dict[str, Any], signature_hex: object
 ) -> bool:
     public_key = Ed25519PublicKey.from_public_bytes(
         bytes.fromhex(normalize_public_key_hex(public_key_hex))

--- a/tests/test_wallets.py
+++ b/tests/test_wallets.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -19,7 +21,14 @@ from app.ledger.service import (
     wallet_link_payload,
     wallet_transfer_payload,
 )
-from app.wallets import address_from_public_key_hex, canonical_wallet_json
+from app.wallets import (
+    WalletError,
+    address_from_public_key_hex,
+    canonical_wallet_json,
+    normalize_public_key_hex,
+    normalize_signature_hex,
+    normalize_wallet_address,
+)
 
 
 def _keypair() -> tuple[Ed25519PrivateKey, str, str]:
@@ -43,6 +52,29 @@ def test_wallet_address_is_derived_from_public_key() -> None:
     assert address.startswith("mrwk1")
     assert len(address) == 45
     assert address_from_public_key_hex(public_hex) == address
+
+
+@pytest.mark.parametrize(
+    ("normalizer", "value", "message"),
+    (
+        (
+            normalize_public_key_hex,
+            123,
+            "public key must be 32 bytes encoded as lowercase hex",
+        ),
+        (
+            normalize_signature_hex,
+            ["00"],
+            "signature must be 64 bytes encoded as lowercase hex",
+        ),
+        (normalize_wallet_address, {"address": "mrwk1"}, "invalid MRWK wallet address"),
+    ),
+)
+def test_wallet_normalizers_reject_non_string_inputs(
+    normalizer: Callable[[object], str], value: object, message: str
+) -> None:
+    with pytest.raises(WalletError, match=message):
+        normalizer(value)
 
 
 def test_wallet_registration_rejects_oversized_label(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #228

## Summary
- Reject non-string values at the shared wallet normalization boundary before calling `.strip()`.
- Keep invalid public key, signature, and wallet address inputs on the existing `WalletError` / `LedgerError` validation path.
- Add regression coverage for non-string public key, signature, and wallet address inputs.

## Repro before fix
Direct wallet-normalizer calls with malformed non-string inputs raised raw Python attribute errors instead of project validation errors:

```text
normalize_public_key_hex(123) -> AttributeError: 'int' object has no attribute 'strip'
normalize_signature_hex(123) -> AttributeError: 'int' object has no attribute 'strip'
normalize_wallet_address(123) -> AttributeError: 'int' object has no attribute 'strip'
```

This is distinct from API JSON field validation because these helpers are the shared boundary for direct service calls, MCP paths, and signature verification.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_wallets.py::test_wallet_normalizers_reject_non_string_inputs tests\test_wallets.py tests\test_wallet_api.py::test_wallet_api_malformed_register_requests_return_4xx tests\test_api_mcp.py::test_mcp_can_register_and_fetch_wallet -q` -> 12 passed
- `.\.venv\Scripts\python.exe -m pytest -q` -> 208 passed, 2 warnings
- `.\.venv\Scripts\python.exe -m ruff check .` -> all checks passed
- `.\.venv\Scripts\python.exe -m ruff format --check .` -> 37 files already formatted
- `.\.venv\Scripts\python.exe -m mypy app` -> success
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `.\.venv\Scripts\python.exe scripts\check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No secrets, wallet private keys, payout details, deployment values, private vulnerability details, or MRWK price claims are included.