### PR TITLE
Expose payout reconciliation report

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,11 @@ from sqlalchemy.orm import Session
 
 from app.config import Settings, get_settings
 from app.db import create_schema, session_scope
+from app.ledger.reconciliation import (
+    AcceptedPayoutCheck,
+    payout_reconciliation_summary,
+    reconcile_accepted_payouts,
+)
 from app.ledger.service import (
     GENESIS_SUPPLY_MICRO,
     TREASURY_ACCOUNT,
@@ -166,6 +171,31 @@ def bounty_list_summary(bounties: list[dict[str, Any]]) -> dict[str, Any]:
         "bounties_shown": len(bounties),
         "open_awards": open_awards,
         "open_pool_mrwk": format_mrwk(open_pool_microunits),
+    }
+
+
+def payout_reconciliation_to_dict(check: AcceptedPayoutCheck) -> dict[str, Any]:
+    return {
+        "status": check.status,
+        "bounty_id": check.bounty_id,
+        "bounty_issue": check.bounty_issue,
+        "submission_id": check.submission_id,
+        "submitter_account": check.submitter_account,
+        "submission_url": check.submission_url,
+        "evidence_count": len(check.evidence),
+        "evidence": [
+            {
+                "proof_hash": evidence.proof_hash,
+                "proof_url": f"/proofs/{evidence.proof_hash}",
+                "ledger_sequence": evidence.ledger_sequence,
+                "ledger_type": evidence.ledger_type,
+                "reference": evidence.reference,
+                "to_account": evidence.to_account,
+                "amount_mrwk": evidence.amount_mrwk,
+                "matches_submission": evidence.matches_submission,
+            }
+            for evidence in check.evidence
+        ],
     }
 
 
@@ -776,6 +806,18 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             result = bounty_to_dict(bounty)
             result["accepted_awards"] = bounty_awards_to_dict(session, bounty.id)
             return result
