### PR TITLE
Extract wallet API route registration

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -40,12 +40,10 @@ from app.ledger.service import (
     ensure_genesis,
     format_mrwk,
     get_balance,
-    link_wallet_to_github,
     pay_bounty,
     public_url_or_none,
     register_wallet,
     resolve_payout_account,
-    submit_github_claim,
     submit_wallet_transfer,
     validate_public_url,
 )
@@ -73,12 +71,12 @@ from app.serializers import (
     bounty_awards_to_dict,
     bounty_list_summary,
     bounty_to_dict,
-    ledger_to_dict,
     payout_reconciliation_to_dict,
     wallet_to_dict,
     wallet_transfer_to_dict,
 )
 from app.status import health_status, system_status
+from app.wallet_api import register_wallet_api_routes
 from app.webhooks.github import handle_github_webhook
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -606,90 +604,17 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         login = github_login_from_request(request)
         return {"authenticated": login is not None, "github_login": login}
 
-    @app.post("/api/v1/wallets/register")
-    async def api_register_wallet(request: Request) -> dict[str, Any]:
-        data = await _json_object(request)
-        with session_scope(db_url) as session:
-            try:
-                wallet = register_wallet(
-                    session,
-                    public_key_hex=_required_str(data, "public_key_hex"),
-                    label=_optional_str(data, "label") if data.get("label") is not None else None,
-                )
-            except LedgerError as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            return wallet_to_dict(session, wallet)
-
-    @app.get("/api/v1/wallets/register", include_in_schema=False)
-    def api_register_wallet_get() -> None:
-        post_only_route()
-
-    @app.get("/api/v1/wallets/link-github", include_in_schema=False)
-    def api_link_wallet_github_get() -> None:
-        post_only_route()
-
-    @app.get("/api/v1/wallets/{address}")
-    def api_wallet(address: str) -> dict[str, Any]:
-        address = normalized_wallet_address(address)
-        with session_scope(db_url) as session:
-            wallet = session.get(Wallet, address)
-            if wallet is None:
-                raise HTTPException(status_code=404, detail="wallet not found")
-            return wallet_to_dict(session, wallet)
-
-    @app.post("/api/v1/wallets/link-github")
-    async def api_link_wallet_github(
-        request: Request, github_login: str = Depends(require_github_login)
-    ) -> dict[str, Any]:
-        data = await _json_object(request)
-        with session_scope(db_url) as session:
-            try:
-                wallet = link_wallet_to_github(
-                    session,
-                    address=_required_str(data, "address"),
-                    github_login=github_login,
-                    nonce=_required_int(data, "nonce"),
-                    signature_hex=_required_str(data, "signature_hex"),
-                )
-            except LedgerError as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            return wallet_to_dict(session, wallet)
-
-    @app.post("/api/v1/github/claim")
-    async def api_github_claim(
-        request: Request, github_login: str = Depends(require_github_login)
-    ) -> dict[str, Any]:
-        data = await _json_object(request)
-        with session_scope(db_url) as session:
-            try:
-                entry = submit_github_claim(
-                    session,
-                    address=_required_str(data, "address"),
-                    github_login=github_login,
-                    nonce=_required_int(data, "nonce"),
-                    signature_hex=_required_str(data, "signature_hex"),
-                )
-            except LedgerError as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            return ledger_to_dict(entry)
-
-    @app.post("/api/v1/transfers")
-    async def api_submit_transfer(request: Request) -> dict[str, Any]:
-        data = await _json_object(request)
-        with session_scope(db_url) as session:
-            try:
-                transfer = submit_wallet_transfer(
-                    session,
-                    from_address=_required_str(data, "from_address"),
-                    to_address=_required_str(data, "to_address"),
-                    amount_mrwk=_required_str(data, "amount_mrwk"),
-                    nonce=_required_int(data, "nonce"),
-                    memo=_optional_str(data, "memo"),
-                    signature_hex=_required_str(data, "signature_hex"),
-                )
-            except LedgerError as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-            return wallet_transfer_to_dict(transfer)
+    register_wallet_api_routes(
+        app,
+        db_url=db_url,
+        require_github_login=require_github_login,
+        json_object=_json_object,
+        required_str=_required_str,
+        required_int=_required_int,
+        optional_str=_optional_str,
+        normalized_wallet_address=normalized_wallet_address,
+        post_only_route=post_only_route,
+    )
 
     @app.get("/api/v1/ledger")
     def api_ledger(limit: Annotated[int, Query(ge=1, le=200)] = 50) -> list[dict[str, Any]]:

