### PR TITLE
Add MCP work-proof guidance

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -992,7 +992,10 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                         {"name": "get_proof", "description": "Get a public proof by hash"},
                         {
                             "name": "submit_work_proof",
-                            "description": "Return submission instructions",
+                            "description": (
+                                "Return submission instructions, optionally for a bounty_id "
+                                "or issue_number"
+                            ),
                         },
                     ]
                 },
@@ -1413,6 +1416,38 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
             raise ValueError(f"{field} must be a string")
         return value
 
+    def work_proof_guidance(bounty: Bounty) -> str:
+        bounty_data = bounty_to_dict(bounty)
+        availability = (
+            "open for submissions"
+            if bounty_data["status"] == "open" and bounty_data["awards_remaining"] > 0
+            else "not currently open for new submissions"
+        )
+        return "\n".join(
+            [
+                f"Bounty #{bounty_data['issue_number']}: {bounty_data['title']}",
+                f"Internal bounty id: {bounty_data['id']}",
+                f"Repository: {bounty_data['repo']}",
+                f"Issue: {bounty_data['issue_url']}",
+                (
+                    f"Status: {bounty_data['status']} ({availability}); "
+                    f"awards remaining: {bounty_data['awards_remaining']} "
+                    f"of {bounty_data['max_awards']}"
+                ),
+                f"Reward: {bounty_data['reward_mrwk']} MRWK per accepted award",
+                f"Acceptance: {bounty_data['acceptance']}",
+                (
+                    "Submit: open a focused PR or issue that links this bounty, include "
+                    "specific test or behavior evidence, then comment /claim with the PR "
+                    "or evidence URL and verification summary."
+                ),
+                (
+                    "Do not include private keys, seed material, secrets, deployment "
+                    "credentials, private vulnerability details, or price claims."
+                ),
+            ]
+        )
+
     with session_scope(database_url) as session:
         if name == "list_bounties":
             bounties = session.scalars(
@@ -1478,6 +1513,25 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
                 }
             )
         if name == "submit_work_proof":
