### PR TITLE
Add reusable PR queue health report

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -97,6 +97,30 @@ Use `limit` to control the number of delivery rows returned (`1` to `200`,
 default `50`), for example:
 `/api/v1/admin/webhook-events?status=missing_submitter&limit=100`.
 
+### PR Queue Health
+
+Use the queue-health script before accepting busy bounty rounds:
+
+```bash
+python scripts/pr_queue_health.py --repo ramimbo/mergework --format text
+```
+
+Live mode requires an authenticated GitHub CLI with access to the repository.
+The command only reads PRs and issues; it does not close PRs, label issues, or
+post comments. It reports missing bounty references, closed or exhausted bounty
+references, dirty or unknown merge state, `mrwk:needs-info`, and likely duplicate
+PR scope within the same bounty issue.
+
+For offline checks, save fixture data and run:
+
+```bash
+python scripts/pr_queue_health.py --input queue.json --format json --fail-on-issues
+```
+
+`--fail-on-issues` exits nonzero when queue-health problems are found, which lets
+maintainers add the check to local release or payout workflows without requiring
+live GitHub access.
+
 ### Final Checks
 
 1. Confirm the webhook or admin API records one ledger payment for that award.

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -11,6 +11,9 @@ from typing import Any
 BOUNTY_REF_RE = re.compile(r"(?:bounty|refs?|fixes|closes)\s+#(\d+)", re.IGNORECASE)
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
 UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
+GH_TIMEOUT_SECONDS = 30
+GH_PR_SAFETY_CAP = 201
+GH_ISSUE_SAFETY_CAP = 201
 
 
 def _labels(raw: dict[str, Any]) -> list[str]:
@@ -209,14 +212,26 @@ def format_text_report(report: dict[str, Any]) -> str:
 
 
 def _run_gh_json(args: list[str]) -> Any:
-    completed = subprocess.run(
-        args,
-        check=True,
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
+    command = " ".join(args)
+    try:
+        completed = subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s: {command}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            "gh command failed "
+            f"(exit {exc.returncode}): {command}\n"
+            f"stdout:\n{exc.stdout or exc.output or ''}\n"
+            f"stderr:\n{exc.stderr or ''}"
+        ) from exc
     return json.loads(completed.stdout)
 
 
@@ -231,11 +246,16 @@ def load_live_queue(repo: str) -> dict[str, Any]:
             "--state",
             "open",
             "--limit",
-            "200",
+            str(GH_PR_SAFETY_CAP),
             "--json",
             "number,title,url,body,labels,mergeStateStatus",
         ]
     )
+    if len(prs) >= GH_PR_SAFETY_CAP:
+        raise RuntimeError(
+            f"gh pr list reached the {GH_PR_SAFETY_CAP} item safety cap; "
+            "use an API-paginated collector before trusting this live report"
+        )
     issues = _run_gh_json(
         [
             "gh",
@@ -246,11 +266,16 @@ def load_live_queue(repo: str) -> dict[str, Any]:
             "--state",
             "all",
             "--limit",
-            "200",
+            str(GH_ISSUE_SAFETY_CAP),
             "--json",
             "number,title,state,labels",
         ]
     )
