### PR TITLE
Report duplicate accepted source URLs

### DIFF
--- a/app/ledger/reconciliation.py
+++ b/app/ledger/reconciliation.py
@@ -139,7 +139,10 @@ def _canonical_source_url(url: str) -> str:
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         return clean
     host = (parsed.hostname or "").lower()
-    port = parsed.port
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
     if (parsed.scheme.lower(), port) in {("http", 80), ("https", 443)}:
         port = None
     netloc = f"{host}:{port}" if port is not None else host

--- a/app/ledger/reconciliation.py
+++ b/app/ledger/reconciliation.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal
+from urllib.parse import urlsplit, urlunsplit
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.ledger.service import format_mrwk
 from app.models import Bounty, LedgerEntry, Proof, Submission
+
+GITHUB_SOURCE_PATH_RE = re.compile(
+    r"/(?P<owner>[^/]+)/(?P<repo>[^/]+)/(?P<kind>issues|pull)/(?P<number>\d+)"
+    r"(?P<view>/(?:files|commits|checks|conversation))?/?",
+    re.IGNORECASE,
+)
 
 PayoutReconciliationStatus = Literal[
     "paid",
@@ -40,6 +48,21 @@ class AcceptedPayoutCheck:
     evidence: tuple[PayoutEvidence, ...]
 
 
+@dataclass(frozen=True)
+class AcceptedSourceReference:
+    bounty_id: int
+    bounty_issue: str
+    submission_id: int
+    submitter_account: str
+    submission_url: str
+
+
+@dataclass(frozen=True)
+class DuplicateAcceptedSourceUrl:
+    source_url: str
+    submissions: tuple[AcceptedSourceReference, ...]
+
+
 def reconcile_accepted_payouts(session: Session) -> list[AcceptedPayoutCheck]:
     submissions = session.scalars(
         select(Submission).where(Submission.status == "accepted").order_by(Submission.id)
@@ -64,6 +87,32 @@ def reconcile_accepted_payouts(session: Session) -> list[AcceptedPayoutCheck]:
     return checks
 
 
+def duplicate_accepted_source_urls(session: Session) -> list[DuplicateAcceptedSourceUrl]:
+    rows = session.execute(
+        select(Submission, Bounty)
+        .join(Bounty, Bounty.id == Submission.bounty_id)
+        .where(Submission.status == "accepted")
+        .order_by(Submission.id)
+    ).all()
+    groups: dict[str, list[AcceptedSourceReference]] = {}
+    for submission, bounty in rows:
+        source_url = _canonical_source_url(submission.url)
+        groups.setdefault(source_url, []).append(
+            AcceptedSourceReference(
+                bounty_id=bounty.id,
+                bounty_issue=f"{bounty.repo}#{bounty.issue_number}",
+                submission_id=submission.id,
+                submitter_account=submission.submitter_account,
+                submission_url=submission.url,
+            )
+        )
+    return [
+        DuplicateAcceptedSourceUrl(source_url=source_url, submissions=tuple(submissions))
+        for source_url, submissions in groups.items()
+        if len(submissions) > 1
+    ]
+
+
 def payout_reconciliation_summary(checks: Sequence[AcceptedPayoutCheck]) -> dict[str, int]:
     summary = {
         "accepted_submissions": len(checks),
@@ -75,6 +124,37 @@ def payout_reconciliation_summary(checks: Sequence[AcceptedPayoutCheck]) -> dict
     for check in checks:
         summary[check.status] += 1
     return summary
+
+
+def duplicate_source_summary(groups: Sequence[DuplicateAcceptedSourceUrl]) -> dict[str, int]:
+    return {
+        "duplicate_source_urls": len(groups),
+        "duplicate_source_submissions": sum(len(group.submissions) for group in groups),
+    }
+
+
+def _canonical_source_url(url: str) -> str:
+    clean = url.strip()
+    parsed = urlsplit(clean)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return clean
+    host = (parsed.hostname or "").lower()
+    port = parsed.port
+    if (parsed.scheme.lower(), port) in {("http", 80), ("https", 443)}:
+        port = None
+    netloc = f"{host}:{port}" if port is not None else host
+    path = parsed.path.rstrip("/") or parsed.path
+    query = parsed.query
+    fragment = parsed.fragment
+    if host == "github.com":
+        match = GITHUB_SOURCE_PATH_RE.fullmatch(path)
+        if match:
+            path = (
+                f"/{match['owner'].lower()}/{match['repo'].lower()}/"
+                f"{match['kind'].lower()}/{match['number']}"
+            )
+            query = ""
+    return urlunsplit((parsed.scheme.lower(), netloc, path, query, fragment))
 
 
 def _payout_evidence(

--- a/app/ledger/reconciliation.py
+++ b/app/ledger/reconciliation.py
@@ -14,7 +14,7 @@ from app.models import Bounty, LedgerEntry, Proof, Submission
 
 GITHUB_SOURCE_PATH_RE = re.compile(
     r"/(?P<owner>[^/]+)/(?P<repo>[^/]+)/(?P<kind>issues|pull)/(?P<number>\d+)"
-    r"(?P<view>/(?:files|commits|checks|conversation))?/?",
+    r"(?P<view>/(?:files|commits|checks))?/?",
     re.IGNORECASE,
 )
 
@@ -157,6 +157,7 @@ def _canonical_source_url(url: str) -> str:
                 f"{match['kind'].lower()}/{match['number']}"
             )
             query = ""
+            fragment = ""
     return urlunsplit((parsed.scheme.lower(), netloc, path, query, fragment))
 
 

--- a/scripts/reconcile_payouts.py
+++ b/scripts/reconcile_payouts.py
@@ -6,6 +6,8 @@ from dataclasses import asdict
 from app.config import get_settings
 from app.db import session_scope
 from app.ledger.reconciliation import (
+    duplicate_accepted_source_urls,
+    duplicate_source_summary,
     payout_reconciliation_summary,
     reconcile_accepted_payouts,
 )
@@ -15,10 +17,23 @@ def main() -> int:
     settings = get_settings()
     with session_scope(settings.database_url) as session:
         checks = reconcile_accepted_payouts(session)
+        duplicate_sources = duplicate_accepted_source_urls(session)
     summary = payout_reconciliation_summary(checks)
+    summary.update(duplicate_source_summary(duplicate_sources))
     issues = [asdict(check) for check in checks if check.status != "paid"]
-    print(json.dumps({"summary": summary, "issues": issues}, indent=2, sort_keys=True))
-    return 1 if issues else 0
+    duplicate_source_urls = [asdict(group) for group in duplicate_sources]
+    print(
+        json.dumps(
+            {
+                "summary": summary,
+                "issues": issues,
+                "duplicate_source_urls": duplicate_source_urls,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 1 if issues or duplicate_source_urls else 0
 
 
 if __name__ == "__main__":

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import pytest
+from sqlalchemy import select
 
 from app.db import create_schema, make_engine, session_scope
 from app.ledger.reconciliation import (
+    duplicate_accepted_source_urls,
+    duplicate_source_summary,
     payout_reconciliation_summary,
     reconcile_accepted_payouts,
 )
@@ -479,6 +482,128 @@ def test_reconcile_accepted_payouts_reports_duplicate_payment_evidence(
         assert summary["duplicate_payment_evidence"] == 1
         assert checks[0].status == "duplicate_payment_evidence"
         assert len(checks[0].evidence) == 2
+
+
+def test_reconcile_accepted_payouts_reports_mismatched_payment_evidence(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=38,
+            issue_url="https://github.com/ramimbo/mergework/issues/38",
+            title="Reconcile mismatched payments",
+            reward_mrwk="12",
+            acceptance="Maintainer applies mrwk:accepted.",
+        )
+        submission = Submission(
+            bounty_id=bounty.id,
+            submitter_account="github:dana",
+            url="https://github.com/ramimbo/mergework/pull/38",
+            status="accepted",
+            verifier_result=canonical_json({"label": "mrwk:accepted"}),
+        )
+        session.add(submission)
+        session.flush()
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:erin",
+            submission_url="https://github.com/ramimbo/mergework/pull/39",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        session.add(
+            Proof(
+                hash="e" * 64,
+                ledger_sequence=proof.ledger_sequence,
+                bounty_id=bounty.id,
+                submission_id=submission.id,
+                kind="bounty_payment",
+                public_json=proof.public_json,
+            )
+        )
+        session.flush()
+
+        checks = reconcile_accepted_payouts(session)
+        mismatched = [check for check in checks if check.submission_id == submission.id]
+
+        assert len(mismatched) == 1
+        assert mismatched[0].status == "mismatched_payment_evidence"
+        assert mismatched[0].evidence[0].matches_submission is False
+        assert verify_hash_chain(session) is True
+        assert verify_supply_conservation(session) is True
+
+
+def test_duplicate_accepted_source_urls_groups_distinct_accepted_submissions(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        first_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=39,
+            issue_url="https://github.com/ramimbo/mergework/issues/39",
+            title="First source URL bounty",
+            reward_mrwk="5",
+            acceptance="Maintainer applies mrwk:accepted.",
+        )
+        second_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=40,
+            issue_url="https://github.com/ramimbo/mergework/issues/40",
+            title="Second source URL bounty",
+            reward_mrwk="5",
+            acceptance="Maintainer applies mrwk:accepted.",
+        )
+        source_url = "https://github.com/ramimbo/mergework/pull/281#discussion_r1"
+        session.add_all(
+            [
+                Submission(
+                    bounty_id=first_bounty.id,
+                    submitter_account="github:alice",
+                    url="HTTPS://GITHUB.COM:443/Ramimbo/MergeWork/PULL/281/files/"
+                    "?diff=split#discussion_r1",
+                    status="accepted",
+                    verifier_result=canonical_json({"label": "mrwk:accepted"}),
+                ),
+                Submission(
+                    bounty_id=second_bounty.id,
+                    submitter_account="github:bob",
+                    url="https://github.com/ramimbo/mergework/pull/281/#discussion_r1",
+                    status="accepted",
+                    verifier_result=canonical_json({"label": "mrwk:accepted"}),
+                ),
+            ]
+        )
+        session.flush()
+        ledger_entries_before = len(session.scalars(select(LedgerEntry)).all())
+        proofs_before = len(session.scalars(select(Proof)).all())
+
+        groups = duplicate_accepted_source_urls(session)
+
+        assert len(groups) == 1
+        assert groups[0].source_url == source_url
+        assert {ref.bounty_issue for ref in groups[0].submissions} == {
+            "ramimbo/mergework#39",
+            "ramimbo/mergework#40",
+        }
+        assert duplicate_source_summary(groups) == {
+            "duplicate_source_urls": 1,
+            "duplicate_source_submissions": 2,
+        }
+        assert len(session.scalars(select(LedgerEntry)).all()) == ledger_entries_before
+        assert len(session.scalars(select(Proof)).all()) == proofs_before
+        assert verify_hash_chain(session) is True
+        assert verify_supply_conservation(session) is True
 
 
 def test_bounty_max_awards_must_be_positive(sqlite_url: str) -> None:

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -570,7 +570,7 @@ def test_duplicate_accepted_source_urls_groups_distinct_accepted_submissions(
                 Submission(
                     bounty_id=first_bounty.id,
                     submitter_account="github:alice",
-                    url="HTTPS://GITHUB.COM:443/Ramimbo/MergeWork/PULL/281/files/"
+                    url="https://github.com:bad/Ramimbo/MergeWork/PULL/281/files/"
                     "?diff=split#discussion_r1",
                     status="accepted",
                     verifier_result=canonical_json({"label": "mrwk:accepted"}),

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -564,12 +564,14 @@ def test_duplicate_accepted_source_urls_groups_distinct_accepted_submissions(
             reward_mrwk="5",
             acceptance="Maintainer applies mrwk:accepted.",
         )
-        source_url = "https://github.com/ramimbo/mergework/pull/281#discussion_r1"
+        source_url = "https://github.com/ramimbo/mergework/pull/281"
         session.add_all(
             [
                 Submission(
                     bounty_id=first_bounty.id,
                     submitter_account="github:alice",
+                    # The bad port is deliberate; this also exercises case,
+                    # path, query, and fragment canonicalization in one URL.
                     url="https://github.com:bad/Ramimbo/MergeWork/PULL/281/files/"
                     "?diff=split#discussion_r1",
                     status="accepted",


### PR DESCRIPTION
Refs #281

## Summary
- add read-only duplicate accepted source URL detection to payout reconciliation
- include duplicate source counts and groups in `scripts/reconcile_payouts.py` JSON output
- add coverage for mismatched payment evidence and canonical duplicate GitHub PR discussion source URLs

## Validation
- `.\.venv\Scripts\python -m pytest -q` -> 220 passed, 2 warnings
- `.\.venv\Scripts\python -m ruff format --check .` -> 37 files already formatted
- `.\.venv\Scripts\python -m ruff check .` -> All checks passed
- `.\.venv\Scripts\python -m mypy app` -> Success: no issues found in 11 source files
- `.\.venv\Scripts\python scripts\docs_smoke.py` -> docs smoke ok
- `.\.venv\Scripts\python scripts\check_agents.py` -> AGENTS.md ok
- `git diff --check` -> passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect duplicate source URLs across accepted bounty submissions and include duplicate summaries in reconciliation output.

* **Improvements**
  * Reconciliation run now returns an error status when duplicate source URLs are detected (in addition to unpaid issues).

* **Tests**
  * Added tests for duplicate source URL grouping and for reporting mismatched payment evidence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->