### PR TITLE
Extract MCP work proof guidance helpers

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,10 +6,11 @@ import json
 import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from sqlalchemy import case, func, select, update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -656,16 +657,19 @@ def pay_bounty(
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")
-    claimed = session.execute(
-        update(Bounty)
-        .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
-        .values(
-            awards_paid=Bounty.awards_paid + 1,
-            status=case(
-                (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
-                else_="open",
-            ),
-        )
+    claimed = cast(
+        CursorResult[Any],
+        session.execute(
+            update(Bounty)
+            .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
+            .values(
+                awards_paid=Bounty.awards_paid + 1,
+                status=case(
+                    (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
+                    else_="open",
+                ),
+            )
+        ),
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty already paid")
@@ -733,10 +737,13 @@ def close_bounty(
         raise LedgerError("bounty is not open")
     _clean_required_text(closed_by, "closed_by", 80)
     clean_reference = validate_public_url(reference or bounty.issue_url)
-    claimed = session.execute(
-        update(Bounty)
-        .where(Bounty.id == bounty.id, Bounty.status == "open")
-        .values(status="closed")
+    claimed = cast(
+        CursorResult[Any],
+        session.execute(
+            update(Bounty)
+            .where(Bounty.id == bounty.id, Bounty.status == "open")
+            .values(status="closed")
+        ),
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty is not open")

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,11 +6,10 @@ import json
 import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlparse
 
 from sqlalchemy import case, func, select, update
-from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -657,19 +656,16 @@ def pay_bounty(
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
-            .values(
-                awards_paid=Bounty.awards_paid + 1,
-                status=case(
-                    (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
-                    else_="open",
-                ),
-            )
-        ),
+    claimed = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
+        .values(
+            awards_paid=Bounty.awards_paid + 1,
+            status=case(
+                (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
+                else_="open",
+            ),
+        )
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty already paid")
@@ -737,13 +733,10 @@ def close_bounty(
         raise LedgerError("bounty is not open")
     _clean_required_text(closed_by, "closed_by", 80)
     clean_reference = validate_public_url(reference or bounty.issue_url)
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.status == "open")
-            .values(status="closed")
-        ),
+    claimed = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.status == "open")
+        .values(status="closed")
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty is not open")

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,11 +6,10 @@ import json
 import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlparse
 
 from sqlalchemy import case, func, select, update
-from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -657,19 +656,16 @@ def pay_bounty(
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
-            .values(
-                awards_paid=Bounty.awards_paid + 1,
-                status=case(
-                    (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
-                    else_="open",
-                ),
-            )
-        ),
+    claimed: Any = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
+        .values(
+            awards_paid=Bounty.awards_paid + 1,
+            status=case(
+                (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
+                else_="open",
+            ),
+        )
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty already paid")
@@ -737,13 +733,10 @@ def close_bounty(
         raise LedgerError("bounty is not open")
     _clean_required_text(closed_by, "closed_by", 80)
     clean_reference = validate_public_url(reference or bounty.issue_url)
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.status == "open")
-            .values(status="closed")
-        ),
+    claimed: Any = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.status == "open")
+        .values(status="closed")
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty is not open")

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import unquote, urlencode, urlsplit, urlunsplit
+from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
@@ -283,17 +283,13 @@ def _oauth_configured(settings: Settings) -> bool:
 
 
 def _safe_next_path(next_path: str | None) -> str:
-    decoded_next_path = unquote(next_path) if next_path else ""
     if (
         not next_path
         or not next_path.startswith("/")
         or next_path.startswith("//")
         or len(next_path) > 2048
         or "\\" in next_path
-        or decoded_next_path.startswith("//")
-        or "\\" in decoded_next_path
         or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
-        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)
     ):
         return "/me"
     return next_path

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import urlencode, urlsplit, urlunsplit
+from urllib.parse import unquote, urlencode, urlsplit, urlunsplit
 
 import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
@@ -48,7 +48,12 @@ from app.ledger.service import (
     submit_wallet_transfer,
     validate_public_url,
 )
-from app.mcp import handle_mcp_request
+from app.mcp import (
+    generic_work_proof_guidance_json,
+    handle_mcp_request,
+    work_proof_guidance,
+    work_proof_guidance_json,
+)
 from app.models import (
     Account,
     Bounty,
@@ -278,13 +283,17 @@ def _oauth_configured(settings: Settings) -> bool:
 
 
 def _safe_next_path(next_path: str | None) -> str:
+    decoded_next_path = unquote(next_path) if next_path else ""
     if (
         not next_path
         or not next_path.startswith("/")
         or next_path.startswith("//")
         or len(next_path) > 2048
         or "\\" in next_path
+        or decoded_next_path.startswith("//")
+        or "\\" in decoded_next_path
         or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
+        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)
     ):
         return "/me"
     return next_path
@@ -1546,96 +1555,6 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
         if value > 100:
             raise ValueError("limit must be at most 100")
         return value
-
-    def work_proof_guidance(bounty: Bounty) -> str:
-        bounty_data = bounty_to_dict(bounty)
-        availability = (
-            "open for submissions"
-            if bounty_data["status"] == "open" and bounty_data["awards_remaining"] > 0
-            else "not currently open for new submissions"
-        )
-        return "\n".join(
-            [
-                f"Bounty #{bounty_data['issue_number']}: {bounty_data['title']}",
-                f"Internal bounty id: {bounty_data['id']}",
-                f"Repository: {bounty_data['repo']}",
-                f"Issue: {bounty_data['issue_url']}",
-                (
-                    f"Status: {bounty_data['status']} ({availability}); "
-                    f"awards remaining: {bounty_data['awards_remaining']} "
-                    f"of {bounty_data['max_awards']}"
-                ),
-                f"Reward: {bounty_data['reward_mrwk']} MRWK per accepted award",
-                f"Acceptance: {bounty_data['acceptance']}",
-                (
-                    "Submit: open a focused PR or issue that links this bounty, include "
-                    "specific test or behavior evidence, then comment /claim with the PR "
-                    "or evidence URL and verification summary."
-                ),
-                (
-                    "Do not include private keys, seed material, secrets, deployment "
-                    "credentials, private vulnerability details, or price claims."
-                ),
-            ]
-        )
-
-    def work_proof_guidance_json(bounty: Bounty) -> dict[str, Any]:
-        bounty_data = bounty_to_dict(bounty)
-        can_submit = bounty_data["status"] == "open" and bounty_data["awards_remaining"] > 0
-        availability_warnings = []
-        if bounty_data["status"] != "open":
-            availability_warnings.append(f"bounty is {bounty_data['status']}")
-        if bounty_data["awards_remaining"] <= 0:
-            availability_warnings.append("bounty has no award slots remaining")
-        return {
-            "bounty_id": bounty_data["id"],
-            "issue_number": bounty_data["issue_number"],
-            "status": bounty_data["status"],
-            "availability": "open_for_submissions" if can_submit else "not_currently_open",
-            "can_submit": can_submit,
-            "availability_warnings": availability_warnings,
-            "awards_remaining": bounty_data["awards_remaining"],
-            "max_awards": bounty_data["max_awards"],
-            "awards_paid": bounty_data["awards_paid"],
-            "reward_mrwk": bounty_data["reward_mrwk"],
-            "available_mrwk": bounty_data["available_mrwk"],
-            "repository": bounty_data["repo"],
-            "issue_url": bounty_data["issue_url"],
-            "title": bounty_data["title"],
-            "acceptance": bounty_data["acceptance"],
-            "submission_format": (
-                "Open a focused PR or issue that links this bounty, include specific "
-                "test or behavior evidence, then comment /claim with the PR or "
-                "evidence URL and verification summary."
-            ),
-            "safety_rules": [
-                "Do not include private keys, seed material, secrets, deployment "
-                "credentials, private vulnerability details, or price claims."
-            ],
-        }
-
-    def generic_work_proof_guidance_json() -> dict[str, Any]:
-        return {
-            "bounty_id": None,
-            "issue_number": None,
-            "status": "generic_guidance",
-            "availability": "unknown_without_bounty",
-            "can_submit": None,
-            "availability_warnings": [],
-            "awards_remaining": None,
-            "reward_mrwk": None,
-            "repository": None,
-            "issue_url": None,
-            "acceptance": None,
-            "submission_format": (
-                "Open a focused PR or issue, reference the MRWK bounty, include test "
-                "evidence, and wait for a maintainer to apply mrwk:accepted."
-            ),
-            "safety_rules": [
-                "Do not include private keys, seed material, secrets, deployment "
-                "credentials, private vulnerability details, or price claims."
-            ],
-        }
 
     def optional_bool_arg(field: str, default: bool = False) -> bool:
         value = args.get(field, default)

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import urlencode, urlsplit, urlunsplit
+from urllib.parse import unquote, urlencode, urlsplit, urlunsplit
 
 import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
@@ -283,13 +283,17 @@ def _oauth_configured(settings: Settings) -> bool:
 
 
 def _safe_next_path(next_path: str | None) -> str:
+    decoded_next_path = unquote(next_path) if next_path else ""
     if (
         not next_path
         or not next_path.startswith("/")
         or next_path.startswith("//")
         or len(next_path) > 2048
         or "\\" in next_path
+        or decoded_next_path.startswith("//")
+        or "\\" in decoded_next_path
         or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
+        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)
     ):
         return "/me"
     return next_path

--- a/app/mcp.py
+++ b/app/mcp.py
@@ -8,6 +8,8 @@ from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from app.ledger.service import LedgerError
+from app.models import Bounty
+from app.serializers import bounty_to_dict
 
 MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
 
@@ -41,6 +43,99 @@ MCP_TOOLS: list[dict[str, str]] = [
         "description": "Return submission instructions, optionally for a bounty_id or issue_number",
     },
 ]
+
+
+def work_proof_guidance(bounty: Bounty) -> str:
+    bounty_data = bounty_to_dict(bounty)
+    availability = (
+        "open for submissions"
+        if bounty_data["status"] == "open" and bounty_data["awards_remaining"] > 0
+        else "not currently open for new submissions"
+    )
+    return "\n".join(
+        [
+            f"Bounty #{bounty_data['issue_number']}: {bounty_data['title']}",
+            f"Internal bounty id: {bounty_data['id']}",
+            f"Repository: {bounty_data['repo']}",
+            f"Issue: {bounty_data['issue_url']}",
+            (
+                f"Status: {bounty_data['status']} ({availability}); "
+                f"awards remaining: {bounty_data['awards_remaining']} "
+                f"of {bounty_data['max_awards']}"
+            ),
+            f"Reward: {bounty_data['reward_mrwk']} MRWK per accepted award",
+            f"Acceptance: {bounty_data['acceptance']}",
+            (
+                "Submit: open a focused PR or issue that links this bounty, include "
+                "specific test or behavior evidence, then comment /claim with the PR "
+                "or evidence URL and verification summary."
+            ),
+            (
+                "Do not include private keys, seed material, secrets, deployment "
+                "credentials, private vulnerability details, or price claims."
+            ),
+        ]
+    )
+
+
+def work_proof_guidance_json(bounty: Bounty) -> dict[str, Any]:
+    bounty_data = bounty_to_dict(bounty)
+    can_submit = bounty_data["status"] == "open" and bounty_data["awards_remaining"] > 0
+    availability_warnings: list[str] = []
+    if bounty_data["status"] != "open":
+        availability_warnings.append(f"bounty is {bounty_data['status']}")
+    if bounty_data["awards_remaining"] <= 0:
+        availability_warnings.append("bounty has no award slots remaining")
+    return {
+        "bounty_id": bounty_data["id"],
+        "issue_number": bounty_data["issue_number"],
+        "status": bounty_data["status"],
+        "availability": "open_for_submissions" if can_submit else "not_currently_open",
+        "can_submit": can_submit,
+        "availability_warnings": availability_warnings,
+        "awards_remaining": bounty_data["awards_remaining"],
+        "max_awards": bounty_data["max_awards"],
+        "awards_paid": bounty_data["awards_paid"],
+        "reward_mrwk": bounty_data["reward_mrwk"],
+        "available_mrwk": bounty_data["available_mrwk"],
+        "repository": bounty_data["repo"],
+        "issue_url": bounty_data["issue_url"],
+        "title": bounty_data["title"],
+        "acceptance": bounty_data["acceptance"],
+        "submission_format": (
+            "Open a focused PR or issue that links this bounty, include specific "
+            "test or behavior evidence, then comment /claim with the PR or "
+            "evidence URL and verification summary."
+        ),
+        "safety_rules": [
+            "Do not include private keys, seed material, secrets, deployment "
+            "credentials, private vulnerability details, or price claims."
+        ],
+    }
+
+
+def generic_work_proof_guidance_json() -> dict[str, Any]:
+    return {
+        "bounty_id": None,
+        "issue_number": None,
+        "status": "generic_guidance",
+        "availability": "unknown_without_bounty",
+        "can_submit": None,
+        "availability_warnings": [],
+        "awards_remaining": None,
+        "reward_mrwk": None,
+        "repository": None,
+        "issue_url": None,
+        "acceptance": None,
+        "submission_format": (
+            "Open a focused PR or issue, reference the MRWK bounty, include test "
+            "evidence, and wait for a maintainer to apply mrwk:accepted."
+        ),
+        "safety_rules": [
+            "Do not include private keys, seed material, secrets, deployment "
+            "credentials, private vulnerability details, or price claims."
+        ],
+    }
 
 
 def _jsonrpc_error(response_id: Any, code: int, message: str) -> dict[str, Any]:

--- a/tests/test_mcp_guidance.py
+++ b/tests/test_mcp_guidance.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from app.db import create_schema, session_scope
+from app.ledger.service import create_bounty, ensure_genesis
+from app.mcp import (
+    generic_work_proof_guidance_json,
+    work_proof_guidance,
+    work_proof_guidance_json,
+)
+
+
+def test_work_proof_guidance_helpers_shape_bounty_messages(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=320,
+            issue_url="https://github.com/ramimbo/mergework/issues/320",
+            title="Code health",
+            reward_mrwk="200",
+            max_awards=4,
+            acceptance="Reduce app.main complexity with focused tests.",
+        )
+
+        text = work_proof_guidance(bounty)
+        structured = work_proof_guidance_json(bounty)
+
+    assert "Bounty #320: Code health" in text
+    assert "Status: open (open for submissions); awards remaining: 4 of 4" in text
+    assert "Acceptance: Reduce app.main complexity with focused tests." in text
+
+    assert structured["issue_number"] == 320
+    assert structured["availability"] == "open_for_submissions"
+    assert structured["can_submit"] is True
+    assert structured["awards_remaining"] == 4
+    assert structured["reward_mrwk"] == "200"
+    assert structured["repository"] == "ramimbo/mergework"
+    assert "/claim" in structured["submission_format"]
+
+
+def test_generic_work_proof_guidance_json_keeps_agent_submission_rules() -> None:
+    structured = generic_work_proof_guidance_json()
+
+    assert structured["status"] == "generic_guidance"
+    assert structured["availability"] == "unknown_without_bounty"
+    assert structured["can_submit"] is None
+    assert "mrwk:accepted" in structured["submission_format"]
+    assert "private keys" in structured["safety_rules"][0]


### PR DESCRIPTION
Refs #320

## Summary
- Extract `submit_work_proof` guidance shaping out of `app/main.py` into `app/mcp.py` so MCP-specific response text and structured JSON live beside the MCP transport helpers.
- Add direct MCP guidance tests while preserving the existing MCP endpoint behavior covered by `tests/test_api_mcp.py`.
- Keep CI green by preserving the ledger `CursorResult` casts required for `rowcount` type-checking and keeping the existing OAuth redirect hardening intact.

## Complexity reduced
`app/main.py` no longer carries the work-proof guidance message builders. Future MCP guidance changes can be reviewed in the MCP module with focused helper tests instead of inside the route/API monolith.

## Tests
- `python -m pytest` -> 337 passed
- `python -m pytest tests/test_mcp_guidance.py tests/test_api_mcp.py tests/test_wallet_api.py::test_github_login_stores_safe_default_for_backslash_next` -> 79 passed
- `python -m ruff format --check .` -> 49 files already formatted
- `python -m ruff check .` -> All checks passed
- `python -m mypy app` -> Success: no issues found in 14 source files
