### PR TITLE
[codex] Bound route ids before database lookup

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -81,6 +81,7 @@ API_DOCS_CSP = (
     "worker-src 'self' blob:"
 )
 API_DOCS_PATHS = {"/api/docs", "/api/redoc"}
+SQLITE_INTEGER_MAX = 2**63 - 1
 
 
 def _request_was_forwarded_https(request: Request) -> bool:
@@ -476,12 +477,16 @@ def _github_login_from_account(account: str) -> str | None:
 def _positive_bounty_id(bounty_id: int) -> int:
     if bounty_id <= 0:
         raise HTTPException(status_code=400, detail="bounty id must be positive")
+    if bounty_id > SQLITE_INTEGER_MAX:
+        raise HTTPException(status_code=400, detail="bounty id is too large")
     return bounty_id
 
 
 def _positive_ledger_sequence(sequence: int) -> int:
     if sequence <= 0:
         raise HTTPException(status_code=400, detail="ledger sequence must be positive")
+    if sequence > SQLITE_INTEGER_MAX:
+        raise HTTPException(status_code=400, detail="ledger sequence is too large")
     return sequence
 
 

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -166,6 +166,13 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert client.get("/api/v1/bounties/0").status_code == 400
     assert client.get("/bounties/0").status_code == 400
 
+    oversized_bounty_id = "9" * 40
+    oversized_api_response = client.get(f"/api/v1/bounties/{oversized_bounty_id}")
+    assert oversized_api_response.status_code == 400
+    assert oversized_api_response.json()["detail"] == "bounty id is too large"
+    oversized_page_response = client.get(f"/bounties/{oversized_bounty_id}")
+    assert oversized_page_response.status_code == 400
+
 
 def test_bounty_detail_shows_accepted_award_history(sqlite_url: str) -> None:
     create_schema(sqlite_url)
@@ -274,6 +281,13 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert "Award paid" in ledger_entry_page.text
     assert client.get("/api/v1/ledger/0").status_code == 400
     assert client.get("/ledger/0").status_code == 400
+
+    oversized_sequence = "9" * 40
+    oversized_api_response = client.get(f"/api/v1/ledger/{oversized_sequence}")
+    assert oversized_api_response.status_code == 400
+    assert oversized_api_response.json()["detail"] == "ledger sequence is too large"
+    oversized_page_response = client.get(f"/ledger/{oversized_sequence}")
+    assert oversized_page_response.status_code == 400
 
     proof_page = client.get(f"/proofs/{proof_hash}")
     assert proof_page.status_code == 200


### PR DESCRIPTION
Bounty #292

## Summary
- reject oversized bounty IDs before `session.get(Bounty, bounty_id)` binds them into SQLite
- reject oversized ledger sequences before ledger-entry lookup binds them into SQLite
- add regression coverage for both API and public page routes

## Repro before fix
These requests raised `OverflowError: Python int too large to convert to SQLite INTEGER` instead of returning a controlled HTTP response:

- `GET /api/v1/bounties/9999999999999999999999999999999999999999`
- `GET /api/v1/ledger/9999999999999999999999999999999999999999`

## Validation
- `.venv/bin/python -m pytest tests/test_bounty_pages.py::test_bounty_detail_highlights_action_fields tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable -q` -> 2 passed
- `.venv/bin/python -m pytest tests/test_bounty_pages.py -q` -> 5 passed
- `.venv/bin/python -m pytest -q` -> 243 passed, 2 warnings
- `.venv/bin/python -m ruff format --check .` -> 37 files already formatted
- `.venv/bin/python -m ruff check .` -> all checks passed
- `.venv/bin/python -m mypy app` -> success
- `git diff --check` -> clean

No secrets, wallet material, deployment credentials, private vulnerability details, payout details, or MRWK price claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Added validation for numeric identifiers. Oversized bounty IDs and ledger sequences are now rejected with clear error messages ("bounty id is too large" or "ledger sequence is too large").

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->