### PR TITLE
Expose admin webhook event report

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -40,7 +40,7 @@ from app.ledger.service import (
     submit_github_claim,
     submit_wallet_transfer,
 )
-from app.models import Account, Bounty, LedgerEntry, Proof, Wallet, WalletTransfer
+from app.models import Account, Bounty, LedgerEntry, Proof, Wallet, WalletTransfer, WebhookEvent
 from app.wallets import WalletError, normalize_wallet_address
 from app.webhooks.github import handle_github_webhook
 
@@ -740,6 +740,36 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         status: str | None = Query(None), q: str | None = Query(None)
     ) -> list[dict[str, Any]]:
         return list_bounties_by_status(status, q)
+
+    @app.get("/api/v1/admin/webhook-events")
+    def api_admin_webhook_events(
+        status: str | None = Query(None),
+        limit: Annotated[int, Query(ge=1, le=200)] = 50,
+        admin_login: str = Depends(require_admin_token),
+    ) -> list[dict[str, Any]]:
+        del admin_login
+        normalized_status = status.strip().lower() if status is not None else None
+        if normalized_status == "":
+            normalized_status = None
+        with session_scope(db_url) as session:
+            query = select(WebhookEvent)
+            if normalized_status is not None:
+                query = query.where(func.lower(WebhookEvent.processed_status) == normalized_status)
+            events = session.scalars(
+                query.order_by(
+                    WebhookEvent.created_at.desc(), WebhookEvent.delivery_id.desc()
+                ).limit(limit)
+            ).all()
+            return [
+                {
+                    "delivery_id": event.delivery_id,
+                    "event_type": event.event_type,
+                    "processed_status": event.processed_status,
+                    "payload_hash": event.payload_hash,
+                    "created_at": event.created_at.isoformat(),
+                }
+                for event in events
+            ]
 
     @app.post("/api/v1/bounties")
     async def api_create_bounty(

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -74,6 +74,24 @@ Manual payout checklist:
 Do not apply `mrwk:accepted` to maintainer-authored bounty issues for payment;
 those issues require the manual payout path.
 
+### Webhook Outcome Inspection
+
+Use the admin-token webhook events API to inspect recent delivery outcomes before
+retrying labels or making manual payouts:
+
+```bash
+curl -s "https://api.mrwk.ltclab.site/api/v1/admin/webhook-events?status=missing_submitter" \
+  -H "x-mergework-admin-token: $MERGEWORK_ADMIN_TOKEN"
+```
+
+The response includes delivery ID, GitHub event type, payload hash, processed
+status, and timestamp. This is useful for confirming duplicate deliveries,
+missing submitters, exhausted bounties, and already-paid submissions without
+guessing from GitHub labels alone.
+Use `limit` to control the number of delivery rows returned (`1` to `200`,
+default `50`), for example:
+`/api/v1/admin/webhook-events?status=missing_submitter&limit=100`.
+
 ### Final Checks
 
 1. Confirm the webhook or admin API records one ledger payment for that award.

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -245,6 +245,71 @@ def test_admin_bounty_api_rejects_fractional_integer_fields(
     assert fractional_awards.json()["detail"] == "max_awards must be an integer"
 
 
+def test_admin_webhook_events_api_lists_and_filters_processing_outcomes(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    create_schema(sqlite_url)
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    with session_scope(sqlite_url) as session:
+        session.add(
+            WebhookEvent(
+                delivery_id="delivery-paid",
+                event_type="pull_request",
+                payload_hash="a" * 64,
+                processed_status="paid",
+            )
+        )
+        session.add(
+            WebhookEvent(
+                delivery_id="delivery-missing",
+                event_type="issues",
+                payload_hash="b" * 64,
+                processed_status="Missing_Submitter",
+            )
+        )
+
+    unauthenticated = client.get("/api/v1/admin/webhook-events")
+    all_events = client.get(
+        "/api/v1/admin/webhook-events",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+    filtered = client.get(
+        "/api/v1/admin/webhook-events?status= Missing_Submitter ",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+    limited = client.get(
+        "/api/v1/admin/webhook-events?limit=1",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+    too_large = client.get(
+        "/api/v1/admin/webhook-events?limit=201",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+
+    assert unauthenticated.status_code == 401
+    assert all_events.status_code == 200
+    all_by_delivery = {event["delivery_id"]: event for event in all_events.json()}
+    assert set(all_by_delivery) == {"delivery-paid", "delivery-missing"}
+    assert all_by_delivery["delivery-paid"]["payload_hash"] == "a" * 64
+    assert filtered.status_code == 200
+    assert filtered.json() == [
+        {
+            "delivery_id": "delivery-missing",
+            "event_type": "issues",
+            "processed_status": "Missing_Submitter",
+            "payload_hash": "b" * 64,
+            "created_at": filtered.json()[0]["created_at"],
+        }
+    ]
+    assert limited.status_code == 200
+    assert len(limited.json()) == 1
+    assert too_large.status_code == 422
+
+
 def test_admin_payout_api_requires_admin_token_not_cookie_auth(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Add an admin-token endpoint for recent webhook delivery outcomes.
- Support optional processed-status filtering and bounded result limits.
- Document the workflow so maintainers can inspect duplicate, missing-submitter, exhausted, and already-paid outcomes before retrying labels or making manual payouts.

Refs #283

## Validation
- uv run pytest tests/test_security.py::test_admin_webhook_events_api_lists_and_filters_processing_outcomes -q
- uv run pytest tests/test_security.py tests/test_webhooks.py -q
- uv run pytest tests/test_api_mcp.py tests/test_docs_public_urls.py -q
- uv run pytest -q
- uv run ruff check app/main.py tests/test_security.py
- uv run ruff format --check app/main.py tests/test_security.py
- uv run mypy app
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-only API to list and filter webhook events (includes delivery ID, event type, processed status, payload hash, and timestamp), with filtering by status and adjustable result limits.

* **Documentation**
  * Added runbook guidance for inspecting webhook outcomes and using the new endpoint to diagnose delivery issues.

* **Tests**
  * Added security and behavior tests covering authentication, filtering, pagination, and response shape.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->