### PR TITLE
Add public bounty summary API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -870,6 +870,12 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     ) -> list[dict[str, Any]]:
         return list_bounties_by_status(status, q)
 
+    @app.get("/api/v1/bounties/summary")
+    def api_bounties_summary(
+        status: str | None = Query(None), q: str | None = Query(None)
+    ) -> dict[str, Any]:
+        return bounty_list_summary(list_bounties_by_status(status, q))
+
     @app.get("/api/v1/admin/webhook-events")
     def api_admin_webhook_events(
         status: str | None = Query(None),

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -15,6 +15,7 @@ Check service status and list bounties:
 curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
 curl -s "$API_HOST/api/v1/bounties?status=open"
+curl -s "$API_HOST/api/v1/bounties/summary?status=open&q=proof"
 ```
 
 The bounties list returns public bounty rows. `status` can be omitted or set to
@@ -43,6 +44,17 @@ Use `id` for the single-bounty API path. Use `issue_number` and `issue_url` when
 linking back to the source GitHub issue. Award counters can change as accepted
 work is paid; refresh concrete examples against the live API before relying on
 available slot counts.
+
+Use `/api/v1/bounties/summary` with the same optional `status` and `q`
+filters when an agent only needs capacity totals instead of full bounty rows:
+
+```json
+{
+  "bounties_shown": 1,
+  "open_awards": 2,
+  "open_pool_mrwk": "50"
+}
+```
 
 Read a single bounty with its internal `id` from `/api/v1/bounties`:
 

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -73,6 +73,59 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert 'href="/bounties?status=paid" aria-current="page"' in paid_rows_uppercase.text
 
 
+def test_bounties_summary_api_matches_public_list_filters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        open_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=62,
+            issue_url="https://github.com/ramimbo/mergework/issues/62",
+            title="Open discovery bounty",
+            reward_mrwk="25",
+            max_awards=3,
+            acceptance="Discovery summary should show remaining public award slots.",
+        )
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=63,
+            issue_url="https://github.com/ramimbo/mergework/issues/63",
+            title="Docs cleanup bounty",
+            reward_mrwk="40",
+            acceptance="Docs cleanup.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=open_bounty.id,
+            to_account="github:contributor",
+            submission_url="https://github.com/ramimbo/mergework/pull/62",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    summary = client.get("/api/v1/bounties/summary?q=discovery").json()
+    assert summary == {
+        "bounties_shown": 1,
+        "open_awards": 2,
+        "open_pool_mrwk": "50",
+    }
+
+    paid_summary = client.get("/api/v1/bounties/summary?status=paid&q=discovery").json()
+    assert paid_summary == {
+        "bounties_shown": 0,
+        "open_awards": 0,
+        "open_pool_mrwk": "0",
+    }
+
+    invalid = client.get("/api/v1/bounties/summary?status=bogus")
+    assert invalid.status_code == 400
+    assert invalid.json()["detail"] == "status must be one of: open, paid, closed"
+
+
 def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -86,6 +86,7 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 
     assert "/api/v1/bounties?status=open" in examples
+    assert "/api/v1/bounties/summary?status=open&q=proof" in examples
     assert "status` can be omitted or set to" in examples
     assert '"id": 36' in examples
     assert '"repo": "ramimbo/mergework"' in examples
@@ -95,7 +96,11 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert '"reserved_mrwk": "500"' in examples
     assert '"awards_paid": 4' in examples
     assert '"awards_remaining": 1' in examples
+    assert '"bounties_shown": 1' in examples
+    assert '"open_awards": 2' in examples
+    assert '"open_pool_mrwk": "50"' in examples
     assert "Award counters can change" in examples
+    assert "capacity totals instead of full bounty rows" in examples
     assert "Use `id` for the single-bounty API path" in examples
 
 


### PR DESCRIPTION
Refs #298

Adds `GET /api/v1/bounties/summary` so contributors and agents can check capacity totals without fetching and reducing the full bounty list. The endpoint uses the same optional `status` and `q` filters as `/api/v1/bounties` and the public `/bounties` page summary.

What changed:
- Added a public bounty summary API returning `bounties_shown`, `open_awards`, and `open_pool_mrwk`.
- Reused the existing list filter path so status/search behavior stays aligned with the bounty list.
- Documented the summary endpoint in public API examples.
- Added regression coverage for filtered capacity totals and invalid status handling.

Validation:
- `uv run pytest tests/test_bounty_pages.py::test_bounties_summary_api_matches_public_list_filters tests/test_docs_public_urls.py::test_api_examples_document_bounty_list_response_shape -q` -> 2 passed.
- `uv run pytest tests/test_bounty_pages.py tests/test_docs_public_urls.py tests/test_api_mcp.py -q` -> 86 passed, one existing httpx deprecation warning.
- `uv run ruff check app/main.py tests/test_bounty_pages.py tests/test_docs_public_urls.py` -> passed.
- `uv run ruff format --check app/main.py tests/test_bounty_pages.py tests/test_docs_public_urls.py` -> passed.
- `uv run mypy app` -> passed.
- `git diff --check` -> passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new bounty summary API endpoint that retrieves aggregated bounty capacity totals with optional filtering by status and search queries.

* **Documentation**
  * Added API documentation and examples for the new summary endpoint, including filtered query examples and detailed response structure information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->