### PR TITLE
Validate bounty payout account before payment

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -583,6 +583,7 @@ def pay_bounty(
     clean_verifier_result = _clean_proof_metadata(verifier_result)
     if "accepted_by" in clean_verifier_result:
         clean_verifier_result["accepted_by"] = clean_accepted_by
+    clean_to_account = _clean_required_text(to_account, "to_account", 128)
     clean_submission_url = validate_public_url(submission_url)
     existing_submission = session.scalar(
         select(Submission)
@@ -614,7 +615,7 @@ def pay_bounty(
 
     submission = Submission(
         bounty_id=bounty.id,
-        submitter_account=to_account,
+        submitter_account=clean_to_account,
         url=clean_submission_url,
         status="accepted",
         verifier_result=canonical_json(clean_verifier_result),
@@ -628,7 +629,7 @@ def pay_bounty(
         session,
         entry_type="bounty_payment",
         from_account=reserve_account,
-        to_account=to_account,
+        to_account=clean_to_account,
         amount_microunits=bounty.reward_microunits,
         reference=clean_submission_url,
     )
@@ -639,7 +640,7 @@ def pay_bounty(
         "issue_number": bounty.issue_number,
         "submission_url": clean_submission_url,
         "accepted_by": clean_accepted_by,
-        "to_account": to_account,
+        "to_account": clean_to_account,
         "amount_mrwk": format_mrwk(bounty.reward_microunits),
         "ledger_sequence": ledger_entry.sequence,
         "ledger_hash": ledger_entry.entry_hash,

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from sqlalchemy import select
 
 from app.db import create_schema, make_engine, session_scope
 from app.ledger.reconciliation import (
@@ -80,6 +81,58 @@ def test_bounty_reserve_and_payout_conserve_supply(sqlite_url: str) -> None:
         assert proof.hash
         assert verify_hash_chain(session) is True
         assert verify_supply_conservation(session) is True
+
+
+def test_pay_bounty_rejects_blank_or_control_character_account(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=8,
+            issue_url="https://github.com/ramimbo/mergework/issues/8",
+            title="Reject malformed payout accounts",
+            reward_mrwk="50",
+            max_awards=2,
+            acceptance="Accepted PRs must record a clean payout account.",
+        )
+
+        for account, message in (
+            ("   ", "to_account is required"),
+            ("github:alice\nbad", "to_account must not contain control characters"),
+        ):
+            with pytest.raises(LedgerError, match=message):
+                pay_bounty(
+                    session,
+                    bounty_id=bounty.id,
+                    to_account=account,
+                    submission_url="https://github.com/ramimbo/mergework/pull/8",
+                    accepted_by="maintainer",
+                    verifier_result={"label": "mrwk:accepted"},
+                )
+
+        session.refresh(bounty)
+        assert bounty.status == "open"
+        assert bounty.awards_paid == 0
+        assert get_balance(session, reserve_account_for_bounty(bounty.id)) == 100_000_000
+        assert session.scalars(select(Submission)).all() == []
+        assert session.scalars(select(Proof)).all() == []
+
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account=" github:alice ",
+            submission_url="https://github.com/ramimbo/mergework/pull/8",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        submission = session.scalars(select(Submission)).one()
+
+        assert submission.submitter_account == "github:alice"
+        assert get_balance(session, "github:alice") == 50_000_000
+        assert '"to_account":"github:alice"' in proof.public_json
 
 
 def test_resolve_payout_account_accepts_mixed_case_prefixes(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #228

## Summary
- reject blank payout accounts at the direct `pay_bounty()` service boundary
- reject payout account strings containing control characters before they reach submissions, ledger entries, or public proof JSON
- trim valid payout account strings once and use the cleaned value consistently in the submission, ledger entry, and proof payload

## Why
Before this change, callers that reached `pay_bounty()` directly could pass values like `"   "` or `"github:alice\nbad"` as `to_account`. Those values were then recorded into accepted submissions, ledger entries, and public proof JSON. Other account-like fields already use the shared text validation helpers, so this applies the same boundary to payout accounts.

## Verification
- `./.venv/bin/python -m pytest tests/test_ledger.py::test_pay_bounty_rejects_blank_or_control_character_account tests/test_ledger.py::test_bounty_reserve_and_payout_conserve_supply -q` -> 2 passed
- `./.venv/bin/python -m pytest tests/test_ledger.py tests/test_security.py tests/test_api_mcp.py tests/test_webhooks.py -q` -> 103 passed, 1 warning
- `./.venv/bin/python -m pytest -q` -> 206 passed, 2 warnings
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m mypy app`
- `./.venv/bin/python scripts/docs_smoke.py`
- `./.venv/bin/python scripts/check_agents.py`
- `git diff --check`
