### PR TITLE
Tolerate invalid stored proof payloads

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -59,9 +59,11 @@ from app.serializers import (
     activity_to_dict,
     bounty_awards_to_dict,
     bounty_list_summary,
+    bounty_payment_payload,
     bounty_to_dict,
     ledger_to_dict,
     payout_reconciliation_to_dict,
+    proof_public_payload,
     safe_accepted_work_for_account,
     safe_account_accepted_summary,
     wallet_to_dict,
@@ -214,8 +216,8 @@ def expire_stale_bounty_attempts(
 
 
 def _payout_response_from_proof(proof: Proof, *, status: str) -> dict[str, Any]:
-    data = json.loads(proof.public_json)
-    if not isinstance(data, dict) or data.get("kind") != "bounty_payment":
+    data = bounty_payment_payload(proof)
+    if data is None:
         raise HTTPException(status_code=500, detail="invalid proof payload")
     return {
         "status": status,
@@ -1099,8 +1101,8 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             proof = session.get(Proof, proof_hash)
             if proof is None:
                 raise HTTPException(status_code=404, detail="proof not found")
-            data = json.loads(proof.public_json)
-            if not isinstance(data, dict):
+            data = proof_public_payload(proof)
+            if data is None:
                 raise HTTPException(status_code=500, detail="invalid proof payload")
             return data
 
@@ -1725,8 +1727,8 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
             proof = session.get(Proof, _proof_hash_from_path(str_arg("hash")))
             if proof is None:
                 return "proof not found"
-            public_payload = json.loads(proof.public_json)
-            if not isinstance(public_payload, dict):
+            public_payload = proof_public_payload(proof)
+            if public_payload is None:
                 raise ValueError("invalid proof payload")
             return json.dumps(
                 {

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -37,6 +37,23 @@ def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
     }
 
 
+def proof_public_payload(proof: Proof) -> dict[str, Any] | None:
+    """Decode a stored public proof payload if it is a JSON object."""
+    try:
+        data = json.loads(proof.public_json)
+    except (TypeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def bounty_payment_payload(proof: Proof) -> dict[str, Any] | None:
+    """Decode a stored bounty payment proof payload."""
+    data = proof_public_payload(proof)
+    if data is None or data.get("kind") != "bounty_payment":
+        return None
+    return data
+
+
 def bounty_awards_to_dict(session: Session, bounty_id: int) -> list[dict[str, Any]]:
     """Return accepted award proof rows for a bounty."""
     proofs = session.scalars(
@@ -46,8 +63,8 @@ def bounty_awards_to_dict(session: Session, bounty_id: int) -> list[dict[str, An
     ).all()
     awards: list[dict[str, Any]] = []
     for proof in proofs:
-        data = json.loads(proof.public_json)
-        if not isinstance(data, dict) or data.get("kind") != "bounty_payment":
+        data = bounty_payment_payload(proof)
+        if data is None:
             continue
         proof_hash = str(proof.hash)
         awards.append(
@@ -128,8 +145,8 @@ def _bounty_detail_url(bounty_id: int | None) -> str | None:
 
 
 def _activity_row(entry: LedgerEntry, proof: Proof) -> dict[str, Any] | None:
-    data = json.loads(proof.public_json)
-    if not isinstance(data, dict) or data.get("kind") != "bounty_payment":
+    data = bounty_payment_payload(proof)
+    if data is None:
         return None
     submission_url = str(data.get("submission_url") or entry.reference)
     repo = data.get("repo")
@@ -288,8 +305,8 @@ def accepted_work_for_account(session: Session, account: str) -> list[dict[str, 
     ).all()
     accepted_work: list[dict[str, Any]] = []
     for proof, entry in rows:
-        data = json.loads(proof.public_json)
-        if not isinstance(data, dict) or data.get("kind") != "bounty_payment":
+        data = bounty_payment_payload(proof)
+        if data is None:
             continue
         repo = data.get("repo")
         issue_number = data.get("issue_number")

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from app.db import create_schema, session_scope
 from app.ledger.service import add_ledger_entry, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
+from app.models import Proof
 
 
 def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -> None:
@@ -109,6 +110,57 @@ def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -
     assert payload["recent"][0]["bounty_id"] == second_bounty.id
     assert payload["recent"][0]["bounty_url"] == f"/bounties/{second_bounty.id}"
     assert all("unproved" not in row["submission_url"] for row in payload["recent"])
+
+
+def test_activity_views_skip_malformed_proof_payloads(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=12,
+            issue_url="https://github.com/ramimbo/mergework/issues/12",
+            title="Activity malformed proof bounty",
+            reward_mrwk="25",
+            max_awards=2,
+            acceptance="Activity should skip malformed proof rows.",
+        )
+        valid_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/12",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        malformed_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:bob",
+            submission_url="https://github.com/ramimbo/mergework/pull/13",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        proof_row = session.get(Proof, malformed_proof.hash)
+        assert proof_row is not None
+        proof_row.public_json = "{"
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/api/v1/activity")
+    page = client.get("/activity")
+
+    assert response.status_code == 200
+    assert page.status_code == 200
+    payload = response.json()
+    assert payload["totals"] == {
+        "accepted_awards": 1,
+        "accepted_mrwk": "25",
+        "contributors": 1,
+    }
+    assert [row["proof_hash"] for row in payload["recent"]] == [valid_proof.hash]
+    assert malformed_proof.hash not in page.text
 
 
 def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1129,6 +1129,51 @@ def test_mcp_get_proof_rejects_malformed_hash(sqlite_url: str) -> None:
     }
 
 
+def test_mcp_get_proof_rejects_malformed_stored_payload(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=46,
+            issue_url="https://github.com/ramimbo/mergework/issues/46",
+            title="Malformed proof payload",
+            reward_mrwk="25",
+            acceptance="Proof payloads should be valid JSON.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/46",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        proof_row = session.get(Proof, proof.hash)
+        assert proof_row is not None
+        proof_row.public_json = "{"
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {"name": "get_proof", "arguments": {"hash": proof.hash}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 4,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
 def test_mcp_submit_work_proof_returns_bounty_specific_guidance(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -1561,9 +1606,11 @@ def test_account_api_keeps_schema_when_accepted_work_proof_is_malformed(
 
     response = client.get("/api/v1/accounts/github:alice")
     account_page = client.get("/accounts/github:alice")
+    accepted_work_response = client.get("/api/v1/accounts/github:alice/accepted-work")
 
     assert response.status_code == 200
     assert account_page.status_code == 200
+    assert accepted_work_response.status_code == 200
     account_api = response.json()
     assert account_api["balance_mrwk"] == "25"
     assert account_api["accepted_work"] == {
@@ -1573,6 +1620,18 @@ def test_account_api_keeps_schema_when_accepted_work_proof_is_malformed(
         "latest_submission_url": None,
         "latest_proof_hash": None,
         "latest_proof_url": None,
+    }
+    assert accepted_work_response.json() == {
+        "account": "github:alice",
+        "summary": {
+            "accepted_awards": 0,
+            "accepted_mrwk": "0",
+            "latest_ledger_sequence": None,
+            "latest_submission_url": None,
+            "latest_proof_hash": None,
+            "latest_proof_url": None,
+        },
+        "accepted_work": [],
     }
 
 

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
+from app.models import Proof
 
 
 def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
@@ -294,6 +296,54 @@ def test_bounty_detail_shows_accepted_award_history(sqlite_url: str) -> None:
     assert "/accounts/github:bob" in page.text
 
 
+def test_bounty_detail_skips_malformed_award_proof_payloads(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=165,
+            issue_url="https://github.com/ramimbo/mergework/issues/165",
+            title="Malformed proof award history",
+            reward_mrwk="50",
+            max_awards=2,
+            acceptance="Bounty detail pages should skip malformed proof rows.",
+        )
+        valid_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/203",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        malformed_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:bob",
+            submission_url="https://github.com/ramimbo/mergework/pull/204",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        proof_row = session.get(Proof, malformed_proof.hash)
+        assert proof_row is not None
+        proof_row.public_json = "{"
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    api_detail = client.get(f"/api/v1/bounties/{bounty_id}")
+    page = client.get(f"/bounties/{bounty_id}")
+
+    assert api_detail.status_code == 200
+    assert page.status_code == 200
+    assert [award["proof_hash"] for award in api_detail.json()["accepted_awards"]] == [
+        valid_proof.hash
+    ]
+    assert malformed_proof.hash not in page.text
+
+
 def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -367,3 +417,37 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert missing_proof.status_code == 404
     assert client.get("/api/v1/proofs/not-a-proof-hash").status_code == 400
     assert client.get("/proofs/not-a-proof-hash").status_code == 400
+
+
+@pytest.mark.parametrize("public_json", ["{", "[]"])
+def test_proof_api_reports_invalid_stored_payload(sqlite_url: str, public_json: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=24,
+            issue_url="https://github.com/ramimbo/mergework/issues/24",
+            title="Malformed proof payload",
+            reward_mrwk="50",
+            acceptance="Direct proof lookups should report invalid stored payloads.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/24",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        proof_row = session.get(Proof, proof.hash)
+        assert proof_row is not None
+        proof_row.public_json = public_json
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(f"/api/v1/proofs/{proof.hash}")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "invalid proof payload"


### PR DESCRIPTION
## Summary
- Decode stored public proof payloads through shared serializer helpers so malformed JSON and non-object JSON are handled consistently.
- Skip only the invalid proof row in aggregate public views such as bounty award history, activity, and account accepted-work responses.
- Return controlled invalid-payload errors for direct proof lookups through the REST API and MCP `get_proof`.

## Repro before fix
A stored bounty payment `Proof.public_json` value like `{` caused public aggregate views that decode proof rows to raise a server error instead of rendering the remaining valid accepted work. Non-object JSON payloads were also not covered explicitly.

## Validation
- `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_account_api_keeps_schema_when_accepted_work_proof_is_malformed tests/test_api_mcp.py::test_mcp_get_proof_rejects_malformed_stored_payload tests/test_activity.py::test_activity_views_skip_malformed_proof_payloads tests/test_bounty_pages.py::test_bounty_detail_skips_malformed_award_proof_payloads tests/test_bounty_pages.py::test_proof_api_reports_invalid_stored_payload -q --capture=no` -> 6 passed
- `uv run --extra dev python -m pytest tests/test_api_mcp.py tests/test_activity.py tests/test_bounty_pages.py -q --capture=no` -> 87 passed
- `uv run --extra dev ruff check app/main.py app/serializers.py tests/test_api_mcp.py tests/test_activity.py tests/test_bounty_pages.py` -> passed
- `uv run --extra dev ruff format --check app/main.py app/serializers.py tests/test_api_mcp.py tests/test_activity.py tests/test_bounty_pages.py` -> passed
- `uv run --extra dev python -m mypy app` -> success
- `uv run --extra dev python -m pytest -q --capture=no` -> 323 passed
- `git diff --check` -> passed

## Bounty
Refs #292

Notes:
- Ported onto the post-#330 serializer layout.
- This is independent from #256, which rejects non-object verifier metadata before proof creation.
- #328 may conflict in `app/serializers.py`, but only partially overlaps activity/account hardening.

No secrets, wallet private keys, payout credentials, deployment values, private vulnerability details, or MRWK price claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for malformed proof payloads across API endpoints and activity/bounty views. Invalid proofs now return HTTP 500 errors instead of breaking page rendering.

* **Refactor**
  * Consolidated proof payload parsing logic into reusable helper functions for consistency across bounty payouts, proof API responses, and MCP tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->