+            has_bounty_id = "bounty_id" in args and args.get("bounty_id") is not None
+            has_issue_number = "issue_number" in args and args.get("issue_number") is not None
+            if has_bounty_id and has_issue_number:
+                raise ValueError("use bounty_id or issue_number, not both")
+            if has_bounty_id:
+                bounty = session.get(Bounty, positive_int_arg("bounty_id"))
+                return "bounty not found" if bounty is None else work_proof_guidance(bounty)
+            if has_issue_number:
+                bounties = session.scalars(
+                    select(Bounty)
+                    .where(Bounty.issue_number == positive_int_arg("issue_number"))
+                    .order_by(Bounty.id.desc())
+                    .limit(2)
+                ).all()
+                if not bounties:
+                    return "bounty not found"
+                if len(bounties) > 1:
+                    raise ValueError("issue_number matches multiple bounties")
+                return work_proof_guidance(bounties[0])
             return (
                 "Open a focused PR or issue, reference the MRWK bounty, include test evidence, "
                 "and wait for a maintainer to apply mrwk:accepted."

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -420,6 +420,10 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
 
     tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()
     assert tools["result"]["tools"][0]["name"] == "list_bounties"
+    submit_tool = next(
+        tool for tool in tools["result"]["tools"] if tool["name"] == "submit_work_proof"
+    )
+    assert "bounty_id or issue_number" in submit_tool["description"]
 
     balance = client.post(
         "/mcp",
@@ -775,6 +779,190 @@ def test_mcp_get_proof_rejects_malformed_hash(sqlite_url: str) -> None:
     assert response.json() == {
         "jsonrpc": "2.0",
         "id": 3,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
+def test_mcp_submit_work_proof_returns_bounty_specific_guidance(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=284,
+            issue_url="https://github.com/ramimbo/mergework/issues/284",
+            title="Agent MCP bounty workflow",
+            reward_mrwk="100",
+            max_awards=3,
+            acceptance="Improve MCP behavior with focused tests.",
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    by_issue = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_work_proof",
+                "arguments": {"issue_number": 284},
+            },
+        },
+    ).json()
+    text = by_issue["result"]["content"][0]["text"]
+
+    assert "Bounty #284: Agent MCP bounty workflow" in text
+    assert f"Internal bounty id: {bounty_id}" in text
+    assert "Repository: ramimbo/mergework" in text
+    assert "Issue: https://github.com/ramimbo/mergework/issues/284" in text
+    assert "Status: open (open for submissions); awards remaining: 3 of 3" in text
+    assert "Reward: 100 MRWK per accepted award" in text
+    assert "Acceptance: Improve MCP behavior with focused tests." in text
+    assert "/claim" in text
+    assert "Do not include private keys" in text
+
+    by_id = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_work_proof",
+                "arguments": {"bounty_id": bounty_id},
+            },
+        },
+    ).json()
+
+    assert by_id["result"]["content"][0]["text"] == text
+
+
+def test_mcp_submit_work_proof_keeps_generic_guidance(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "submit_work_proof", "arguments": {}},
+        },
+    ).json()
+
+    assert result["result"]["content"][0]["text"] == (
+        "Open a focused PR or issue, reference the MRWK bounty, include test evidence, "
+        "and wait for a maintainer to apply mrwk:accepted."
+    )
+
+
+def test_mcp_submit_work_proof_reports_unknown_bounty(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_work_proof",
+                "arguments": {"issue_number": 999},
+            },
+        },
+    ).json()
+
+    assert result["result"]["content"][0]["text"] == "bounty not found"
+
+
+@pytest.mark.parametrize(
+    ("arguments", "request_id"),
+    [
+        ({"bounty_id": 0}, 21),
+        ({"bounty_id": True}, 22),
+        ({"issue_number": 0}, 23),
+        ({"issue_number": 1.5}, 24),
+        ({"bounty_id": 1, "issue_number": 1}, 25),
+    ],
+)
+def test_mcp_submit_work_proof_rejects_invalid_bounty_selectors(
+    sqlite_url: str, arguments: dict[str, object], request_id: int
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {"name": "submit_work_proof", "arguments": arguments},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
+def test_mcp_submit_work_proof_rejects_ambiguous_issue_number(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=284,
+            issue_url="https://github.com/ramimbo/mergework/issues/284",
+            title="First bounty",
+            reward_mrwk="100",
+            acceptance="First acceptance.",
+        )
+        create_bounty(
+            session,
+            repo="example/mergework",
+            issue_number=284,
+            issue_url="https://github.com/example/mergework/issues/284",
+            title="Second bounty",
+            reward_mrwk="100",
+            acceptance="Second acceptance.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 26,
+            "method": "tools/call",
+            "params": {"name": "submit_work_proof", "arguments": {"issue_number": 284}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 26,
         "error": {"code": -32602, "message": "invalid tool arguments"},
     }
 


### PR DESCRIPTION
Bounty #284

## Summary
- Adds bounty-specific guidance to the MCP `submit_work_proof` tool.
- Keeps the existing generic guidance unchanged when no bounty selector is supplied.
- Lets agents request guidance by internal `bounty_id` or GitHub `issue_number`.
- Includes current bounty status, awards remaining, reward, repository, issue URL, acceptance text, and safe `/claim` guidance in the tool response.
- Rejects ambiguous or invalid selectors through the existing JSON-RPC invalid-arguments path.

## Exact MCP behavior
- `submit_work_proof` with `{}` still returns the existing generic instruction text.
- `submit_work_proof` with `{ "issue_number": 284 }` returns bounty-specific guidance for that GitHub issue number.
- `submit_work_proof` with `{ "bounty_id": <id> }` returns the same guidance for the internal bounty id.
- Unknown selectors return `bounty not found`.
- Passing both selectors, a non-positive id, a boolean id, or a fractional id returns the existing invalid-arguments error.

## Verification
- `.venv/bin/python -m pytest tests/test_api_mcp.py::test_mcp_tools_list_and_call tests/test_api_mcp.py::test_mcp_submit_work_proof_returns_bounty_specific_guidance tests/test_api_mcp.py::test_mcp_submit_work_proof_keeps_generic_guidance tests/test_api_mcp.py::test_mcp_submit_work_proof_reports_unknown_bounty tests/test_api_mcp.py::test_mcp_submit_work_proof_rejects_invalid_bounty_selectors -q` -> 9 passed
- `.venv/bin/python -m pytest tests/test_api_mcp.py -q` -> 49 passed, 1 warning
- `.venv/bin/python -m pytest -q` -> 217 passed, 2 warnings
- `.venv/bin/ruff check .` -> all checks passed
- `.venv/bin/ruff format --check .` -> 37 files already formatted
- `.venv/bin/python -m mypy app` -> success
- `.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `.venv/bin/python scripts/check_agents.py` -> AGENTS.md ok
- `git diff --check` -> clean

No private keys, wallet material, deployment credentials, payout details, private vulnerability details, or price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Work-proof submission guidance can be filtered by bounty ID or issue number and returns detailed bounty-specific instructions, acceptance criteria, reward details, and security reminders.
* **Bug Fixes**
  * Requests specifying both selectors or ambiguous/invalid selectors are rejected with clear error responses; unknown bounties return a "bounty not found" reply.
* **Tests**
  * Added tests covering tool listing, bounty-specific and generic guidance, not-found responses, and selector validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->