### PR TITLE
Document public health response shape

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -12,10 +12,25 @@ MCP_HOST=https://mcp.mrwk.ltclab.site
 Check service status and list bounties:
 
 ```bash
+curl -s "$API_HOST/health"
 curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
 curl -s "$API_HOST/api/v1/bounties?status=open"
 ```
+
+The `/health` endpoint returns a compact public liveness payload:
+
+```json
+{
+  "ok": true,
+  "service": "mergework",
+  "ticker": "MRWK",
+  "ledger_height": 123
+}
+```
+
+`ledger_height` is a numeric ledger counter that changes whenever new ledger
+entries are appended, so treat the example value as illustrative.
 
 The bounties list returns public bounty rows. `status` can be omitted or set to
 `open`, `paid`, or `closed`:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -20,6 +20,13 @@ def test_readme_lists_live_ltclab_urls() -> None:
 def test_api_examples_document_internal_bounty_ids() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 
+    assert "$API_HOST/health" in examples
+    assert '"ok": true' in examples
+    assert '"service": "mergework"' in examples
+    assert '"ticker": "MRWK"' in examples
+    assert '"ledger_height": 123' in examples
+    assert "numeric ledger counter" in examples
+    assert "illustrative" in examples
     assert "https://api.mrwk.ltclab.site" in examples
     assert "https://mcp.mrwk.ltclab.site" in examples
     assert "/api/v1/bounties/<bounty_id>" in examples


### PR DESCRIPTION
Bounty #229

## Summary
- add the public `/health` endpoint to `docs/api-examples.md`
- document its response shape: `ok`, `service`, `ticker`, and numeric `ledger_height`
- avoid hardcoding a live moving ledger height by using an illustrative number and an explicit note that the counter changes as ledger entries are appended
- add docs regression assertions for the endpoint and response-shape guidance

## Evidence
- Compared the docs change against `app/main.py::health()`, which returns `ok`, `service`, `ticker`, and `ledger_height`.
- Live readback from `https://api.mrwk.ltclab.site/health` returned HTTP 200 JSON with the same shape and a moving `ledger_height` counter.
- This is intentionally scoped to the shape and durability issue, so the docs do not present the current production counter as a fixed expected value.

## Verification
- `./.venv/bin/python -m pytest tests/test_docs_public_urls.py::test_api_examples_document_internal_bounty_ids -q` -> 1 passed
- `./.venv/bin/python -m pytest tests/test_docs_public_urls.py -q` -> 13 passed
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `./.venv/bin/python -m ruff check docs/api-examples.md tests/test_docs_public_urls.py` -> passed
- `./.venv/bin/python -m ruff format --check --preview docs/api-examples.md tests/test_docs_public_urls.py` -> 2 files already formatted
- `git diff --check` -> clean

No secrets, wallet material, private keys, payout details, deployment values, private vulnerability details, or MRWK price claims are included.
