### PR TITLE
Validate ledger account identifiers

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -218,11 +218,14 @@ def compute_entry_hash(entry: LedgerEntry) -> str:
 
 
 def ensure_account(session: Session, account_id: str) -> Account:
-    account = session.get(Account, account_id)
+    clean_account_id = _clean_required_text(account_id, "account_id", 128)
+    account = session.get(Account, clean_account_id)
     if account is not None:
         return account
-    github_login = account_id.removeprefix("github:") if account_id.startswith("github:") else None
-    account = Account(id=account_id, github_login=github_login, display_name=github_login)
+    github_login = (
+        clean_account_id.removeprefix("github:") if clean_account_id.startswith("github:") else None
+    )
+    account = Account(id=clean_account_id, github_login=github_login, display_name=github_login)
     session.add(account)
     session.flush()
     return account
@@ -332,15 +335,23 @@ def add_ledger_entry(
 ) -> LedgerEntry:
     if amount_microunits < 0:
         raise LedgerError("ledger amount cannot be negative")
-    if from_account:
-        ensure_account(session, from_account)
-    if to_account:
-        ensure_account(session, to_account)
+    clean_from_account = (
+        _clean_required_text(from_account, "from_account", 128)
+        if from_account is not None
+        else None
+    )
+    clean_to_account = (
+        _clean_required_text(to_account, "to_account", 128) if to_account is not None else None
+    )
+    if clean_from_account is not None:
+        ensure_account(session, clean_from_account)
+    if clean_to_account is not None:
+        ensure_account(session, clean_to_account)
     entry = LedgerEntry(
         sequence=_next_sequence(session),
         entry_type=entry_type,
-        from_account=from_account,
-        to_account=to_account,
+        from_account=clean_from_account,
+        to_account=clean_to_account,
         amount_microunits=amount_microunits,
         reference=reference,
         previous_hash=_previous_hash(session),

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -11,6 +11,7 @@ from app.ledger.service import (
     GENESIS_SUPPLY_MICRO,
     TREASURY_ACCOUNT,
     LedgerError,
+    add_ledger_entry,
     canonical_json,
     close_bounty,
     create_bounty,
@@ -80,6 +81,54 @@ def test_bounty_reserve_and_payout_conserve_supply(sqlite_url: str) -> None:
         assert proof.hash
         assert verify_hash_chain(session) is True
         assert verify_supply_conservation(session) is True
+
+
+def test_add_ledger_entry_rejects_blank_or_control_character_accounts(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+        with pytest.raises(LedgerError, match="from_account is required"):
+            add_ledger_entry(
+                session,
+                entry_type="test",
+                from_account="   ",
+                to_account="github:alice",
+                amount_microunits=1,
+                reference="test",
+            )
+        with pytest.raises(LedgerError, match="to_account must not contain control characters"):
+            add_ledger_entry(
+                session,
+                entry_type="test",
+                from_account=TREASURY_ACCOUNT,
+                to_account="github:alice\nadmin",
+                amount_microunits=1,
+                reference="test",
+            )
+
+        assert get_balance(session, "github:alice\nadmin") == 0
+
+
+def test_add_ledger_entry_trims_account_ids(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+        entry = add_ledger_entry(
+            session,
+            entry_type="test",
+            from_account=f" {TREASURY_ACCOUNT} ",
+            to_account=" github:alice ",
+            amount_microunits=1,
+            reference="test",
+        )
+
+        assert entry.from_account == TREASURY_ACCOUNT
+        assert entry.to_account == "github:alice"
+        assert get_balance(session, "github:alice") == 1
 
 
 def test_resolve_payout_account_accepts_mixed_case_prefixes(sqlite_url: str) -> None:


### PR DESCRIPTION
/claim #228

## Summary
- Validate direct ledger `from_account` and `to_account` values before account creation and ledger writes.
- Reject blank and control-character account identifiers at the shared `add_ledger_entry()` / `ensure_account()` boundary.
- Trim valid account identifiers before persisting ledger entries.

## Repro before fix
A direct service caller could write a ledger entry with an invalid account id containing a control character:

```python
add_ledger_entry(
    session,
    entry_type="probe",
    from_account="treasury:mrwk",
    to_account="github:alice\nadmin",
    amount_microunits=1,
    reference="probe",
)
```

That created a public ledger/account value with `to_account == "github:alice\nadmin"` instead of rejecting malformed account metadata before hashing and persistence.

## Verification
- `./.venv/bin/python -m pytest tests/test_ledger.py::test_add_ledger_entry_rejects_blank_or_control_character_accounts tests/test_ledger.py::test_add_ledger_entry_trims_account_ids tests/test_ledger.py::test_bounty_reserve_and_payout_conserve_supply -q` -> 3 passed
- `./.venv/bin/python -m pytest tests/test_ledger.py tests/test_wallets.py tests/test_wallet_api.py tests/test_api_mcp.py tests/test_security.py -q` -> 122 passed, 1 warning
- `./.venv/bin/python -m pytest -q` -> 207 passed, 2 warnings
- `./.venv/bin/ruff check .` -> all checks passed
- `./.venv/bin/ruff format --check .` -> 37 files already formatted
- `./.venv/bin/python -m mypy app` -> success
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `./.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No secrets, wallet material, private payout details, deployment values, private vulnerability details, or MRWK price claims are included.
