### PR TITLE
[codex] Reject oversized API integer strings

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -693,7 +693,12 @@ def _parse_int(value: Any, field: str) -> int:
     if isinstance(value, str):
         clean = value.strip()
         if clean and clean.lstrip("+-").isdigit():
-            return int(clean)
+            try:
+                return int(clean)
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=400, detail=f"{field} must be an integer"
+                ) from exc
     raise HTTPException(status_code=400, detail=f"{field} must be an integer")
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -239,7 +239,7 @@ def test_admin_bounty_api_rejects_fractional_integer_fields(
         headers={"x-mergework-admin-token": "admin-token-for-tests"},
         json={**payload, "max_awards": 1.5},
     )
-    oversized_issue = client.post(
+    oversized_integer_issue = client.post(
         "/api/v1/bounties",
         headers={"x-mergework-admin-token": "admin-token-for-tests"},
         json={
@@ -248,13 +248,27 @@ def test_admin_bounty_api_rejects_fractional_integer_fields(
             "issue_url": f"https://github.com/ramimbo/mergework/issues/{2**63}",
         },
     )
+    oversized_string_issue = client.post(
+        "/api/v1/bounties",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json={**payload, "issue_number": "9" * 5000},
+    )
+    oversized_string_awards = client.post(
+        "/api/v1/bounties",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json={**payload, "max_awards": "9" * 5000},
+    )
 
     assert fractional_issue.status_code == 400
     assert fractional_issue.json()["detail"] == "issue_number must be an integer"
     assert fractional_awards.status_code == 400
     assert fractional_awards.json()["detail"] == "max_awards must be an integer"
-    assert oversized_issue.status_code == 400
-    assert oversized_issue.json()["detail"] == "issue_number is too large"
+    assert oversized_integer_issue.status_code == 400
+    assert oversized_integer_issue.json()["detail"] == "issue_number is too large"
+    assert oversized_string_issue.status_code == 400
+    assert oversized_string_issue.json()["detail"] == "issue_number must be an integer"
+    assert oversized_string_awards.status_code == 400
+    assert oversized_string_awards.json()["detail"] == "max_awards must be an integer"
 
 
 def test_admin_webhook_events_api_lists_and_filters_processing_outcomes(


### PR DESCRIPTION
## Summary
- Catch Python integer string conversion failures in the shared JSON integer parser
- Return controlled 400 validation errors for oversized numeric strings instead of a 500
- Add admin bounty API regression coverage for required and optional integer fields

Bounty #292

## Validation
- uv run pytest tests/test_security.py::test_admin_bounty_api_rejects_fractional_integer_fields
- uv run ruff check .
- uv run mypy app
- uv run pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened integer parsing for API inputs so invalid conversions consistently return a clear 400 error ("must be an integer").

* **Tests**
  * Expanded tests to ensure fractional, oversized, and extremely long string numeric fields are rejected with the same 400 validation response.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->