### PR TITLE
Clear private key after GitHub wallet actions

### DIFF
--- a/app/static/wallet.js
+++ b/app/static/wallet.js
@@ -252,10 +252,11 @@ function setupGithubActions() {
           body: JSON.stringify({address, nonce, signature_hex: signature}),
         });
         setText(resultSelector, result);
-        clearPrivateKeyField(form);
         await getNextNonce(address, statusSelector);
       } catch (error) {
         setText(resultSelector, error.message);
+      } finally {
+        clearPrivateKeyField(form);
       }
     });
   }

--- a/app/static/wallet.js
+++ b/app/static/wallet.js
@@ -215,6 +215,13 @@ function setupTransfer() {
   });
 }
 
+function clearPrivateKeyField(form) {
+  const privateKeyField = form.querySelector('[name="private_key_hex"]');
+  if (privateKeyField) {
+    privateKeyField.value = "";
+  }
+}
+
 function setupGithubActions() {
   const root = document.querySelector("[data-github-tool]");
   if (!root) {
@@ -245,6 +252,7 @@ function setupGithubActions() {
           body: JSON.stringify({address, nonce, signature_hex: signature}),
         });
         setText(resultSelector, result);
+        clearPrivateKeyField(form);
         await getNextNonce(address, statusSelector);
       } catch (error) {
         setText(resultSelector, error.message);

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -553,20 +553,30 @@ def test_wallet_pages_do_not_require_manual_nonce(sqlite_url: str, monkeypatch) 
     assert "Clear this field after use. Never share your private key." in me
 
 
-def test_github_wallet_actions_clear_private_key_after_success() -> None:
+def test_github_wallet_actions_clear_private_key_after_submit_attempt() -> None:
     wallet_js = Path("app/static/wallet.js").read_text(encoding="utf-8")
     set_result = "setText(resultSelector, result);"
+    set_error = "setText(resultSelector, error.message);"
+    finally_block = "} finally {"
     clear_private_key = "clearPrivateKeyField(form);"
     refresh_nonce = "await getNextNonce(address, statusSelector);"
 
     assert "function clearPrivateKeyField(form)" in wallet_js
     assert 'for (const action of ["link-github", "claim-github"])' in wallet_js
     idx_set_result = wallet_js.find(set_result)
-    idx_clear_private_key = wallet_js.find(clear_private_key, idx_set_result)
-    idx_refresh_nonce = wallet_js.find(refresh_nonce, idx_clear_private_key)
+    idx_refresh_nonce = wallet_js.find(refresh_nonce, idx_set_result)
+    idx_set_error = wallet_js.find(set_error, idx_refresh_nonce)
+    idx_finally = wallet_js.find(finally_block, idx_set_error)
+    idx_clear_private_key = wallet_js.find(clear_private_key, idx_finally)
 
-    assert -1 not in {idx_set_result, idx_clear_private_key, idx_refresh_nonce}
-    assert idx_set_result < idx_clear_private_key < idx_refresh_nonce
+    assert -1 not in {
+        idx_set_result,
+        idx_refresh_nonce,
+        idx_set_error,
+        idx_finally,
+        idx_clear_private_key,
+    }
+    assert idx_set_result < idx_refresh_nonce < idx_set_error < idx_finally < idx_clear_private_key
 
 
 def test_reject_self_transfer(sqlite_url: str) -> None:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -555,14 +555,18 @@ def test_wallet_pages_do_not_require_manual_nonce(sqlite_url: str, monkeypatch) 
 
 def test_github_wallet_actions_clear_private_key_after_success() -> None:
     wallet_js = Path("app/static/wallet.js").read_text(encoding="utf-8")
+    set_result = "setText(resultSelector, result);"
+    clear_private_key = "clearPrivateKeyField(form);"
+    refresh_nonce = "await getNextNonce(address, statusSelector);"
 
     assert "function clearPrivateKeyField(form)" in wallet_js
     assert 'for (const action of ["link-github", "claim-github"])' in wallet_js
-    assert (
-        "setText(resultSelector, result);\n"
-        "        clearPrivateKeyField(form);\n"
-        "        await getNextNonce(address, statusSelector);"
-    ) in wallet_js
+    idx_set_result = wallet_js.find(set_result)
+    idx_clear_private_key = wallet_js.find(clear_private_key, idx_set_result)
+    idx_refresh_nonce = wallet_js.find(refresh_nonce, idx_clear_private_key)
+
+    assert -1 not in {idx_set_result, idx_clear_private_key, idx_refresh_nonce}
+    assert idx_set_result < idx_clear_private_key < idx_refresh_nonce
 
 
 def test_reject_self_transfer(sqlite_url: str) -> None:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -550,6 +551,18 @@ def test_wallet_pages_do_not_require_manual_nonce(sqlite_url: str, monkeypatch) 
     assert me.count('name="private_key_hex" rows="5" autocomplete="off"') == 2
     assert "Clear this field after use. Never share your private key." in transfer
     assert "Clear this field after use. Never share your private key." in me
+
+
+def test_github_wallet_actions_clear_private_key_after_success() -> None:
+    wallet_js = Path("app/static/wallet.js").read_text(encoding="utf-8")
+
+    assert "function clearPrivateKeyField(form)" in wallet_js
+    assert 'for (const action of ["link-github", "claim-github"])' in wallet_js
+    assert (
+        "setText(resultSelector, result);\n"
+        "        clearPrivateKeyField(form);\n"
+        "        await getNextNonce(address, statusSelector);"
+    ) in wallet_js
 
 
 def test_reject_self_transfer(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #282

## Summary
- clear the `/me` private key textarea after a successful GitHub wallet link or GitHub-balance claim
- keep the existing result display and nonce refresh behavior
- add a focused regression test for the shared link/claim handler

## Why
I ran into this while using the claim flow: after the request succeeded, the page showed the result but left the private key sitting in the form, even though the page asks people to clear it after use. Clearing it on success makes that flow a little less easy to mess up.

## Verification
- `.\.venv\Scripts\python -m pytest tests/test_wallet_api.py tests/test_wallets.py -q`
- `.\.venv\Scripts\python -m ruff check tests/test_wallet_api.py`
- `.\.venv\Scripts\python -m ruff format --check tests/test_wallet_api.py`
- `git diff --check`

No private keys, wallet material, payout details, deployment values, private vulnerability details, or MRWK price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Private key input now clears automatically after GitHub wallet form submission attempts, ensuring sensitive data is removed regardless of success or failure.

* **Tests**
  * Added test coverage to verify the private key field is cleared after GitHub wallet submission attempts and that UI update ordering is preserved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->