### PR TITLE
Ignore blank admin payout notes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -691,7 +691,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             "accepted_by": accepted_by,
         }
         if data.get("note") is not None:
-            verifier_result["note"] = _optional_str(data, "note")[:240]
+            note = _optional_str(data, "note").strip()
+            if note:
+                verifier_result["note"] = note[:240]
         with session_scope(db_url) as session:
             try:
                 to_account = resolve_payout_account(session, requested_account)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -25,7 +25,7 @@ from app.ledger.service import (
     register_wallet,
 )
 from app.main import _signed_value, create_app
-from app.models import LedgerEntry, WebhookEvent
+from app.models import LedgerEntry, Proof, WebhookEvent
 from app.webhooks.github import handle_github_webhook
 
 
@@ -641,6 +641,88 @@ def test_admin_payout_api_rejects_control_character_note(
     assert response.json()["detail"] == ("verifier_result.note must not contain control characters")
     with session_scope(sqlite_url) as session:
         assert get_balance(session, "github:alice") == 0
+
+
+def test_admin_payout_api_omits_blank_note_from_public_proof(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    create_schema(sqlite_url)
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=18,
+            issue_url="https://github.com/ramimbo/mergework/issues/18",
+            title="Admin blank proof note",
+            reward_mrwk="25",
+            acceptance="Maintainer verifies payout.",
+        )
+        bounty_id = bounty.id
+
+    response = client.post(
+        f"/api/v1/bounties/{bounty_id}/pay",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json={
+            "to_account": "github:alice",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/18",
+            "accepted_by": "maintainer",
+            "note": "   ",
+        },
+    )
+
+    assert response.status_code == 200
+    with session_scope(sqlite_url) as session:
+        proof = session.scalars(select(Proof)).one()
+        verifier_result = json.loads(proof.public_json)["verifier_result"]
+        assert verifier_result == {"accepted_by": "maintainer", "source": "admin_api"}
+        assert get_balance(session, "github:alice") == 25_000_000
+
+
+def test_admin_payout_api_trims_note_in_public_proof(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    create_schema(sqlite_url)
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=19,
+            issue_url="https://github.com/ramimbo/mergework/issues/19",
+            title="Admin trimmed proof note",
+            reward_mrwk="25",
+            acceptance="Maintainer verifies payout.",
+        )
+        bounty_id = bounty.id
+
+    response = client.post(
+        f"/api/v1/bounties/{bounty_id}/pay",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json={
+            "to_account": "github:bob",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/19",
+            "accepted_by": "maintainer",
+            "note": "  verified manually  ",
+        },
+    )
+
+    assert response.status_code == 200
+    with session_scope(sqlite_url) as session:
+        proof = session.scalars(select(Proof)).one()
+        verifier_result = json.loads(proof.public_json)["verifier_result"]
+        assert verifier_result["note"] == "verified manually"
+        assert get_balance(session, "github:bob") == 25_000_000
 
 
 def test_bounty_urls_reject_control_characters(sqlite_url: str) -> None:


### PR DESCRIPTION
/claim #228

## Summary
- Treat whitespace-only admin payout `note` values as omitted before building public proof metadata.
- Trim nonblank admin notes before storing them in `verifier_result`.
- Add regressions proving blank notes are omitted from public proof JSON and nonblank notes are trimmed.

## Why
A payout request with `"note": "   "` should not leave a meaningless whitespace-only field in the immutable public proof payload. This keeps optional payout metadata clean while preserving existing validation for non-string and control-character notes.

## Evidence
Before this patch, an admin payout with `"note": "   "` returned 200 and stored public proof metadata like:

```python
{'accepted_by': 'maintainer', 'note': '   ', 'source': 'admin_api'}
```

After this patch, the same payout omits `note`; a nonblank note such as `"  verified manually  "` is stored as `"verified manually"`.

## Verification
- `./.venv/bin/python -m pytest tests/test_security.py::test_admin_payout_api_omits_blank_note_from_public_proof tests/test_security.py::test_admin_payout_api_trims_note_in_public_proof tests/test_security.py::test_admin_payout_api_rejects_control_character_note tests/test_security.py::test_admin_payout_api_rejects_non_string_metadata_fields -q` -> 4 passed
- `./.venv/bin/python -m pytest tests/test_security.py tests/test_api_mcp.py tests/test_webhooks.py -q` -> 88 passed, 1 warning
- `./.venv/bin/python -m pytest -q` -> 207 passed, 2 warnings
- `./.venv/bin/ruff check .` -> all checks passed
- `./.venv/bin/ruff format --check .` -> 37 files already formatted
- `./.venv/bin/python -m mypy app` -> success
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No secrets, wallet material, private payout details, deployment values, private vulnerability details, or MRWK price claims are included.
