### PR TITLE
Normalize wallet transfer timestamps

### DIFF
--- a/app/serializers.py
+++ b/app/serializers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
@@ -346,7 +346,7 @@ def safe_accepted_work_for_account(session: Session, account: str) -> list[dict[
 
 def _wallet_timestamp(value: datetime) -> str:
     if value.tzinfo is not None:
-        value = value.replace(tzinfo=None)
+        value = value.astimezone(UTC).replace(tzinfo=None)
     return value.isoformat()
 
 
@@ -375,5 +375,5 @@ def wallet_transfer_to_dict(transfer: WalletTransfer) -> dict[str, Any]:
         "amount_mrwk": format_mrwk(transfer.amount_microunits),
         "nonce": transfer.nonce,
         "memo": transfer.memo,
-        "created_at": transfer.created_at.isoformat(),
+        "created_at": _wallet_timestamp(transfer.created_at),
     }

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta, timezone
+
 from app.db import create_schema, session_scope
 from app.ledger.service import create_bounty, ensure_genesis, pay_bounty, register_wallet
-from app.models import Bounty
+from app.models import Bounty, WalletTransfer
 from app.serializers import (
     accepted_work_for_account,
     account_accepted_summary,
     bounty_list_summary,
     bounty_to_dict,
     wallet_to_dict,
+    wallet_transfer_to_dict,
 )
 
 
@@ -78,3 +81,21 @@ def test_account_and_wallet_serializers_preserve_public_shapes(sqlite_url: str) 
     assert wallet_data["label"] == "Serializer wallet"
     assert wallet_data["balance_mrwk"] == "0"
     assert wallet_data["next_nonce"] == 1
+
+
+def test_wallet_transfer_serializer_normalizes_aware_timestamp() -> None:
+    transfer = WalletTransfer(
+        hash="abc123",
+        ledger_sequence=42,
+        from_address="mrwk1from",
+        to_address="mrwk1to",
+        amount_microunits=1_500_000,
+        nonce=7,
+        memo="test transfer",
+        created_at=datetime(2026, 5, 25, 12, 30, tzinfo=timezone(timedelta(hours=3))),
+    )
+
+    assert (
+        wallet_transfer_to_dict(transfer)["created_at"]
+        == datetime(2026, 5, 25, 9, 30, tzinfo=UTC).replace(tzinfo=None).isoformat()
+    )


### PR DESCRIPTION
## Summary

- Normalize timezone-aware wallet timestamps through UTC before emitting naive ISO strings.
- Route `wallet_transfer_to_dict()` through the same timestamp helper used by wallet serialization.
- Add a regression for aware wallet-transfer timestamps so offsets cannot leak into public API/MCP response payloads.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: wallet serializer timestamps used `_wallet_timestamp()`, but wallet transfer serialization called `transfer.created_at.isoformat()` directly. With an aware timestamp such as `2026-05-25T12:30:00+03:00`, public transfer payloads could expose an offset-bearing local timestamp while adjacent wallet responses use normalized naive timestamps.
- Repro before fix: `tests/test_serializers.py::test_wallet_transfer_serializer_normalizes_aware_timestamp` failed with `2026-05-25T12:30:00+03:00` instead of the normalized UTC value `2026-05-25T09:30:00`.

## Test Evidence

- [x] `python -m pytest tests/test_serializers.py::test_wallet_transfer_serializer_normalizes_aware_timestamp -q` failed before the fix as expected.
- [x] `python -m pytest tests/test_serializers.py tests/test_wallet_api.py -q` -> 33 passed.
- [x] `python -m ruff check app/serializers.py tests/test_serializers.py tests/test_wallet_api.py` -> passed.
- [x] `python -m ruff format --check app/serializers.py tests/test_serializers.py tests/test_wallet_api.py` -> passed.
- [x] `python -m mypy app/serializers.py` -> success.
- [x] `python scripts/docs_smoke.py` -> docs smoke ok.
- [x] `git diff --check` -> clean.

## MRWK

Refs #292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Wallet transfer timestamps are now consistently normalized to UTC format in API responses and exports, ensuring uniform datetime representation across all timezone environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->