### PR TITLE
Add MCP bounty filters

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -976,7 +976,12 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 "id": response_id,
                 "result": {
                     "tools": [
-                        {"name": "list_bounties", "description": "List open MRWK bounties"},
+                        {
+                            "name": "list_bounties",
+                            "description": (
+                                "List MRWK bounties with optional status, q, and limit filters"
+                            ),
+                        },
                         {"name": "get_bounty", "description": "Get a bounty by id"},
                         {"name": "get_balance", "description": "Get an account balance"},
                         {
@@ -1413,10 +1418,53 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
             raise ValueError(f"{field} must be a string")
         return value
 
+    def optional_clean_str_arg(field: str) -> str | None:
+        value = args.get(field)
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise ValueError(f"{field} must be a string")
+        clean = value.strip()
+        return clean or None
+
+    def mcp_issue_number_search_value(query_text: str) -> int | None:
+        if not query_text.isdigit():
+            return None
+        issue_number = int(query_text)
+        return issue_number if issue_number <= 2**63 - 1 else None
+
+    def list_limit_arg(default: int = 25) -> int:
+        if "limit" not in args or args.get("limit") is None:
+            return default
+        value = positive_int_arg("limit")
+        if value > 100:
+            raise ValueError("limit must be at most 100")
+        return value
+
     with session_scope(database_url) as session:
         if name == "list_bounties":
+            status = optional_clean_str_arg("status") or "open"
+            normalized_status = status.lower()
+            if normalized_status not in {"open", "paid", "closed"}:
+                raise ValueError("status must be one of: open, paid, closed")
+            query = select(Bounty).where(Bounty.status == normalized_status)
+            query_text = optional_clean_str_arg("q")
+            if query_text:
+                escaped_query = (
+                    query_text.lower().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+                )
+                like_query = f"%{escaped_query}%"
+                issue_number = mcp_issue_number_search_value(query_text)
+                text_filter = or_(
+                    func.lower(Bounty.repo).like(like_query, escape="\\"),
+                    func.lower(Bounty.title).like(like_query, escape="\\"),
+                    func.lower(Bounty.acceptance).like(like_query, escape="\\"),
+                )
+                if issue_number is not None:
+                    text_filter = or_(text_filter, Bounty.issue_number == issue_number)
+                query = query.where(text_filter)
             bounties = session.scalars(
-                select(Bounty).where(Bounty.status == "open").order_by(Bounty.id.desc()).limit(25)
+                query.order_by(Bounty.id.desc()).limit(list_limit_arg())
             ).all()
             return json.dumps([bounty_to_dict(bounty) for bounty in bounties])
         if name == "get_bounty":

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -420,6 +420,7 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
 
     tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()
     assert tools["result"]["tools"][0]["name"] == "list_bounties"
+    assert "status, q, and limit filters" in tools["result"]["tools"][0]["description"]
 
     balance = client.post(
         "/mcp",
@@ -432,6 +433,150 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     ).json()
     assert balance["result"]["content"][0]["type"] == "text"
     assert "100000000" in balance["result"]["content"][0]["text"]
+
+
+def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        open_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=284,
+            issue_url="https://github.com/ramimbo/mergework/issues/284",
+            title="Agent MCP workflow filters",
+            reward_mrwk="100",
+            acceptance="Agents should find open MCP bounty workflow work.",
+        )
+        paid_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=285,
+            issue_url="https://github.com/ramimbo/mergework/issues/285",
+            title="Paid proof lookup workflow",
+            reward_mrwk="100",
+            acceptance="Agents should inspect proof lookup behavior.",
+        )
+        closed_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=286,
+            issue_url="https://github.com/ramimbo/mergework/issues/286",
+            title="Closed MCP cleanup",
+            reward_mrwk="100",
+            acceptance="Closed bounty workflow inspection.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=paid_bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/285",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        close_bounty(
+            session,
+            bounty_id=closed_bounty.id,
+            closed_by="maintainer",
+            reference="https://github.com/ramimbo/mergework/issues/286#close",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    default_result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "list_bounties", "arguments": {}},
+        },
+    ).json()
+    default_payload = json.loads(default_result["result"]["content"][0]["text"])
+    assert [item["id"] for item in default_payload] == [open_bounty.id]
+
+    paid_result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounties",
+                "arguments": {"status": " Paid ", "q": "proof", "limit": 1},
+            },
+        },
+    ).json()
+    paid_payload = json.loads(paid_result["result"]["content"][0]["text"])
+    assert [item["id"] for item in paid_payload] == [paid_bounty.id]
+    assert paid_payload[0]["status"] == "paid"
+
+    closed_result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounties",
+                "arguments": {"status": "closed", "q": "286"},
+            },
+        },
+    ).json()
+    closed_payload = json.loads(closed_result["result"]["content"][0]["text"])
+    assert [item["id"] for item in closed_payload] == [closed_bounty.id]
+
+    oversized_result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounties",
+                "arguments": {"q": "9" * 40},
+            },
+        },
+    ).json()
+    oversized_payload = json.loads(oversized_result["result"]["content"][0]["text"])
+    assert oversized_payload == []
+
+
+@pytest.mark.parametrize(
+    ("arguments", "request_id"),
+    [
+        ({"status": "all"}, 31),
+        ({"status": True}, 32),
+        ({"q": 284}, 33),
+        ({"limit": 0}, 34),
+        ({"limit": 101}, 35),
+    ],
+)
+def test_mcp_list_bounties_rejects_invalid_filters(
+    sqlite_url: str, arguments: dict[str, object], request_id: int
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {"name": "list_bounties", "arguments": arguments},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
 
 
 def test_mcp_rejects_malformed_requests_without_500(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #284

## Summary
- Adds optional `status`, `q`, and `limit` arguments to the MCP `list_bounties` tool.
- Keeps the default MCP behavior as open bounties only, ordered newest first, capped at 25.
- Lets agents inspect paid or closed bounty state and search by repo/title/acceptance text or issue number without scraping REST pages.
- Updates the MCP tool description so agents can discover the available filters through `tools/list`.

## Exact MCP behavior
- `list_bounties` with `{}` still returns open bounty rows only.
- `list_bounties` with `{ "status": "paid", "q": "proof", "limit": 1 }` returns matching paid bounty rows through the same JSON-RPC text content wrapper.
- `list_bounties` with `{ "status": "closed", "q": "286" }` can find a closed bounty by GitHub issue number.
- Invalid status, non-string query text, zero limit, or limit above 100 return the existing JSON-RPC invalid-arguments error path.

## Verification
- `.venv/bin/python -m pytest tests/test_api_mcp.py::test_mcp_tools_list_and_call tests/test_api_mcp.py::test_mcp_list_bounties_filters_status_query_and_limit tests/test_api_mcp.py::test_mcp_list_bounties_rejects_invalid_filters -q` -> 7 passed
- `.venv/bin/python -m pytest tests/test_api_mcp.py -q` -> 47 passed, 1 warning
- `.venv/bin/python -m pytest -q` -> 215 passed, 2 warnings
- `.venv/bin/ruff check .` -> all checks passed
- `.venv/bin/ruff format --check .` -> 37 files already formatted
- `.venv/bin/python -m mypy app` -> success
- `.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No private keys, wallet material, deployment credentials, payout details, private vulnerability details, or price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bounty listing now supports optional filtering by status (open, paid, closed), text search capabilities, and customizable result limits (1–100, default 25) instead of showing only open bounties with a fixed limit.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->