--- a/app/wallet_api.py
+++ b/app/wallet_api.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from fastapi import Depends, FastAPI, HTTPException, Request
+
+from app.db import session_scope
+from app.ledger.service import (
+    LedgerError,
+    link_wallet_to_github,
+    register_wallet,
+    submit_github_claim,
+    submit_wallet_transfer,
+)
+from app.models import Wallet
+from app.serializers import ledger_to_dict, wallet_to_dict, wallet_transfer_to_dict
+
+JsonObjectLoader = Callable[[Request], Awaitable[dict[str, Any]]]
+LoginDependency = Callable[[Request], str]
+RequiredString = Callable[[dict[str, Any], str], str]
+RequiredInteger = Callable[[dict[str, Any], str], int]
+OptionalString = Callable[[dict[str, Any], str], str]
+NormalizeWalletAddress = Callable[[str], str]
+PostOnlyRoute = Callable[[], None]
+
+
+def register_wallet_api_routes(
+    app: FastAPI,
+    *,
+    db_url: str,
+    require_github_login: LoginDependency,
+    json_object: JsonObjectLoader,
+    required_str: RequiredString,
+    required_int: RequiredInteger,
+    optional_str: OptionalString,
+    normalized_wallet_address: NormalizeWalletAddress,
+    post_only_route: PostOnlyRoute,
+) -> None:
+    @app.post("/api/v1/wallets/register")
+    async def api_register_wallet(request: Request) -> dict[str, Any]:
+        data = await json_object(request)
+        with session_scope(db_url) as session:
+            try:
+                wallet = register_wallet(
+                    session,
+                    public_key_hex=required_str(data, "public_key_hex"),
+                    label=optional_str(data, "label") if data.get("label") is not None else None,
+                )
+            except LedgerError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            return wallet_to_dict(session, wallet)
+
+    @app.get("/api/v1/wallets/register", include_in_schema=False)
+    def api_register_wallet_get() -> None:
+        post_only_route()
+
+    @app.get("/api/v1/wallets/link-github", include_in_schema=False)
+    def api_link_wallet_github_get() -> None:
+        post_only_route()
+
+    @app.get("/api/v1/wallets/{address}")
+    def api_wallet(address: str) -> dict[str, Any]:
+        address = normalized_wallet_address(address)
+        with session_scope(db_url) as session:
+            wallet = session.get(Wallet, address)
+            if wallet is None:
+                raise HTTPException(status_code=404, detail="wallet not found")
+            return wallet_to_dict(session, wallet)
+
+    @app.post("/api/v1/wallets/link-github")
+    async def api_link_wallet_github(
+        request: Request, github_login: str = Depends(require_github_login)
+    ) -> dict[str, Any]:
+        data = await json_object(request)
+        with session_scope(db_url) as session:
+            try:
+                wallet = link_wallet_to_github(
+                    session,
+                    address=required_str(data, "address"),
+                    github_login=github_login,
+                    nonce=required_int(data, "nonce"),
+                    signature_hex=required_str(data, "signature_hex"),
+                )
+            except LedgerError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            return wallet_to_dict(session, wallet)
+
+    @app.post("/api/v1/github/claim")
+    async def api_github_claim(
+        request: Request, github_login: str = Depends(require_github_login)
+    ) -> dict[str, Any]:
+        data = await json_object(request)
+        with session_scope(db_url) as session:
+            try:
+                entry = submit_github_claim(
+                    session,
+                    address=required_str(data, "address"),
+                    github_login=github_login,
+                    nonce=required_int(data, "nonce"),
+                    signature_hex=required_str(data, "signature_hex"),
+                )
+            except LedgerError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            return ledger_to_dict(entry)
+
+    @app.post("/api/v1/transfers")
+    async def api_submit_transfer(request: Request) -> dict[str, Any]:
+        data = await json_object(request)
+        with session_scope(db_url) as session:
+            try:
+                transfer = submit_wallet_transfer(
+                    session,
+                    from_address=required_str(data, "from_address"),
+                    to_address=required_str(data, "to_address"),
+                    amount_mrwk=required_str(data, "amount_mrwk"),
+                    nonce=required_int(data, "nonce"),
+                    memo=optional_str(data, "memo"),
+                    signature_hex=required_str(data, "signature_hex"),
+                )
+            except LedgerError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            return wallet_transfer_to_dict(transfer)

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -18,6 +18,7 @@ from app.ledger.service import (
     submit_wallet_transfer,
     wallet_claim_payload,
     wallet_link_payload,
+    wallet_transfer_payload,
 )
 from app.main import _safe_next_path, _signed_value, _verified_value, create_app
 from app.wallets import address_from_public_key_hex, canonical_wallet_json
