### PR TITLE
[codex] Bound reserve account bounty ids

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -81,6 +81,7 @@ API_DOCS_CSP = (
     "worker-src 'self' blob:"
 )
 API_DOCS_PATHS = {"/api/docs", "/api/redoc"}
+SQLITE_INTEGER_MAX = 2**63 - 1
 
 
 def _request_was_forwarded_https(request: Request) -> bool:
@@ -451,9 +452,15 @@ def _normalized_account(account: str) -> str:
                 status_code=400, detail="reserve account must use reserve:bounty:<id>"
             )
         bounty_id = lower.removeprefix(reserve_prefix)
-        if not bounty_id.isdigit() or int(bounty_id) <= 0:
+        try:
+            normalized_bounty_id = int(bounty_id) if bounty_id.isdigit() else 0
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="reserve bounty id is too large") from exc
+        if normalized_bounty_id <= 0:
             raise HTTPException(status_code=400, detail="reserve bounty id must be positive")
-        return f"{reserve_prefix}{int(bounty_id)}"
+        if normalized_bounty_id > SQLITE_INTEGER_MAX:
+            raise HTTPException(status_code=400, detail="reserve bounty id is too large")
+        return f"{reserve_prefix}{normalized_bounty_id}"
     if lower.startswith("mrwk1"):
         return clean.lower()
     if lower.startswith("github:"):

--- a/tests/test_account_validation.py
+++ b/tests/test_account_validation.py
@@ -202,6 +202,7 @@ def test_account_views_accept_valid_reserve_bounty_account(sqlite_url: str) -> N
         "reserve:bounty:0",
         "reserve:bounty:-1",
         "reserve:bounty:not-a-number",
+        "reserve:bounty:" + "9" * 5000,
     ],
 )
 def test_account_views_reject_malformed_reserve_accounts(sqlite_url: str, account: str) -> None:


### PR DESCRIPTION
Bounty #292

## Summary
- handle oversized `reserve:bounty:<id>` account paths before Python integer conversion can raise
- reject reserve bounty ids above SQLite's integer range with a controlled 400 response
- cover the account API, account page, and MCP `get_balance` paths through the existing malformed reserve-account test matrix

## Repro before fix
`GET /api/v1/accounts/reserve:bounty:<5000 digit number>` raised `ValueError: Exceeds the limit (4300 digits) for integer string conversion` inside `_normalized_account()` instead of returning a controlled 400 response.

## Validation
- `.venv/bin/python -m pytest tests/test_account_validation.py::test_account_views_reject_malformed_reserve_accounts -q` -> 7 passed
- `.venv/bin/python -m pytest tests/test_account_validation.py -q` -> 21 passed
- `.venv/bin/python -m pytest -q` -> 244 passed, 2 warnings
- `.venv/bin/python -m ruff format --check .` -> 37 files already formatted
- `.venv/bin/python -m ruff check .` -> all checks passed
- `.venv/bin/python -m mypy app` -> success
- `git diff --check` -> clean

No secrets, wallet material, deployment credentials, private vulnerability details, payout details, or MRWK price claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for reserve bounty account identifiers to properly reject oversized numeric values and return consistent error messages.

* **Tests**
  * Added test coverage for edge cases with extremely large bounty identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->