### PR TITLE
Expose account accepted work list API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -875,6 +875,16 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 "transfer_status": transfer_status,
             }
 
+    @app.get("/api/v1/accounts/{account}/accepted-work")
+    def api_account_accepted_work(account: str) -> dict[str, Any]:
+        account = _normalized_account(account)
+        with session_scope(db_url) as session:
+            return {
+                "account": account,
+                "summary": account_accepted_summary(session, account),
+                "accepted_work": accepted_work_for_account(session, account),
+            }
+
     @app.get("/api/v1/auth/me")
     def api_auth_me(request: Request) -> dict[str, Any]:
         login = github_login_from_request(request)

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -193,6 +193,46 @@ For `treasury:` and `reserve:` accounts, `github_login` is `null` and
 `transfer_status` explains that direct MRWK wallet transfers are only available
 for registered `mrwk1` addresses.
 
+Read the proof-backed accepted-work list for a single account:
+
+```bash
+curl -s "$API_HOST/api/v1/accounts/github:tatelyman/accepted-work"
+```
+
+The response includes the account summary plus the same accepted-work rows used
+by the public account page, so agents can inspect recent proof, ledger,
+submission, source issue, and maintainer acceptance details without scraping
+HTML:
+
+```json
+{
+  "account": "github:tatelyman",
+  "summary": {
+    "accepted_awards": 2,
+    "accepted_mrwk": "140",
+    "latest_ledger_sequence": 401,
+    "latest_submission_url": "https://github.com/ramimbo/mergework/pull/189",
+    "latest_proof_hash": "507413ce756056804e80d6782641222fda1444e8d541992d27b4ddd418792d68",
+    "latest_proof_url": "/proofs/507413ce756056804e80d6782641222fda1444e8d541992d27b4ddd418792d68"
+  },
+  "accepted_work": [
+    {
+      "ledger_sequence": 401,
+      "ledger_url": "/ledger/401",
+      "proof_hash": "507413ce756056804e80d6782641222fda1444e8d541992d27b4ddd418792d68",
+      "proof_url": "/proofs/507413ce756056804e80d6782641222fda1444e8d541992d27b4ddd418792d68",
+      "amount_mrwk": "100",
+      "submission_url": "https://github.com/ramimbo/mergework/pull/189",
+      "issue_url": "https://github.com/ramimbo/mergework/issues/291",
+      "repo": "ramimbo/mergework",
+      "issue_number": 291,
+      "accepted_by": "maintainer",
+      "created_at": "2026-05-25T20:12:59.000000"
+    }
+  ]
+}
+```
+
 Register a wallet public key. Keep the private key local; only send the public
 key to MergeWork.
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -845,6 +845,7 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     entry = client.get("/ledger/3").text
     proof_page = client.get(f"/proofs/{proof.hash}").text
     account_api = client.get("/api/v1/accounts/github:alice").json()
+    accepted_work_api = client.get("/api/v1/accounts/github:alice/accepted-work").json()
     account = client.get("/accounts/github:alice").text
 
     assert "/ledger/3" in ledger
@@ -863,6 +864,31 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     assert account_api["transfer_status"] == (
         "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
     )
+    assert accepted_work_api["account"] == "github:alice"
+    assert accepted_work_api["summary"] == {
+        "accepted_awards": 1,
+        "accepted_mrwk": "25",
+        "latest_ledger_sequence": 3,
+        "latest_submission_url": "https://github.com/ramimbo/mergework/pull/3",
+        "latest_proof_hash": proof.hash,
+        "latest_proof_url": f"/proofs/{proof.hash}",
+    }
+    accepted_work = accepted_work_api["accepted_work"]
+    assert len(accepted_work) == 1
+    assert accepted_work[0]["created_at"]
+    assert accepted_work[0] | {"created_at": "<checked>"} == {
+        "ledger_sequence": 3,
+        "ledger_url": "/ledger/3",
+        "proof_hash": proof.hash,
+        "proof_url": f"/proofs/{proof.hash}",
+        "amount_mrwk": "25",
+        "submission_url": "https://github.com/ramimbo/mergework/pull/3",
+        "issue_url": "https://github.com/ramimbo/mergework/issues/2",
+        "repo": "ramimbo/mergework",
+        "issue_number": 2,
+        "accepted_by": "maintainer",
+        "created_at": "<checked>",
+    }
     assert "Claim GitHub balances from /me" in account
     assert 'href="https://github.com/alice">@alice</a>' in account
     assert "Accepted work summary" in account


### PR DESCRIPTION
Refs #298

## Summary

- Adds `GET /api/v1/accounts/{account}/accepted-work` so agents and contributors can fetch the proof-backed accepted-work list for one ledger account without scraping the HTML account page.
- Response includes the existing accepted-work summary plus the existing account-page accepted-work rows: ledger/proof links, amount, submission URL, source issue metadata, maintainer acceptance, and timestamp.
- Documents the new endpoint in `docs/api-examples.md` and extends account explorer regression coverage.

## Contributor Discovery Impact

The account page already exposes detailed accepted-work cards, while `/api/v1/activity` exposes global recent activity. This closes the account-specific API gap: external dashboards and agents can drill into one contributor's accepted work directly from the public API.

## Validation

- `uv run pytest tests/test_api_mcp.py tests/test_docs_public_urls.py -q` -> 60 passed, 1 existing httpx warning.
- `uv run ruff check app/main.py tests/test_api_mcp.py` -> passed.
- `uv run ruff format --check app/main.py tests/test_api_mcp.py` -> passed.
- `uv run mypy app` -> passed.
- `uv run python scripts/docs_smoke.py` -> passed.
- `uv run python scripts/check_agents.py` -> passed.
- `git diff --check` -> passed.

No secrets, wallet material, deployment credentials, private vulnerability details, payout details, or MRWK price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new REST API endpoint to retrieve accepted work entries for a specific account, including acceptance summary and detailed work item information.

* **Documentation**
  * Added comprehensive API documentation with curl examples and sample JSON responses for the new accepted-work endpoint.

* **Tests**
  * Updated test suite to validate the new API endpoint returns correct account data, acceptance summaries, and work item details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->