+    if len(issues) >= GH_ISSUE_SAFETY_CAP:
+        raise RuntimeError(
+            f"gh issue list reached the {GH_ISSUE_SAFETY_CAP} item safety cap; "
+            "use an API-paginated collector before trusting this live report"
+        )
     bounty_issues = [
         {
             "number": issue["number"],

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from typing import Any
+
+BOUNTY_REF_RE = re.compile(r"(?:bounty|refs?|fixes|closes)\s+#(\d+)", re.IGNORECASE)
+NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
+UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
+
+
+def _labels(raw: dict[str, Any]) -> list[str]:
+    labels = raw.get("labels", [])
+    names: list[str] = []
+    for label in labels:
+        if isinstance(label, str):
+            names.append(label)
+        elif isinstance(label, dict) and isinstance(label.get("name"), str):
+            names.append(label["name"])
+    return names
+
+
+def _merge_state(raw: dict[str, Any]) -> str:
+    for key in ("merge_state", "mergeStateStatus", "mergeable", "mergeable_state"):
+        value = raw.get(key)
+        if isinstance(value, str) and value:
+            return value.lower()
+    return "unknown"
+
+
+def _scope_key(raw: dict[str, Any]) -> str:
+    explicit = raw.get("scope")
+    if isinstance(explicit, str) and explicit.strip():
+        return " ".join(explicit.lower().split())
+    title = str(raw.get("title") or "")
+    title = NOISY_TITLE_PREFIX_RE.sub("", title)
+    return " ".join(title.lower().split())
+
+
+def _bounty_refs(raw: dict[str, Any]) -> list[int]:
+    explicit = raw.get("bounty_refs")
+    if isinstance(explicit, list):
+        refs = [item for item in explicit if isinstance(item, int)]
+        if refs:
+            return sorted(set(refs))
+    text = "\n".join(
+        str(raw.get(key) or "")
+        for key in ("title", "body", "description")
+        if raw.get(key) is not None
+    )
+    return sorted({int(match) for match in BOUNTY_REF_RE.findall(text)})
+
+
+def _is_open_bounty(raw: dict[str, Any]) -> bool:
+    state = str(raw.get("state") or "").lower()
+    remaining = raw.get("awards_remaining", raw.get("awardsRemaining"))
+    if state and state != "open":
+        return False
+    if remaining is not None:
+        try:
+            return int(remaining) > 0
+        except (TypeError, ValueError):
+            return False
+    return state == "open"
+
+
+def _issue(pr: dict[str, Any], reason: str, detail: str) -> dict[str, Any]:
+    return {
+        "pull_request": pr["number"],
+        "title": pr["title"],
+        "url": pr.get("url"),
+        "reason": reason,
+        "detail": detail,
+    }
+
+
+def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
+    bounties = {
+        int(item["number"]): item
+        for item in data.get("bounties", [])
+        if isinstance(item, dict) and isinstance(item.get("number"), int)
+    }
+    prs = [item for item in data.get("pull_requests", []) if isinstance(item, dict)]
+    normalized_prs: list[dict[str, Any]] = []
+    for pr in prs:
+        if not isinstance(pr.get("number"), int):
+            continue
+        normalized_prs.append(
+            {
+                "number": int(pr["number"]),
+                "title": str(pr.get("title") or ""),
+                "url": pr.get("url"),
+                "refs": _bounty_refs(pr),
+                "labels": _labels(pr),
+                "merge_state": _merge_state(pr),
+                "scope": _scope_key(pr),
+            }
+        )
+
+    closed_bounty_references: list[dict[str, Any]] = []
+    missing_bounty_references: list[dict[str, Any]] = []
+    dirty_or_unstable_merge_state: list[dict[str, Any]] = []
+    needs_info: list[dict[str, Any]] = []
+    duplicate_groups: dict[tuple[int, str], list[int]] = defaultdict(list)
+
+    for pr in normalized_prs:
+        if not pr["refs"]:
+            missing_bounty_references.append(
+                _issue(pr, "missing_bounty_reference", "No Bounty #<issue> or Refs #<issue> found")
+            )
+        for ref in pr["refs"]:
+            bounty = bounties.get(ref)
+            if bounty is None:
+                closed_bounty_references.append(
+                    _issue(
+                        pr,
+                        "unknown_bounty_reference",
+                        f"Referenced bounty #{ref} was not in input",
+                    )
+                )
+            elif not _is_open_bounty(bounty):
+                closed_bounty_references.append(
+                    _issue(
+                        pr,
+                        "closed_or_exhausted_bounty",
+                        f"Referenced bounty #{ref} is not payable",
+                    )
+                )
+            duplicate_groups[(ref, pr["scope"])].append(pr["number"])
+        if pr["merge_state"] in UNSTABLE_MERGE_STATES:
+            dirty_or_unstable_merge_state.append(
+                _issue(pr, "dirty_or_unstable_merge_state", f"Merge state is {pr['merge_state']}")
+            )
+        if any(label.lower() == "mrwk:needs-info" for label in pr["labels"]):
+            needs_info.append(_issue(pr, "mrwk_needs_info", "PR has mrwk:needs-info label"))
+
+    duplicate_scope_groups = [
+        {"bounty": bounty, "scope": scope, "pull_requests": sorted(numbers)}
+        for (bounty, scope), numbers in sorted(duplicate_groups.items())
+        if len(numbers) > 1 and scope
+    ]
+    closed_or_exhausted_count = sum(
+        1 for bounty in bounties.values() if not _is_open_bounty(bounty)
+    )
+    report = {
+        "summary": {
+            "pull_requests": len(normalized_prs),
+            "open_bounties": len(bounties) - closed_or_exhausted_count,
+            "closed_or_exhausted_bounties": closed_or_exhausted_count,
+            "closed_bounty_references": len(closed_bounty_references),
+            "missing_bounty_references": len(missing_bounty_references),
+            "dirty_or_unstable_merge_state": len(dirty_or_unstable_merge_state),
+            "needs_info": len(needs_info),
+            "duplicate_scope_groups": len(duplicate_scope_groups),
+        },
+        "closed_bounty_references": closed_bounty_references,
+        "missing_bounty_references": missing_bounty_references,
+        "dirty_or_unstable_merge_state": dirty_or_unstable_merge_state,
+        "needs_info": needs_info,
+        "duplicate_scope_groups": duplicate_scope_groups,
+    }
+    return report
+
+
+def has_queue_issues(report: dict[str, Any]) -> bool:
+    return any(
+        report[key]
+        for key in (
+            "closed_bounty_references",
+            "missing_bounty_references",
+            "dirty_or_unstable_merge_state",
+            "needs_info",
+            "duplicate_scope_groups",
+        )
+    )
+
+
+def format_text_report(report: dict[str, Any]) -> str:
+    lines = ["PR queue health summary"]
+    for key, value in report["summary"].items():
+        lines.append(f"- {key.replace('_', ' ')}: {value}")
+    if not has_queue_issues(report):
+        lines.append("")
+        lines.append("No queue-health issues found.")
+        return "\n".join(lines)
+    sections = [
+        ("Closed or exhausted bounty references", "closed_bounty_references"),
+        ("Missing bounty references", "missing_bounty_references"),
+        ("Dirty or unstable merge state", "dirty_or_unstable_merge_state"),
+        ("Needs info", "needs_info"),
+    ]
+    for title, key in sections:
+        if report[key]:
+            lines.append("")
+            lines.append(title)
+            for item in report[key]:
+                lines.append(f"- PR #{item['pull_request']}: {item['title']} ({item['detail']})")
+    if report["duplicate_scope_groups"]:
+        lines.append("")
+        lines.append("Likely duplicate bounty scope")
+        for item in report["duplicate_scope_groups"]:
+            prs = ", ".join(f"#{number}" for number in item["pull_requests"])
+            lines.append(f"- Bounty #{item['bounty']}: {item['scope']} ({prs})")
+    return "\n".join(lines)
+
+
+def _run_gh_json(args: list[str]) -> Any:
+    completed = subprocess.run(
+        args,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    return json.loads(completed.stdout)
+
+
+def load_live_queue(repo: str) -> dict[str, Any]:
+    prs = _run_gh_json(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,title,url,body,labels,mergeStateStatus",
+        ]
+    )
+    issues = _run_gh_json(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "all",
+            "--limit",
+            "200",
+            "--json",
+            "number,title,state,labels",
+        ]
+    )
+    bounty_issues = [
+        {
+            "number": issue["number"],
+            "title": issue.get("title"),
+            "state": issue.get("state"),
+            "awards_remaining": 1 if issue.get("state") == "OPEN" else 0,
+        }
+        for issue in issues
+        if "bounty" in str(issue.get("title", "")).lower()
+    ]
+    return {"pull_requests": prs, "bounties": bounty_issues}
+
+
+def _load_input(path: str) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("queue input must be a JSON object")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Summarize MergeWork open PR queue health.")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--input", help="Read queue data from a JSON fixture file.")
+    source.add_argument(
+        "--repo",
+        help="Collect live queue data with gh, for example ramimbo/mergework.",
+    )
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--fail-on-issues", action="store_true")
+    args = parser.parse_args(argv)
+
+    data = _load_input(args.input) if args.input else load_live_queue(args.repo)
+    report = analyze_queue(data)
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(format_text_report(report))
+    return 1 if args.fail_on_issues and has_queue_issues(report) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import json
+import subprocess
 
