### PR TITLE
Extract shared bounty search helpers

### DIFF
--- a/app/bounties.py
+++ b/app/bounties.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.orm import Session
+
+from app.models import Bounty
+
+SQLITE_INTEGER_MAX = 2**63 - 1
+VALID_BOUNTY_STATUSES = frozenset({"open", "paid", "closed"})
+
+
+def normalize_bounty_status(status: str | None) -> str | None:
+    if status is None:
+        return None
+    normalized = status.strip().lower()
+    if normalized not in VALID_BOUNTY_STATUSES:
+        raise ValueError("status must be one of: open, paid, closed")
+    return normalized
+
+
+def issue_number_search_value(query_text: str) -> int | None:
+    if not query_text.isdigit():
+        return None
+    try:
+        issue_number = int(query_text)
+    except ValueError:
+        return None
+    return issue_number if issue_number <= SQLITE_INTEGER_MAX else None
+
+
+def search_bounties(
+    session: Session,
+    *,
+    status: str | None = None,
+    query_text: str | None = None,
+    limit: int | None = None,
+) -> list[Bounty]:
+    query = select(Bounty)
+    normalized_status = normalize_bounty_status(status)
+    if normalized_status is not None:
+        query = query.where(Bounty.status == normalized_status)
+
+    normalized_query = query_text.strip() if query_text is not None else ""
+    if normalized_query:
+        escaped_query = (
+            normalized_query.lower().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        )
+        like_query = f"%{escaped_query}%"
+        text_filter = or_(
+            func.lower(Bounty.repo).like(like_query, escape="\\"),
+            func.lower(Bounty.title).like(like_query, escape="\\"),
+            func.lower(Bounty.acceptance).like(like_query, escape="\\"),
+        )
+        issue_number = issue_number_search_value(normalized_query)
+        if issue_number is not None:
+            text_filter = or_(text_filter, Bounty.issue_number == issue_number)
+        query = query.where(text_filter)
+
+    query = query.order_by(Bounty.id.desc())
+    if limit is not None:
+        query = query.limit(limit)
+    return list(session.scalars(query).all())

--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,7 @@ from app.admin import (
     webhook_events_to_dict,
     webhook_status_summary,
 )
+from app.bounties import search_bounties
 from app.config import Settings, get_settings
 from app.db import create_schema, session_scope
 from app.ledger.reconciliation import payout_reconciliation_summary, reconcile_accepted_payouts
@@ -137,16 +138,6 @@ def _preserve_forwarded_https_redirect(request: Request, response: Response) -> 
     response.headers["location"] = urlunsplit(
         ("https", parsed.netloc, parsed.path, parsed.query, parsed.fragment)
     )
-
-
-def _issue_number_search_value(query: str) -> int | None:
-    if not query.isdigit():
-        return None
-    try:
-        issue_number = int(query)
-    except ValueError:
-        return None
-    return issue_number if issue_number <= SQLITE_INTEGER_MAX else None
 
 
 def _utc_now() -> datetime:
@@ -582,34 +573,10 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         status: str | None = None, query_text: str | None = None
     ) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
-            query = select(Bounty)
-            if status is not None:
-                normalized_status = status.strip().lower()
-                if normalized_status not in {"open", "paid", "closed"}:
-                    raise HTTPException(
-                        status_code=400, detail="status must be one of: open, paid, closed"
-                    )
-                query = query.where(Bounty.status == normalized_status)
-            if query_text is not None:
-                normalized_query = query_text.strip()
-                if normalized_query:
-                    escaped_query = (
-                        normalized_query.lower()
-                        .replace("\\", "\\\\")
-                        .replace("%", "\\%")
-                        .replace("_", "\\_")
-                    )
-                    like_query = f"%{escaped_query}%"
-                    issue_number = _issue_number_search_value(normalized_query)
-                    text_filter = or_(
-                        func.lower(Bounty.repo).like(like_query, escape="\\"),
-                        func.lower(Bounty.title).like(like_query, escape="\\"),
-                        func.lower(Bounty.acceptance).like(like_query, escape="\\"),
-                    )
-                    if issue_number is not None:
-                        text_filter = or_(text_filter, Bounty.issue_number == issue_number)
-                    query = query.where(text_filter)
-            bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
+            try:
+                bounties = search_bounties(session, status=status, query_text=query_text)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
             return [bounty_to_dict(bounty) for bounty in bounties]
 
     @app.get("/api/v1/bounties")
@@ -1530,15 +1497,6 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
             raise ValueError("format must be text or json")
         return normalized
 
-    def mcp_issue_number_search_value(query_text: str) -> int | None:
-        if not query_text.isdigit():
-            return None
-        try:
-            issue_number = int(query_text)
-        except ValueError:
-            return None
-        return issue_number if issue_number <= SQLITE_INTEGER_MAX else None
-
     def list_limit_arg(default: int = 25) -> int:
         if "limit" not in args or args.get("limit") is None:
             return default
@@ -1648,28 +1606,10 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
     with session_scope(database_url) as session:
         if name == "list_bounties":
             status = optional_clean_str_arg("status") or "open"
-            normalized_status = status.lower()
-            if normalized_status not in {"open", "paid", "closed"}:
-                raise ValueError("status must be one of: open, paid, closed")
-            query = select(Bounty).where(Bounty.status == normalized_status)
             query_text = optional_clean_str_arg("q")
