### PR TITLE
Extract proof helpers from app.main

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,10 +6,11 @@ import json
 import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from sqlalchemy import case, func, select, update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -656,16 +657,19 @@ def pay_bounty(
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")
-    claimed: Any = session.execute(
-        update(Bounty)
-        .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
-        .values(
-            awards_paid=Bounty.awards_paid + 1,
-            status=case(
-                (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
-                else_="open",
-            ),
-        )
+    claimed = cast(
+        CursorResult[Any],
+        session.execute(
+            update(Bounty)
+            .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
+            .values(
+                awards_paid=Bounty.awards_paid + 1,
+                status=case(
+                    (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
+                    else_="open",
+                ),
+            )
+        ),
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty already paid")
@@ -733,10 +737,13 @@ def close_bounty(
         raise LedgerError("bounty is not open")
     _clean_required_text(closed_by, "closed_by", 80)
     clean_reference = validate_public_url(reference or bounty.issue_url)
-    claimed: Any = session.execute(
-        update(Bounty)
-        .where(Bounty.id == bounty.id, Bounty.status == "open")
-        .values(status="closed")
+    claimed = cast(
+        CursorResult[Any],
+        session.execute(
+            update(Bounty)
+            .where(Bounty.id == bounty.id, Bounty.status == "open")
+            .values(status="closed")
+        ),
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty is not open")

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,11 +6,10 @@ import json
 import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlparse
 
 from sqlalchemy import case, func, select, update
-from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -657,19 +656,16 @@ def pay_bounty(
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
-            .values(
-                awards_paid=Bounty.awards_paid + 1,
-                status=case(
-                    (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
-                    else_="open",
-                ),
-            )
-        ),
+    claimed: Any = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
+        .values(
+            awards_paid=Bounty.awards_paid + 1,
+            status=case(
+                (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
+                else_="open",
+            ),
+        )
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty already paid")
@@ -737,13 +733,10 @@ def close_bounty(
         raise LedgerError("bounty is not open")
     _clean_required_text(closed_by, "closed_by", 80)
     clean_reference = validate_public_url(reference or bounty.issue_url)
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.status == "open")
-            .values(status="closed")
-        ),
+    claimed: Any = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.status == "open")
+        .values(status="closed")
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty is not open")

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import urlencode, urlsplit, urlunsplit
+from urllib.parse import unquote, urlencode, urlsplit, urlunsplit
 
 import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
@@ -275,13 +275,17 @@ def _oauth_configured(settings: Settings) -> bool:
 
 
 def _safe_next_path(next_path: str | None) -> str:
+    decoded_next_path = unquote(next_path) if next_path else ""
     if (
         not next_path
         or not next_path.startswith("/")
         or next_path.startswith("//")
         or len(next_path) > 2048
         or "\\" in next_path
+        or decoded_next_path.startswith("//")
+        or "\\" in decoded_next_path
         or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
+        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)
     ):
         return "/me"
     return next_path

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import unquote, urlencode, urlsplit, urlunsplit
+from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
@@ -275,17 +275,13 @@ def _oauth_configured(settings: Settings) -> bool:
 
 
 def _safe_next_path(next_path: str | None) -> str:
-    decoded_next_path = unquote(next_path) if next_path else ""
     if (
         not next_path
         or not next_path.startswith("/")
         or next_path.startswith("//")
         or len(next_path) > 2048
         or "\\" in next_path
-        or decoded_next_path.startswith("//")
-        or "\\" in decoded_next_path
         or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
-        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)
     ):
         return "/me"
     return next_path

--- a/app/main.py
+++ b/app/main.py
@@ -58,6 +58,13 @@ from app.models import (
     Submission,
     Wallet,
 )
+from app.proofs import (
+    mcp_proof_to_dict,
+    proof_hash_for_sequence,
+    proof_hash_from_path,
+    proof_hashes_by_sequence,
+    public_proof_payload,
+)
 from app.serializers import (
     accepted_work_for_account,
     account_accepted_summary,
@@ -97,7 +104,6 @@ SECURITY_HEADERS = {
     "X-Frame-Options": "DENY",
 }
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
-HEX_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 API_DOCS_CSP = (
     "default-src 'self'; "
     "base-uri 'self'; "
@@ -260,15 +266,6 @@ def _is_ltc_lab_host(request: Request) -> bool:
     return _host_without_port(request) in {"ltclab.site", "www.ltclab.site"}
 
 
-def _proof_hashes_by_sequence(session: Session, sequences: list[int]) -> dict[int, str]:
-    if not sequences:
-        return {}
-    rows = session.execute(
-        select(Proof.ledger_sequence, Proof.hash).where(Proof.ledger_sequence.in_(sequences))
-    ).all()
-    return {int(sequence): str(proof_hash) for sequence, proof_hash in rows}
-
-
 def _oauth_configured(settings: Settings) -> bool:
     return bool(
         settings.github_oauth_client_id
@@ -357,15 +354,6 @@ def _normalized_wallet_address(address: str) -> str:
         return normalize_wallet_address(address)
     except WalletError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-
-def _proof_hash_from_path(proof_hash: str) -> str:
-    if proof_hash != proof_hash.strip():
-        raise HTTPException(status_code=400, detail="proof hash must be 64 hex characters")
-    clean = proof_hash.lower()
-    if not HEX_HASH_RE.fullmatch(clean):
-        raise HTTPException(status_code=400, detail="proof hash must be 64 hex characters")
-    return clean
 
 
 def _signed_value(value: str, secret: str) -> str:
@@ -1064,7 +1052,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             entries = session.scalars(
                 select(LedgerEntry).order_by(LedgerEntry.sequence.desc()).limit(limit)
             ).all()
-            proofs = _proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
+            proofs = proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
             return [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
 
     @app.get("/api/v1/ledger/{sequence}")
@@ -1074,20 +1062,16 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             entry = session.get(LedgerEntry, sequence)
             if entry is None:
                 raise HTTPException(status_code=404, detail="ledger entry not found")
-            proof = session.scalar(select(Proof).where(Proof.ledger_sequence == sequence).limit(1))
-            return ledger_to_dict(entry, proof.hash if proof else None)
+            return ledger_to_dict(entry, proof_hash_for_sequence(session, sequence))
 
     @app.get("/api/v1/proofs/{proof_hash}")
     def api_proof(proof_hash: str) -> dict[str, Any]:
-        proof_hash = _proof_hash_from_path(proof_hash)
+        proof_hash = proof_hash_from_path(proof_hash)
         with session_scope(db_url) as session:
             proof = session.get(Proof, proof_hash)
             if proof is None:
                 raise HTTPException(status_code=404, detail="proof not found")
-            data = json.loads(proof.public_json)
-            if not isinstance(data, dict):
-                raise HTTPException(status_code=500, detail="invalid proof payload")
-            return data
+            return public_proof_payload(proof)
 
     @app.get("/api/v1/activity")
     def api_activity(q: str | None = Query(None)) -> dict[str, Any]:
@@ -1203,7 +1187,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 .order_by(LedgerEntry.sequence.desc())
                 .limit(100)
             ).all()
-            proofs = _proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
+            proofs = proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
             transactions = [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
             accepted_work = safe_accepted_work_for_account(session, account)
         return templates.TemplateResponse(
@@ -1245,7 +1229,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 .order_by(LedgerEntry.sequence.desc())
                 .limit(100)
             ).all()
-            proofs = _proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
+            proofs = proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
             transactions = [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
         return templates.TemplateResponse(
             request,
@@ -1730,28 +1714,14 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
             entry = session.get(LedgerEntry, positive_int_arg("sequence"))
             if entry is None:
                 return "ledger entry not found"
-            proof = session.scalar(
-                select(Proof).where(Proof.ledger_sequence == entry.sequence).limit(1)
+            return json.dumps(
+                ledger_to_dict(entry, proof_hash_for_sequence(session, entry.sequence))
             )
-            return json.dumps(ledger_to_dict(entry, proof.hash if proof else None))
         if name == "get_proof":
-            proof = session.get(Proof, _proof_hash_from_path(str_arg("hash")))
+            proof = session.get(Proof, proof_hash_from_path(str_arg("hash")))
             if proof is None:
                 return "proof not found"
-            public_payload = json.loads(proof.public_json)
-            if not isinstance(public_payload, dict):
-                raise ValueError("invalid proof payload")
-            return json.dumps(
-                {
-                    "hash": proof.hash,
-                    "kind": proof.kind,
-                    "ledger_sequence": proof.ledger_sequence,
-                    "bounty_id": proof.bounty_id,
-                    "submission_id": proof.submission_id,
-                    "created_at": proof.created_at.isoformat(),
-                    "proof": public_payload,
-                }
-            )
+            return json.dumps(mcp_proof_to_dict(proof))
         if name == "submit_work_proof":
             output_format = output_format_arg()
             has_bounty_id = "bounty_id" in args and args.get("bounty_id") is not None

--- a/app/proofs.py
+++ b/app/proofs.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models import Proof
+
+PROOF_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def proof_hash_from_path(proof_hash: str) -> str:
+    if proof_hash != proof_hash.strip():
+        raise HTTPException(status_code=400, detail="proof hash must be 64 hex characters")
+    clean = proof_hash.lower()
+    if not PROOF_HASH_RE.fullmatch(clean):
+        raise HTTPException(status_code=400, detail="proof hash must be 64 hex characters")
+    return clean
+
+
+def proof_hashes_by_sequence(session: Session, sequences: list[int]) -> dict[int, str]:
+    if not sequences:
+        return {}
+    rows = session.execute(
+        select(Proof.ledger_sequence, Proof.hash).where(Proof.ledger_sequence.in_(sequences))
+    ).all()
+    return {int(sequence): str(proof_hash) for sequence, proof_hash in rows}
+
+
+def proof_hash_for_sequence(session: Session, sequence: int) -> str | None:
+    return session.scalar(select(Proof.hash).where(Proof.ledger_sequence == sequence).limit(1))
+
+
+def public_proof_payload(proof: Proof) -> dict[str, Any]:
+    payload = json.loads(proof.public_json)
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=500, detail="invalid proof payload")
+    return payload
+
+
+def mcp_proof_to_dict(proof: Proof) -> dict[str, Any]:
+    return {
+        "hash": proof.hash,
+        "kind": proof.kind,
+        "ledger_sequence": proof.ledger_sequence,
+        "bounty_id": proof.bounty_id,
+        "submission_id": proof.submission_id,
+        "created_at": proof.created_at.isoformat(),
+        "proof": public_proof_payload(proof),
+    }

--- a/app/proofs.py
+++ b/app/proofs.py
@@ -36,7 +36,10 @@ def proof_hash_for_sequence(session: Session, sequence: int) -> str | None:
 
 
 def public_proof_payload(proof: Proof) -> dict[str, Any]:
-    payload = json.loads(proof.public_json)
+    try:
+        payload = json.loads(proof.public_json)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=500, detail="invalid proof payload") from exc
     if not isinstance(payload, dict):
         raise HTTPException(status_code=500, detail="invalid proof payload")
     return payload

--- a/tests/test_proofs.py
+++ b/tests/test_proofs.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
 import pytest
 from fastapi import HTTPException
 
@@ -61,3 +64,26 @@ def test_proof_helpers_shape_api_and_mcp_payloads(sqlite_url: str) -> None:
     assert api_payload["submission_url"] == "https://github.com/ramimbo/mergework/pull/320"
     assert mcp_payload["hash"] == proof.hash
     assert mcp_payload["proof"] == api_payload
+
+
+def test_proof_payload_helpers_reject_malformed_or_non_object_payloads() -> None:
+    for raw_payload in ("{", "[]"):
+        proof = SimpleNamespace(
+            hash="a" * 64,
+            kind="bounty_payment",
+            ledger_sequence=1,
+            bounty_id=1,
+            submission_id=None,
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            public_json=raw_payload,
+        )
+
+        with pytest.raises(HTTPException) as public_exc_info:
+            public_proof_payload(proof)  # type: ignore[arg-type]
+        assert public_exc_info.value.status_code == 500
+        assert public_exc_info.value.detail == "invalid proof payload"
+
+        with pytest.raises(HTTPException) as mcp_exc_info:
+            mcp_proof_to_dict(proof)  # type: ignore[arg-type]
+        assert mcp_exc_info.value.status_code == 500
+        assert mcp_exc_info.value.detail == "invalid proof payload"

--- a/tests/test_proofs.py
+++ b/tests/test_proofs.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.db import create_schema, session_scope
+from app.ledger.service import create_bounty, ensure_genesis, pay_bounty
+from app.proofs import (
+    mcp_proof_to_dict,
+    proof_hash_for_sequence,
+    proof_hash_from_path,
+    proof_hashes_by_sequence,
+    public_proof_payload,
+)
+
+
+def test_proof_hash_from_path_normalizes_and_rejects_malformed_hashes() -> None:
+    assert proof_hash_from_path("A" * 64) == "a" * 64
+
+    for proof_hash in (" " + ("a" * 64), "not-a-proof-hash", "g" * 64):
+        with pytest.raises(HTTPException) as exc_info:
+            proof_hash_from_path(proof_hash)
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "proof hash must be 64 hex characters"
+
+
+def test_proof_helpers_shape_api_and_mcp_payloads(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=320,
+            issue_url="https://github.com/ramimbo/mergework/issues/320",
+            title="Proof helper extraction",
+            reward_mrwk="25",
+            acceptance="Proof lookup helpers should be independently testable.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/320",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+        proof_by_sequence = proof_hashes_by_sequence(session, [proof.ledger_sequence, 999])
+        single_proof_hash = proof_hash_for_sequence(session, proof.ledger_sequence)
+        missing_proof_hash = proof_hash_for_sequence(session, 999)
+        api_payload = public_proof_payload(proof)
+        mcp_payload = mcp_proof_to_dict(proof)
+        empty_lookup = proof_hashes_by_sequence(session, [])
+
+    assert empty_lookup == {}
+    assert proof_by_sequence == {proof.ledger_sequence: proof.hash}
+    assert single_proof_hash == proof.hash
+    assert missing_proof_hash is None
+    assert api_payload["kind"] == "bounty_payment"
+    assert api_payload["submission_url"] == "https://github.com/ramimbo/mergework/pull/320"
+    assert mcp_payload["hash"] == proof.hash
+    assert mcp_payload["proof"] == api_payload


### PR DESCRIPTION
Refs #320

## Summary
- Extract proof hash validation, proof lookup helpers, public proof payload shaping, and MCP proof response shaping from `app/main.py` into `app/proofs.py`.
- Reuse the helpers from ledger API responses, account transaction views, `/api/v1/proofs/{hash}`, and MCP `get_ledger_entry` / `get_proof` without changing public behavior.
- Add focused proof helper tests for hash normalization/rejection, sequence proof lookup, API payload shaping, and MCP payload shaping.

## Complexity reduced
`app/main.py` no longer owns proof-specific hash parsing, ledger-sequence proof lookup, or MCP proof serialization. Proof behavior can now be reviewed in one small module with direct tests, while route code stays focused on wiring.

## Tests
- `python -m pytest` -> 337 passed
- `python -m pytest tests/test_proofs.py tests/test_api_mcp.py::test_mcp_get_ledger_entry_includes_payment_proof_hash tests/test_api_mcp.py::test_mcp_get_proof_returns_public_proof_details tests/test_api_mcp.py::test_explorer_links_ledger_proof_and_account` -> 5 passed
- `python -m ruff format --check .` -> 50 files already formatted
- `python -m ruff check .` -> All checks passed
- `python -m mypy app` -> Success: no issues found in 15 source files
- `git diff --check` -> clean
- Hosted `Quality, readiness, docs, and image checks` -> passed
- CodeRabbit -> passed

No private keys, seed material, secrets, deployment credentials, private vulnerability details, payout credentials, or MRWK price claims are included.
