### PR TITLE
Add public safety checks to submission gate

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -225,8 +225,10 @@ The gate is advisory. It does not reserve work, claim acceptance, make payments,
 or block maintainer decisions. It checks for a `Bounty #<issue>` or
 `Refs #<issue>` reference, whether the referenced bounty appears open, whether
 the bounty has recent maintainer activity, whether the draft includes a concise
-summary and validation evidence, and whether a similar open PR already
-references the same bounty. When live GitHub or
+summary and validation evidence, whether the draft includes restricted public
+content such as secrets, deployment credentials, private keys, or MRWK price and
+payout claims, and whether a similar open PR already references the same bounty.
+When live GitHub or
 MergeWork API data is unavailable, the gate degrades to advisory warnings
 instead of blocking submission.
 
@@ -235,10 +237,12 @@ Results:
 - `PASS`: the draft has the expected reference, summary, evidence, and no
   obvious duplicate from the available GitHub data.
 - `WARN`: the draft may still be valid, but agents should fix missing evidence,
-  add a clearer summary, inspect similar open PRs, or confirm a stale bounty
-  round still has maintainer activity before submitting.
+  add a clearer summary, remove MRWK price or payout claims, inspect similar
+  open PRs, or confirm a stale bounty round still has maintainer activity before
+  submitting.
 - `FAIL`: do not submit until the missing bounty reference or closed/exhausted
-  bounty reference is fixed.
+  bounty reference is fixed, or until restricted secret or credential material
+  has been removed from the public draft.
 
 For offline or testable runs, provide fixture data:
 

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -17,6 +17,20 @@ EVIDENCE_RE = re.compile(
     re.IGNORECASE,
 )
 SUMMARY_RE = re.compile(r"\b(summary|what changed|changes?)\b", re.IGNORECASE)
+RESTRICTED_PUBLIC_CONTENT_RE = re.compile(
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----"
+    r"|\b(?:seed phrase|mnemonic)\b\s*[:=]"
+    r"|\b(?:[A-Z0-9_]*[_ -])?(?:api[_ -]?key|auth[_ -]?token|access[_ -]?token|secret|password|"
+    r"private[_ -]?key|deployment[_ -]?credential)\b\s*[:=]\s*\S+"
+    r"|\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,})\b",
+    re.IGNORECASE,
+)
+MRWK_PRICE_OR_PAYOUT_CLAIM_RE = re.compile(
+    r"\bmrwk\b.{0,80}\b(?:worth|price|value|profit|return|moon|pump|usd|\$)"
+    r"|\b(?:worth|price|value|profit|return|moon|pump|usd|\$).{0,80}\bmrwk\b"
+    r"|\b(?:guaranteed|confirmed|already)\s+(?:payout|payment|paid|accepted)\b",
+    re.IGNORECASE,
+)
 GH_TIMEOUT_SECONDS = 30
 DEFAULT_API_HOST = "https://api.mrwk.ltclab.site"
 DEFAULT_MAX_MAINTAINER_AGE_DAYS = 14
@@ -130,6 +144,22 @@ def _has_evidence(text: str) -> bool:
     return False
 
 
+def _public_safety_check(text: str) -> dict[str, str]:
+    if RESTRICTED_PUBLIC_CONTENT_RE.search(text):
+        return _check(
+            "public_safety",
+            "fail",
+            "submission text appears to include restricted secrets or credentials",
+        )
+    if MRWK_PRICE_OR_PAYOUT_CLAIM_RE.search(text):
+        return _check(
+            "public_safety",
+            "warn",
+            "avoid MRWK price, payout, or investment claims in public artifacts",
+        )
+    return _check("public_safety", "pass", "no restricted public artifact content found")
+
+
 def _matching_pr_bounty_refs(pr: dict[str, Any]) -> list[int]:
     text = "\n".join(str(pr.get(key) or "") for key in ("title", "body"))
     return _bounty_refs(text)
@@ -230,6 +260,8 @@ def evaluate_submission(data: dict[str, Any]) -> dict[str, Any]:
                 "include concrete test or validation evidence before submission",
             )
         )
+
+    checks.append(_public_safety_check(text))
 
     similar = _similar_open_prs(pull_requests, bounty_ref, _title_from_submission(text))
     if similar:

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -31,6 +31,7 @@ def test_submission_quality_gate_passes_open_bounty_with_evidence(capsys, tmp_pa
         "bounty_payable": "pass",
         "summary_present": "pass",
         "evidence_present": "pass",
+        "public_safety": "pass",
         "similar_open_pr": "pass",
     }
 
@@ -122,6 +123,52 @@ def test_submission_quality_gate_warns_for_similar_open_pr() -> None:
             "url": "https://github.com/ramimbo/mergework/pull/12",
         }
     ]
+
+
+def test_submission_quality_gate_fails_private_key_in_submission_text() -> None:
+    result = evaluate_submission(
+        {
+            "submission_text": """
+            Summary: add validation.
+            Refs #319
+            Validation: pytest passed.
+
+            DEPLOYMENT_PRIVATE_KEY=abc123
+            """,
+            "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [],
+        }
+    )
+
+    assert result["status"] == "fail"
+    assert {
+        "name": "public_safety",
+        "status": "fail",
+        "message": "submission text appears to include restricted secrets or credentials",
+    } in result["checks"]
+
+
+def test_submission_quality_gate_warns_for_mrwk_price_claims() -> None:
+    result = evaluate_submission(
+        {
+            "submission_text": """
+            Summary: add validation.
+            Refs #319
+            Validation: pytest passed.
+
+            This proves MRWK will be worth $5 soon.
+            """,
+            "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [],
+        }
+    )
+
+    assert result["status"] == "warn"
+    assert {
+        "name": "public_safety",
+        "status": "warn",
+        "message": "avoid MRWK price, payout, or investment claims in public artifacts",
+    } in result["checks"]
 
 
 def test_submission_quality_gate_passes_recent_maintainer_activity() -> None:


### PR DESCRIPTION
Bounty #319

## Summary
- Add a public safety check to the submission quality gate.
- Fail drafts that include secret-like material such as private keys, tokens, passwords, or deployment credentials.
- Warn on unsupported public value or reward-status claims before agents post public artifacts.
- Document the new pass/warn/fail behavior for contributors and agents.

## Why this helps
Issue #319 explicitly asks agents not to post private keys, seed material, secrets, deployment credentials, private vulnerability details, or unsupported public claims. The reusable gate can now catch those public-artifact risks before a PR body or claim comment is submitted.

## Validation
- `uv run --extra dev python -m pytest tests/test_submission_quality_gate.py -q` -> 18 passed.
- `uv run --extra dev python -m pytest tests/test_submission_quality_gate.py tests/test_docs_public_urls.py -q` -> 35 passed.
- `uv run --extra dev python -m pytest -q` -> 328 passed.
- `uv run --extra dev ruff format --check .` -> 46 files already formatted.
- `uv run --extra dev ruff check .` -> All checks passed.
- `uv run --extra dev mypy app` -> Success: no issues found in 13 source files.
- `git diff --check` -> clean.
- `uv run --extra dev python scripts/submission_quality_gate.py --text-file <this PR body> --repo ramimbo/mergework --format text` -> PASS.

This PR does not claim acceptance; it only adds an advisory pre-submission check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Submission Quality Gate now detects and flags restricted content, including secrets, deployment credentials, and private keys.
  * Added detection for MRWK price and payout claims in submissions.

* **Documentation**
  * Updated Submission Quality Gate documentation to clarify checked criteria and outcomes.

* **Tests**
  * Added test coverage for restricted content and investment claim detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/344?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->