### PR TITLE
Validate MRWK wallet-like account IDs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -356,7 +356,7 @@ def _normalized_account(account: str) -> str:
             raise HTTPException(status_code=400, detail="reserve bounty id must be positive")
         return f"{reserve_prefix}{int(bounty_id)}"
     if lower.startswith("mrwk1"):
-        return clean.lower()
+        return _normalized_wallet_address(clean)
     if lower.startswith("github:"):
         login = clean.split(":", 1)[1].lower()
         if not GITHUB_LOGIN_RE.fullmatch(login):

--- a/tests/test_account_validation.py
+++ b/tests/test_account_validation.py
@@ -193,6 +193,59 @@ def test_account_views_accept_valid_reserve_bounty_account(sqlite_url: str) -> N
     assert mcp_resp.json()["result"]["content"][0]["text"] == "reserve:bounty:1: 50 MRWK"
 
 
+def test_account_views_accept_valid_mrwk_wallet_account(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    account = "mrwk1" + ("0" * 40)
+
+    api_resp = client.get(f"/api/v1/accounts/{account}")
+    page_resp = client.get(f"/accounts/{account}")
+    mcp_resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": {"name": "get_balance", "arguments": {"account": account.upper()}},
+        },
+    )
+
+    assert api_resp.status_code == 200
+    assert api_resp.json()["account"] == account
+    assert page_resp.status_code == 200
+    assert mcp_resp.status_code == 200
+    assert mcp_resp.json()["result"]["content"][0]["text"] == f"{account}: 0 MRWK"
+
+
+@pytest.mark.parametrize(
+    "account",
+    [
+        "mrwk1bad",
+        "mrwk1" + ("0" * 39),
+        "mrwk1" + ("g" * 40),
+    ],
+)
+def test_account_views_reject_malformed_mrwk_wallet_accounts(sqlite_url: str, account: str) -> None:
+    client = _setup_app(sqlite_url)
+
+    api_resp = client.get(f"/api/v1/accounts/{account}")
+    page_resp = client.get(f"/accounts/{account}")
+    mcp_resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": {"name": "get_balance", "arguments": {"account": account}},
+        },
+    )
+
+    assert api_resp.status_code == 400
+    assert api_resp.json()["detail"] == "invalid MRWK wallet address"
+    assert page_resp.status_code == 400
+    assert mcp_resp.status_code == 200
+    assert mcp_resp.json()["error"]["code"] == -32602
+
+
 @pytest.mark.parametrize(
     "account",
     [


### PR DESCRIPTION
Bounty #228

## Summary
- Reject malformed account identifiers that start with `mrwk1` by routing them through the existing MRWK wallet-address validator.
- Preserve valid wallet-like account lookups, including uppercase input normalization through the MCP `get_balance` path.
- Add regression coverage across the REST account API, public account page, and MCP `get_balance` tool.

## Repro Before Fix
The live public API currently treats malformed wallet-like account IDs as normal transferable wallet accounts:

```text
GET https://api.mrwk.ltclab.site/api/v1/accounts/mrwk1bad -> 200
```

Observed response includes `"account":"mrwk1bad"`, `"exists":false`, and `"transfer_status":"MRWK wallet transfers are enabled for registered mrwk1 addresses."`.

A malformed value with the reserved wallet-address prefix should be rejected instead of displayed as a wallet-transfer-capable account.

## Verification
- `.venv/bin/python -m pytest tests/test_account_validation.py -q` -> 24 passed
- `.venv/bin/python -m pytest tests/test_account_validation.py tests/test_api_mcp.py -q` -> 65 passed, 1 existing warning
- `.venv/bin/python -m pytest -q` -> 209 passed, 2 existing warnings
- `.venv/bin/python -m ruff check .` -> all checks passed
- `.venv/bin/python -m ruff format --check .` -> 37 files already formatted
- `.venv/bin/python -m mypy app` -> success
- `.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No secrets, wallet private keys, payout details, deployment values, private vulnerability details, or MRWK price claims are included.