@@ -98,6 +99,38 @@ def test_wallet_api_register_lookup_and_transfer(sqlite_url: str) -> None:
     assert transfer["type"] == "wallet_transfer"
     assert transfer["amount_mrwk"] == "3"
     assert client.get(f"/api/v1/wallets/{receiver_address}").json()["balance_mrwk"] == "3"
+
+
+def test_wallet_transfer_api_rejects_replayed_signed_body(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    sender_key, sender_public, sender_address = _keypair()
+    _, receiver_public, receiver_address = _keypair()
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _register_wallet(client, sender_public)
+    _register_wallet(client, receiver_public)
+    _fund_wallet(sqlite_url, sender_address)
+    payload = wallet_transfer_payload(
+        from_address=sender_address,
+        to_address=receiver_address,
+        amount_microunits=1_000_000,
+        nonce=1,
+        memo="api replay",
+    )
+    body = {
+        "from_address": sender_address,
+        "to_address": receiver_address,
+        "amount_mrwk": "1",
+        "nonce": 1,
+        "memo": "api replay",
+        "signature_hex": _sign(sender_key, payload),
+    }
+
+    first = client.post("/api/v1/transfers", json=body)
+    second = client.post("/api/v1/transfers", json=body)
+
+    assert first.status_code == 200
+    assert second.status_code == 400
+    assert second.json()["detail"] == "invalid nonce"
 
 
 @pytest.mark.parametrize(
@@ -269,10 +302,11 @@ def test_wallet_method_boundary_routes_are_hidden_from_openapi(sqlite_url: str) 
 
     paths = client.get("/openapi.json").json()["paths"]
 
-    assert "post" in paths["/api/v1/wallets/register"]
-    assert "get" not in paths["/api/v1/wallets/register"]
-    assert "post" in paths["/api/v1/wallets/link-github"]
-    assert "get" not in paths["/api/v1/wallets/link-github"]
+    assert set(paths["/api/v1/wallets/register"]) == {"post"}
+    assert set(paths["/api/v1/wallets/link-github"]) == {"post"}
+    assert set(paths["/api/v1/wallets/{address}"]) == {"get"}
+    assert set(paths["/api/v1/github/claim"]) == {"post"}
+    assert set(paths["/api/v1/transfers"]) == {"post"}
 
 
 def test_wallet_api_malformed_transfer_requests_return_4xx(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary

- Extract wallet API route registration from `app/main.py` into focused `app/wallet_api.py`.
- Move wallet registration, wallet lookup, GitHub wallet linking, GitHub balance claim, and signed wallet transfer routes behind one route-registration boundary.
- Keep `app/main.py` responsible for app wiring and shared dependencies while preserving existing public API behavior.
- Extend wallet OpenAPI regression coverage to keep the moved lookup, claim, and transfer routes registered with the expected methods.

## Complexity reduced

`app/main.py` no longer owns wallet-specific request parsing, ledger error handling, wallet lookup, GitHub link/claim, and transfer response shaping for wallet API routes. The wallet API can now be reviewed independently from bounty, admin, webhook, OAuth/session, MCP, ledger, account, and page routing code.

## Why this is distinct

This PR targets only the wallet API route boundary. It is distinct from accepted #328, #337, #364, #375, and #376, and from #388 which targets account-route normalization/context/page boundaries.

## Rebase update

Rebased onto current `origin/main` after #320 and #377 filled, and retargeted for the current code-health round.

## Validation

- `uv run --extra dev python -m pytest tests/test_wallet_api.py tests/test_wallets.py -q` -> 43 passed
- `uv run --extra dev python -m pytest -q` -> 372 passed
- `uv run --extra dev ruff check app/main.py app/wallet_api.py tests/test_wallet_api.py` -> passed
- `uv run --extra dev ruff format --check app/main.py app/wallet_api.py tests/test_wallet_api.py` -> 3 files already formatted
- `uv run --extra dev python -m mypy app/main.py app/wallet_api.py` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean

## MRWK

Bounty #390

No private keys, seed material, secrets, deployment credentials, private vulnerability details, payout credentials, or MRWK price claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Wallet REST endpoints (registration, wallet↔GitHub linking, GitHub claims, transfers, and wallet lookup) are now registered via a centralized route registration and hide some GET boundary routes from the public OpenAPI contract.

* **Bug Fixes**
  * Transfer submissions enforce nonce replay protection and reject replayed signed requests with an error.
  * Wallet lookup returns 404 for missing addresses.

* **Tests**
  * Added tests for transfer replay protection and exact API method visibility in the OpenAPI contract.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->