### PR TITLE
[codex] Link accepted work to bounty details

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -184,6 +184,10 @@ def ledger_to_dict(entry: LedgerEntry, proof_hash: str | None = None) -> dict[st
     }
 
 
+def _bounty_detail_url(bounty_id: int | None) -> str | None:
+    return f"/bounties/{bounty_id}" if bounty_id is not None else None
+
+
 def _activity_row(entry: LedgerEntry, proof: Proof) -> dict[str, Any] | None:
     data = json.loads(proof.public_json)
     if not isinstance(data, dict) or data.get("kind") != "bounty_payment":
@@ -206,6 +210,7 @@ def _activity_row(entry: LedgerEntry, proof: Proof) -> dict[str, Any] | None:
         "proof_hash": proof.hash,
         "proof_url": f"/proofs/{proof.hash}",
         "bounty_id": proof.bounty_id,
+        "bounty_url": _bounty_detail_url(proof.bounty_id),
         "created_at": entry.created_at.isoformat(),
     }
 
@@ -355,6 +360,8 @@ def accepted_work_for_account(session: Session, account: str) -> list[dict[str, 
                 "issue_url": issue_url,
                 "repo": repo,
                 "issue_number": issue_number,
+                "bounty_id": proof.bounty_id,
+                "bounty_url": _bounty_detail_url(proof.bounty_id),
                 "accepted_by": data.get("accepted_by"),
                 "created_at": entry.created_at.isoformat(),
             }

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -79,7 +79,11 @@
           <div class="ledger-field ledger-field--reference reference-cell">
             <dt>Bounty</dt>
             {% set issue_url = safe_public_url(work.issue_url) %}
-            <dd>{% if issue_url %}<a href="{{ issue_url }}">{{ work.repo }} #{{ work.issue_number }}</a>{% else %}-{% endif %}</dd>
+            <dd>
+              {% if work.bounty_url %}<a href="{{ work.bounty_url }}">Bounty #{{ work.bounty_id }}</a>{% endif %}
+              {% if work.bounty_url and issue_url %} · {% endif %}
+              {% if issue_url %}<a href="{{ issue_url }}">{{ work.repo }} #{{ work.issue_number }}</a>{% elif not work.bounty_url %}-{% endif %}
+            </dd>
           </div>
           <div class="ledger-field ledger-field--reference reference-cell">
             <dt>Submission</dt>

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -75,7 +75,11 @@
           <div class="ledger-field ledger-field--reference reference-cell">
             <dt>Bounty</dt>
             {% set bounty_issue_url = safe_public_url(row.bounty_issue_url) %}
-            <dd>{% if bounty_issue_url %}<a href="{{ bounty_issue_url }}">{{ row.bounty_repo }} #{{ row.bounty_issue_number }}</a>{% else %}-{% endif %}</dd>
+            <dd>
+              {% if row.bounty_url %}<a href="{{ row.bounty_url }}">Bounty #{{ row.bounty_id }}</a>{% endif %}
+              {% if row.bounty_url and bounty_issue_url %} · {% endif %}
+              {% if bounty_issue_url %}<a href="{{ bounty_issue_url }}">{{ row.bounty_repo }} #{{ row.bounty_issue_number }}</a>{% elif not row.bounty_url %}-{% endif %}
+            </dd>
           </div>
           <div class="ledger-field ledger-field--reference reference-cell">
             <dt>Accepted work</dt>

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -103,6 +103,8 @@ def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -
     )
     assert payload["recent"][0]["bounty_repo"] == "ramimbo/mergework"
     assert payload["recent"][0]["bounty_issue_number"] == 11
+    assert payload["recent"][0]["bounty_id"] == second_bounty.id
+    assert payload["recent"][0]["bounty_url"] == f"/bounties/{second_bounty.id}"
     assert all("unproved" not in row["submission_url"] for row in payload["recent"])
 
 
@@ -197,6 +199,7 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert "75 MRWK" in paid.text
     assert 'role="search"' in paid.text
     assert 'name="q"' in paid.text
+    assert f'href="/bounties/{bounty.id}">Bounty #{bounty.id}</a>' in paid.text
     assert 'href="https://github.com/ramimbo/mergework/issues/12"' in paid.text
     assert 'href="https://github.com/ramimbo/mergework/pull/12"' in paid.text
     assert f'href="/proofs/{proof.hash}"' in paid.text

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -873,6 +873,7 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     assert 'via <a href="/ledger/3">#3</a>' in account
     assert "Accepted work" in account
     assert "Proof-backed bounty payments made to this account." in account
+    assert f'href="/bounties/{bounty.id}">Bounty #{bounty.id}</a>' in account
     assert 'href="https://github.com/ramimbo/mergework/issues/2"' in account
     assert 'href="/accounts/reserve:bounty:1"' in account
     assert 'href="/accounts/github:alice"' in account


### PR DESCRIPTION
Bounty #298

## Summary
- add `bounty_url` to accepted-work activity rows so API consumers can jump from a payment/proof row to the internal bounty detail page
- add `bounty_url` to account accepted-work rows for the same drill-down path
- render internal `Bounty #<id>` links next to the source GitHub issue on `/activity` and `/accounts/{account}`

## Contributor Discovery Impact
Accepted-work surfaces already show proof, ledger, account, submission, and source issue links. This closes the remaining navigation gap by letting contributors move directly from an accepted payment row to the MergeWork bounty detail page, where award state and accepted-award history are easier to inspect.

## Validation
- `.venv/bin/python -m pytest tests/test_activity.py tests/test_api_mcp.py::test_explorer_links_ledger_proof_and_account -q` -> 4 passed
- `.venv/bin/python -m pytest -q` -> 243 passed, 2 warnings
- `.venv/bin/python -m ruff format --check .` -> 37 files already formatted
- `.venv/bin/python -m ruff check .` -> all checks passed
- `.venv/bin/python -m mypy app` -> success
- `git diff --check` -> clean

No secrets, wallet material, deployment credentials, private vulnerability details, payout details, or MRWK price claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bounty references in activity and accepted work lists are now clickable links
  * Improved formatting displays bounty and repository/issue references with clear separators when both are present
  * Bounty links direct to the dedicated bounty detail page for easier navigation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->