### PR TITLE
Add admin webhook status summary

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -111,6 +111,15 @@ SQLITE_INTEGER_MAX = 2**63 - 1
 DEFAULT_ATTEMPT_TTL_SECONDS = 24 * 60 * 60
 MIN_ATTEMPT_TTL_SECONDS = 60
 MAX_ATTEMPT_TTL_SECONDS = 7 * 24 * 60 * 60
+WEBHOOK_OUTCOME_SCAN_ORDER = {
+    "missing_submitter": 0,
+    "bounty_not_found": 1,
+    "exhausted_bounty": 2,
+    "duplicate_delivery": 3,
+    "delivery_payload_mismatch": 4,
+    "already_paid": 5,
+    "paid": 6,
+}
 
 
 def _request_was_forwarded_https(request: Request) -> bool:
@@ -244,6 +253,27 @@ def _existing_payout_proof_for_submission(
         select(Proof)
         .where(Proof.submission_id == submission.id, Proof.kind == "bounty_payment")
         .limit(1)
+    )
+
+
+def webhook_status_summary(session: Session) -> list[dict[str, Any]]:
+    status_expr = func.lower(WebhookEvent.processed_status)
+    count_expr = func.count(WebhookEvent.delivery_id)
+    rows = session.execute(
+        select(status_expr, count_expr)
+        .group_by(status_expr)
+        .order_by(count_expr.desc(), status_expr.asc())
+    ).all()
+    summary = [
+        {"processed_status": str(status), "count": int(count)} for status, count in rows if status
+    ]
+    return sorted(
+        summary,
+        key=lambda item: (
+            WEBHOOK_OUTCOME_SCAN_ORDER.get(str(item["processed_status"]), 100),
+            -int(item["count"]),
+            str(item["processed_status"]),
+        ),
     )
 
 
@@ -1432,6 +1462,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                     WebhookEvent.created_at.desc(), WebhookEvent.delivery_id.desc()
                 ).limit(webhook_limit)
             ).all()
