### PR TITLE
Extract account helpers from app.main

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -9,9 +9,7 @@ from app.wallets import WalletError, normalize_wallet_address
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 SQLITE_INTEGER_MAX = 2**63 - 1
 
-GITHUB_TRANSFER_STATUS = (
-    "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
-)
+GITHUB_TRANSFER_STATUS = "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
 INTERNAL_LEDGER_TRANSFER_STATUS = (
     "Internal ledger account. MRWK wallet transfers are only available "
     "for registered mrwk1 addresses."

--- a/app/accounts.py
+++ b/app/accounts.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from app.ledger.service import TREASURY_ACCOUNT
+from app.wallets import WalletError, normalize_wallet_address
+
+GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+SQLITE_INTEGER_MAX = 2**63 - 1
+
+GITHUB_TRANSFER_STATUS = (
+    "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
+)
+INTERNAL_LEDGER_TRANSFER_STATUS = (
+    "Internal ledger account. MRWK wallet transfers are only available "
+    "for registered mrwk1 addresses."
+)
+WALLET_TRANSFER_STATUS = "MRWK wallet transfers are enabled for registered mrwk1 addresses."
+
+
+class AccountError(ValueError):
+    pass
+
+
+def normalize_account(account: str) -> str:
+    if not account or not account.strip():
+        raise AccountError("account must not be empty")
+    if re.search(r"[\x00-\x1f\x7f]", account):
+        raise AccountError("account must not contain control characters")
+    clean = account.strip()
+    lower = clean.lower()
+    if lower == TREASURY_ACCOUNT:
+        return TREASURY_ACCOUNT
+    if lower.startswith("treasury:"):
+        raise AccountError("treasury account must be treasury:mrwk")
+    if lower.startswith("reserve:"):
+        return _normalize_reserve_account(lower)
+    if lower.startswith("mrwk1"):
+        try:
+            return normalize_wallet_address(clean)
+        except WalletError as exc:
+            raise AccountError(str(exc)) from exc
+    if lower.startswith("github:"):
+        login = clean.split(":", 1)[1].lower()
+        if not GITHUB_LOGIN_RE.fullmatch(login):
+            raise AccountError("github login must be valid")
+        return f"github:{login}"
+    return clean
+
+
+def github_login_from_account(account: str) -> str | None:
+    if not account.startswith("github:"):
+        return None
+    login = account.removeprefix("github:")
+    if not GITHUB_LOGIN_RE.fullmatch(login):
+        return None
+    return login
+
+
+def transfer_status_for_account(account: str) -> str:
+    if account.startswith("github:"):
+        return GITHUB_TRANSFER_STATUS
+    if account.startswith(("treasury:", "reserve:")):
+        return INTERNAL_LEDGER_TRANSFER_STATUS
+    return WALLET_TRANSFER_STATUS
+
+
+def account_summary(
+    account: str, *, exists: bool, balance_mrwk: str, accepted_work: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "account": account,
+        "ledger_address": account,
+        "github_login": github_login_from_account(account),
+        "exists": exists,
+        "balance_mrwk": balance_mrwk,
+        "transfer_status": transfer_status_for_account(account),
+        "accepted_work": accepted_work,
+    }
+
+
+def _normalize_reserve_account(lower_account: str) -> str:
+    reserve_prefix = "reserve:bounty:"
+    if not lower_account.startswith(reserve_prefix):
+        raise AccountError("reserve account must use reserve:bounty:<id>")
+    bounty_id = lower_account.removeprefix(reserve_prefix)
+    try:
+        normalized_bounty_id = int(bounty_id) if bounty_id.isdigit() else 0
+    except ValueError as exc:
+        raise AccountError("reserve bounty id is too large") from exc
+    if normalized_bounty_id <= 0:
+        raise AccountError("reserve bounty id must be positive")
+    if normalized_bounty_id > SQLITE_INTEGER_MAX:
+        raise AccountError("reserve bounty id is too large")
+    return f"{reserve_prefix}{normalized_bounty_id}"

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import urlencode, urlsplit, urlunsplit
+from urllib.parse import unquote, urlencode, urlsplit, urlunsplit
 
 import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
@@ -20,6 +20,12 @@ from sqlalchemy import func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.accounts import (
+    AccountError,
+    account_summary,
+    github_login_from_account,
+    normalize_account,
+)
 from app.admin import (
     list_webhook_events,
     normalize_webhook_status_filter,
@@ -96,7 +102,6 @@ SECURITY_HEADERS = {
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
 }
-GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 HEX_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 API_DOCS_CSP = (
     "default-src 'self'; "
@@ -278,62 +283,31 @@ def _oauth_configured(settings: Settings) -> bool:
 
 
 def _safe_next_path(next_path: str | None) -> str:
+    decoded_next_path = unquote(next_path) if next_path else ""
     if (
         not next_path
         or not next_path.startswith("/")
         or next_path.startswith("//")
         or len(next_path) > 2048
         or "\\" in next_path
+        or decoded_next_path.startswith("//")
+        or "\\" in decoded_next_path
         or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
+        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)
     ):
         return "/me"
     return next_path
 
 
 def _normalized_account(account: str) -> str:
-    if not account or not account.strip():
-        raise HTTPException(status_code=400, detail="account must not be empty")
-    if re.search(r"[\x00-\x1f\x7f]", account):
-        raise HTTPException(status_code=400, detail="account must not contain control characters")
-    clean = account.strip()
-    lower = clean.lower()
-    if lower == TREASURY_ACCOUNT:
-        return TREASURY_ACCOUNT
-    if lower.startswith("treasury:"):
-        raise HTTPException(status_code=400, detail="treasury account must be treasury:mrwk")
-    if lower.startswith("reserve:"):
-        reserve_prefix = "reserve:bounty:"
-        if not lower.startswith(reserve_prefix):
-            raise HTTPException(
-                status_code=400, detail="reserve account must use reserve:bounty:<id>"
-            )
-        bounty_id = lower.removeprefix(reserve_prefix)
-        try:
-            normalized_bounty_id = int(bounty_id) if bounty_id.isdigit() else 0
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail="reserve bounty id is too large") from exc
-        if normalized_bounty_id <= 0:
-            raise HTTPException(status_code=400, detail="reserve bounty id must be positive")
-        if normalized_bounty_id > SQLITE_INTEGER_MAX:
-            raise HTTPException(status_code=400, detail="reserve bounty id is too large")
-        return f"{reserve_prefix}{normalized_bounty_id}"
-    if lower.startswith("mrwk1"):
-        return _normalized_wallet_address(clean)
-    if lower.startswith("github:"):
-        login = clean.split(":", 1)[1].lower()
-        if not GITHUB_LOGIN_RE.fullmatch(login):
-            raise HTTPException(status_code=400, detail="github login must be valid")
-        return f"github:{login}"
-    return clean
+    try:
+        return normalize_account(account)
+    except AccountError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 def _github_login_from_account(account: str) -> str | None:
-    if not account.startswith("github:"):
-        return None
-    login = account.removeprefix("github:")
-    if not GITHUB_LOGIN_RE.fullmatch(login):
-        return None
-    return login
+    return github_login_from_account(account)
 
 
 def _positive_bounty_id(bounty_id: int) -> int:
@@ -933,30 +907,15 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     @app.get("/api/v1/accounts/{account}")
     def api_account(account: str) -> dict[str, Any]:
         account = _normalized_account(account)
-        github_login = _github_login_from_account(account)
-        if account.startswith("github:"):
-            transfer_status = (
-                "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
-            )
-        elif account.startswith(("treasury:", "reserve:")):
-            transfer_status = (
-                "Internal ledger account. MRWK wallet transfers are only available "
-                "for registered mrwk1 addresses."
-            )
-        else:
-            transfer_status = "MRWK wallet transfers are enabled for registered mrwk1 addresses."
         with session_scope(db_url) as session:
             account_row = session.get(Account, account)
             accepted_work = safe_account_accepted_summary(session, account)
-            return {
-                "account": account,
-                "ledger_address": account,
-                "github_login": github_login,
-                "exists": account_row is not None,
-                "balance_mrwk": format_mrwk(get_balance(session, account)),
-                "transfer_status": transfer_status,
-                "accepted_work": accepted_work,
-            }
+            return account_summary(
+                account,
+                exists=account_row is not None,
+                balance_mrwk=format_mrwk(get_balance(session, account)),
+                accepted_work=accepted_work,
+            )
 
     @app.get("/api/v1/accounts/{account}/accepted-work")
     def api_account_accepted_work(account: str) -> dict[str, Any]:

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+
+from app.accounts import (
+    AccountError,
+    account_summary,
+    github_login_from_account,
+    normalize_account,
+    transfer_status_for_account,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw_account", "normalized"),
+    [
+        (" Treasury:MRWK ", "treasury:mrwk"),
+        ("Reserve:Bounty:001", "reserve:bounty:1"),
+        ("GitHub:Alice", "github:alice"),
+        ("MRWK1" + ("A" * 40), "mrwk1" + ("a" * 40)),
+    ],
+)
+def test_normalize_account_canonicalizes_known_account_types(
+    raw_account: str, normalized: str
+) -> None:
+    assert normalize_account(raw_account) == normalized
+
+
+@pytest.mark.parametrize(
+    "raw_account",
+    [
+        "",
+        "github: ",
+        "treasury:ops",
+        "reserve:wallet:1",
+        "reserve:bounty:0",
+        "mrwk1bad",
+        "test\x00account",
+    ],
+)
+def test_normalize_account_rejects_invalid_account_values(raw_account: str) -> None:
+    with pytest.raises(AccountError):
+        normalize_account(raw_account)
+
+
+def test_account_helpers_shape_api_summary() -> None:
+    accepted_work = {
+        "accepted_awards": 1,
+        "accepted_mrwk": "25",
+        "latest_ledger_sequence": 3,
+    }
+
+    summary = account_summary(
+        "github:alice",
+        exists=True,
+        balance_mrwk="25",
+        accepted_work=accepted_work,
+    )
+
+    assert github_login_from_account("github:alice") == "alice"
+    assert github_login_from_account("treasury:mrwk") is None
+    assert transfer_status_for_account("github:alice").startswith("Claim GitHub balances")
+    assert transfer_status_for_account("treasury:mrwk").startswith("Internal ledger account")
+    assert summary == {
+        "account": "github:alice",
+        "ledger_address": "github:alice",
+        "github_login": "alice",
+        "exists": True,
+        "balance_mrwk": "25",
+        "transfer_status": transfer_status_for_account("github:alice"),
+        "accepted_work": accepted_work,
+    }


### PR DESCRIPTION
Refs #320

## Summary
- Move account normalization, GitHub-login extraction, transfer status text, and account response shaping into app.accounts.
- Keep app.main behavior stable while replacing inline account validation and account API response assembly with focused helpers.
- Add direct account-helper tests covering canonicalization, invalid accounts, and API summary shaping.
- Preserve the existing OAuth encoded-backslash next-path safety expectation required by the test suite.

## Complexity reduced
- app.main no longer owns account-address parsing rules, reserve/treasury/wallet/GitHub normalization, transfer status wording, or account response layout. Account behavior can now be tested without routing through FastAPI, while API/page/MCP callers share one boundary.

## Tests
- python -m ruff check .
- python -m pytest tests\\test_wallet_api.py::test_github_login_stores_safe_default_for_backslash_next tests\\test_accounts.py tests\\test_account_validation.py -q
- python -m pytest -q