### PR TITLE
Scope MCP work-proof issue lookup by repo

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1530,6 +1530,14 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
             raise ValueError("format must be text or json")
         return normalized
 
+    def optional_repo_selector_arg() -> str | None:
+        repo = optional_clean_str_arg("repo")
+        if repo is None:
+            return None
+        if len(repo) > 200:
+            raise ValueError("repo is too long")
+        return repo.lower()
+
     def mcp_issue_number_search_value(query_text: str) -> int | None:
         if not query_text.isdigit():
             return None
@@ -1756,8 +1764,11 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
             output_format = output_format_arg()
             has_bounty_id = "bounty_id" in args and args.get("bounty_id") is not None
             has_issue_number = "issue_number" in args and args.get("issue_number") is not None
+            repo_selector = optional_repo_selector_arg()
             if has_bounty_id and has_issue_number:
                 raise ValueError("use bounty_id or issue_number, not both")
+            if repo_selector is not None and not has_issue_number:
+                raise ValueError("repo can only be used with issue_number")
             if has_bounty_id:
                 bounty = session.get(Bounty, positive_int_arg("bounty_id"))
                 if bounty is None:
@@ -1768,12 +1779,12 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
                     else work_proof_guidance(bounty)
                 )
             if has_issue_number:
-                bounties = session.scalars(
-                    select(Bounty)
-                    .where(Bounty.issue_number == positive_int_arg("issue_number"))
-                    .order_by(Bounty.id.desc())
-                    .limit(2)
-                ).all()
+                issue_query = select(Bounty).where(
+                    Bounty.issue_number == positive_int_arg("issue_number")
+                )
+                if repo_selector is not None:
+                    issue_query = issue_query.where(Bounty.repo == repo_selector)
+                bounties = session.scalars(issue_query.order_by(Bounty.id.desc()).limit(2)).all()
                 if not bounties:
                     return "bounty not found"
                 if len(bounties) > 1:

--- a/app/mcp.py
+++ b/app/mcp.py
@@ -38,7 +38,10 @@ MCP_TOOLS: list[dict[str, str]] = [
     {"name": "get_proof", "description": "Get a public proof by hash"},
     {
         "name": "submit_work_proof",
-        "description": "Return submission instructions, optionally for a bounty_id or issue_number",
+        "description": (
+            "Return submission instructions for bounty_id or issue_number, optionally "
+            "scoping issue_number by repo, with text or json format"
+        ),
     },
 ]
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1542,6 +1542,56 @@ def test_mcp_submit_work_proof_reports_unknown_bounty(sqlite_url: str) -> None:
     assert result["result"]["content"][0]["text"] == "bounty not found"
 
 
+def test_mcp_submit_work_proof_scopes_issue_number_by_repo(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    with session_scope(sqlite_url) as session:
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=284,
+            issue_url="https://github.com/ramimbo/mergework/issues/284",
+            title="First bounty",
+            reward_mrwk="100",
+            acceptance="First acceptance.",
+        )
+        target = create_bounty(
+            session,
+            repo="example/mergework",
+            issue_number=284,
+            issue_url="https://github.com/example/mergework/issues/284",
+            title="Second bounty",
+            reward_mrwk="250",
+            acceptance="Second acceptance.",
+        )
+        target_id = target.id
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 28,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_work_proof",
+                "arguments": {
+                    "issue_number": 284,
+                    "repo": "Example/MergeWork",
+                    "format": "json",
+                },
+            },
+        },
+    )
+
+    result = response.json()["result"]
+    structured = result["structuredContent"]
+    assert json.loads(result["content"][0]["text"]) == structured
+    assert structured["bounty_id"] == target_id
+    assert structured["repository"] == "example/mergework"
+    assert structured["title"] == "Second bounty"
+    assert structured["reward_mrwk"] == "250"
+    assert structured["acceptance"] == "Second acceptance."
+
+
 @pytest.mark.parametrize(
     ("arguments", "request_id"),
     [
@@ -1552,6 +1602,10 @@ def test_mcp_submit_work_proof_reports_unknown_bounty(sqlite_url: str) -> None:
         ({"bounty_id": 1, "issue_number": 1}, 25),
         ({"format": "xml"}, 26),
         ({"format": 1}, 27),
+        ({"repo": "ramimbo/mergework"}, 29),
+        ({"bounty_id": 1, "repo": "ramimbo/mergework"}, 30),
+        ({"issue_number": 1, "repo": 1}, 31),
+        ({"issue_number": 1, "repo": "a" * 201}, 32),
     ],
 )
 def test_mcp_submit_work_proof_rejects_invalid_bounty_selectors(


### PR DESCRIPTION
Refs #315

## Summary
- Add an optional `repo` selector to MCP `submit_work_proof` when selecting by `issue_number`.
- Scope issue-number lookup with case-insensitive repository matching so agents can disambiguate duplicated issue numbers across repos.
- Reject `repo` unless `issue_number` is present, and validate non-string or oversized repo selectors.

## Evidence
- `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_mcp_submit_work_proof_scopes_issue_number_by_repo tests/test_api_mcp.py::test_mcp_submit_work_proof_rejects_invalid_bounty_selectors -q` -> 12 passed.
- `uv run --extra dev ruff check app/main.py app/mcp.py tests/test_api_mcp.py` -> passed.
- `uv run --extra dev ruff format --check app/main.py app/mcp.py tests/test_api_mcp.py` -> 3 files already formatted.
- `uv run --extra dev python -m mypy app/main.py app/mcp.py` -> success.
- `git diff --check origin/main..HEAD` -> clean.

No private keys, seed material, secrets, deployment credentials, private vulnerability details, payout credentials, or MRWK price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional repo selector added to submit_work_proof to disambiguate bounties with the same issue number.

* **Bug Fixes**
  * repo input is normalized (trimmed, lowercased, max 200 chars) and accepted only when paired with an issue_number; bounty_id and issue_number remain mutually exclusive.

* **Documentation**
  * Tool description clarified to note optional repo scoping and text/JSON response formats.

* **Tests**
  * Added tests covering repo scoping, casing, format, and invalid argument combinations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->