### PR TITLE
Validate ledger entry fields

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -176,6 +176,12 @@ def _normalize_repo_name(repo: str) -> str:
     return _clean_required_text(repo, "repo", 200).lower()
 
 
+def _clean_optional_account_id(value: str | None, field: str) -> str | None:
+    if value is None:
+        return None
+    return _clean_required_text(value, field, 128)
+
+
 def _clean_proof_metadata(verifier_result: dict[str, Any]) -> dict[str, Any]:
     clean = dict(verifier_result)
     for key, value in clean.items():
@@ -359,17 +365,21 @@ def add_ledger_entry(
 ) -> LedgerEntry:
     if amount_microunits < 0:
         raise LedgerError("ledger amount cannot be negative")
-    if from_account:
-        ensure_account(session, from_account)
-    if to_account:
-        ensure_account(session, to_account)
+    clean_entry_type = _clean_required_text(entry_type, "entry_type", 40)
+    clean_from_account = _clean_optional_account_id(from_account, "from_account")
+    clean_to_account = _clean_optional_account_id(to_account, "to_account")
+    clean_reference = _clean_required_text(reference, "reference", 500)
+    if clean_from_account:
+        ensure_account(session, clean_from_account)
+    if clean_to_account:
+        ensure_account(session, clean_to_account)
     entry = LedgerEntry(
         sequence=_next_sequence(session),
-        entry_type=entry_type,
-        from_account=from_account,
-        to_account=to_account,
+        entry_type=clean_entry_type,
+        from_account=clean_from_account,
+        to_account=clean_to_account,
         amount_microunits=amount_microunits,
-        reference=reference,
+        reference=clean_reference,
         previous_hash=_previous_hash(session),
         entry_hash="",
         created_at=utc_now(),

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -65,6 +65,7 @@ def test_add_ledger_entry_rejects_malformed_public_fields(sqlite_url: str) -> No
             ("to_account", "github:" + "a" * 122, "to_account is too long"),
             ("reference", "manual\nref", "reference must not contain control characters"),
             ("reference", "   ", "reference is required"),
+            ("reference", "x" * 501, "reference is too long"),
         )
         for field, value, message in bad_cases:
             kwargs = {**base_kwargs, field: value}

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -11,6 +11,7 @@ from app.ledger.service import (
     GENESIS_SUPPLY_MICRO,
     TREASURY_ACCOUNT,
     LedgerError,
+    add_ledger_entry,
     canonical_json,
     close_bounty,
     create_bounty,
@@ -39,6 +40,51 @@ def test_genesis_creates_fixed_supply_once(sqlite_url: str) -> None:
         assert get_balance(session, TREASURY_ACCOUNT) == GENESIS_SUPPLY_MICRO
         assert verify_hash_chain(session) is True
         assert verify_supply_conservation(session) is True
+
+
+def test_add_ledger_entry_rejects_malformed_public_fields(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        base_kwargs = {
+            "entry_type": "manual_adjustment",
+            "from_account": TREASURY_ACCOUNT,
+            "to_account": "github:alice",
+            "amount_microunits": 1,
+            "reference": "manual:test",
+        }
+
+        bad_cases = (
+            ("entry_type", "manual\nadjustment", "entry_type must not contain control characters"),
+            ("entry_type", "   ", "entry_type is required"),
+            ("entry_type", "x" * 41, "entry_type is too long"),
+            ("from_account", "treasury:\nmrwk", "from_account must not contain control characters"),
+            ("from_account", "x" * 129, "from_account is too long"),
+            ("to_account", "github:\nalice", "to_account must not contain control characters"),
+            ("to_account", "github:" + "a" * 122, "to_account is too long"),
+            ("reference", "manual\nref", "reference must not contain control characters"),
+            ("reference", "   ", "reference is required"),
+        )
+        for field, value, message in bad_cases:
+            kwargs = {**base_kwargs, field: value}
+            with pytest.raises(LedgerError, match=message):
+                add_ledger_entry(session, **kwargs)
+
+        entry = add_ledger_entry(
+            session,
+            entry_type=" manual_adjustment ",
+            from_account=None,
+            to_account=" github:alice ",
+            amount_microunits=1,
+            reference=" manual:test ",
+        )
+
+        assert entry.entry_type == "manual_adjustment"
+        assert entry.from_account is None
+        assert entry.to_account == "github:alice"
+        assert entry.reference == "manual:test"
+        assert verify_hash_chain(session) is True
 
 
 def test_make_engine_accepts_windows_absolute_sqlite_url(tmp_path) -> None:

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -71,20 +71,35 @@ def test_add_ledger_entry_rejects_malformed_public_fields(sqlite_url: str) -> No
             with pytest.raises(LedgerError, match=message):
                 add_ledger_entry(session, **kwargs)
 
-        entry = add_ledger_entry(
+        nullable_entry = add_ledger_entry(
             session,
             entry_type=" manual_adjustment ",
             from_account=None,
+            to_account=None,
+            amount_microunits=0,
+            reference=" manual:none ",
+        )
+
+        assert nullable_entry.entry_type == "manual_adjustment"
+        assert nullable_entry.from_account is None
+        assert nullable_entry.to_account is None
+        assert nullable_entry.reference == "manual:none"
+
+        balanced_entry = add_ledger_entry(
+            session,
+            entry_type=" manual_adjustment ",
+            from_account=f" {TREASURY_ACCOUNT} ",
             to_account=" github:alice ",
             amount_microunits=1,
             reference=" manual:test ",
         )
 
-        assert entry.entry_type == "manual_adjustment"
-        assert entry.from_account is None
-        assert entry.to_account == "github:alice"
-        assert entry.reference == "manual:test"
+        assert balanced_entry.entry_type == "manual_adjustment"
+        assert balanced_entry.from_account == TREASURY_ACCOUNT
+        assert balanced_entry.to_account == "github:alice"
+        assert balanced_entry.reference == "manual:test"
         assert verify_hash_chain(session) is True
+        assert verify_supply_conservation(session) is True
 
 
 def test_make_engine_accepts_windows_absolute_sqlite_url(tmp_path) -> None:


### PR DESCRIPTION
For Bounty #228.

## What changed
- Validate `entry_type`, `from_account`, `to_account`, and `reference` at the shared ledger-entry writer boundary.
- Reject blank/control-character public ledger fields before a ledger row is created.
- Normalize surrounding whitespace for accepted fields before hashing and persistence.
- Add regression coverage proving malformed direct service inputs fail and valid trimmed values keep the hash chain valid.

## Repro before fix
A direct `add_ledger_entry(...)` call could create public ledger rows with values like `entry_type="manual\nadjustment"` or `reference="bad\nref"`, and the malformed values were persisted in the ledger/hash payload.

## Verification
- `.venv/bin/python -m pytest tests/test_ledger.py::test_add_ledger_entry_rejects_malformed_public_fields -q` -> 1 passed
- `.venv/bin/python -m pytest tests/test_ledger.py tests/test_security.py tests/test_api_mcp.py -q` -> 90 passed, 1 warning
- `.venv/bin/python -m pytest -q` -> 206 passed, 2 warnings
- `.venv/bin/ruff check .` -> all checks passed
- `.venv/bin/ruff format --check .` -> 37 files already formatted
- `.venv/bin/python -m mypy app` -> success
- `.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No secrets, wallet material, private payout details, deployment values, private vulnerability details, or MRWK price claims included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Public-facing ledger fields are validated and sanitized: control characters rejected, length limits enforced, and whitespace trimmed. Cleaned values are persisted. Optional account identifiers are normalized and only existence-checked when present.

* **Tests**
  * New tests verify rejection of malformed inputs, normalization behavior (trimming/null handling), and ledger integrity/supply conservation after inserts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->