### PR TITLE
Extract account explorer helpers

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from app.ledger.service import TREASURY_ACCOUNT
+from app.wallets import WalletError, normalize_wallet_address
+
+GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+SQLITE_INTEGER_MAX = 2**63 - 1
+
+GITHUB_TRANSFER_STATUS = "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
+INTERNAL_LEDGER_TRANSFER_STATUS = (
+    "Internal ledger account. MRWK wallet transfers are only available "
+    "for registered mrwk1 addresses."
+)
+WALLET_TRANSFER_STATUS = "MRWK wallet transfers are enabled for registered mrwk1 addresses."
+
+
+class AccountError(ValueError):
+    pass
+
+
+def normalize_account(account: str) -> str:
+    if not account or not account.strip():
+        raise AccountError("account must not be empty")
+    if re.search(r"[\x00-\x1f\x7f]", account):
+        raise AccountError("account must not contain control characters")
+    clean = account.strip()
+    lower = clean.lower()
+    if lower == TREASURY_ACCOUNT:
+        return TREASURY_ACCOUNT
+    if lower.startswith("treasury:"):
+        raise AccountError("treasury account must be treasury:mrwk")
+    if lower.startswith("reserve:"):
+        return _normalize_reserve_account(lower)
+    if lower.startswith("mrwk1"):
+        try:
+            return normalize_wallet_address(clean)
+        except WalletError as exc:
+            raise AccountError(str(exc)) from exc
+    if lower.startswith("github:"):
+        login = clean.split(":", 1)[1].lower()
+        if not GITHUB_LOGIN_RE.fullmatch(login):
+            raise AccountError("github login must be valid")
+        return f"github:{login}"
+    return clean
+
+
+def github_login_from_account(account: str) -> str | None:
+    if not account.startswith("github:"):
+        return None
+    login = account.removeprefix("github:")
+    if not GITHUB_LOGIN_RE.fullmatch(login):
+        return None
+    return login
+
+
+def transfer_status_for_account(account: str) -> str:
+    if account.startswith("github:"):
+        return GITHUB_TRANSFER_STATUS
+    if account.startswith(("treasury:", "reserve:")):
+        return INTERNAL_LEDGER_TRANSFER_STATUS
+    return WALLET_TRANSFER_STATUS
+
+
+def account_summary(
+    account: str, *, exists: bool, balance_mrwk: str, accepted_work: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "account": account,
+        "ledger_address": account,
+        "github_login": github_login_from_account(account),
+        "exists": exists,
+        "balance_mrwk": balance_mrwk,
+        "transfer_status": transfer_status_for_account(account),
+        "accepted_work": accepted_work,
+    }
+
+
+def _normalize_reserve_account(lower_account: str) -> str:
+    reserve_prefix = "reserve:bounty:"
+    if not lower_account.startswith(reserve_prefix):
+        raise AccountError("reserve account must use reserve:bounty:<id>")
+    bounty_id = lower_account.removeprefix(reserve_prefix)
+    try:
+        normalized_bounty_id = int(bounty_id) if bounty_id.isdigit() else 0
+    except ValueError as exc:
+        raise AccountError("reserve bounty id is too large") from exc
+    if normalized_bounty_id <= 0:
+        raise AccountError("reserve bounty id must be positive")
+    if normalized_bounty_id > SQLITE_INTEGER_MAX:
+        raise AccountError("reserve bounty id is too large")
+    return f"{reserve_prefix}{normalized_bounty_id}"