+import pytest
+
+from scripts import pr_queue_health
 from scripts.pr_queue_health import analyze_queue, format_text_report, main
 
 
@@ -101,3 +105,66 @@ def test_pr_queue_health_text_report_is_pasteable() -> None:
     assert "PR queue health summary" in text
     assert "pull requests: 1" in text
     assert "No queue-health issues found." in text
+
+
+def test_pr_queue_health_wraps_gh_failures(monkeypatch) -> None:
+    def fake_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(
+            returncode=2,
+            cmd=["gh", "pr", "list"],
+            output="partial",
+            stderr="network unavailable",
+        )
+
+    monkeypatch.setattr(pr_queue_health.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="gh command failed"):
+        pr_queue_health._run_gh_json(["gh", "pr", "list"])
+
+
+def test_pr_queue_health_fails_fast_when_issue_fetch_hits_cap(monkeypatch) -> None:
+    def fake_run(args, **kwargs):
+        if args[:3] == ["gh", "pr", "list"]:
+            stdout = "[]"
+        elif args[:3] == ["gh", "issue", "list"]:
+            stdout = json.dumps(
+                [
+                    {"number": number, "title": "MRWK bounty: many", "state": "OPEN"}
+                    for number in range(1, 202)
+                ]
+            )
+        else:
+            raise AssertionError(args)
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(pr_queue_health.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="issue list reached the 201 item safety cap"):
+        pr_queue_health.load_live_queue("ramimbo/mergework")
+
+
+def test_pr_queue_health_fails_fast_when_pr_fetch_hits_cap(monkeypatch) -> None:
+    def fake_run(args, **kwargs):
+        if args[:3] == ["gh", "pr", "list"]:
+            stdout = json.dumps(
+                [
+                    {
+                        "number": number,
+                        "title": "Open PR",
+                        "body": "Refs #1",
+                        "labels": [],
+                        "mergeStateStatus": "clean",
+                    }
+                    for number in range(1, 202)
+                ]
+            )
+        elif args[:3] == ["gh", "issue", "list"]:
+            stdout = "[]"
+        else:
+            raise AssertionError(args)
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(pr_queue_health.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="pr list reached the 201 item safety cap"):
+        pr_queue_health.load_live_queue("ramimbo/mergework")

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+
+from scripts.pr_queue_health import analyze_queue, format_text_report, main
+
+
+def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
+    fixture = {
+        "bounties": [
+            {"number": 292, "state": "OPEN", "awards_remaining": 13},
+            {"number": 293, "state": "CLOSED", "awards_remaining": 0},
+            {"number": 310, "state": "OPEN", "awards_remaining": 8},
+        ],
+        "pull_requests": [
+            {
+                "number": 1,
+                "title": "Add public bounty summary API",
+                "url": "https://github.com/ramimbo/mergework/pull/1",
+                "body": "Refs #293",
+                "merge_state": "clean",
+                "labels": [],
+            },
+            {
+                "number": 2,
+                "title": "Improve bounty filters",
+                "url": "https://github.com/ramimbo/mergework/pull/2",
+                "body": "",
+                "merge_state": "clean",
+                "labels": [],
+            },
+            {
+                "number": 3,
+                "title": "Guard MCP bounty search oversized numeric query",
+                "url": "https://github.com/ramimbo/mergework/pull/3",
+                "body": "Bounty #292",
+                "merge_state": "dirty",
+                "labels": ["mrwk:needs-info"],
+            },
+            {
+                "number": 4,
+                "title": "Guard MCP bounty search oversized numeric query",
+                "url": "https://github.com/ramimbo/mergework/pull/4",
+                "body": "Refs #292",
+                "merge_state": "unknown",
+                "labels": [],
+            },
+        ],
+    }
+
+    report = analyze_queue(fixture)
+
+    assert report["summary"] == {
+        "pull_requests": 4,
+        "open_bounties": 2,
+        "closed_or_exhausted_bounties": 1,
+        "closed_bounty_references": 1,
+        "missing_bounty_references": 1,
+        "dirty_or_unstable_merge_state": 2,
+        "needs_info": 1,
+        "duplicate_scope_groups": 1,
+    }
+    assert report["closed_bounty_references"][0]["pull_request"] == 1
+    assert report["missing_bounty_references"][0]["pull_request"] == 2
+    assert {item["pull_request"] for item in report["dirty_or_unstable_merge_state"]} == {3, 4}
+    assert report["needs_info"][0]["pull_request"] == 3
+    assert report["duplicate_scope_groups"] == [
+        {
+            "bounty": 292,
+            "scope": "guard mcp bounty search oversized numeric query",
+            "pull_requests": [3, 4],
+        }
+    ]
+
+    input_path = tmp_path / "queue.json"
+    input_path.write_text(json.dumps(fixture), encoding="utf-8")
+    exit_code = main(["--input", str(input_path), "--format", "json", "--fail-on-issues"])
+    assert exit_code == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["summary"]["pull_requests"] == 4
+
+
+def test_pr_queue_health_text_report_is_pasteable() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 5}],
+            "pull_requests": [
+                {
+                    "number": 8,
+                    "title": "Review open PRs",
+                    "body": "Refs #310",
+                    "merge_state": "clean",
+                    "labels": [],
+                }
+            ],
+        }
+    )
+
+    text = format_text_report(report)
+
+    assert "PR queue health summary" in text
+    assert "pull requests: 1" in text
+    assert "No queue-health issues found." in text

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -122,6 +122,16 @@ def test_pr_queue_health_wraps_gh_failures(monkeypatch) -> None:
         pr_queue_health._run_gh_json(["gh", "pr", "list"])
 
 
