### PR TITLE
Document MCP bounty response examples

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -198,6 +198,28 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_bounties","arguments":{}}}'
 ```
 
+The first content block is a JSON string containing an array of open bounty rows.
+The rows use the same public shape as `/api/v1/bounties`, ordered newest first
+and limited to the most recent 25 open bounties:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "[{\"id\":39,\"repo\":\"ramimbo/mergework\",\"issue_number\":229,\"issue_url\":\"https://github.com/ramimbo/mergework/issues/229\",\"title\":\"MRWK bounty: public API examples accuracy, round 2\",\"reward_mrwk\":\"75\",\"reserved_mrwk\":\"450\",\"max_awards\":6,\"awards_paid\":2,\"awards_remaining\":4,\"status\":\"open\",\"acceptance\":\"Focused public documentation PRs that make API or MCP examples match actual MergeWork response shapes, with evidence and docs/tests. Duplicate, invented, stale, style-only, or unrelated changes do not qualify.\",\"created_at\":\"2026-05-25T08:15:18.624552\"}]"
+      }
+    ]
+  }
+}
+```
+
+Award counters in MCP bounty rows can change for the same reasons as the REST
+bounty API. Refresh live values before relying on exact slot counts.
+
 Call `get_bounty` with the internal bounty `id` returned by `list_bounties`,
 not the GitHub issue number:
 
@@ -206,6 +228,27 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_bounty","arguments":{"id":11}}}'
 ```
+
+The response returns one JSON-string bounty row inside the JSON-RPC content
+block:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"id\":39,\"repo\":\"ramimbo/mergework\",\"issue_number\":229,\"issue_url\":\"https://github.com/ramimbo/mergework/issues/229\",\"title\":\"MRWK bounty: public API examples accuracy, round 2\",\"reward_mrwk\":\"75\",\"reserved_mrwk\":\"450\",\"max_awards\":6,\"awards_paid\":2,\"awards_remaining\":4,\"status\":\"open\",\"acceptance\":\"Focused public documentation PRs that make API or MCP examples match actual MergeWork response shapes, with evidence and docs/tests. Duplicate, invented, stale, style-only, or unrelated changes do not qualify.\",\"created_at\":\"2026-05-25T08:15:18.624552\"}"
+      }
+    ]
+  }
+}
+```
+
+If the internal id is valid but not found, `get_bounty` returns the plain text
+`bounty not found` inside the same JSON-RPC content wrapper.
 
 Call `get_proof` with the proof hash returned by `/api/v1/ledger`,
 `/api/v1/activity`, or `get_ledger_entry`:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -30,6 +30,21 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "public_key_hex" in examples
 
 
+def test_api_examples_document_mcp_bounty_response_shapes() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert '"name":"list_bounties"' in examples
+    assert "JSON string containing an array of open bounty rows" in examples
+    assert "same public shape as `/api/v1/bounties`" in examples
+    assert "limited to the most recent 25 open bounties" in examples
+    assert '\\"repo\\":\\"ramimbo/mergework\\"' in examples
+    assert '\\"issue_number\\":229' in examples
+    assert '\\"awards_remaining\\":4' in examples
+    assert "Award counters in MCP bounty rows can change" in examples
+    assert "one JSON-string bounty row" in examples
+    assert "bounty not found" in examples
+
+
 def test_api_examples_document_mcp_get_proof_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- Documented the MCP `list_bounties` response wrapper and the JSON-string array of open bounty rows.
- Documented the MCP `get_bounty` response wrapper, the internal-id lookup shape, and the plain-text not-found response.
- Added docs regression coverage for the MCP bounty response examples.

Bounty #229

## Evidence

Compared the examples against the live public MCP endpoint and `app/main.py::_call_mcp_tool()`:

```bash
curl -s -X POST https://mcp.mrwk.ltclab.site/mcp \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_bounties","arguments":{}}}'

curl -s -X POST https://mcp.mrwk.ltclab.site/mcp \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_bounty","arguments":{"id":39}}}'
```

This is distinct from the existing REST bounty examples because it documents the MCP JSON-RPC content wrapper and JSON-string payload for bounty lookup tools.

## Verification

- `.venv/bin/python -m pytest tests/test_docs_public_urls.py -q` -> 14 passed
- `.venv/bin/python -m pytest tests/test_docs_public_urls.py tests/test_api_mcp.py -q` -> 55 passed, 1 existing warning
- `.venv/bin/python -m pytest -q` -> 206 passed, 2 existing warnings
- `.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `.venv/bin/ruff check .` -> all checks passed
- `.venv/bin/ruff format --check .` -> 37 files already formatted
- `.venv/bin/ruff format --check --preview docs/api-examples.md tests/test_docs_public_urls.py` -> 2 files already formatted
- `.venv/bin/python -m mypy app` -> success
- `.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No private keys, wallet secrets, payout credentials, deployment values, private vulnerability details, or MRWK price claims are included.
