### PR TITLE
Warn on mixed bounty references in submission gate

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -225,8 +225,9 @@ The gate is advisory. It does not reserve work, claim acceptance, make payments,
 or block maintainer decisions. It checks for a `Bounty #<issue>` or
 `Refs #<issue>` reference, whether the referenced bounty appears open, whether
 the bounty has recent maintainer activity, whether the draft includes a concise
-summary and validation evidence, and whether a similar open PR already
-references the same bounty. When live GitHub or
+summary and validation evidence, whether multiple bounty references are mixed
+into one draft, and whether a similar open PR already references the same
+bounty. When live GitHub or
 MergeWork API data is unavailable, the gate degrades to advisory warnings
 instead of blocking submission.
 
@@ -235,8 +236,9 @@ Results:
 - `PASS`: the draft has the expected reference, summary, evidence, and no
   obvious duplicate from the available GitHub data.
 - `WARN`: the draft may still be valid, but agents should fix missing evidence,
-  add a clearer summary, inspect similar open PRs, or confirm a stale bounty
-  round still has maintainer activity before submitting.
+  add a clearer summary, keep one bounty target per submission, inspect similar
+  open PRs, or confirm a stale bounty round still has maintainer activity before
+  submitting.
 - `FAIL`: do not submit until the missing bounty reference or closed/exhausted
   bounty reference is fixed.
 

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -28,7 +28,15 @@ def _check(name: str, status: str, message: str) -> dict[str, str]:
 
 
 def _bounty_refs(text: str) -> list[int]:
-    return sorted({int(match) for match in BOUNTY_REF_RE.findall(text)})
+    refs: list[int] = []
+    seen: set[int] = set()
+    for match in BOUNTY_REF_RE.findall(text):
+        ref = int(match)
+        if ref in seen:
+            continue
+        seen.add(ref)
+        refs.append(ref)
+    return refs
 
 
 def _bounty_is_payable(raw: dict[str, Any]) -> bool:
@@ -181,6 +189,16 @@ def evaluate_submission(data: dict[str, Any]) -> dict[str, Any]:
         )
     else:
         checks.append(_check("bounty_reference", "pass", f"found bounty reference #{bounty_ref}"))
+        if len(refs) > 1:
+            joined_refs = ", ".join(f"#{ref}" for ref in refs)
+            checks.append(
+                _check(
+                    "single_bounty_reference",
+                    "warn",
+                    f"submission references multiple bounties ({joined_refs}); "
+                    "keep one bounty target or split the work",
+                )
+            )
         bounty = bounties.get(bounty_ref)
         if bounty is None:
             checks.append(

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -124,6 +124,49 @@ def test_submission_quality_gate_warns_for_similar_open_pr() -> None:
     ]
 
 
+def test_submission_quality_gate_warns_for_multiple_bounty_references() -> None:
+    result = evaluate_submission(
+        {
+            "submission_text": """
+            Summary:
+            Add focused quality-gate validation.
+
+            Bounty #320
+            Closes #319
+
+            Validation:
+            - pytest passed.
+            """,
+            "bounties": [
+                {"number": 319, "state": "CLOSED", "awards_remaining": 0},
+                {"number": 320, "state": "OPEN", "awards_remaining": 1},
+            ],
+            "pull_requests": [],
+        }
+    )
+
+    assert result["status"] == "warn"
+    assert result["bounty_reference"] == 320
+    assert {
+        "name": "bounty_payable",
+        "status": "pass",
+        "message": "referenced bounty #320 is open",
+    } in result["checks"]
+    assert {
+        "name": "single_bounty_reference",
+        "status": "warn",
+        "message": (
+            "submission references multiple bounties (#320, #319); "
+            "keep one bounty target or split the work"
+        ),
+    } in result["checks"]
+    assert {
+        "name": "bounty_payable",
+        "status": "fail",
+        "message": "referenced bounty #319 is closed or exhausted",
+    } not in result["checks"]
+
+
 def test_submission_quality_gate_passes_recent_maintainer_activity() -> None:
     result = evaluate_submission(
         {


### PR DESCRIPTION
Bounty #319

## Summary
- Preserve submission quality gate bounty-reference order instead of sorting distinct references.
- Warn when a draft mixes multiple bounty targets so agents keep one bounty target per submission or split the work.
- Document the new warning in the agent guide.

## Why this helps
A draft can name its intended bounty first and later include another close/fixes reference. The gate previously sorted unique references before picking one, which could make it evaluate a different bounty than the author intended. This keeps the first referenced target as the evaluated bounty while still warning about mixed targets before submission.

## Validation
- `uv run --extra dev python -m pytest tests/test_submission_quality_gate.py -q` -> 17 passed.
- `uv run --extra dev ruff check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py docs/agent-guide.md` -> passed.
- `uv run --extra dev ruff format --check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` -> passed.
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `uv run --extra dev python -m mypy scripts/submission_quality_gate.py` -> success.
- `git diff --check origin/main...HEAD` -> clean.
- `uv run --extra dev python scripts/submission_quality_gate.py --text-file <this PR body> --repo ramimbo/mergework --format text` -> PASS.

No secrets, wallet private keys, private payout details, deployment values, private vulnerability details, or MRWK price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Submissions referencing multiple bounties now trigger a validation warning with guidance to keep a single bounty target per submission or split work.

* **Documentation**
  * Enhanced submission quality gate advisory with clearer instructions emphasizing the requirement to maintain one bounty target per submission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->