+
+    @app.get("/api/v1/reconciliation/payouts")
+    def api_payout_reconciliation(
+        admin_login: str = Depends(require_admin_token),
+    ) -> dict[str, Any]:
+        with session_scope(db_url) as session:
+            checks = reconcile_accepted_payouts(session)
+            return {
+                "generated_by": admin_login,
+                "summary": payout_reconciliation_summary(checks),
+                "checks": [payout_reconciliation_to_dict(check) for check in checks],
+            }
 
     @app.post("/api/v1/bounties/{bounty_id}/pay")
     async def api_pay_bounty(

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -377,7 +377,14 @@ def test_admin_payout_reconciliation_api_reports_missing_and_duplicate_evidence(
         f"/proofs/{proof.hash}",
         f"/proofs/{'e' * 64}",
     }
-    assert all(evidence["matches_submission"] for evidence in duplicate_check["evidence"])
+    for evidence in duplicate_check["evidence"]:
+        assert isinstance(evidence["ledger_sequence"], int)
+        assert evidence["ledger_sequence"] == proof.ledger_sequence
+        assert evidence["ledger_type"] == "bounty_payment"
+        assert evidence["reference"] == "https://github.com/ramimbo/mergework/pull/282"
+        assert evidence["to_account"] == "github:bob"
+        assert evidence["amount_mrwk"] == "15"
+        assert evidence["matches_submission"] is True
 
 
 def test_admin_payout_api_returns_400_for_malformed_json(

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -15,6 +15,7 @@ from app.ledger.service import (
     TREASURY_ACCOUNT,
     LedgerError,
     add_ledger_entry,
+    canonical_json,
     close_bounty,
     create_bounty,
     ensure_genesis,
@@ -26,7 +27,7 @@ from app.ledger.service import (
     validate_public_url,
 )
 from app.main import _safe_next_path, _signed_value, create_app
-from app.models import LedgerEntry, WebhookEvent
+from app.models import LedgerEntry, Proof, Submission, WebhookEvent
 from app.webhooks.github import handle_github_webhook
 
 
@@ -289,6 +290,94 @@ def test_admin_payout_api_requires_admin_token_not_cookie_auth(
     assert token_auth.json()["to_account"] == wallet_address
     with session_scope(sqlite_url) as session:
         assert get_balance(session, wallet_address) == 25_000_000
+
+
+def test_admin_payout_reconciliation_api_reports_missing_and_duplicate_evidence(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    create_schema(sqlite_url)
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        missing_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=281,
+            issue_url="https://github.com/ramimbo/mergework/issues/281",
+            title="Reconcile missing payout",
+            reward_mrwk="15",
+            acceptance="Maintainer needs accepted-but-unpaid work surfaced.",
+        )
+        duplicate_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=282,
+            issue_url="https://github.com/ramimbo/mergework/issues/282",
+            title="Reconcile duplicate payout evidence",
+            reward_mrwk="15",
+            acceptance="Maintainer needs duplicate payment evidence surfaced.",
+        )
+        missing_submission = Submission(
+            bounty_id=missing_bounty.id,
+            submitter_account="github:alice",
+            url="https://github.com/ramimbo/mergework/pull/281",
+            status="accepted",
+            verifier_result=canonical_json({"label": "mrwk:accepted"}),
+        )
+        session.add(missing_submission)
+        proof = pay_bounty(
+            session,
+            bounty_id=duplicate_bounty.id,
+            to_account="github:bob",
+            submission_url="https://github.com/ramimbo/mergework/pull/282",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        session.add(
+            Proof(
+                hash="e" * 64,
+                ledger_sequence=proof.ledger_sequence,
+                bounty_id=duplicate_bounty.id,
+                submission_id=proof.submission_id,
+                kind="bounty_payment",
+                public_json=proof.public_json,
+            )
+        )
+
+    unauthorized = client.get("/api/v1/reconciliation/payouts")
+    response = client.get(
+        "/api/v1/reconciliation/payouts",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+
+    assert unauthorized.status_code == 401
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["generated_by"] == "api-token"
+    assert payload["summary"] == {
+        "accepted_submissions": 2,
+        "paid": 0,
+        "missing_payment": 1,
+        "duplicate_payment_evidence": 1,
+        "mismatched_payment_evidence": 0,
+    }
+    by_status = {check["status"]: check for check in payload["checks"]}
+    assert by_status["missing_payment"]["submission_url"] == (
+        "https://github.com/ramimbo/mergework/pull/281"
+    )
+    assert by_status["missing_payment"]["evidence"] == []
+    duplicate_check = by_status["duplicate_payment_evidence"]
+    assert duplicate_check["submission_url"] == "https://github.com/ramimbo/mergework/pull/282"
+    assert duplicate_check["evidence_count"] == 2
+    assert {evidence["proof_url"] for evidence in duplicate_check["evidence"]} == {
+        f"/proofs/{proof.hash}",
+        f"/proofs/{'e' * 64}",
+    }
+    assert all(evidence["matches_submission"] for evidence in duplicate_check["evidence"])
 
 
 def test_admin_payout_api_returns_400_for_malformed_json(


### PR DESCRIPTION
Refs #281

## Summary
- add an admin-token protected `GET /api/v1/reconciliation/payouts` report
- expose summary counts plus per-submission payout evidence with proof URLs, ledger sequence, account, amount, and match status
- cover missing accepted payout and duplicate payment evidence in the API test

## Validation
- `uv run pytest tests/test_security.py tests/test_ledger.py -q`
- `uv run pytest tests/test_security.py tests/test_ledger.py tests/test_activity.py -q`
- `uv run ruff check app/main.py tests/test_security.py`
- `uv run ruff format --check app/main.py tests/test_security.py`
- `uv run mypy app`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-only API endpoint that generates payout reconciliation reports. Responses include who generated the report, an aggregated summary, per-check statuses, detailed evidence entries, and ledger reference fields to aid investigation.

* **Tests**
  * Added a security test ensuring the endpoint requires admin auth and correctly reports missing vs. duplicate payout evidence with expected summary counters and per-check details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->