### PR TITLE
Docs: add /api/v1/auth/me public API example

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -41,6 +41,14 @@ Read accepted-work activity summarized from proof-backed bounty payments:
 curl -s "$API_HOST/api/v1/activity"
 ```
 
+Check whether the current browser session is authenticated:
+
+```bash
+curl -s "$API_HOST/api/v1/auth/me"
+```
+
+Unauthenticated requests return `{"authenticated":false,"github_login":null}`.
+
 Inspect a proof, account, or registered wallet:
 
 ```bash

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -23,11 +23,14 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "https://api.mrwk.ltclab.site" in examples
     assert "https://mcp.mrwk.ltclab.site" in examples
     assert "/api/v1/bounties/<bounty_id>" in examples
+    assert "/api/v1/auth/me" in examples
     assert '"name":"get_bounty"' in examples
     assert '"arguments":{"id":11}' in examples
     assert '"id":4' in examples
     assert "not the GitHub issue" in examples
     assert "public_key_hex" in examples
+    assert '"authenticated":false' in examples
+    assert '"github_login":null' in examples
 
 
 def test_agent_guide_explains_internal_bounty_ids() -> None:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -396,7 +396,9 @@ def test_auth_routes_exist_when_oauth_is_unconfigured(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
     assert client.get("/auth/github/login").status_code == 503
-    assert client.get("/api/v1/auth/me").json()["authenticated"] is False
+    auth_me = client.get("/api/v1/auth/me").json()
+    assert auth_me["authenticated"] is False
+    assert auth_me["github_login"] is None
 
 
 def test_github_login_redirects_when_oauth_is_configured(sqlite_url: str, monkeypatch) -> None:


### PR DESCRIPTION
Refs #229

What
- Documented `GET /api/v1/auth/me` in `docs/api-examples.md`, including the unauthenticated JSON shape.
- Added regression assertions in `tests/test_docs_public_urls.py` to keep the example from drifting.
- Tightened `tests/test_wallet_api.py` to assert `github_login` is null when unauthenticated.

Evidence
- Code: `app/main.py` implements `/api/v1/auth/me` returning `{authenticated, github_login}`.

Validation
- `./.venv/bin/python scripts/docs_smoke.py`
- `./.venv/bin/python -m pytest -q tests/test_docs_public_urls.py tests/test_wallet_api.py`
