### PR TITLE
Advertise submit_work_proof MCP input schema

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -11,7 +11,7 @@ from app.ledger.service import LedgerError
 
 MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
 
-MCP_TOOLS: list[dict[str, str]] = [
+MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
         "description": "List MRWK bounties with optional status, q, and limit filters",
@@ -39,6 +39,32 @@ MCP_TOOLS: list[dict[str, str]] = [
     {
         "name": "submit_work_proof",
         "description": "Return submission instructions, optionally for a bounty_id or issue_number",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "bounty_id": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Internal MRWK bounty id. Use either bounty_id or issue_number.",
+                },
+                "issue_number": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": (
+                        "GitHub issue number for an MRWK bounty. "
+                        "Use either issue_number or bounty_id."
+                    ),
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["text", "json"],
+                    "default": "text",
+                    "description": "Use json for machine-readable structuredContent guidance.",
+                },
+            },
+            "additionalProperties": False,
+            "not": {"required": ["bounty_id", "issue_number"]},
+        },
     },
 ]
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -182,7 +182,8 @@ Tools:
 - `submit_wallet_transfer`
 - `get_ledger_entry`
 - `get_proof`
-- `submit_work_proof`
+- `submit_work_proof` (`format: "json"` returns structuredContent; `tools/list`
+  advertises the selector and format schema)
 
 ## Contribution Rules
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -430,6 +430,13 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
         tool for tool in tools["result"]["tools"] if tool["name"] == "submit_work_proof"
     )
     assert "bounty_id or issue_number" in submit_tool["description"]
+    submit_schema = submit_tool["inputSchema"]
+    assert submit_schema["additionalProperties"] is False
+    assert submit_schema["properties"]["format"]["enum"] == ["text", "json"]
+    assert submit_schema["properties"]["format"]["default"] == "text"
+    assert submit_schema["properties"]["bounty_id"]["minimum"] == 1
+    assert submit_schema["properties"]["issue_number"]["minimum"] == 1
+    assert submit_schema["not"] == {"required": ["bounty_id", "issue_number"]}
     bounty_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_bounty")
     assert "accepted awards" in bounty_tool["description"]
     attempt_tool = next(


### PR DESCRIPTION
## Summary

- Advertise an explicit MCP `inputSchema` for `submit_work_proof` in `tools/list`.
- Include `bounty_id`, `issue_number`, and `format` with the `text`/`json` enum so agents can discover structured guidance without hard-coded arguments.
- Update the agent guide and MCP regression coverage while preserving existing `submit_work_proof` call behavior.

## Why this is distinct

PR #317 and PR #339 added structured guidance output and availability state. This PR makes that contract discoverable through MCP tool metadata, so clients can learn the selector and format fields from `tools/list` before calling the tool.

## Test Evidence

- `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_mcp_tools_list_and_call tests/test_api_mcp.py::test_mcp_submit_work_proof_returns_structured_bounty_guidance tests/test_api_mcp.py::test_mcp_submit_work_proof_returns_structured_generic_guidance tests/test_api_mcp.py::test_mcp_submit_work_proof_rejects_invalid_bounty_selectors -q` -> 10 passed.
- `uv run --extra dev python -m pytest -q` -> 332 passed.
- `uv run --extra dev ruff check .` -> passed.
- `uv run --extra dev ruff format --check .` -> 46 files already formatted.
- `uv run --extra dev python -m mypy app` -> success.
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.

## MRWK

Bounty #315

No private keys, seed material, secrets, deployment credentials, private vulnerability details, payout credentials, or MRWK price claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Stricter validation for the work submission tool: format limited to text or JSON (default text), IDs must be positive, extra fields disallowed, and at least one of bounty ID or issue number is required.

* **Documentation**
  * Agent guide clarified: JSON format returns structured content and tool listing exposes selector and format schema.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->