### PR TITLE
Add MCP bounty attempt visibility

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -213,6 +213,23 @@ def expire_stale_bounty_attempts(
     session.execute(query.values(status="expired", updated_at=now))
 
 
+def bounty_attempts_to_dict(
+    session: Session, bounty: Bounty, *, include_expired: bool = False, now: datetime | None = None
+) -> dict[str, Any]:
+    now = now or _utc_now()
+    query = select(BountyAttempt).where(BountyAttempt.bounty_id == bounty.id)
+    if not include_expired:
+        query = query.where(*_active_attempt_conditions(bounty.id, now))
+    attempts = session.scalars(
+        query.order_by(BountyAttempt.created_at.desc(), BountyAttempt.id.desc())
+    ).all()
+    return {
+        "bounty_id": bounty.id,
+        "warnings": bounty_attempt_warnings(session, bounty, now),
+        "attempts": [bounty_attempt_to_dict(attempt, now) for attempt in attempts],
+    }
+
+
 def _payout_response_from_proof(proof: Proof, *, status: str) -> dict[str, Any]:
     data = json.loads(proof.public_json)
     if not isinstance(data, dict) or data.get("kind") != "bounty_payment":
@@ -693,17 +710,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             bounty = session.get(Bounty, bounty_id)
             if bounty is None:
                 raise HTTPException(status_code=404, detail="bounty not found")
-            query = select(BountyAttempt).where(BountyAttempt.bounty_id == bounty_id)
-            if not include_expired:
-                query = query.where(*_active_attempt_conditions(bounty_id, now))
-            attempts = session.scalars(
-                query.order_by(BountyAttempt.created_at.desc(), BountyAttempt.id.desc())
-            ).all()
-            return {
-                "bounty_id": bounty_id,
-                "warnings": bounty_attempt_warnings(session, bounty, now),
-                "attempts": [bounty_attempt_to_dict(attempt, now) for attempt in attempts],
-            }
+            return bounty_attempts_to_dict(
+                session, bounty, include_expired=include_expired, now=now
+            )
 
     @app.post("/api/v1/bounties/{bounty_id}/attempts")
     async def api_create_bounty_attempt(
@@ -1687,6 +1696,15 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
             if optional_bool_arg("include_awards"):
                 bounty_data["awards"] = bounty_awards_to_dict(session, bounty.id)
             return json.dumps(bounty_data)
+        if name == "list_bounty_attempts":
+            bounty = session.get(Bounty, positive_int_arg("bounty_id"))
+            if bounty is None:
+                return "bounty not found"
+            return bounty_attempts_to_dict(
+                session,
+                bounty,
+                include_expired=optional_bool_arg("include_expired"),
+            )
         if name == "get_balance":
             account = _normalized_account(str_arg("account"))
             return f"{account}: {format_mrwk(get_balance(session, account))} MRWK"

--- a/app/mcp.py
+++ b/app/mcp.py
@@ -20,6 +20,10 @@ MCP_TOOLS: list[dict[str, str]] = [
         "name": "get_bounty",
         "description": "Get a bounty by id, optionally with accepted awards",
     },
+    {
+        "name": "list_bounty_attempts",
+        "description": "List advisory active attempts and warnings for a bounty",
+    },
     {"name": "get_balance", "description": "Get an account balance"},
     {
         "name": "register_wallet",

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -154,18 +154,27 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_bounties","arguments":{}}}'
 ```
 
+Inspect active attempt reservations for a bounty through MCP:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_bounty_attempts","arguments":{"bounty_id":11}}}'
+```
+
 Look up a public proof by hash:
 
 ```bash
 curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_proof","arguments":{"hash":"<proof_hash>"}}}'
+  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"get_proof","arguments":{"hash":"<proof_hash>"}}}'
 ```
 
 Tools:
 
 - `list_bounties`
 - `get_bounty`
+- `list_bounty_attempts`
 - `get_balance`
 - `register_wallet`
 - `get_wallet`

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -482,7 +482,7 @@ ledger sequence, addresses, amount, nonce, memo, and timestamp:
 ```json
 {
   "jsonrpc": "2.0",
-  "id": 6,
+  "id": 7,
   "result": {
     "content": [
       {
@@ -500,7 +500,7 @@ block is a JSON string with proof metadata plus the stored public proof payload:
 ```json
 {
   "jsonrpc": "2.0",
-  "id": 5,
+  "id": 6,
   "result": {
     "content": [
       {

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -447,13 +447,22 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_bounty","arguments":{"id":11}}}'
 ```
 
+Call `list_bounty_attempts` before opening a PR to inspect active advisory
+attempts and warnings for the internal bounty `id`:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"list_bounty_attempts","arguments":{"bounty_id":11}}}'
+```
+
 Call `get_proof` with the proof hash returned by `/api/v1/ledger`,
 `/api/v1/activity`, or `get_ledger_entry`:
 
 ```bash
 curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"get_proof","arguments":{"hash":"<proof_hash>"}}}'
+  -d '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"get_proof","arguments":{"hash":"<proof_hash>"}}}'
 ```
 
 Call `submit_wallet_transfer` with the same signed transfer fields used by the
@@ -463,7 +472,7 @@ send private keys to MergeWork:
 ```bash
 curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"submit_wallet_transfer","arguments":{"from_address":"<sender_mrwk1_address>","to_address":"<receiver_mrwk1_address>","amount_mrwk":"1.5","nonce":3,"memo":"agent payout consolidation","signature_hex":"<128 lowercase hex chars>"}}}'
+  -d '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"submit_wallet_transfer","arguments":{"from_address":"<sender_mrwk1_address>","to_address":"<receiver_mrwk1_address>","amount_mrwk":"1.5","nonce":3,"memo":"agent payout consolidation","signature_hex":"<128 lowercase hex chars>"}}}'
 ```
 
 Successful MCP transfer responses wrap a JSON-string transfer object in the

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 
 from fastapi.testclient import TestClient
@@ -225,3 +226,136 @@ def test_attempt_registration_rejects_closed_and_exhausted_bounties(
         "bounty is paid",
         "bounty has no award slots remaining",
     ]
+
+
+def test_mcp_lists_bounty_attempts_for_agent_visibility(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    now = datetime.now(UTC)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=321,
+            issue_url="https://github.com/ramimbo/mergework/issues/321",
+            title="MCP attempt visibility",
+            reward_mrwk="250",
+            max_awards=3,
+            acceptance="Agents should see active attempts before opening PRs.",
+        )
+        session.add_all(
+            [
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account="github:alice",
+                    source_url="https://github.com/ramimbo/mergework/pull/501",
+                    status="active",
+                    expires_at=now + timedelta(hours=1),
+                    created_at=now - timedelta(minutes=3),
+                    updated_at=now - timedelta(minutes=3),
+                ),
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account="github:bob",
+                    source_url="https://github.com/ramimbo/mergework/pull/502",
+                    status="active",
+                    expires_at=now + timedelta(hours=1),
+                    created_at=now - timedelta(minutes=2),
+                    updated_at=now - timedelta(minutes=2),
+                ),
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account="github:carol",
+                    source_url=None,
+                    status="released",
+                    expires_at=now + timedelta(hours=1),
+                    created_at=now - timedelta(minutes=4),
+                    updated_at=now - timedelta(minutes=1),
+                ),
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account="github:dave",
+                    source_url=None,
+                    status="active",
+                    expires_at=now - timedelta(minutes=1),
+                    created_at=now - timedelta(minutes=5),
+                    updated_at=now - timedelta(minutes=5),
+                ),
+            ]
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()
+    tool_names = {tool["name"] for tool in tools["result"]["tools"]}
+    assert "list_bounty_attempts" in tool_names
+
+    active_result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounty_attempts",
+                "arguments": {"bounty_id": bounty.id},
+            },
+        },
+    ).json()
+
+    active_payload = active_result["result"]["structuredContent"]
+    assert active_payload["warnings"] == ["bounty has 2 active attempts"]
+    assert [attempt["submitter_account"] for attempt in active_payload["attempts"]] == [
+        "github:bob",
+        "github:alice",
+    ]
+    assert json.loads(active_result["result"]["content"][0]["text"]) == active_payload
+
+    all_result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounty_attempts",
+                "arguments": {"bounty_id": bounty.id, "include_expired": True},
+            },
+        },
+    ).json()
+
+    all_payload = all_result["result"]["structuredContent"]
+    assert [attempt["status"] for attempt in all_payload["attempts"]] == [
+        "active",
+        "active",
+        "released",
+        "expired",
+    ]
+
+    unknown_result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounty_attempts",
+                "arguments": {"bounty_id": 999},
+            },
+        },
+    ).json()
+    assert unknown_result["result"]["content"][0]["text"] == "bounty not found"
+
+    invalid_result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounty_attempts",
+                "arguments": {"bounty_id": bounty.id, "include_expired": "yes"},
+            },
+        },
+    ).json()
+    assert invalid_result["error"] == {"code": -32602, "message": "invalid tool arguments"}


