### PR TITLE
Clarify bounty detail action states

### DIFF
--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -36,6 +36,35 @@
     </article>
   </div>
 
+  <section class="acceptance-card" aria-labelledby="contributor-action-heading">
+    <p class="eyebrow">Contributor action</p>
+    {% if bounty.status == "open" and bounty.awards_remaining > 0 %}
+      <h2 id="contributor-action-heading">Ready for contributors</h2>
+      <p>
+        This bounty is open for {{ bounty.awards_remaining }} more award{% if bounty.awards_remaining != 1 %}s{% endif %}.
+        Submit focused work that cites <code>Bounty #{{ bounty.issue_number }}</code> and matches the acceptance criteria.
+      </p>
+    {% elif bounty.status == "open" %}
+      <h2 id="contributor-action-heading">Review before starting</h2>
+      <p>
+        This bounty is still marked open, but no award slots remain.
+        Check maintainer comments or a newer round before starting new work.
+      </p>
+    {% elif bounty.status == "paid" %}
+      <h2 id="contributor-action-heading">All awards paid</h2>
+      <p>
+        This bounty has used its award slots.
+        Use the source issue and proof links to inspect accepted work instead of starting a new claim.
+      </p>
+    {% else %}
+      <h2 id="contributor-action-heading">Closed for new work</h2>
+      <p>
+        This bounty is closed.
+        Use the source issue and ledger history for context, but look for an open bounty before starting new work.
+      </p>
+    {% endif %}
+  </section>
+
   <section class="acceptance-card" aria-labelledby="acceptance-heading">
     <p class="eyebrow">Acceptance</p>
     <h2 id="acceptance-heading">What has to be true</h2>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -149,6 +149,9 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert "<span>Awards</span>" in response.text
     assert "<span>Issue</span>" in response.text
     assert "100 MRWK" in response.text
+    assert "Ready for contributors" in response.text
+    assert "open for 1 more award" in response.text
+    assert "Bounty #4" in response.text
     assert "What has to be true" in response.text
     assert "Focused PR improves status, reward, issue link, and acceptance text." in response.text
 
@@ -156,6 +159,59 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert missing_response.status_code == 404
     assert client.get("/api/v1/bounties/0").status_code == 400
     assert client.get("/bounties/0").status_code == 400
+
+
+def test_bounty_detail_explains_paid_and_closed_action_states(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        paid_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=14,
+            issue_url="https://github.com/ramimbo/mergework/issues/14",
+            title="Paid discovery bounty",
+            reward_mrwk="50",
+            max_awards=1,
+            acceptance="Accepted work should make the paid state obvious.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=paid_bounty.id,
+            to_account="github:contributor",
+            submission_url="https://github.com/ramimbo/mergework/pull/14",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        closed_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=15,
+            issue_url="https://github.com/ramimbo/mergework/issues/15",
+            title="Closed discovery bounty",
+            reward_mrwk="50",
+            acceptance="Closed work should not look claimable.",
+        )
+        close_bounty(
+            session,
+            bounty_id=closed_bounty.id,
+            closed_by="maintainer",
+            reference="https://github.com/ramimbo/mergework/issues/15",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    paid_response = client.get(f"/bounties/{paid_bounty.id}")
+    assert paid_response.status_code == 200
+    assert "All awards paid" in paid_response.text
+    assert "used its award slots" in paid_response.text
+    assert "Ready for contributors" not in paid_response.text
+
+    closed_response = client.get(f"/bounties/{closed_bounty.id}")
+    assert closed_response.status_code == 200
+    assert "Closed for new work" in closed_response.text
+    assert "look for an open bounty" in closed_response.text
+    assert "Ready for contributors" not in closed_response.text
 
 
 def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #164

## Summary
- Add a contributor-action section to bounty detail pages so users can tell whether a bounty is ready for work, full, paid, or closed.
- Show the remaining award count and the exact `Bounty #<issue>` reference for open actionable bounties.
- Add regression coverage for open, paid, and closed bounty detail states.

## Evidence
- Compared the change against the existing bounty detail fields from `bounty_to_dict()`: `status`, `awards_remaining`, `max_awards`, and `issue_number`.
- This is distinct from the bounty list search/source-link work because it makes the single-bounty detail page clearer at the moment a contributor decides whether to start work.

## Verification
- `.venv/bin/python -m pytest tests/test_bounty_pages.py -q` -> 5 passed
- `.venv/bin/python -m pytest tests/test_bounty_pages.py tests/test_activity.py tests/test_api_mcp.py -q` -> 49 passed, 1 existing warning
- `.venv/bin/python -m pytest -q` -> 206 passed, 2 existing warnings
- `.venv/bin/ruff check .` -> all checks passed
- `.venv/bin/ruff format --check .` -> 37 files already formatted
- `.venv/bin/python -m mypy app` -> success
- `.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No secrets, wallet material, deployment values, private vulnerability details, payout details, or MRWK price claims are included.