### PR TITLE
Add structured MCP work-proof availability state

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1601,10 +1601,19 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
 
     def work_proof_guidance_json(bounty: Bounty) -> dict[str, Any]:
         bounty_data = bounty_to_dict(bounty)
+        can_submit = bounty_data["status"] == "open" and bounty_data["awards_remaining"] > 0
+        availability_warnings = []
+        if bounty_data["status"] != "open":
+            availability_warnings.append(f"bounty is {bounty_data['status']}")
+        if bounty_data["awards_remaining"] <= 0:
+            availability_warnings.append("bounty has no award slots remaining")
         return {
             "bounty_id": bounty_data["id"],
             "issue_number": bounty_data["issue_number"],
             "status": bounty_data["status"],
+            "availability": "open_for_submissions" if can_submit else "not_currently_open",
+            "can_submit": can_submit,
+            "availability_warnings": availability_warnings,
             "awards_remaining": bounty_data["awards_remaining"],
             "max_awards": bounty_data["max_awards"],
             "awards_paid": bounty_data["awards_paid"],
@@ -1630,6 +1639,9 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
             "bounty_id": None,
             "issue_number": None,
             "status": "generic_guidance",
+            "availability": "unknown_without_bounty",
+            "can_submit": None,
+            "availability_warnings": [],
             "awards_remaining": None,
             "reward_mrwk": None,
             "repository": None,

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1246,6 +1246,9 @@ def test_mcp_submit_work_proof_returns_structured_bounty_guidance(sqlite_url: st
     assert structured["bounty_id"] == bounty_id
     assert structured["issue_number"] == 315
     assert structured["status"] == "open"
+    assert structured["availability"] == "open_for_submissions"
+    assert structured["can_submit"] is True
+    assert structured["availability_warnings"] == []
     assert structured["awards_remaining"] == 3
     assert structured["max_awards"] == 3
     assert structured["awards_paid"] == 0
@@ -1282,6 +1285,9 @@ def test_mcp_submit_work_proof_returns_structured_generic_guidance(sqlite_url: s
         "bounty_id": None,
         "issue_number": None,
         "status": "generic_guidance",
+        "availability": "unknown_without_bounty",
+        "can_submit": None,
+        "availability_warnings": [],
         "awards_remaining": None,
         "reward_mrwk": None,
         "repository": None,
@@ -1297,6 +1303,85 @@ def test_mcp_submit_work_proof_returns_structured_generic_guidance(sqlite_url: s
         ],
     }
     assert json.loads(response_result["content"][0]["text"]) == result
+
+
+def test_mcp_submit_work_proof_structures_terminal_bounty_availability(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        paid_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=316,
+            issue_url="https://github.com/ramimbo/mergework/issues/316",
+            title="Paid structured guidance",
+            reward_mrwk="100",
+            acceptance="Expose paid guidance state.",
+        )
+        closed_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=317,
+            issue_url="https://github.com/ramimbo/mergework/issues/317",
+            title="Closed structured guidance",
+            reward_mrwk="100",
+            max_awards=2,
+            acceptance="Expose closed guidance state.",
+        )
+        paid_bounty_id = paid_bounty.id
+        closed_bounty_id = closed_bounty.id
+        pay_bounty(
+            session,
+            bounty_id=paid_bounty_id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/316",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        close_bounty(
+            session,
+            bounty_id=closed_bounty_id,
+            closed_by="maintainer",
+            reference="https://github.com/ramimbo/mergework/issues/317#close",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    def structured_guidance(bounty_id: int, request_id: int) -> dict[str, object]:
+        response = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": "tools/call",
+                "params": {
+                    "name": "submit_work_proof",
+                    "arguments": {"bounty_id": bounty_id, "format": "json"},
+                },
+            },
+        ).json()["result"]
+        assert json.loads(response["content"][0]["text"]) == response["structuredContent"]
+        return response["structuredContent"]
+
+    paid = structured_guidance(paid_bounty_id, 1)
+    closed = structured_guidance(closed_bounty_id, 2)
+
+    assert paid["status"] == "paid"
+    assert paid["availability"] == "not_currently_open"
+    assert paid["can_submit"] is False
+    assert paid["availability_warnings"] == [
+        "bounty is paid",
+        "bounty has no award slots remaining",
+    ]
+    assert closed["status"] == "closed"
+    assert closed["availability"] == "not_currently_open"
+    assert closed["can_submit"] is False
+    assert closed["availability_warnings"] == [
+        "bounty is closed",
+        "bounty has no award slots remaining",
+    ]
 
 
 def test_mcp_submit_work_proof_reports_unknown_bounty(sqlite_url: str) -> None:


### PR DESCRIPTION
Refs #315

## Summary

- Add explicit structured availability fields to MCP `submit_work_proof` JSON guidance: `availability`, `can_submit`, and `availability_warnings`.
- Keep existing text-mode `submit_work_proof` behavior unchanged.
- Add focused MCP regressions for open, generic, paid, and closed guidance states.

## Agent impact

Structured MCP callers can now decide whether a bounty is actually open for submissions without inferring from separate `status` and `awards_remaining` fields. Paid, closed, and exhausted bounties return `can_submit: false`, `availability: "not_currently_open"`, and concrete warnings such as `bounty is paid` and `bounty has no award slots remaining`.

Generic no-selector guidance remains machine-readable but reports `availability: "unknown_without_bounty"` and `can_submit: null` because no concrete bounty was selected.

## Validation

- `./.venv/bin/python -m pytest tests/test_api_mcp.py::test_mcp_submit_work_proof_returns_structured_bounty_guidance tests/test_api_mcp.py::test_mcp_submit_work_proof_returns_structured_generic_guidance tests/test_api_mcp.py::test_mcp_submit_work_proof_structures_terminal_bounty_availability -q` -> 3 passed
- `./.venv/bin/python -m pytest tests/test_api_mcp.py -q` -> 74 passed
- `./.venv/bin/python -m pytest -q` -> 319 passed
- `./.venv/bin/python -m ruff check app/main.py tests/test_api_mcp.py` -> passed
- `./.venv/bin/python -m ruff format --check app/main.py tests/test_api_mcp.py` -> passed
- `./.venv/bin/python -m mypy app/main.py` -> passed
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No secrets, wallet private keys, payout credentials, private vulnerability details, deployment values, or MRWK price claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Work proof submission guidance now includes structured availability metadata (submission eligibility, availability status, and warnings) based on bounty state.

* **Tests**
  * Added test coverage for work proof submission guidance on terminal bounties (paid or closed states).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->