### PR TITLE
Expose duplicate admin payout proof links

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -44,8 +44,9 @@ from app.ledger.service import (
     resolve_payout_account,
     submit_github_claim,
     submit_wallet_transfer,
+    validate_public_url,
 )
-from app.models import Account, Bounty, LedgerEntry, Proof, Wallet, WalletTransfer
+from app.models import Account, Bounty, LedgerEntry, Proof, Submission, Wallet, WalletTransfer
 from app.wallets import WalletError, normalize_wallet_address
 from app.webhooks.github import handle_github_webhook
 
@@ -168,6 +169,40 @@ def bounty_awards_to_dict(session: Session, bounty_id: int) -> list[dict[str, An
             }
         )
     return awards
+
+
+def _payout_response_from_proof(proof: Proof, *, status: str) -> dict[str, Any]:
+    data = json.loads(proof.public_json)
+    if not isinstance(data, dict) or data.get("kind") != "bounty_payment":
+        raise HTTPException(status_code=500, detail="invalid proof payload")
+    return {
+        "status": status,
+        "bounty_id": proof.bounty_id,
+        "to_account": data.get("to_account"),
+        "submission_id": proof.submission_id,
+        "submission_url": data.get("submission_url"),
+        "ledger_sequence": proof.ledger_sequence,
+        "ledger_url": f"/ledger/{proof.ledger_sequence}",
+        "proof_hash": proof.hash,
+        "proof_url": f"/proofs/{proof.hash}",
+    }
+
+
+def _existing_payout_proof_for_submission(
+    session: Session, bounty_id: int, submission_url: str
+) -> Proof | None:
+    submission = session.scalar(
+        select(Submission)
+        .where(Submission.bounty_id == bounty_id, Submission.url == submission_url)
+        .limit(1)
+    )
+    if submission is None:
+        return None
+    return session.scalar(
+        select(Proof)
+        .where(Proof.submission_id == submission.id, Proof.kind == "bounty_payment")
+        .limit(1)
+    )
 
 
 def bounty_list_summary(bounties: list[dict[str, Any]]) -> dict[str, Any]:
@@ -879,12 +914,13 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         bounty_id: int,
         request: Request,
         admin_login: str = Depends(require_admin_token),
-    ) -> dict[str, Any]:
+    ) -> Any:
         bounty_id = _positive_bounty_id(bounty_id)
         data = await _json_object(request)
         try:
             requested_account = _required_str(data, "to_account")
             submission_url = _required_str(data, "submission_url")
+            clean_submission_url = validate_public_url(submission_url)
         except HTTPException as exc:
             if str(exc.detail).endswith(" is required"):
                 field = str(exc.detail).removesuffix(" is required")
@@ -892,6 +928,8 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                     status_code=400, detail=f"missing required field: {field}"
                 ) from exc
             raise
+        except LedgerError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
         accepted_by = _optional_str(data, "accepted_by", admin_login) or admin_login
         verifier_result = {
             "source": "admin_api",
@@ -906,7 +944,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                     session,
                     bounty_id=bounty_id,
                     to_account=to_account,
-                    submission_url=submission_url,
+                    submission_url=clean_submission_url,
                     accepted_by=accepted_by,
                     verifier_result=verifier_result,
                 )
@@ -916,19 +954,28 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 bounty_state = bounty_to_dict(bounty)
                 proof_payload = json.loads(proof.public_json)
             except LedgerError as exc:
