### PR TITLE
Validate bounty GitHub issue URLs match source

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -89,6 +89,20 @@ def validate_public_url(url: str) -> str:
     return clean
 
 
+def _github_issue_url_matches_bounty(issue_url: str, *, repo: str, issue_number: int) -> bool:
+    parsed = urlparse(issue_url)
+    if parsed.hostname is None or parsed.hostname.lower() != "github.com":
+        return True
+    parts = [part for part in parsed.path.strip("/").split("/") if part]
+    if len(parts) < 4 or parts[2].lower() != "issues":
+        return True
+    if not parts[3].isdigit():
+        return True
+    return (
+        f"{parts[0].lower()}/{parts[1].lower()}" == repo.lower() and int(parts[3]) == issue_number
+    )
+
+
 def public_url_or_none(url: str | None) -> str | None:
     if not url:
         return None
@@ -397,6 +411,10 @@ def create_bounty(
     clean_acceptance = _clean_required_text(acceptance, "acceptance", 5_000)
     if get_balance(session, TREASURY_ACCOUNT) < reserved:
         raise LedgerError("treasury balance too low")
+    if not _github_issue_url_matches_bounty(
+        clean_issue_url, repo=clean_repo, issue_number=issue_number
+    ):
+        raise LedgerError("issue_url must match repo and issue_number")
     bounty = Bounty(
         repo=clean_repo,
         issue_number=issue_number,

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -139,6 +139,34 @@ def test_create_bounty_rejects_duplicate_repo_issue(sqlite_url: str) -> None:
             )
 
 
+def test_create_bounty_rejects_mismatched_github_issue_url(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+        with pytest.raises(LedgerError, match="issue_url must match repo and issue_number"):
+            create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=7,
+                issue_url="https://github.com/ramimbo/mergework/issues/8",
+                title="Mismatched issue number",
+                reward_mrwk="25",
+                acceptance="Issue URL should point at the same bounty issue.",
+            )
+        with pytest.raises(LedgerError, match="issue_url must match repo and issue_number"):
+            create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=7,
+                issue_url="https://github.com/other/project/issues/7",
+                title="Mismatched repository",
+                reward_mrwk="25",
+                acceptance="Issue URL should point at the same bounty repository.",
+            )
+
+
 def test_multi_award_bounty_pays_distinct_submissions_until_exhausted(
     sqlite_url: str,
 ) -> None:


### PR DESCRIPTION
Refs #228.

## What changed
- Add a focused guard for GitHub issue URLs when creating bounties.
- If `issue_url` points at `github.com/<owner>/<repo>/issues/<number>`, require it to match the provided `repo` and `issue_number`.
- Add regression coverage for mismatched repository and mismatched issue-number inputs.

## Why
Before this change, an admin/API caller could create a bounty indexed under one `repo`/`issue_number` while the public `issue_url` pointed at a different GitHub issue. That can make public bounty pages and payment proof point at the wrong source issue while webhook lookup still uses the stored repo/issue fields.

## Verification
- `./.venv/bin/python -m pytest tests/test_ledger.py::test_create_bounty_rejects_mismatched_github_issue_url tests/test_ledger.py::test_create_bounty_rejects_duplicate_repo_issue -q` -> 2 passed
- `./.venv/bin/python -m pytest tests/test_ledger.py tests/test_security.py tests/test_api_mcp.py tests/test_webhooks.py -q` -> 103 passed, 1 warning
- `./.venv/bin/python -m ruff check app/ledger/service.py tests/test_ledger.py` -> passed
- `./.venv/bin/python -m ruff format --check app/ledger/service.py tests/test_ledger.py` -> passed
- `./.venv/bin/python -m mypy app` -> success
- `git diff --check` -> clean

No secrets, wallet material, private vulnerability details, deployment values, payout details, or MRWK price claims are included.