### PR TITLE
[codex] Reject oversized bounty issue numbers

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -36,6 +36,7 @@ from app.wallets import (
 TREASURY_ACCOUNT = "treasury:mrwk"
 MICRO_UNITS = 1_000_000
 GENESIS_SUPPLY_MICRO = 100_000_000 * MICRO_UNITS
+SQLITE_INTEGER_MAX = 2**63 - 1
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 MRWK_AMOUNT_RE = re.compile(r"^-?\d+(?:\.\d+)?$")
@@ -420,6 +421,8 @@ def create_bounty(
         raise LedgerError("max_awards is too large")
     reserved = reward * max_awards
     clean_repo = _normalize_repo_name(repo)
+    if issue_number > SQLITE_INTEGER_MAX:
+        raise LedgerError("issue_number is too large")
     existing_bounty = find_bounty_by_issue(session, clean_repo, issue_number)
     if existing_bounty is not None:
         raise LedgerError("bounty already exists for issue")

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -134,6 +134,25 @@ def test_create_bounty_rejects_non_positive_issue_number(sqlite_url: str) -> Non
                 )
 
 
+def test_create_bounty_rejects_oversized_issue_number(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        issue_number = 2**63
+
+        with pytest.raises(LedgerError, match="issue_number is too large"):
+            create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=issue_number,
+                issue_url=f"https://github.com/ramimbo/mergework/issues/{issue_number}",
+                title="Oversized issue bounty",
+                reward_mrwk="1",
+                acceptance="Should not be created",
+            )
+
+
 def test_create_bounty_rejects_duplicate_repo_issue(sqlite_url: str) -> None:
     create_schema(sqlite_url)
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -238,11 +238,22 @@ def test_admin_bounty_api_rejects_fractional_integer_fields(
         headers={"x-mergework-admin-token": "admin-token-for-tests"},
         json={**payload, "max_awards": 1.5},
     )
+    oversized_issue = client.post(
+        "/api/v1/bounties",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json={
+            **payload,
+            "issue_number": 2**63,
+            "issue_url": f"https://github.com/ramimbo/mergework/issues/{2**63}",
+        },
+    )
 
     assert fractional_issue.status_code == 400
     assert fractional_issue.json()["detail"] == "issue_number must be an integer"
     assert fractional_awards.status_code == 400
     assert fractional_awards.json()["detail"] == "max_awards must be an integer"
+    assert oversized_issue.status_code == 400
+    assert oversized_issue.json()["detail"] == "issue_number is too large"
 
 
 def test_admin_payout_api_requires_admin_token_not_cookie_auth(


### PR DESCRIPTION
Bounty #292

## Summary
- reject oversized `issue_number` values at the `create_bounty()` service boundary before duplicate lookup binds them into SQLite
- surface the same controlled validation error through the admin bounty creation API
- add regression coverage for direct service usage and API usage

## Repro before fix
Creating a bounty with `issue_number = 2**63` passed the positive-number check, then `find_bounty_by_issue()` attempted to bind it into the `Bounty.issue_number == issue_number` query and raised `OverflowError: Python int too large to convert to SQLite INTEGER`.

## Validation
- `.venv/bin/python -m pytest tests/test_ledger.py::test_create_bounty_rejects_oversized_issue_number tests/test_security.py::test_admin_bounty_api_rejects_fractional_integer_fields -q` -> 2 passed
- `.venv/bin/python -m pytest tests/test_ledger.py tests/test_security.py -q` -> 68 passed
- `.venv/bin/python -m pytest -q` -> 244 passed, 2 warnings
- `.venv/bin/python -m ruff format --check .` -> 37 files already formatted
- `.venv/bin/python -m ruff check .` -> all checks passed
- `.venv/bin/python -m mypy app` -> success
- `git diff --check` -> clean

No secrets, wallet material, deployment credentials, private vulnerability details, payout details, or MRWK price claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent bounty creation with excessively large issue numbers. When an issue number exceeds the system's maximum integer limit, the request is now rejected with a descriptive error message, preventing potential database issues and improving data integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->