### PR DESCRIPTION
Bounty #321
/claim #321

## Summary
- Add a `list_bounty_attempts` MCP tool so agents can inspect active advisory attempts and warnings before opening overlapping PRs.
- Reuse the REST attempt serialization path for consistent active/default and include_expired behavior.
- Document the MCP attempt-visibility workflow in the agent guide and API examples.

This is read-only MCP visibility. It does not create payments, claim acceptance, mutate ledger balances, register attempts, or release attempts.

## Validation
- `uv run --extra dev python -m pytest tests/test_bounty_attempts.py tests/test_api_mcp.py::test_mcp_tools_list_and_call -q` -> 5 passed
- `uv run --extra dev python -m pytest tests/test_bounty_attempts.py tests/test_api_mcp.py tests/test_docs_public_urls.py -q` -> 94 passed
- `uv run --extra dev python -m pytest -q` -> 319 passed
- `uv run --extra dev ruff check .` -> passed
- `uv run --extra dev ruff format --check .` -> 46 files already formatted
- `uv run --extra dev python -m mypy app` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No private keys, seed material, secrets, private vulnerability details, deployment credentials, wallet addresses, or price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a discoverable tool to list a bounty’s active attempts, warnings, and historical attempts (supports include_expired flag); returns clear "bounty not found" for missing bounties.

* **Documentation**
  * Updated agent and API guides with examples showing how to discover and call the new bounty-attempts tool.

* **Tests**
  * Added tests covering discovery, successful responses, expired inclusion, missing-bounty, and invalid-argument cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->