### PR TITLE
Extract auth helpers from app.main

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -128,28 +128,44 @@ async def _github_oauth_login_from_callback(
         raise HTTPException(status_code=401, detail="invalid OAuth state") from exc
     next_path = safe_next_path(next_path)
     async with httpx.AsyncClient(timeout=10) as client:
-        token_response = await client.post(
-            "https://github.com/login/oauth/access_token",
-            headers={"Accept": "application/json"},
-            data={
-                "client_id": settings.github_oauth_client_id,
-                "client_secret": settings.github_oauth_client_secret,
-                "code": code,
-                "redirect_uri": f"{settings.public_base_url}/auth/github/callback",
-            },
-        )
-        token_response.raise_for_status()
+        try:
+            token_response = await client.post(
+                "https://github.com/login/oauth/access_token",
+                headers={"Accept": "application/json"},
+                data={
+                    "client_id": settings.github_oauth_client_id,
+                    "client_secret": settings.github_oauth_client_secret,
+                    "code": code,
+                    "redirect_uri": f"{settings.public_base_url}/auth/github/callback",
+                },
+            )
+            token_response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise HTTPException(
+                status_code=401, detail="GitHub OAuth token exchange failed"
+            ) from exc
+        except httpx.RequestError as exc:
+            raise HTTPException(
+                status_code=502, detail="GitHub OAuth token exchange unavailable"
+            ) from exc
         access_token = token_response.json().get("access_token")
         if not access_token:
             raise HTTPException(status_code=401, detail="GitHub OAuth token exchange failed")
-        user_response = await client.get(
-            "https://api.github.com/user",
-            headers={
-                "Accept": "application/vnd.github+json",
-                "Authorization": f"Bearer {access_token}",
-            },
-        )
-        user_response.raise_for_status()
+        try:
+            user_response = await client.get(
+                "https://api.github.com/user",
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": f"Bearer {access_token}",
+                },
+            )
+            user_response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise HTTPException(status_code=401, detail="GitHub OAuth user lookup failed") from exc
+        except httpx.RequestError as exc:
+            raise HTTPException(
+                status_code=502, detail="GitHub OAuth user lookup unavailable"
+            ) from exc
         login = str(user_response.json().get("login", "")).lower()
         if not login:
             raise HTTPException(status_code=401, detail="GitHub OAuth user lookup failed")

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+import time
+from urllib.parse import unquote, urlencode
+
+import httpx
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import RedirectResponse
+
+from app.config import Settings
+
+OAUTH_STATE_COOKIE = "mrwk_oauth_state"
+USER_COOKIE = "mrwk_user"
+ADMIN_COOKIE = "mrwk_admin"
+OAUTH_STATE_MAX_AGE_SECONDS = 600
+USER_SESSION_MAX_AGE_SECONDS = 604_800
+ADMIN_SESSION_MAX_AGE_SECONDS = 86_400
+CSRF_MAX_AGE_SECONDS = 3_600
+
+
+def oauth_configured(settings: Settings) -> bool:
+    return bool(
+        settings.github_oauth_client_id
+        and settings.github_oauth_client_secret
+        and settings.cookie_secret
+    )
+
+
+def safe_next_path(next_path: str | None) -> str:
+    decoded_next_path = unquote(next_path) if next_path else ""
+    if (
+        not next_path
+        or not next_path.startswith("/")
+        or next_path.startswith("//")
+        or len(next_path) > 2048
+        or "\\" in next_path
+        or decoded_next_path.startswith("//")
+        or "\\" in decoded_next_path
+        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
+        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)
+    ):
+        return "/me"
+    return next_path
+
+
+def signed_value(value: str, secret: str) -> str:
+    timestamp = str(int(time.time()))
+    body = f"{value}|{timestamp}"
+    signature = hmac.new(secret.encode(), body.encode(), hashlib.sha256).hexdigest()
+    return f"{body}|{signature}"
+
+
+def verified_value(token: str | None, secret: str, max_age_seconds: int) -> str | None:
+    if not token or not secret:
+        return None
+    try:
+        value, timestamp, signature = token.rsplit("|", 2)
+        age = int(time.time()) - int(timestamp)
+    except ValueError:
+        return None
+    if age < 0 or age > max_age_seconds:
+        return None
+    expected = hmac.new(
+        secret.encode(), f"{value}|{timestamp}".encode(), hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(signature, expected):
+        return None
+    return value
+
+
+def csrf_token(action: str, login: str, secret: str) -> str:
+    return signed_value(f"{action}:{login}", secret)
+
+
+def verify_csrf_token(
+    token: str | None,
+    *,
+    action: str,
+    login: str,
+    secret: str,
+    max_age_seconds: int = CSRF_MAX_AGE_SECONDS,
+) -> bool:
+    expected = f"{action}:{login}"
+    return verified_value(token, secret, max_age_seconds) == expected
+
+
+def admin_login_from_request(request: Request, settings: Settings) -> str | None:
+    token = request.headers.get("x-mergework-admin-token", "")
+    if settings.admin_token and hmac.compare_digest(token, settings.admin_token):
+        return "api-token"
+    login = verified_value(
+        request.cookies.get(ADMIN_COOKIE), settings.cookie_secret, ADMIN_SESSION_MAX_AGE_SECONDS
+    )
+    if login and login.lower() in settings.admin_logins:
+        return login.lower()
+    return None
+
+
+def github_login_from_request(request: Request, settings: Settings) -> str | None:
+    login = verified_value(
+        request.cookies.get(USER_COOKIE), settings.cookie_secret, USER_SESSION_MAX_AGE_SECONDS
+    )
+    return login.lower() if login else None
+
+
+def require_admin_token_from_request(request: Request, settings: Settings) -> str:
+    token = request.headers.get("x-mergework-admin-token", "")
+    if settings.admin_token and hmac.compare_digest(token, settings.admin_token):
+        return "api-token"
+    raise HTTPException(status_code=401, detail="admin token required")
+
+
+async def _github_oauth_login_from_callback(
+    request: Request, settings: Settings, code: str, state: str
+) -> tuple[str, str]:
+    cookie_state = request.cookies.get(OAUTH_STATE_COOKIE)
+    if not cookie_state or not hmac.compare_digest(cookie_state, state):
+        raise HTTPException(status_code=401, detail="invalid OAuth state")
+    state_value = verified_value(state, settings.cookie_secret, OAUTH_STATE_MAX_AGE_SECONDS)
+    if state_value is None:
+        raise HTTPException(status_code=401, detail="expired OAuth state")
+    try:
+        _, next_path = state_value.split(",", 1)
+    except ValueError as exc:
+        raise HTTPException(status_code=401, detail="invalid OAuth state") from exc
+    next_path = safe_next_path(next_path)
+    async with httpx.AsyncClient(timeout=10) as client:
+        token_response = await client.post(
+            "https://github.com/login/oauth/access_token",
+            headers={"Accept": "application/json"},
+            data={
+                "client_id": settings.github_oauth_client_id,
+                "client_secret": settings.github_oauth_client_secret,
+                "code": code,
+                "redirect_uri": f"{settings.public_base_url}/auth/github/callback",
+            },
+        )
+        token_response.raise_for_status()
+        access_token = token_response.json().get("access_token")
+        if not access_token:
+            raise HTTPException(status_code=401, detail="GitHub OAuth token exchange failed")
+        user_response = await client.get(
+            "https://api.github.com/user",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {access_token}",
+            },
+        )
+        user_response.raise_for_status()
+        login = str(user_response.json().get("login", "")).lower()
+        if not login:
+            raise HTTPException(status_code=401, detail="GitHub OAuth user lookup failed")
+    return login, next_path
+
+
+def _set_github_session_cookies(
+    response: RedirectResponse, login: str, settings: Settings
+) -> RedirectResponse:
+    response.set_cookie(
+        USER_COOKIE,
+        signed_value(login, settings.cookie_secret),
+        httponly=True,
+        secure=True,
+        samesite="lax",
+        max_age=USER_SESSION_MAX_AGE_SECONDS,
+    )
+    if login in settings.admin_logins:
+        response.set_cookie(
+            ADMIN_COOKIE,
+            signed_value(login, settings.cookie_secret),
+            httponly=True,
+            secure=True,
+            samesite="lax",
+            max_age=ADMIN_SESSION_MAX_AGE_SECONDS,
+        )
+    return response
+
+
+def register_auth_routes(app: FastAPI, settings: Settings) -> None:
+    @app.get("/auth/github/login")
+    def auth_github_login(next_path: str | None = Query(None, alias="next")) -> RedirectResponse:
+        if not oauth_configured(settings):
+            raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
+        state_value = f"{secrets.token_urlsafe(24)},{safe_next_path(next_path)}"
+        state = signed_value(state_value, settings.cookie_secret)
+        query = urlencode(
+            {
+                "client_id": settings.github_oauth_client_id,
+                "redirect_uri": f"{settings.public_base_url}/auth/github/callback",
+                "scope": "read:user",
+                "state": state,
+            }
+        )
+        response = RedirectResponse(
+            f"https://github.com/login/oauth/authorize?{query}", status_code=302
+        )
+        response.set_cookie(
+            OAUTH_STATE_COOKIE,
+            state,
+            httponly=True,
+            secure=True,
+            samesite="lax",
+            max_age=OAUTH_STATE_MAX_AGE_SECONDS,
+        )
+        return response
+
+    @app.get("/auth/github/callback")
+    async def auth_github_callback(request: Request, code: str, state: str) -> RedirectResponse:
+        if not oauth_configured(settings):
+            raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
+        login, next_path = await _github_oauth_login_from_callback(request, settings, code, state)
+        response = _set_github_session_cookies(
+            RedirectResponse(next_path, status_code=302), login, settings
+        )
+        response.delete_cookie(OAUTH_STATE_COOKIE)
+        return response
+
+    @app.get("/admin/login")
+    def admin_login() -> RedirectResponse:
+        return RedirectResponse("/auth/github/login?next=/admin", status_code=302)
+
+    @app.get("/admin/callback")
+    async def admin_callback(request: Request) -> RedirectResponse:
+        suffix = f"?{request.url.query}" if request.url.query else ""
+        return RedirectResponse(f"/auth/github/callback{suffix}", status_code=302)
+
+    @app.post("/auth/logout")
+    def auth_logout() -> RedirectResponse:
+        response = RedirectResponse("/", status_code=303)
+        response.delete_cookie(USER_COOKIE)
+        response.delete_cookie(ADMIN_COOKIE)
+        return response

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,10 +6,11 @@ import json
 import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from sqlalchemy import case, func, select, update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -656,16 +657,19 @@ def pay_bounty(
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")
-    claimed = session.execute(
-        update(Bounty)
-        .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
-        .values(
-            awards_paid=Bounty.awards_paid + 1,
-            status=case(
-                (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
-                else_="open",
-            ),
-        )
+    claimed = cast(
+        CursorResult[Any],
+        session.execute(
+            update(Bounty)
+            .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
+            .values(
+                awards_paid=Bounty.awards_paid + 1,
+                status=case(
+                    (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
+                    else_="open",
+                ),
+            )
+        ),
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty already paid")
@@ -733,10 +737,13 @@ def close_bounty(
         raise LedgerError("bounty is not open")
     _clean_required_text(closed_by, "closed_by", 80)
     clean_reference = validate_public_url(reference or bounty.issue_url)
-    claimed = session.execute(
-        update(Bounty)
-        .where(Bounty.id == bounty.id, Bounty.status == "open")
-        .values(status="closed")
+    claimed = cast(
+        CursorResult[Any],
+        session.execute(
+            update(Bounty)
+            .where(Bounty.id == bounty.id, Bounty.status == "open")
+            .values(status="closed")
+        ),
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty is not open")

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,11 +6,10 @@ import json
 import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlparse
 
 from sqlalchemy import case, func, select, update
-from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -657,19 +656,16 @@ def pay_bounty(
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
-            .values(
-                awards_paid=Bounty.awards_paid + 1,
-                status=case(
-                    (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
-                    else_="open",
-                ),
-            )
-        ),
+    claimed = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
+        .values(
+            awards_paid=Bounty.awards_paid + 1,
+            status=case(
+                (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
+                else_="open",
+            ),
+        )
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty already paid")
@@ -737,13 +733,10 @@ def close_bounty(
         raise LedgerError("bounty is not open")
     _clean_required_text(closed_by, "closed_by", 80)
     clean_reference = validate_public_url(reference or bounty.issue_url)
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.status == "open")
-            .values(status="closed")
-        ),
+    claimed = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.status == "open")
+        .values(status="closed")
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty is not open")

--- a/app/main.py
+++ b/app/main.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
-import hashlib
-import hmac
 import json
 import re
-import secrets
-import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import urlencode, urlsplit, urlunsplit
+from urllib.parse import urlsplit, urlunsplit
 
-import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
@@ -20,13 +15,14 @@ from sqlalchemy import func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app import auth as auth_helpers
 from app.admin import (
     list_webhook_events,
     normalize_webhook_status_filter,
     webhook_events_to_dict,
     webhook_status_summary,
 )
-from app.config import Settings, get_settings
+from app.config import get_settings
 from app.db import create_schema, session_scope
 from app.ledger.reconciliation import payout_reconciliation_summary, reconcile_accepted_payouts
 from app.ledger.service import (
@@ -116,6 +112,12 @@ SQLITE_INTEGER_MAX = 2**63 - 1
 DEFAULT_ATTEMPT_TTL_SECONDS = 24 * 60 * 60
 MIN_ATTEMPT_TTL_SECONDS = 60
 MAX_ATTEMPT_TTL_SECONDS = 7 * 24 * 60 * 60
+_oauth_configured = auth_helpers.oauth_configured
+_safe_next_path = auth_helpers.safe_next_path
+_signed_value = auth_helpers.signed_value
+_verified_value = auth_helpers.verified_value
+_csrf_token = auth_helpers.csrf_token
+_verify_csrf_token = auth_helpers.verify_csrf_token
 
 
 def _request_was_forwarded_https(request: Request) -> bool:
@@ -269,27 +271,6 @@ def _proof_hashes_by_sequence(session: Session, sequences: list[int]) -> dict[in
     return {int(sequence): str(proof_hash) for sequence, proof_hash in rows}
 
 
-def _oauth_configured(settings: Settings) -> bool:
-    return bool(
-        settings.github_oauth_client_id
-        and settings.github_oauth_client_secret
-        and settings.cookie_secret
-    )
-
-
-def _safe_next_path(next_path: str | None) -> str:
-    if (
-        not next_path
-        or not next_path.startswith("/")
-        or next_path.startswith("//")
-        or len(next_path) > 2048
-        or "\\" in next_path
-        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
-    ):
-        return "/me"
-    return next_path
-
-
 def _normalized_account(account: str) -> str:
     if not account or not account.strip():
         raise HTTPException(status_code=400, detail="account must not be empty")
@@ -368,31 +349,6 @@ def _proof_hash_from_path(proof_hash: str) -> str:
     return clean
 
 
-def _signed_value(value: str, secret: str) -> str:
-    timestamp = str(int(time.time()))
-    body = f"{value}|{timestamp}"
-    signature = hmac.new(secret.encode(), body.encode(), hashlib.sha256).hexdigest()
-    return f"{body}|{signature}"
-
-
-def _verified_value(token: str | None, secret: str, max_age_seconds: int) -> str | None:
-    if not token or not secret:
-        return None
-    try:
-        value, timestamp, signature = token.rsplit("|", 2)
-        age = int(time.time()) - int(timestamp)
-    except ValueError:
-        return None
-    if age < 0 or age > max_age_seconds:
-        return None
-    expected = hmac.new(
-        secret.encode(), f"{value}|{timestamp}".encode(), hashlib.sha256
-    ).hexdigest()
-    if not hmac.compare_digest(signature, expected):
-        return None
-    return value
-
-
 async def _json_object(request: Request) -> dict[str, Any]:
     try:
         data = await request.json()
@@ -450,17 +406,6 @@ def _optional_int(data: dict[str, Any], field: str, default: int) -> int:
     return _parse_int(value, field)
 
 
-def _csrf_token(action: str, login: str, secret: str) -> str:
-    return _signed_value(f"{action}:{login}", secret)
-
-
-def _verify_csrf_token(
-    token: str | None, *, action: str, login: str, secret: str, max_age_seconds: int = 3_600
-) -> bool:
-    expected = f"{action}:{login}"
-    return _verified_value(token, secret, max_age_seconds) == expected
-
-
 def create_app(database_url: str | None = None, webhook_secret: str | None = None) -> FastAPI:
     settings = get_settings()
     db_url = database_url or settings.database_url
@@ -513,19 +458,13 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     static_dir = BASE_DIR / "static"
     if static_dir.exists():
         app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+    auth_helpers.register_auth_routes(app, settings)
 
     def admin_login_from_request(request: Request) -> str | None:
-        token = request.headers.get("x-mergework-admin-token", "")
-        if settings.admin_token and hmac.compare_digest(token, settings.admin_token):
-            return "api-token"
-        login = _verified_value(request.cookies.get("mrwk_admin"), settings.cookie_secret, 86_400)
-        if login and login.lower() in settings.admin_logins:
-            return login.lower()
-        return None
+        return auth_helpers.admin_login_from_request(request, settings)
 
     def github_login_from_request(request: Request) -> str | None:
-        login = _verified_value(request.cookies.get("mrwk_user"), settings.cookie_secret, 604_800)
-        return login.lower() if login else None
+        return auth_helpers.github_login_from_request(request, settings)
 
     def require_github_login(request: Request) -> str:
         login = github_login_from_request(request)
@@ -540,10 +479,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         return login
 
     def require_admin_token(request: Request) -> str:
-        token = request.headers.get("x-mergework-admin-token", "")
-        if settings.admin_token and hmac.compare_digest(token, settings.admin_token):
-            return "api-token"
-        raise HTTPException(status_code=401, detail="admin token required")
+        return auth_helpers.require_admin_token_from_request(request, settings)
 
     def attempt_submitter_account(data: dict[str, Any], github_login: str) -> str:
         submitter_account = f"github:{github_login}"
@@ -1266,107 +1202,6 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     @app.get("/docs", response_class=HTMLResponse)
     def docs_page(request: Request) -> HTMLResponse:
         return templates.TemplateResponse(request, "docs.html")
-
-    @app.get("/auth/github/login")
-    def auth_github_login(next_path: str | None = Query(None, alias="next")) -> RedirectResponse:
-        if not _oauth_configured(settings):
-            raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
-        safe_next = _safe_next_path(next_path)
-        state_value = f"{secrets.token_urlsafe(24)},{safe_next}"
-        state = _signed_value(state_value, settings.cookie_secret)
-        query = urlencode(
-            {
-                "client_id": settings.github_oauth_client_id,
-                "redirect_uri": f"{settings.public_base_url}/auth/github/callback",
-                "scope": "read:user",
-                "state": state,
-            }
-        )
-        response = RedirectResponse(
-            f"https://github.com/login/oauth/authorize?{query}", status_code=302
-        )
-        response.set_cookie(
-            "mrwk_oauth_state", state, httponly=True, secure=True, samesite="lax", max_age=600
-        )
-        return response
-
-    @app.get("/auth/github/callback")
-    async def auth_github_callback(request: Request, code: str, state: str) -> RedirectResponse:
-        if not _oauth_configured(settings):
-            raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
-        cookie_state = request.cookies.get("mrwk_oauth_state")
-        if not cookie_state or not hmac.compare_digest(cookie_state, state):
-            raise HTTPException(status_code=401, detail="invalid OAuth state")
-        state_value = _verified_value(state, settings.cookie_secret, 600)
-        if state_value is None:
-            raise HTTPException(status_code=401, detail="expired OAuth state")
-        try:
-            _, next_path = state_value.split(",", 1)
-        except ValueError as exc:
-            raise HTTPException(status_code=401, detail="invalid OAuth state") from exc
-        next_path = _safe_next_path(next_path)
-        async with httpx.AsyncClient(timeout=10) as client:
-            token_response = await client.post(
-                "https://github.com/login/oauth/access_token",
-                headers={"Accept": "application/json"},
-                data={
-                    "client_id": settings.github_oauth_client_id,
-                    "client_secret": settings.github_oauth_client_secret,
-                    "code": code,
-                    "redirect_uri": f"{settings.public_base_url}/auth/github/callback",
-                },
-            )
-            token_response.raise_for_status()
-            access_token = token_response.json().get("access_token")
-            if not access_token:
-                raise HTTPException(status_code=401, detail="GitHub OAuth token exchange failed")
-            user_response = await client.get(
-                "https://api.github.com/user",
-                headers={
-                    "Accept": "application/vnd.github+json",
-                    "Authorization": f"Bearer {access_token}",
-                },
-            )
-            user_response.raise_for_status()
-            login = str(user_response.json().get("login", "")).lower()
-            if not login:
-                raise HTTPException(status_code=401, detail="GitHub OAuth user lookup failed")
-        response = RedirectResponse(next_path, status_code=302)
-        response.set_cookie(
-            "mrwk_user",
-            _signed_value(login, settings.cookie_secret),
-            httponly=True,
-            secure=True,
-            samesite="lax",
-            max_age=604_800,
-        )
-        if login in settings.admin_logins:
-            response.set_cookie(
-                "mrwk_admin",
-                _signed_value(login, settings.cookie_secret),
-                httponly=True,
-                secure=True,
-                samesite="lax",
-                max_age=86_400,
-            )
-        response.delete_cookie("mrwk_oauth_state")
-        return response
-
-    @app.get("/admin/login")
-    def admin_login() -> RedirectResponse:
-        return RedirectResponse("/auth/github/login?next=/admin", status_code=302)
-
-    @app.get("/admin/callback")
-    async def admin_callback(request: Request) -> RedirectResponse:
-        suffix = f"?{request.url.query}" if request.url.query else ""
-        return RedirectResponse(f"/auth/github/callback{suffix}", status_code=302)
-
-    @app.post("/auth/logout")
-    def auth_logout() -> RedirectResponse:
-        response = RedirectResponse("/", status_code=303)
-        response.delete_cookie("mrwk_user")
-        response.delete_cookie("mrwk_admin")
-        return response
 
     @app.get("/me", response_class=HTMLResponse)
     def me_page(request: Request) -> HTMLResponse:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -16,6 +16,16 @@ def test_signed_value_round_trips_and_rejects_wrong_secret() -> None:
     assert verified_value(token, "wrong-secret", 60) is None
 
 
+def test_signed_value_rejects_expired_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.auth.time.time", lambda: 1_000_000)
+    token = signed_value("github:alice", "test-cookie-secret")
+
+    assert verified_value(token, "test-cookie-secret", 60) == "github:alice"
+
+    monkeypatch.setattr("app.auth.time.time", lambda: 1_000_061)
+    assert verified_value(token, "test-cookie-secret", 60) is None
+
+
 @pytest.mark.parametrize(
     ("next_path", "expected"),
     [

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import safe_next_path, signed_value, verified_value
+from app.main import create_app
+
+
+def test_signed_value_round_trips_and_rejects_wrong_secret() -> None:
+    token = signed_value("github:alice", "test-cookie-secret")
+
+    assert verified_value(token, "test-cookie-secret", 60) == "github:alice"
+    assert verified_value(token, "wrong-secret", 60) is None
+
+
+@pytest.mark.parametrize(
+    ("next_path", "expected"),
+    [
+        ("/me", "/me"),
+        ("/bounties?status=open", "/bounties?status=open"),
+        ("/%2f%2fevil.example/me", "/me"),
+        ("/%5cevil.example/me", "/me"),
+        ("/me%0d%0aLocation:%20https://evil.example", "/me"),
+    ],
+)
+def test_safe_next_path_rejects_encoded_redirect_ambiguity(next_path: str, expected: str) -> None:
+    assert safe_next_path(next_path) == expected
+
+
+def test_auth_login_route_uses_safe_next_path(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    monkeypatch.setenv("MERGEWORK_PUBLIC_BASE_URL", "https://mrwk.example.test")
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(
+        "/auth/github/login?next=/%2f%2fevil.example/path", follow_redirects=False
+    )
+
+    assert response.status_code == 302
+    query = parse_qs(urlparse(response.headers["location"]).query)
+    state_value = verified_value(query["state"][0], "test-cookie-secret", 600)
+    assert state_value is not None
+    _nonce, next_path = state_value.split(",", 1)
+    assert next_path == "/me"


### PR DESCRIPTION
Refs #320

## Summary
- Move OAuth route registration, signed cookie verification, CSRF token helpers, session cookie names, and auth request helpers into a focused app.auth module.
- Keep app.main compatibility aliases for existing tests/callers while replacing inline auth logic with module calls.
- Harden OAuth next-path validation against percent-encoded network-path, backslash, and header-injection ambiguity.
- Add focused auth tests for signed value round-tripping, encoded next-path rejection, and the login route state fallback.

## Complexity reduced
- app.main no longer owns GitHub OAuth exchange, cookie signing, session cookie lifetime constants, or auth route wiring; those are isolated in app.auth for smaller review surfaces around admin/API/page routes.

## Tests
- python -m pytest -q
- python -m ruff check .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub OAuth login with cookie-based user and admin sessions
  * Logout support
  * CSRF protection and signed session/state tokens
  * Sanitized post-login redirect handling to prevent unsafe redirects

* **Tests**
  * Added tests for auth helpers, signed-token validation, and redirect safety

* **Refactor**
  * Authentication logic moved to a dedicated auth module for cleaner organization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->