### PR TITLE
Add MCP bounty award details

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -977,7 +977,10 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 "result": {
                     "tools": [
                         {"name": "list_bounties", "description": "List open MRWK bounties"},
-                        {"name": "get_bounty", "description": "Get a bounty by id"},
+                        {
+                            "name": "get_bounty",
+                            "description": "Get a bounty by id, optionally with accepted awards",
+                        },
                         {"name": "get_balance", "description": "Get an account balance"},
                         {
                             "name": "register_wallet",
@@ -1413,6 +1416,14 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
             raise ValueError(f"{field} must be a string")
         return value
 
+    def optional_bool_arg(field: str, default: bool = False) -> bool:
+        value = args.get(field, default)
+        if value is None:
+            return default
+        if not isinstance(value, bool):
+            raise ValueError(f"{field} must be a boolean")
+        return value
+
     with session_scope(database_url) as session:
         if name == "list_bounties":
             bounties = session.scalars(
@@ -1423,7 +1434,10 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
             bounty = session.get(Bounty, positive_int_arg("id"))
             if bounty is None:
                 return "bounty not found"
-            return json.dumps(bounty_to_dict(bounty))
+            bounty_data = bounty_to_dict(bounty)
+            if optional_bool_arg("include_awards"):
+                bounty_data["awards"] = bounty_awards_to_dict(session, bounty.id)
+            return json.dumps(bounty_data)
         if name == "get_balance":
             account = _normalized_account(str_arg("account"))
             return f"{account}: {format_mrwk(get_balance(session, account))} MRWK"

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -420,6 +420,8 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
 
     tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()
     assert tools["result"]["tools"][0]["name"] == "list_bounties"
+    bounty_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_bounty")
+    assert "accepted awards" in bounty_tool["description"]
 
     balance = client.post(
         "/mcp",
@@ -518,6 +520,75 @@ def test_mcp_rejects_unknown_tool_name(sqlite_url: str) -> None:
     }
 
 
+def test_mcp_get_bounty_can_include_accepted_awards(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=284,
+            issue_url="https://github.com/ramimbo/mergework/issues/284",
+            title="MCP accepted awards",
+            reward_mrwk="75",
+            acceptance="Agents should inspect accepted award proofs.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/284",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    default_result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "get_bounty", "arguments": {"id": bounty_id}},
+        },
+    ).json()
+    default_payload = json.loads(default_result["result"]["content"][0]["text"])
+    assert "awards" not in default_payload
+
+    result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "get_bounty",
+                "arguments": {"id": bounty_id, "include_awards": True},
+            },
+        },
+    ).json()
+    payload = json.loads(result["result"]["content"][0]["text"])
+    assert payload["id"] == bounty_id
+    assert payload["status"] == "paid"
+    assert payload["awards_paid"] == 1
+    assert payload["awards_remaining"] == 0
+    assert payload["awards"] == [
+        {
+            "proof_hash": proof.hash,
+            "proof_url": f"/proofs/{proof.hash}",
+            "ledger_sequence": proof.ledger_sequence,
+            "ledger_url": f"/ledger/{proof.ledger_sequence}",
+            "account": "github:alice",
+            "amount_mrwk": "75",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/284",
+            "accepted_by": "maintainer",
+            "created_at": proof.created_at.replace(tzinfo=None).isoformat(),
+        }
+    ]
+
+
 def test_mcp_get_bounty_rejects_fractional_id(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -542,6 +613,47 @@ def test_mcp_get_bounty_rejects_fractional_id(sqlite_url: str) -> None:
             "id": 12,
             "method": "tools/call",
             "params": {"name": "get_bounty", "arguments": {"id": bounty_id + 0.9}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 12,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
+@pytest.mark.parametrize("include_awards", ["true", 1, []])
+def test_mcp_get_bounty_rejects_non_boolean_include_awards(
+    sqlite_url: str, include_awards: object
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=104,
+            issue_url="https://github.com/ramimbo/mergework/issues/104",
+            title="MCP awards flag validation",
+            reward_mrwk="75",
+            acceptance="MCP tools should reject non-boolean include_awards.",
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 12,
+            "method": "tools/call",
+            "params": {
+                "name": "get_bounty",
+                "arguments": {"id": bounty_id, "include_awards": include_awards},
+            },
         },
     )
 


### PR DESCRIPTION
## Summary
- Bounty #284: Add an optional `include_awards` flag to the MCP `get_bounty` tool.
- Keep the default `get_bounty` response unchanged unless an agent explicitly asks for award details.
- When requested, include accepted-award proof hashes, proof URLs, ledger links, account, amount, submission URL, accepted-by, and created-at fields from the existing public award data.
- Reject non-boolean `include_awards` values through the existing MCP invalid-arguments path.

## Validation
- `PYTHONPATH=. .venv/bin/pytest tests/test_api_mcp.py::test_mcp_tools_list_and_call tests/test_api_mcp.py::test_mcp_get_bounty_can_include_accepted_awards tests/test_api_mcp.py::test_mcp_get_bounty_rejects_non_boolean_include_awards -q` -> 5 passed.
- `PYTHONPATH=. .venv/bin/pytest -q` -> 222 passed, 2 existing warnings.
- `.venv/bin/ruff format --check .` -> passed.
- `.venv/bin/ruff check .` -> passed.
- `PYTHONPATH=. .venv/bin/mypy app` -> passed.
- `PYTHONPATH=. .venv/bin/python scripts/docs_smoke.py` -> passed.
- `PYTHONPATH=. .venv/bin/python scripts/check_agents.py` -> passed.
- `git diff --check` -> passed.

## Safety
- No private keys, wallet material, deployment credentials, payout details, private vulnerability details, or price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `get_bounty` tool now supports an optional parameter to include accepted awards in the response, enabling retrieval of award and proof details when requested.

* **Tests**
  * Added test coverage for the awards parameter, including validation of non-boolean input handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->