+def test_pr_queue_health_wraps_gh_timeouts(monkeypatch) -> None:
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=["gh", "pr", "list"], timeout=30)
+
+    monkeypatch.setattr(pr_queue_health.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="gh command timed out"):
+        pr_queue_health._run_gh_json(["gh", "pr", "list"])
+
+
 def test_pr_queue_health_fails_fast_when_issue_fetch_hits_cap(monkeypatch) -> None:
     def fake_run(args, **kwargs):
         if args[:3] == ["gh", "pr", "list"]:


### PR DESCRIPTION
Refs #322

## Summary
- Add `scripts/pr_queue_health.py`, a non-destructive PR queue health report that supports fixture JSON input and optional live `gh` collection.
- Report closed/exhausted bounty references, missing bounty references, dirty/unstable merge states, `mrwk:needs-info`, and likely duplicate bounty scope.
- Document live GitHub CLI requirements and offline fixture usage in the admin runbook.

## Evidence
- `python -m pytest tests/test_pr_queue_health.py -q` -> 2 passed.
- `python -m pytest tests/test_pr_queue_health.py tests/test_docs_public_urls.py -q` -> 19 passed.
- `python -m ruff check scripts/pr_queue_health.py tests/test_pr_queue_health.py` -> All checks passed.
- `python -m ruff format --check scripts/pr_queue_health.py tests/test_pr_queue_health.py` -> 2 files already formatted.
- `python -m mypy scripts/pr_queue_health.py` -> success.
- `python scripts/docs_smoke.py` -> docs smoke ok.
- `python scripts/pr_queue_health.py --repo ramimbo/mergework --format json` -> produced a live read-only queue report successfully.
- `git diff --check` -> clean.

## Safety
- The script only reads fixture files or GitHub PR/issue metadata through `gh`.
- It does not close PRs, label issues, post comments, or make destructive changes.
- No secrets, wallet private keys, private payout details, deployment values, private vulnerability details, or MRWK price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PR queue health inspection tool that detects missing bounty references, non-payable/absent bounties, unstable/dirty/blocked merge states, duplicate bounty+scope submissions, and can output JSON or text and fail CI when issues are present.
* **Documentation**
  * Added admin guidance for running the PR queue health check before accepting busy bounty rounds.
* **Tests**
  * Expanded coverage for analysis, report formatting, CI failure behavior, CLI error handling, and live-data safety caps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->