--- a/app/explorer.py
+++ b/app/explorer.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from app.models import LedgerEntry, Proof
+from app.serializers import ledger_to_dict
+
+
+def proof_hashes_by_sequence(session: Session, sequences: Sequence[int]) -> dict[int, str]:
+    if not sequences:
+        return {}
+    rows = session.execute(
+        select(Proof.ledger_sequence, Proof.hash).where(Proof.ledger_sequence.in_(sequences))
+    ).all()
+    return {int(sequence): str(proof_hash) for sequence, proof_hash in rows}
+
+
+def ledger_transactions_for_account(
+    session: Session, account: str, *, limit: int = 100
+) -> list[dict[str, Any]]:
+    entries = session.scalars(
+        select(LedgerEntry)
+        .where(or_(LedgerEntry.from_account == account, LedgerEntry.to_account == account))
+        .order_by(LedgerEntry.sequence.desc())
+        .limit(limit)
+    ).all()
+    proofs = proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
+    return [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,10 +6,11 @@ import json
 import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from sqlalchemy import case, func, select, update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -656,16 +657,19 @@ def pay_bounty(
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")
-    claimed = session.execute(
-        update(Bounty)
-        .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
-        .values(
-            awards_paid=Bounty.awards_paid + 1,
-            status=case(
-                (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
-                else_="open",
-            ),
-        )
+    claimed = cast(
+        CursorResult[Any],
+        session.execute(
+            update(Bounty)
+            .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
+            .values(
+                awards_paid=Bounty.awards_paid + 1,
+                status=case(
+                    (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
+                    else_="open",
+                ),
+            )
+        ),
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty already paid")
@@ -733,10 +737,13 @@ def close_bounty(
         raise LedgerError("bounty is not open")
     _clean_required_text(closed_by, "closed_by", 80)
     clean_reference = validate_public_url(reference or bounty.issue_url)
-    claimed = session.execute(
-        update(Bounty)
-        .where(Bounty.id == bounty.id, Bounty.status == "open")
-        .values(status="closed")
+    claimed = cast(
+        CursorResult[Any],
+        session.execute(
+            update(Bounty)
+            .where(Bounty.id == bounty.id, Bounty.status == "open")
+            .values(status="closed")
+        ),
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty is not open")

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,11 +6,10 @@ import json
 import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlparse
 
 from sqlalchemy import case, func, select, update
-from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -657,19 +656,16 @@ def pay_bounty(
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
-            .values(
-                awards_paid=Bounty.awards_paid + 1,
-                status=case(
-                    (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
-                    else_="open",
-                ),
-            )
-        ),
+    claimed = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
+        .values(
+            awards_paid=Bounty.awards_paid + 1,
+            status=case(
+                (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
+                else_="open",
+            ),
+        )
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty already paid")
@@ -737,13 +733,10 @@ def close_bounty(
         raise LedgerError("bounty is not open")
     _clean_required_text(closed_by, "closed_by", 80)
     clean_reference = validate_public_url(reference or bounty.issue_url)
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.status == "open")
-            .values(status="closed")
-        ),
+    claimed = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.status == "open")
+        .values(status="closed")
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty is not open")

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import urlencode, urlsplit, urlunsplit
+from urllib.parse import unquote, urlencode, urlsplit, urlunsplit
 
 import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
@@ -20,6 +20,12 @@ from sqlalchemy import func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.accounts import (
+    AccountError,
+    account_summary,
+    github_login_from_account,
+    normalize_account,
+)
 from app.admin import (
     list_webhook_events,
     normalize_webhook_status_filter,
@@ -28,6 +34,7 @@ from app.admin import (
 )
 from app.config import Settings, get_settings
 from app.db import create_schema, session_scope
+from app.explorer import ledger_transactions_for_account, proof_hashes_by_sequence
 from app.ledger.reconciliation import payout_reconciliation_summary, reconcile_accepted_payouts
 from app.ledger.service import (
     GENESIS_SUPPLY_MICRO,
@@ -96,7 +103,6 @@ SECURITY_HEADERS = {
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
 }
-GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 HEX_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 API_DOCS_CSP = (
     "default-src 'self'; "
@@ -260,15 +266,6 @@ def _is_ltc_lab_host(request: Request) -> bool:
     return _host_without_port(request) in {"ltclab.site", "www.ltclab.site"}
 
 
-def _proof_hashes_by_sequence(session: Session, sequences: list[int]) -> dict[int, str]:
-    if not sequences:
-        return {}
-    rows = session.execute(
-        select(Proof.ledger_sequence, Proof.hash).where(Proof.ledger_sequence.in_(sequences))
-    ).all()
-    return {int(sequence): str(proof_hash) for sequence, proof_hash in rows}
-
-
 def _oauth_configured(settings: Settings) -> bool:
     return bool(
         settings.github_oauth_client_id
@@ -278,62 +275,31 @@ def _oauth_configured(settings: Settings) -> bool:
 
 
 def _safe_next_path(next_path: str | None) -> str:
+    decoded_next_path = unquote(next_path) if next_path else ""
     if (
         not next_path
         or not next_path.startswith("/")
         or next_path.startswith("//")
         or len(next_path) > 2048
         or "\\" in next_path
+        or decoded_next_path.startswith("//")
+        or "\\" in decoded_next_path
         or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
+        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)
     ):
         return "/me"
     return next_path
 
 
 def _normalized_account(account: str) -> str:
-    if not account or not account.strip():
-        raise HTTPException(status_code=400, detail="account must not be empty")
-    if re.search(r"[\x00-\x1f\x7f]", account):
-        raise HTTPException(status_code=400, detail="account must not contain control characters")
-    clean = account.strip()
-    lower = clean.lower()
-    if lower == TREASURY_ACCOUNT:
-        return TREASURY_ACCOUNT
-    if lower.startswith("treasury:"):
-        raise HTTPException(status_code=400, detail="treasury account must be treasury:mrwk")
-    if lower.startswith("reserve:"):
-        reserve_prefix = "reserve:bounty:"
-        if not lower.startswith(reserve_prefix):
-            raise HTTPException(
-                status_code=400, detail="reserve account must use reserve:bounty:<id>"
-            )
-        bounty_id = lower.removeprefix(reserve_prefix)
-        try:
-            normalized_bounty_id = int(bounty_id) if bounty_id.isdigit() else 0
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail="reserve bounty id is too large") from exc
-        if normalized_bounty_id <= 0:
-            raise HTTPException(status_code=400, detail="reserve bounty id must be positive")
-        if normalized_bounty_id > SQLITE_INTEGER_MAX:
-            raise HTTPException(status_code=400, detail="reserve bounty id is too large")
-        return f"{reserve_prefix}{normalized_bounty_id}"
-    if lower.startswith("mrwk1"):
-        return _normalized_wallet_address(clean)
-    if lower.startswith("github:"):
-        login = clean.split(":", 1)[1].lower()
-        if not GITHUB_LOGIN_RE.fullmatch(login):
-            raise HTTPException(status_code=400, detail="github login must be valid")
-        return f"github:{login}"
-    return clean
+    try:
+        return normalize_account(account)
+    except AccountError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 def _github_login_from_account(account: str) -> str | None:
-    if not account.startswith("github:"):
-        return None
-    login = account.removeprefix("github:")
-    if not GITHUB_LOGIN_RE.fullmatch(login):
-        return None
-    return login
+    return github_login_from_account(account)
 
 
 def _positive_bounty_id(bounty_id: int) -> int:
@@ -933,30 +899,15 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     @app.get("/api/v1/accounts/{account}")
     def api_account(account: str) -> dict[str, Any]:
         account = _normalized_account(account)
-        github_login = _github_login_from_account(account)
-        if account.startswith("github:"):
-            transfer_status = (
-                "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
-            )
-        elif account.startswith(("treasury:", "reserve:")):
-            transfer_status = (
-                "Internal ledger account. MRWK wallet transfers are only available "
-                "for registered mrwk1 addresses."
-            )
-        else:
-            transfer_status = "MRWK wallet transfers are enabled for registered mrwk1 addresses."
         with session_scope(db_url) as session:
             account_row = session.get(Account, account)
             accepted_work = safe_account_accepted_summary(session, account)
-            return {
-                "account": account,
-                "ledger_address": account,
-                "github_login": github_login,
-                "exists": account_row is not None,
-                "balance_mrwk": format_mrwk(get_balance(session, account)),
-                "transfer_status": transfer_status,
-                "accepted_work": accepted_work,
-            }
+            return account_summary(
+                account,
+                exists=account_row is not None,
+                balance_mrwk=format_mrwk(get_balance(session, account)),
+                accepted_work=accepted_work,
+            )
 
     @app.get("/api/v1/accounts/{account}/accepted-work")
     def api_account_accepted_work(account: str) -> dict[str, Any]:
@@ -1064,7 +1015,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             entries = session.scalars(
                 select(LedgerEntry).order_by(LedgerEntry.sequence.desc()).limit(limit)
             ).all()
-            proofs = _proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
+            proofs = proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
             return [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
 
     @app.get("/api/v1/ledger/{sequence}")
@@ -1197,14 +1148,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         with session_scope(db_url) as session:
             account_data = api_account(account)
             accepted_summary = safe_account_accepted_summary(session, account)
-            entries = session.scalars(
-                select(LedgerEntry)
-                .where(or_(LedgerEntry.from_account == account, LedgerEntry.to_account == account))
-                .order_by(LedgerEntry.sequence.desc())
-                .limit(100)
-            ).all()
-            proofs = _proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
-            transactions = [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
+            transactions = ledger_transactions_for_account(session, account)
             accepted_work = safe_accepted_work_for_account(session, account)
         return templates.TemplateResponse(
             request,
@@ -1234,19 +1178,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             if wallet is None:
                 raise HTTPException(status_code=404, detail="wallet not found")
             wallet_data = wallet_to_dict(session, wallet)
-            entries = session.scalars(
-                select(LedgerEntry)
-                .where(
-                    or_(
-                        LedgerEntry.from_account == wallet.address,
-                        LedgerEntry.to_account == wallet.address,
-                    )
-                )
-                .order_by(LedgerEntry.sequence.desc())
-                .limit(100)
-            ).all()
-            proofs = _proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
-            transactions = [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
+            transactions = ledger_transactions_for_account(session, wallet.address)
         return templates.TemplateResponse(
             request,
             "wallet_detail.html",

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+
+from app.accounts import (
+    AccountError,
+    account_summary,
+    github_login_from_account,
+    normalize_account,
+    transfer_status_for_account,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw_account", "normalized"),
+    [
+        (" Treasury:MRWK ", "treasury:mrwk"),
+        ("Reserve:Bounty:001", "reserve:bounty:1"),
+        ("GitHub:Alice", "github:alice"),
+        ("MRWK1" + ("A" * 40), "mrwk1" + ("a" * 40)),
+    ],
+)
+def test_normalize_account_canonicalizes_known_account_types(
+    raw_account: str, normalized: str
+) -> None:
+    assert normalize_account(raw_account) == normalized
+
+
+@pytest.mark.parametrize(
+    "raw_account",
+    [
+        "",
+        "github: ",
+        "treasury:ops",
+        "reserve:wallet:1",
+        "reserve:bounty:0",
+        "mrwk1bad",
+        "test\x00account",
+    ],
+)
+def test_normalize_account_rejects_invalid_account_values(raw_account: str) -> None:
+    with pytest.raises(AccountError):
+        normalize_account(raw_account)
+
+
+def test_account_helpers_shape_api_summary() -> None:
+    accepted_work = {
+        "accepted_awards": 1,
+        "accepted_mrwk": "25",
+        "latest_ledger_sequence": 3,
+    }
+
+    summary = account_summary(
+        "github:alice",
+        exists=True,
+        balance_mrwk="25",
+        accepted_work=accepted_work,
+    )
+
+    assert github_login_from_account("github:alice") == "alice"
+    assert github_login_from_account("treasury:mrwk") is None
+    assert transfer_status_for_account("github:alice").startswith("Claim GitHub balances")
+    assert transfer_status_for_account("treasury:mrwk").startswith("Internal ledger account")
+    assert summary == {
+        "account": "github:alice",
+        "ledger_address": "github:alice",
+        "github_login": "alice",
+        "exists": True,
+        "balance_mrwk": "25",
+        "transfer_status": transfer_status_for_account("github:alice"),
+        "accepted_work": accepted_work,
+    }

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from app.db import create_schema, session_scope
+from app.explorer import ledger_transactions_for_account, proof_hashes_by_sequence
+from app.ledger.service import add_ledger_entry, create_bounty, ensure_genesis, pay_bounty
+
+
+def test_proof_hashes_by_sequence_handles_empty_and_paid_entries(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=320,
+            issue_url="https://github.com/ramimbo/mergework/issues/320",
+            title="Explorer helpers",
+            reward_mrwk="25",
+            acceptance="Account and wallet pages should share explorer query helpers.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/320",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+        assert proof_hashes_by_sequence(session, []) == {}
+        assert proof_hashes_by_sequence(session, [proof.ledger_sequence]) == {
+            proof.ledger_sequence: proof.hash
+        }
+
+
+def test_ledger_transactions_for_account_orders_and_attaches_proofs(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=321,
+            issue_url="https://github.com/ramimbo/mergework/issues/321",
+            title="Explorer transactions",
+            reward_mrwk="10",
+            acceptance="Transaction helper should preserve proof links.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/321",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        manual = add_ledger_entry(
+            session,
+            entry_type="wallet_transfer",
+            from_account="github:alice",
+            to_account="github:bob",
+            amount_microunits=1_000_000,
+            reference="manual-transfer",
+        )
+
+        rows = ledger_transactions_for_account(session, "github:alice")
+        limited = ledger_transactions_for_account(session, "github:alice", limit=1)
+
+    assert [row["sequence"] for row in rows] == [manual.sequence, proof.ledger_sequence]
+    assert rows[0]["proof_hash"] is None
+    assert rows[1]["proof_hash"] == proof.hash
+    assert [row["sequence"] for row in limited] == [manual.sequence]


### PR DESCRIPTION
Refs #320

## Summary
- Extract account normalization, GitHub-login lookup, transfer status, and account summary shaping into `app/accounts.py`.
- Extract proof lookup and account/wallet transaction row building into `app/explorer.py`, then reuse it from ledger, account, and wallet page routes.
- Add focused unit tests for account helper behavior and explorer transaction/proof shaping.
- Keep repository checks green by removing redundant ledger casts reported by `mypy app` and by sanitizing percent-decoded OAuth `next` paths covered by the existing OAuth regression test.

## Complexity reduced
`app/main.py` no longer owns account canonicalization rules, account API response shaping, proof hash lookup, or duplicated account/wallet transaction queries. Those responsibilities now live in small modules with direct tests, while route handlers remain thin wrappers around request/session/template concerns.

## Tests
- `python -m pytest -q` -> 349 passed
- `python -m pytest tests/test_accounts.py tests/test_explorer.py tests/test_account_validation.py tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows tests/test_api_mcp.py::test_explorer_links_ledger_proof_and_account -q` -> 41 passed
- `python -m pytest tests/test_explorer.py tests/test_account_validation.py tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows tests/test_api_mcp.py::test_explorer_links_ledger_proof_and_account tests/test_ledger.py -q` -> 59 passed
- `python -m ruff format --check app/accounts.py app/explorer.py app/main.py app/ledger/service.py tests/test_accounts.py tests/test_explorer.py`
- `python -m ruff check app/accounts.py app/explorer.py app/main.py app/ledger/service.py tests/test_accounts.py tests/test_explorer.py`
- `python -m mypy app`