### PR TITLE
[codex] Match reconciliation proofs by source URL

### DIFF
--- a/app/ledger/reconciliation.py
+++ b/app/ledger/reconciliation.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal
 from urllib.parse import urlsplit, urlunsplit
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 
 from app.ledger.service import format_mrwk
@@ -166,11 +167,16 @@ def _payout_evidence(
 ) -> tuple[PayoutEvidence, ...]:
     proofs = session.scalars(
         select(Proof)
-        .where(Proof.submission_id == submission.id, Proof.kind == "bounty_payment")
+        .where(
+            Proof.kind == "bounty_payment",
+            or_(Proof.submission_id == submission.id, Proof.bounty_id == bounty.id),
+        )
         .order_by(Proof.created_at, Proof.hash)
     ).all()
     evidence: list[PayoutEvidence] = []
     for proof in proofs:
+        if not _matches_submission_source(proof, submission, bounty):
+            continue
         entry = session.get(LedgerEntry, proof.ledger_sequence)
         evidence.append(
             PayoutEvidence(
@@ -184,6 +190,24 @@ def _payout_evidence(
             )
         )
     return tuple(evidence)
+
+
+def _matches_submission_source(proof: Proof, submission: Submission, bounty: Bounty) -> bool:
+    if proof.submission_id == submission.id:
+        return True
+    if proof.submission_id is not None:
+        return False
+    if proof.bounty_id != bounty.id:
+        return False
+    try:
+        data = json.loads(proof.public_json)
+    except ValueError:
+        return False
+    return (
+        isinstance(data, dict)
+        and data.get("kind") == "bounty_payment"
+        and data.get("submission_url") == submission.url
+    )
 
 
 def _matches_submission(

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -480,6 +480,198 @@ def test_reconcile_accepted_payouts_reports_missing_payment(sqlite_url: str) -> 
         assert checks[0].evidence == ()
 
 
+def test_reconcile_accepted_payouts_matches_legacy_proof_source_url(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=38,
+            issue_url="https://github.com/ramimbo/mergework/issues/38",
+            title="Reconcile legacy source proofs",
+            reward_mrwk="12",
+            acceptance="Maintainer applies mrwk:accepted.",
+        )
+        submission = Submission(
+            bounty_id=bounty.id,
+            submitter_account="github:dora",
+            url="https://github.com/ramimbo/mergework/pull/38",
+            status="accepted",
+            verifier_result=canonical_json({"label": "mrwk:accepted"}),
+        )
+        session.add(submission)
+        session.flush()
+        entry = add_ledger_entry(
+            session,
+            entry_type="bounty_payment",
+            from_account=reserve_account_for_bounty(bounty.id),
+            to_account="github:dora",
+            amount_microunits=bounty.reward_microunits,
+            reference=submission.url,
+        )
+        session.add(
+            Proof(
+                hash="a" * 64,
+                ledger_sequence=entry.sequence,
+                bounty_id=bounty.id,
+                submission_id=None,
+                kind="bounty_payment",
+                public_json=canonical_json(
+                    {
+                        "kind": "bounty_payment",
+                        "bounty_id": bounty.id,
+                        "submission_url": submission.url,
+                    }
+                ),
+            )
+        )
+        session.flush()
+
+        checks = reconcile_accepted_payouts(session)
+        summary = payout_reconciliation_summary(checks)
+
+        assert summary["paid"] == 1
+        assert summary["missing_payment"] == 0
+        assert checks[0].status == "paid"
+        assert checks[0].evidence[0].proof_hash == "a" * 64
+        assert checks[0].evidence[0].matches_submission is True
+
+
+def test_reconcile_accepted_payouts_reports_legacy_source_mismatch(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=39,
+            issue_url="https://github.com/ramimbo/mergework/issues/39",
+            title="Reconcile mismatched legacy proof",
+            reward_mrwk="12",
+            acceptance="Maintainer applies mrwk:accepted.",
+        )
+        submission = Submission(
+            bounty_id=bounty.id,
+            submitter_account="github:erin",
+            url="https://github.com/ramimbo/mergework/pull/39",
+            status="accepted",
+            verifier_result=canonical_json({"label": "mrwk:accepted"}),
+        )
+        session.add(submission)
+        session.flush()
+        entry = add_ledger_entry(
+            session,
+            entry_type="bounty_payment",
+            from_account=reserve_account_for_bounty(bounty.id),
+            to_account="github:mallory",
+            amount_microunits=bounty.reward_microunits,
+            reference=submission.url,
+        )
+        session.add(
+            Proof(
+                hash="b" * 64,
+                ledger_sequence=entry.sequence,
+                bounty_id=bounty.id,
+                submission_id=None,
+                kind="bounty_payment",
+                public_json=canonical_json(
+                    {
+                        "kind": "bounty_payment",
+                        "bounty_id": bounty.id,
+                        "submission_url": submission.url,
+                    }
+                ),
+            )
+        )
+        session.flush()
+
+        checks = reconcile_accepted_payouts(session)
+        summary = payout_reconciliation_summary(checks)
+
+        assert summary["mismatched_payment_evidence"] == 1
+        assert checks[0].status == "mismatched_payment_evidence"
+        assert checks[0].evidence[0].proof_hash == "b" * 64
+        assert checks[0].evidence[0].matches_submission is False
+
+
+def test_reconcile_accepted_payouts_rejects_wrong_explicit_submission_link(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=40,
+            issue_url="https://github.com/ramimbo/mergework/issues/40",
+            title="Reconcile explicit proof links",
+            reward_mrwk="12",
+            max_awards=2,
+            acceptance="Maintainer applies mrwk:accepted.",
+        )
+        first_submission = Submission(
+            bounty_id=bounty.id,
+            submitter_account="github:fran",
+            url="https://github.com/ramimbo/mergework/pull/40",
+            status="accepted",
+            verifier_result=canonical_json({"label": "mrwk:accepted"}),
+        )
+        second_submission = Submission(
+            bounty_id=bounty.id,
+            submitter_account="github:gabe",
+            url="https://github.com/ramimbo/mergework/pull/41",
+            status="accepted",
+            verifier_result=canonical_json({"label": "mrwk:accepted"}),
+        )
+        session.add_all([first_submission, second_submission])
+        session.flush()
+        entry = add_ledger_entry(
+            session,
+            entry_type="bounty_payment",
+            from_account=reserve_account_for_bounty(bounty.id),
+            to_account=first_submission.submitter_account,
+            amount_microunits=bounty.reward_microunits,
+            reference=first_submission.url,
+        )
+        session.add(
+            Proof(
+                hash="c" * 64,
+                ledger_sequence=entry.sequence,
+                bounty_id=bounty.id,
+                submission_id=second_submission.id,
+                kind="bounty_payment",
+                public_json=canonical_json(
+                    {
+                        "kind": "bounty_payment",
+                        "bounty_id": bounty.id,
+                        "submission_url": first_submission.url,
+                    }
+                ),
+            )
+        )
+        session.flush()
+
+        checks = reconcile_accepted_payouts(session)
+        checks_by_url = {check.submission_url: check for check in checks}
+
+        first_check = checks_by_url[first_submission.url]
+        assert first_check.status == "missing_payment"
+        assert first_check.evidence == ()
+        second_check = checks_by_url[second_submission.url]
+        assert second_check.status == "mismatched_payment_evidence"
+        assert second_check.evidence[0].proof_hash == "c" * 64
+        assert second_check.evidence[0].matches_submission is False
+
+
 def test_reconcile_accepted_payouts_reports_duplicate_payment_evidence(
     sqlite_url: str,
 ) -> None:


### PR DESCRIPTION
Bounty #281

## Summary
- let payout reconciliation match bounty-payment proofs by public `submission_url` when legacy or repaired proof rows do not have `submission_id` populated
- keep exact `submission_id` matching first, then source-URL matching within the same bounty
- add tests for two reconciliation failure modes: legacy proof evidence that should count as paid, and legacy proof evidence that should be flagged as mismatched

## Maintainer Reconciliation Impact
Accepted work can otherwise appear unpaid when the payment proof exists but the proof row is missing a direct `submission_id` link. Matching same-bounty proof evidence by `submission_url` makes source URL reconciliation more robust while still checking ledger type, reference, recipient, and amount before reporting the row as paid.

## Validation
- `.venv/bin/python -m pytest tests/test_ledger.py::test_reconcile_accepted_payouts_reports_missing_payment tests/test_ledger.py::test_reconcile_accepted_payouts_matches_legacy_proof_source_url tests/test_ledger.py::test_reconcile_accepted_payouts_reports_legacy_source_mismatch tests/test_ledger.py::test_reconcile_accepted_payouts_reports_duplicate_payment_evidence -q` -> 4 passed
- `.venv/bin/python -m pytest tests/test_ledger.py -q` -> 22 passed
- `.venv/bin/python -m pytest -q` -> 245 passed, 2 warnings
- `.venv/bin/python -m ruff format --check .` -> 37 files already formatted
- `.venv/bin/python -m ruff check .` -> all checks passed
- `.venv/bin/python -m mypy app` -> success
- `git diff --check` -> clean

No secrets, wallet material, deployment credentials, private vulnerability details, payout details, or MRWK price claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened payout reconciliation to consider evidence tied to either the submission or the bounty, including legacy proofs lacking a direct submission reference.
  * Added additional source verification that parses legacy evidence and flags mismatched payment evidence.

* **Tests**
  * Added tests covering legacy proof scenarios: matching legacy evidence by URL and reporting mismatched legacy evidence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->