+            webhook_summary = webhook_status_summary(session)
         return templates.TemplateResponse(
             request,
             "admin.html",
@@ -1439,6 +1470,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 "login": login,
                 "csrf_token": _csrf_token("admin-bounty", login, settings.cookie_secret),
                 "webhook_events": webhook_events,
+                "webhook_status_summary": webhook_summary,
                 "webhook_limit": webhook_limit,
                 "webhook_limit_options": [10, 25, 50, 100],
                 "webhook_status": normalized_status,

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -21,6 +21,16 @@
 <section class="detail">
   <p class="eyebrow">Webhooks</p>
   <h2>Recent delivery outcomes</h2>
+  {% if webhook_status_summary %}
+  <div class="bounty-list-summary" aria-label="Webhook processed status summary">
+    {% for item in webhook_status_summary %}
+    <article>
+      <span><code>{{ item.processed_status }}</code></span>
+      <strong>{{ item.count }}</strong>
+    </article>
+    {% endfor %}
+  </div>
+  {% endif %}
   <form method="get" action="/admin" class="inline-form">
     <label>Processed status
       <input name="webhook_status" value="{{ webhook_status }}" placeholder="missing_submitter">

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -201,11 +201,16 @@ def test_admin_page_renders_safe_webhook_events_for_cookie_admin(
     assert re.search(
         r"<code>missing_submitter</code>\s*</span>\s*<strong>2</strong>", all_events.text
     )
+    summary_match = re.search(
+        r'<div class="bounty-list-summary"[^>]*>.*?</div>', all_events.text, flags=re.S
+    )
+    assert summary_match is not None
+    summary_html = summary_match.group(0)
     status_summary_positions = [
-        all_events.text.index("<code>missing_submitter</code>"),
-        all_events.text.index("<code>bounty_not_found</code>"),
-        all_events.text.index("<code>exhausted_bounty</code>"),
-        all_events.text.index("<code>paid</code>"),
+        summary_html.index("<code>missing_submitter</code>"),
+        summary_html.index("<code>bounty_not_found</code>"),
+        summary_html.index("<code>exhausted_bounty</code>"),
+        summary_html.index("<code>paid</code>"),
     ]
     assert status_summary_positions == sorted(status_summary_positions)
     assert "paid" in all_events.text

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -162,6 +162,22 @@ def test_admin_page_renders_safe_webhook_events_for_cookie_admin(
         )
         session.add(
             WebhookEvent(
+                delivery_id="delivery-missing-submitter-uppercase",
+                event_type="pull_request",
+                payload_hash="d" * 64,
+                processed_status="Missing_Submitter",
+            )
+        )
+        session.add(
+            WebhookEvent(
+                delivery_id="delivery-exhausted-bounty",
+                event_type="pull_request",
+                payload_hash="e" * 64,
+                processed_status="exhausted_bounty",
+            )
+        )
+        session.add(
+            WebhookEvent(
                 delivery_id="delivery-paid-secret-payload-body",
                 event_type="pull_request",
                 payload_hash="c" * 64,
@@ -181,11 +197,17 @@ def test_admin_page_renders_safe_webhook_events_for_cookie_admin(
     assert all_events.status_code == 200
     assert "missing_submitter" in all_events.text
     assert "bounty_not_found" in all_events.text
+    assert "exhausted_bounty" in all_events.text
+    assert re.search(
+        r"<code>missing_submitter</code>\s*</span>\s*<strong>2</strong>", all_events.text
+    )
     assert "paid" in all_events.text
     assert filtered.status_code == 200
     assert "delivery-missing-submitter" in filtered.text
+    assert "delivery-missing-submitter-uppercase" in filtered.text
     assert "missing_submitter" in filtered.text
     assert "delivery-bounty-not-found" not in filtered.text
+    assert "bounty_not_found" in filtered.text
     assert "a" * 64 in filtered.text
     assert "secret-payload-body" not in filtered.text
     assert limited.status_code == 200

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -201,6 +201,13 @@ def test_admin_page_renders_safe_webhook_events_for_cookie_admin(
     assert re.search(
         r"<code>missing_submitter</code>\s*</span>\s*<strong>2</strong>", all_events.text
     )
+    status_summary_positions = [
+        all_events.text.index("<code>missing_submitter</code>"),
+        all_events.text.index("<code>bounty_not_found</code>"),
+        all_events.text.index("<code>exhausted_bounty</code>"),
+        all_events.text.index("<code>paid</code>"),
+    ]
+    assert status_summary_positions == sorted(status_summary_positions)
     assert "paid" in all_events.text
     assert filtered.status_code == 200
     assert "delivery-missing-submitter" in filtered.text


### PR DESCRIPTION
Refs #316

What changed:
- Added a read-only processed-status summary to the browser `/admin` webhook outcomes section.
- Groups webhook delivery outcomes case-insensitively and prioritizes high-signal statuses such as `missing_submitter`, `bounty_not_found`, `exhausted_bounty`, duplicate delivery, already-paid, and paid.
- Keeps the existing event table, processed-status filter, and bounded limit behavior intact.
- Uses the existing admin cookie flow through `/admin`; no admin-token-only API path or mutation control is added.
- Renders only aggregate processed-status labels and counts, plus the existing safe table fields. No payload bodies, secrets, token values, deployment details, payout details, or private vulnerability details are rendered.

Why this is distinct:
- PR #318 added the recent delivery table with filtering and limit controls.
- This PR adds a scan layer above that table so maintainers can see outcome counts before drilling into individual deliveries.

Post-rebase validation:
- `C:\Users\sebas\Documents\BountyBar\work\mergework-281\.venv\Scripts\python.exe -m pytest -q` -> 318 passed.
- `C:\Users\sebas\Documents\BountyBar\work\mergework-281\.venv\Scripts\python.exe -m ruff check app/main.py tests/test_security.py` -> passed.
- `C:\Users\sebas\Documents\BountyBar\work\mergework-281\.venv\Scripts\python.exe -m ruff format --check app/main.py tests/test_security.py` -> passed.
- `C:\Users\sebas\Documents\BountyBar\work\mergework-281\.venv\Scripts\python.exe -m mypy app` -> success.
- `git diff --check origin/main...HEAD` -> clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Recent delivery outcomes" summary section on the admin page showing webhook status counts, prioritized ordering, and conditional display when data exists.
  * Status aggregation is now case-insensitive so differently-cased entries are grouped.

* **Tests**
  * Expanded tests to cover the summary display, ordering, case-insensitive matching, and inclusion of newly represented statuses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->