### PR TITLE
[codex] Bound MCP integer arguments

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1675,12 +1675,21 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str:
         if isinstance(value, bool):
             raise ValueError(f"{field} must be an integer")
         if isinstance(value, int):
-            return value
-        if isinstance(value, str):
+            parsed = value
+        elif isinstance(value, str):
             clean = value.strip()
             if clean and clean.lstrip("+-").isdigit():
-                return int(clean)
-        raise ValueError(f"{field} must be an integer")
+                try:
+                    parsed = int(clean)
+                except ValueError as exc:
+                    raise ValueError(f"{field} must be an integer") from exc
+            else:
+                raise ValueError(f"{field} must be an integer")
+        else:
+            raise ValueError(f"{field} must be an integer")
+        if parsed < -SQLITE_INTEGER_MAX - 1 or parsed > SQLITE_INTEGER_MAX:
+            raise ValueError(f"{field} is too large")
+        return parsed
 
     def positive_int_arg(field: str) -> int:
         value = int_arg(field)

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -847,6 +847,46 @@ def test_mcp_get_bounty_rejects_non_positive_id(sqlite_url: str, bounty_id: int)
 @pytest.mark.parametrize(
     ("tool_name", "arguments", "request_id"),
     [
+        ("get_bounty", {"id": "9" * 40}, 16),
+        ("get_bounty", {"id": 2**63}, 17),
+        ("get_ledger_entry", {"sequence": "9" * 40}, 18),
+        ("submit_work_proof", {"bounty_id": "9" * 40}, 19),
+        ("submit_work_proof", {"issue_number": "9" * 40}, 20),
+    ],
+)
+def test_mcp_rejects_oversized_integer_arguments_without_500(
+    sqlite_url: str, tool_name: str, arguments: dict[str, object], request_id: int
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        raise_server_exceptions=False,
+    )
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments", "request_id"),
+    [
         ("get_balance", {"account": True}, 13),
         ("get_balance", {"account": 123}, 14),
         ("get_balance", {"account": ""}, 15),


### PR DESCRIPTION
## Summary
- Bound shared MCP integer arguments to SQLite's integer range before database lookups
- Return JSON-RPC invalid argument errors instead of 500s for oversized `get_bounty`, `get_ledger_entry`, and `submit_work_proof` integer inputs
- Add regression coverage for oversized string and JSON integer inputs

Bounty #292

## Repro Before Fix
- MCP `get_bounty` with `id = "9" * 40` returned 500 Internal Server Error
- MCP `get_ledger_entry` with `sequence = "9" * 40` returned 500 Internal Server Error

## Validation
- `uv run pytest tests/test_api_mcp.py::test_mcp_rejects_oversized_integer_arguments_without_500 tests/test_api_mcp.py::test_mcp_get_bounty_rejects_fractional_id tests/test_api_mcp.py::test_mcp_get_bounty_rejects_non_positive_id -q` -> 8 passed
- `uv run ruff check app/main.py tests/test_api_mcp.py` -> passed
- `uv run mypy app` -> passed
- `uv run ruff check .` -> passed
- `uv run pytest` -> 279 passed, 2 warnings
- `git diff --check` -> passed

No secrets, wallet material, deployment credentials, private vulnerability details, payout details, or MRWK price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integer argument validation with stricter bounds checking to prevent invalid values.
  * Enhanced error handling for oversized integer inputs, returning appropriate error messages instead of server errors.

* **Tests**
  * Added regression test for oversized integer argument rejection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->