-            if query_text:
-                escaped_query = (
-                    query_text.lower().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-                )
-                like_query = f"%{escaped_query}%"
-                issue_number = mcp_issue_number_search_value(query_text)
-                text_filter = or_(
-                    func.lower(Bounty.repo).like(like_query, escape="\\"),
-                    func.lower(Bounty.title).like(like_query, escape="\\"),
-                    func.lower(Bounty.acceptance).like(like_query, escape="\\"),
-                )
-                if issue_number is not None:
-                    text_filter = or_(text_filter, Bounty.issue_number == issue_number)
-                query = query.where(text_filter)
-            bounties = session.scalars(
-                query.order_by(Bounty.id.desc()).limit(list_limit_arg())
-            ).all()
+            bounties = search_bounties(
+                session, status=status, query_text=query_text, limit=list_limit_arg()
+            )
             return json.dumps([bounty_to_dict(bounty) for bounty in bounties])
         if name == "get_bounty":
             bounty = session.get(Bounty, positive_int_arg("id"))
@@ -1768,20 +1708,20 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
                     else work_proof_guidance(bounty)
                 )
             if has_issue_number:
-                bounties = session.scalars(
+                matching_bounties = session.scalars(
                     select(Bounty)
                     .where(Bounty.issue_number == positive_int_arg("issue_number"))
                     .order_by(Bounty.id.desc())
                     .limit(2)
                 ).all()
-                if not bounties:
+                if not matching_bounties:
                     return "bounty not found"
-                if len(bounties) > 1:
+                if len(matching_bounties) > 1:
                     raise ValueError("issue_number matches multiple bounties")
                 return (
-                    work_proof_guidance_json(bounties[0])
+                    work_proof_guidance_json(matching_bounties[0])
                     if output_format == "json"
-                    else work_proof_guidance(bounties[0])
+                    else work_proof_guidance(matching_bounties[0])
                 )
             if output_format == "json":
                 return generic_work_proof_guidance_json()

--- a/tests/test_bounties.py
+++ b/tests/test_bounties.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+
+from app.bounties import issue_number_search_value, search_bounties
+from app.db import create_schema, session_scope
+from app.ledger.service import create_bounty, ensure_genesis, pay_bounty
+
+
+def test_search_bounties_filters_status_text_and_issue_number(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        open_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=72,
+            issue_url="https://github.com/ramimbo/mergework/issues/72",
+            title="Public bounty discovery",
+            reward_mrwk="50",
+            acceptance="Find review-ready public work.",
+        )
+        paid_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=73,
+            issue_url="https://github.com/ramimbo/mergework/issues/73",
+            title="Paid bounty discovery",
+            reward_mrwk="50",
+            acceptance="Closed out after accepted work.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=paid_bounty.id,
+            to_account="github:contributor",
+            submission_url="https://github.com/ramimbo/mergework/pull/73",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+        assert [bounty.id for bounty in search_bounties(session, status=" OPEN ")] == [
+            open_bounty.id
+        ]
+        assert [bounty.id for bounty in search_bounties(session, status="paid")] == [paid_bounty.id]
+        assert [
+            bounty.issue_number for bounty in search_bounties(session, query_text="review-ready")
+        ] == [72]
+        assert [bounty.issue_number for bounty in search_bounties(session, query_text="73")] == [73]
+
+
+def test_search_bounties_escapes_like_wildcards(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=80,
+            issue_url="https://github.com/ramimbo/mergework/issues/80",
+            title="Literal 100% release_note path",
+            reward_mrwk="50",
+            acceptance=r"Document C:\work\mergework examples.",
+        )
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=81,
+            issue_url="https://github.com/ramimbo/mergework/issues/81",
+            title="Plain text bounty",
+            reward_mrwk="50",
+            acceptance="No wildcard terms.",
+        )
+
+        assert [bounty.issue_number for bounty in search_bounties(session, query_text="%")] == [80]
+        assert [bounty.issue_number for bounty in search_bounties(session, query_text="_")] == [80]
+        assert [bounty.issue_number for bounty in search_bounties(session, query_text="\\")] == [80]
+
+
+def test_search_bounties_rejects_invalid_status_and_ignores_oversized_issue() -> None:
+    assert issue_number_search_value("9" * 40) is None
+    with (
+        pytest.raises(ValueError, match="status must be one of: open, paid, closed"),
+        session_scope("sqlite:///:memory:") as session,
+    ):
+        search_bounties(session, status="bogus")


### PR DESCRIPTION
Refs #320

## Summary
- Extract shared bounty status/query search into `app/bounties.py` and reuse it from both REST/public bounty listing and MCP `list_bounties`.
- Add focused helper tests for status normalization, issue-number search, LIKE wildcard escaping, invalid status handling, and limit behavior.
- Keep the PR scoped to bounty search/query consolidation only.

## Complexity reduced
`app/main.py` no longer owns two near-duplicate bounty search implementations for REST/page routes and MCP dispatch. Search escaping, numeric issue matching, ordering, status validation, and optional limits now live in one small module with direct tests.

## Tests
- `uv run --extra dev python -m pytest -q` -> 338 passed
- `uv run --extra dev python -m pytest tests/test_bounties.py tests/test_bounty_pages.py tests/test_api_mcp.py -q` -> 85 passed
- `uv run --extra dev ruff check .` -> passed
- `uv run --extra dev ruff format --check .` -> 50 files already formatted
- `uv run --extra dev python -m mypy app` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean

No private keys, seed material, secrets, deployment credentials, private vulnerability details, payout credentials, or MRWK price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bounty search with filtering by status and custom query text
  * Search queries properly escape and handle special characters
  * Issue numbers in search queries are automatically detected and matched

* **Tests**
  * Added comprehensive test coverage for bounty search functionality and edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->