### PR TITLE
Ignore blank admin payout notes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -691,7 +691,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             "accepted_by": accepted_by,
         }
         if data.get("note") is not None:
-            verifier_result["note"] = _optional_str(data, "note")[:240]
+            note = _optional_str(data, "note")
+            if note.strip():
+                verifier_result["note"] = note[:240]
         with session_scope(db_url) as session:
             try:
                 to_account = resolve_payout_account(session, requested_account)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -25,7 +25,7 @@ from app.ledger.service import (
     register_wallet,
 )
 from app.main import _signed_value, create_app
-from app.models import LedgerEntry, WebhookEvent
+from app.models import LedgerEntry, Proof, WebhookEvent
 from app.webhooks.github import handle_github_webhook
 
 
@@ -641,6 +641,49 @@ def test_admin_payout_api_rejects_control_character_note(
     assert response.json()["detail"] == ("verifier_result.note must not contain control characters")
     with session_scope(sqlite_url) as session:
         assert get_balance(session, "github:alice") == 0
+
+
+def test_admin_payout_api_ignores_blank_note(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    create_schema(sqlite_url)
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=18,
+            issue_url="https://github.com/ramimbo/mergework/issues/18",
+            title="Admin proof metadata blank note",
+            reward_mrwk="25",
+            acceptance="Maintainer verifies payout.",
+        )
+        bounty_id = bounty.id
+
+    response = client.post(
+        f"/api/v1/bounties/{bounty_id}/pay",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json={
+            "to_account": "github:alice",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/18",
+            "accepted_by": "maintainer",
+            "note": "   ",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "paid"
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:alice") == 25_000_000
+        proof = session.get(Proof, response.json()["proof_hash"])
+        assert proof is not None
+        verifier_result = json.loads(proof.public_json)["verifier_result"]
+        assert "note" not in verifier_result
 
 
 def test_bounty_urls_reject_control_characters(sqlite_url: str) -> None:


### PR DESCRIPTION
/claim #228

## Summary
- Treat whitespace-only admin payout `note` values as omitted instead of slicing a missing optional value.
- Add a regression proving a blank note payout succeeds and credits the target account.
- Keep the existing non-string and control-character note guards intact.

## Why
A payout request with `"note": "   "` reached `_optional_str()`, normalized to no note, then attempted to slice that missing value. This could produce a server error instead of treating the optional note as absent.

## Verification
- `.venv/bin/python -m pytest tests/test_security.py::test_admin_payout_api_ignores_blank_note tests/test_security.py::test_admin_payout_api_rejects_control_character_note tests/test_security.py::test_admin_payout_api_rejects_non_string_metadata_fields -q` -> 3 passed
- `.venv/bin/python -m pytest tests/test_security.py tests/test_api_mcp.py -q` -> 74 passed, 1 warning
- `.venv/bin/ruff check app/main.py tests/test_security.py` -> all checks passed
- `.venv/bin/ruff format --check app/main.py tests/test_security.py` -> 2 files already formatted
- `.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No secrets, wallet material, private payout details, deployment values, or MRWK price claims are included.