+                if str(exc) == "submission already paid":
+                    existing_proof = _existing_payout_proof_for_submission(
+                        session, bounty_id, clean_submission_url
+                    )
+                    if existing_proof is not None:
+                        return JSONResponse(
+                            status_code=409,
+                            content=_payout_response_from_proof(
+                                existing_proof, status="already_paid"
+                            ),
+                        )
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
-            return {
-                "status": "paid",
-                "bounty_id": bounty_id,
-                "bounty_status": bounty_state["status"],
-                "awards_paid": bounty_state["awards_paid"],
-                "awards_remaining": bounty_state["awards_remaining"],
-                "to_account": to_account,
-                "submission_url": proof_payload["submission_url"],
-                "proof_hash": proof.hash,
-                "proof_url": f"/proofs/{proof.hash}",
-                "ledger_sequence": proof.ledger_sequence,
-            }
+            payout_response = _payout_response_from_proof(proof, status="paid")
+            payout_response.update(
+                {
+                    "bounty_status": bounty_state["status"],
+                    "awards_paid": bounty_state["awards_paid"],
+                    "awards_remaining": bounty_state["awards_remaining"],
+                    "submission_url": proof_payload["submission_url"],
+                }
+            )
+            return payout_response
 
     @app.post("/api/v1/bounties/{bounty_id}/close")
     async def api_close_bounty(

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -61,6 +61,11 @@ curl -X POST https://api.mrwk.ltclab.site/api/v1/bounties/<id>/pay \
 ```
 
 `to_account` must be a registered `mrwk1...` wallet or `github:{login}`.
+Successful responses include `submission_id`, `ledger_sequence`, `ledger_url`,
+`proof_hash`, and `proof_url` so operators can reconcile the payment without
+scraping the ledger. If the same bounty/submission URL is paid twice, the API
+returns `409` with `status: "already_paid"` and the existing proof links instead
+of creating another ledger entry.
 
 Manual payout checklist:
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -299,11 +299,15 @@ def test_admin_payout_api_requires_admin_token_not_cookie_auth(
     assert cookie_only.status_code == 401
     assert token_auth.status_code == 200
     assert token_auth.json()["to_account"] == wallet_address
+    assert token_auth.json()["submission_id"] is not None
+    assert token_auth.json()["ledger_sequence"] is not None
+    assert token_auth.json()["ledger_url"].startswith("/ledger/")
+    assert token_auth.json()["proof_url"].startswith("/proofs/")
     with session_scope(sqlite_url) as session:
         assert get_balance(session, wallet_address) == 25_000_000
 
 
-def test_admin_payout_api_reports_award_state_and_blocks_duplicate_submission(
+def test_admin_payout_api_returns_existing_proof_for_duplicate_submission(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     create_schema(sqlite_url)
@@ -345,6 +349,8 @@ def test_admin_payout_api_reports_award_state_and_blocks_duplicate_submission(
     assert first_body["submission_url"] == "https://github.com/ramimbo/mergework/pull/283"
     assert first_body["proof_hash"]
     assert first_body["proof_url"] == f"/proofs/{first_body['proof_hash']}"
+    assert first_body["ledger_url"] == f"/ledger/{first_body['ledger_sequence']}"
+    assert first_body["submission_id"] is not None
     assert isinstance(first_body["ledger_sequence"], int)
 
     duplicate = client.post(
@@ -353,13 +359,21 @@ def test_admin_payout_api_reports_award_state_and_blocks_duplicate_submission(
         json={**first_payload, "to_account": "github:carol"},
     )
 
-    assert duplicate.status_code == 400
-    assert duplicate.json()["detail"] == "submission already paid"
+    assert duplicate.status_code == 409
+    assert duplicate.json()["status"] == "already_paid"
+    assert duplicate.json()["proof_hash"] == first_body["proof_hash"]
+    assert duplicate.json()["ledger_sequence"] == first_body["ledger_sequence"]
+    assert duplicate.json()["submission_id"] == first_body["submission_id"]
+    assert duplicate.json()["submission_url"] == first_body["submission_url"]
     with session_scope(sqlite_url) as session:
         bounty = session.get(Bounty, bounty_id)
+        payments = session.scalars(
+            select(LedgerEntry).where(LedgerEntry.entry_type == "bounty_payment")
+        ).all()
         assert bounty is not None
         assert bounty.awards_paid == 1
         assert bounty.status == "open"
+        assert len(payments) == 1
         assert get_balance(session, "github:alice") == 15_000_000
 
     final = client.post(


### PR DESCRIPTION
## Summary
- Return proof, ledger, and submission links from admin payout responses.
- Return a 409 already_paid response with the existing proof links when an admin retries the same bounty/submission URL, avoiding ambiguous duplicate-payment errors.
- Document the payout response and duplicate retry behavior in the admin runbook.

Refs #283

## Validation
- uv run pytest tests/test_security.py::test_admin_payout_api_requires_admin_token_not_cookie_auth tests/test_security.py::test_admin_payout_api_returns_existing_proof_for_duplicate_submission -q
- uv run pytest tests/test_security.py tests/test_api_mcp.py tests/test_ledger.py -q
- uv run pytest -q
- uv run ruff check app/main.py tests/test_security.py
- uv run ruff format --check app/main.py tests/test_security.py
- uv run mypy app
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payout endpoint validates submission URLs and returns clearer 400 errors for missing fields.
  * Successful payments return comprehensive proof and ledger details plus submission and bounty state.

* **Bug Fixes**
  * Duplicate payout submissions now return HTTP 409 with the existing proof/ledger details instead of creating a new payout.

* **Documentation**
  * Admin runbook updated with payout response format and idempotent duplicate behavior.

* **Tests**
  * Added/updated tests to verify duplicate submission handling and ledger/state consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->