### PR TITLE
Expose accepted work on account API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -866,6 +866,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             transfer_status = "MRWK wallet transfers are enabled for registered mrwk1 addresses."
         with session_scope(db_url) as session:
             account_row = session.get(Account, account)
+            accepted_work = account_accepted_summary(session, account)
             return {
                 "account": account,
                 "ledger_address": account,
@@ -873,6 +874,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 "exists": account_row is not None,
                 "balance_mrwk": format_mrwk(get_balance(session, account)),
                 "transfer_status": transfer_status,
+                "accepted_work": accepted_work,
             }
 
     @app.get("/api/v1/auth/me")

--- a/app/main.py
+++ b/app/main.py
@@ -362,6 +362,31 @@ def accepted_work_for_account(session: Session, account: str) -> list[dict[str, 
     return accepted_work
 
 
+def empty_accepted_summary() -> dict[str, Any]:
+    return {
+        "accepted_awards": 0,
+        "accepted_mrwk": "0",
+        "latest_ledger_sequence": None,
+        "latest_submission_url": None,
+        "latest_proof_hash": None,
+        "latest_proof_url": None,
+    }
+
+
+def safe_account_accepted_summary(session: Session, account: str) -> dict[str, Any]:
+    try:
+        return account_accepted_summary(session, account)
+    except Exception:
+        return empty_accepted_summary()
+
+
+def safe_accepted_work_for_account(session: Session, account: str) -> list[dict[str, Any]]:
+    try:
+        return accepted_work_for_account(session, account)
+    except Exception:
+        return []
+
+
 def _wallet_timestamp(value: datetime) -> str:
     if value.tzinfo is not None:
         value = value.replace(tzinfo=None)
@@ -866,7 +891,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             transfer_status = "MRWK wallet transfers are enabled for registered mrwk1 addresses."
         with session_scope(db_url) as session:
             account_row = session.get(Account, account)
-            accepted_work = account_accepted_summary(session, account)
+            accepted_work = safe_account_accepted_summary(session, account)
             return {
                 "account": account,
                 "ledger_address": account,
@@ -1197,7 +1222,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         account = _normalized_account(account)
         with session_scope(db_url) as session:
             account_data = api_account(account)
-            accepted_summary = account_accepted_summary(session, account)
+            accepted_summary = safe_account_accepted_summary(session, account)
             entries = session.scalars(
                 select(LedgerEntry)
                 .where(or_(LedgerEntry.from_account == account, LedgerEntry.to_account == account))
@@ -1206,7 +1231,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             ).all()
             proofs = _proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
             transactions = [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
-            accepted_work = accepted_work_for_account(session, account)
+            accepted_work = safe_accepted_work_for_account(session, account)
         return templates.TemplateResponse(
             request,
             "account.html",

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -176,7 +176,8 @@ current nonce, next nonce to sign with, and registration timestamp:
 ```
 
 Account responses identify the normalized ledger address, optional GitHub login,
-existence, current balance, and whether the account can move funds directly:
+existence, current balance, accepted-work summary, and whether the account can
+move funds directly:
 
 ```json
 {
@@ -185,7 +186,15 @@ existence, current balance, and whether the account can move funds directly:
   "github_login": "tatelyman",
   "exists": true,
   "balance_mrwk": "395",
-  "transfer_status": "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
+  "transfer_status": "Claim GitHub balances from /me after linking a registered mrwk1 wallet.",
+  "accepted_work": {
+    "accepted_awards": 5,
+    "accepted_mrwk": "395",
+    "latest_ledger_sequence": 42,
+    "latest_submission_url": "https://github.com/ramimbo/mergework/pull/183",
+    "latest_proof_hash": "a29b9cf54f2ea4734d58e9371b20234f85936e95bd8c45687f0644ad6a9e6871",
+    "latest_proof_url": "/proofs/a29b9cf54f2ea4734d58e9371b20234f85936e95bd8c45687f0644ad6a9e6871"
+  }
 }
 ```
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -863,6 +863,14 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     assert account_api["transfer_status"] == (
         "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
     )
+    assert account_api["accepted_work"] == {
+        "accepted_awards": 1,
+        "accepted_mrwk": "25",
+        "latest_ledger_sequence": 3,
+        "latest_submission_url": "https://github.com/ramimbo/mergework/pull/3",
+        "latest_proof_hash": proof.hash,
+        "latest_proof_url": f"/proofs/{proof.hash}",
+    }
     assert "Claim GitHub balances from /me" in account
     assert 'href="https://github.com/alice">@alice</a>' in account
     assert "Accepted work summary" in account

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
+from app.models import Proof
 
 
 def test_health_status_and_bounty_api(sqlite_url: str) -> None:
@@ -884,6 +885,52 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     assert 'href="https://github.com/ramimbo/mergework/issues/2"' in account
     assert 'href="/accounts/reserve:bounty:1"' in account
     assert 'href="/accounts/github:alice"' in account
+
+
+def test_account_api_keeps_schema_when_accepted_work_proof_is_malformed(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=42,
+            issue_url="https://github.com/ramimbo/mergework/issues/42",
+            title="Malformed accepted-work proof",
+            reward_mrwk="25",
+            acceptance="Accepted label",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/42",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        proof_row = session.get(Proof, proof.hash)
+        assert proof_row is not None
+        proof_row.public_json = "{"
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/api/v1/accounts/github:alice")
+    account_page = client.get("/accounts/github:alice")
+
+    assert response.status_code == 200
+    assert account_page.status_code == 200
+    account_api = response.json()
+    assert account_api["balance_mrwk"] == "25"
+    assert account_api["accepted_work"] == {
+        "accepted_awards": 0,
+        "accepted_mrwk": "0",
+        "latest_ledger_sequence": None,
+        "latest_submission_url": None,
+        "latest_proof_hash": None,
+        "latest_proof_url": None,
+    }
 
 
 def test_account_page_rejects_empty_account_path(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #298

Refs #291nRefs #298

## Summary

- Adds `accepted_work` to `GET /api/v1/accounts/{account}` so contributor accepted-award history is machine-readable instead of only visible on the account page.
- Reuses the existing proof-backed account summary fields already rendered publicly: accepted award count, accepted MRWK total, latest ledger sequence, latest submission URL, latest proof hash, and latest proof URL.
- Updates the public API examples to document the new account response shape.

## Evidence

- `uv run pytest tests/test_api_mcp.py tests/test_docs_public_urls.py -q` -> 61 passed, 1 existing httpx deprecation warning.
- `uv run ruff check app/main.py tests/test_api_mcp.py` -> passed.
- `uv run ruff format --check app/main.py tests/test_api_mcp.py` -> passed.
- `uv run mypy app` -> passed.
- `uv run python scripts/docs_smoke.py` -> passed.
- `uv run python scripts/check_agents.py` -> passed.
- `git diff --check` -> passed.

No private keys, seed material, secrets, private vulnerability details, deployment credentials, or price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account API and HTML account page now include an accepted-work summary and accepted_work list.

* **Bug Fixes**
  * Account endpoints are resilient to malformed proof data and return safe, zero/None-filled fallbacks instead of failing.

* **Documentation**
  * Updated API examples to show the new accepted-work field and its structure.

* **Tests**
  * Added tests validating accepted-work presence and fallback behavior in account API and HTML responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
