### PR TITLE
Let activity search match source bounties

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -223,6 +223,8 @@ def _activity_row_matches(row: dict[str, Any], query: str) -> bool:
         row["submission_url"],
         row["proof_hash"],
         row["bounty_id"],
+        row["bounty_repo"],
+        row["bounty_issue_url"],
         row["bounty_issue_number"],
     )
     return any(query in str(value or "").lower() for value in searchable_values)

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -140,6 +140,7 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
     by_account = client.get("/api/v1/activity?q=ALICE").json()
+    by_repo = client.get("/api/v1/activity?q=ramimbo%2Fmergework").json()
     by_proof = client.get(f"/api/v1/activity?q={alice_proof.hash[:12]}").json()
     no_match = client.get("/api/v1/activity?q=carol").json()
 
@@ -151,6 +152,11 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
     }
     assert by_account["contributors"][0]["account"] == "github:alice"
     assert by_account["recent"][0]["submission_url"].endswith("/pull/164")
+    assert by_repo["totals"] == {
+        "accepted_awards": 2,
+        "accepted_mrwk": "200",
+        "contributors": 2,
+    }
     assert by_proof["recent"][0]["proof_hash"] == alice_proof.hash
     assert no_match["totals"] == {
         "accepted_awards": 0,


### PR DESCRIPTION
Refs #292

## Summary

- Includes source bounty repo and issue URL in the accepted-work activity search index.
- Keeps existing activity response fields unchanged while making searches like `ramimbo/mergework` find accepted work tied to that source bounty.
- Adds regression coverage for repo-qualified activity search.

## Evidence

- `uv run pytest tests/test_activity.py -q` -> 3 passed.
- `uv run pytest tests/test_activity.py tests/test_api_mcp.py -q` -> 46 passed, 1 existing httpx deprecation warning.
- `uv run ruff check app/main.py tests/test_activity.py` -> passed.
- `uv run ruff format --check app/main.py tests/test_activity.py` -> passed.
- `uv run mypy app` -> passed.
- `git diff --check` -> passed.

No private keys, seed material, secrets, private vulnerability details, deployment credentials, or price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity API search expanded to include repository and issue information in query results, enabling more comprehensive filtering of activity records.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->