### PR TITLE
test: use httpx content for raw MCP payload

### DIFF
--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -437,7 +437,11 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
 def test_mcp_rejects_malformed_requests_without_500(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
-    malformed = client.post("/mcp", data="not-json", headers={"content-type": "application/json"})
+    malformed = client.post(
+        "/mcp",
+        content="not-json",
+        headers={"content-type": "application/json"},
+    )
     assert malformed.status_code == 400
     assert malformed.json() == {
         "jsonrpc": "2.0",


### PR DESCRIPTION
## Summary

Refs #228.

The malformed MCP request test sends raw JSON text using `data=...`, which httpx now warns is deprecated for raw request bodies.

This switches the test to `content=...`, preserving the same request body and headers while avoiding the deprecation path.

## Validation

```bash
.venv/bin/python -W error::DeprecationWarning -m pytest tests/test_api_mcp.py::test_mcp_rejects_malformed_requests_without_500 -q
# 1 passed

.venv/bin/python -m pytest -q
# 205 passed, 1 warning

.venv/bin/python -m ruff check .
# All checks passed!

.venv/bin/python -m ruff format --check .
# 37 files already formatted

.venv/bin/python -m mypy app
# Success: no issues found in 11 source files
```

The remaining warning is the Alembic `path_separator` warning addressed separately in #264.