### PR TITLE
[codex] Harden bounty search issue parsing

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -79,6 +79,7 @@ API_DOCS_CSP = (
     "worker-src 'self' blob:"
 )
 API_DOCS_PATHS = {"/api/docs", "/api/redoc"}
+SQLITE_INTEGER_MAX = 2**63 - 1
 
 
 def _request_was_forwarded_https(request: Request) -> bool:
@@ -100,6 +101,15 @@ def _preserve_forwarded_https_redirect(request: Request, response: Response) -> 
     response.headers["location"] = urlunsplit(
         ("https", parsed.netloc, parsed.path, parsed.query, parsed.fragment)
     )
+
+
+def _issue_number_search_value(query: str) -> int | None:
+    if not query.isdigit():
+        return None
+    issue_number = int(query)
+    if issue_number > SQLITE_INTEGER_MAX:
+        return None
+    return issue_number
 
 
 def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
@@ -613,9 +623,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                         .replace("_", "\\_")
                     )
                     like_query = f"%{escaped_query}%"
-                    issue_number = None
-                    if normalized_query.isdigit():
-                        issue_number = int(normalized_query)
+                    issue_number = _issue_number_search_value(normalized_query)
                     text_filter = or_(
                         func.lower(Bounty.repo).like(like_query, escape="\\"),
                         func.lower(Bounty.title).like(like_query, escape="\\"),

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -111,6 +111,14 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     assert issue_search.status_code == 200
     assert [row["issue_number"] for row in issue_search.json()] == [65]
 
+    oversized_issue_search = client.get("/api/v1/bounties", params={"q": "9" * 40})
+    assert oversized_issue_search.status_code == 200
+    assert oversized_issue_search.json() == []
+
+    oversized_issue_page = client.get("/bounties", params={"q": "9" * 40})
+    assert oversized_issue_page.status_code == 200
+    assert "No bounties yet." in oversized_issue_page.text
+
     percent_search = client.get("/api/v1/bounties?q=%25")
     assert percent_search.status_code == 200
     assert [row["issue_number"] for row in percent_search.json()] == [66]


### PR DESCRIPTION
Bounty #292

Previously submitted under #228 before that round was filled.

## Summary
- avoid adding an exact issue-number SQL filter when a numeric bounty search query exceeds SQLite's signed integer range
- keep existing text search behavior for oversized numeric strings, so the API/page return a normal empty result set instead of raising
- add regression coverage for both `/api/v1/bounties` and the public `/bounties` page

## Repro before fix
A request such as `GET /api/v1/bounties?q=9999999999999999999999999999999999999999` parsed the query as a Python `int`, then SQLAlchemy/SQLite raised `OverflowError: Python int too large to convert to SQLite INTEGER` while binding `Bounty.issue_number == issue_number`.

## Validation
- `.venv/bin/python -m pytest tests/test_bounty_pages.py::test_bounties_page_and_api_search_by_text_and_issue_number -q` -> 1 passed
- `.venv/bin/python -m pytest tests/test_bounty_pages.py -q` -> 4 passed
- `.venv/bin/python -m ruff format --check .` -> 37 files already formatted
- `.venv/bin/python -m ruff check .` -> all checks passed
- `.venv/bin/python -m mypy app` -> success
- `.venv/bin/python -m pytest -q` -> 209 passed, 2 warnings
- `git diff --check` -> clean

No secrets, wallet material, private payout details, deployment values, private vulnerability details, or MRWK price claims are included.

