### PR TITLE
Extract bounty attempt reservation helpers

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import func, select, update
+from sqlalchemy.orm import Session
+
+from app.models import Bounty, BountyAttempt
+
+
+def as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def attempt_effective_status(attempt: BountyAttempt, now: datetime) -> str:
+    if attempt.status == "active" and as_utc(attempt.expires_at) <= now:
+        return "expired"
+    return attempt.status
+
+
+def bounty_attempt_to_dict(attempt: BountyAttempt, now: datetime) -> dict[str, Any]:
+    return {
+        "id": attempt.id,
+        "bounty_id": attempt.bounty_id,
+        "submitter_account": attempt.submitter_account,
+        "source_url": attempt.source_url,
+        "status": attempt_effective_status(attempt, now),
+        "expires_at": as_utc(attempt.expires_at).isoformat(),
+        "created_at": as_utc(attempt.created_at).isoformat(),
+        "updated_at": as_utc(attempt.updated_at).isoformat(),
+    }
+
+
+def active_attempt_conditions(bounty_id: int, now: datetime) -> tuple[Any, ...]:
+    return (
+        BountyAttempt.bounty_id == bounty_id,
+        BountyAttempt.status == "active",
+        BountyAttempt.expires_at > now,
+    )
+
+
+def bounty_attempt_warnings(session: Session, bounty: Bounty, now: datetime) -> list[str]:
+    warnings: list[str] = []
+    awards_remaining = max(0, bounty.max_awards - bounty.awards_paid)
+    if bounty.status != "open":
+        warnings.append(f"bounty is {bounty.status}")
+        awards_remaining = 0
+    if awards_remaining <= 0:
+        warnings.append("bounty has no award slots remaining")
+    active_count = session.scalar(
+        select(func.count())
+        .select_from(BountyAttempt)
+        .where(*active_attempt_conditions(bounty.id, now))
+    )
+    if active_count and active_count > 1:
+        warnings.append(f"bounty has {active_count} active attempts")
+    return warnings
+
+
+def expire_stale_bounty_attempts(
+    session: Session, bounty_id: int, now: datetime, submitter_account: str | None = None
+) -> None:
+    query = update(BountyAttempt).where(
+        BountyAttempt.bounty_id == bounty_id,
+        BountyAttempt.status == "active",
+        BountyAttempt.expires_at <= now,
+    )
+    if submitter_account is not None:
+        query = query.where(BountyAttempt.submitter_account == submitter_account)
+    session.execute(query.values(status="expired", updated_at=now))

--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,7 @@ from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from sqlalchemy import func, or_, select, update
+from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -25,6 +25,13 @@ from app.admin import (
     normalize_webhook_status_filter,
     webhook_events_to_dict,
     webhook_status_summary,
+)
+from app.bounty_attempts import (
+    active_attempt_conditions,
+    attempt_effective_status,
+    bounty_attempt_to_dict,
+    bounty_attempt_warnings,
+    expire_stale_bounty_attempts,
 )
 from app.config import Settings, get_settings
 from app.db import create_schema, session_scope
@@ -151,71 +158,6 @@ def _issue_number_search_value(query: str) -> int | None:
 
 def _utc_now() -> datetime:
     return datetime.now(UTC)
-
-
-def _as_utc(value: datetime) -> datetime:
-    if value.tzinfo is None:
-        return value.replace(tzinfo=UTC)
-    return value.astimezone(UTC)
-
-
-def _attempt_effective_status(attempt: BountyAttempt, now: datetime) -> str:
-    if attempt.status == "active" and _as_utc(attempt.expires_at) <= now:
-        return "expired"
-    return attempt.status
-
-
-def bounty_attempt_to_dict(attempt: BountyAttempt, now: datetime | None = None) -> dict[str, Any]:
-    now = now or _utc_now()
-    return {
-        "id": attempt.id,
-        "bounty_id": attempt.bounty_id,
-        "submitter_account": attempt.submitter_account,
-        "source_url": attempt.source_url,
-        "status": _attempt_effective_status(attempt, now),
-        "expires_at": _as_utc(attempt.expires_at).isoformat(),
-        "created_at": _as_utc(attempt.created_at).isoformat(),
-        "updated_at": _as_utc(attempt.updated_at).isoformat(),
-    }
-
-
-def _active_attempt_conditions(bounty_id: int, now: datetime) -> tuple[Any, ...]:
-    return (
-        BountyAttempt.bounty_id == bounty_id,
-        BountyAttempt.status == "active",
-        BountyAttempt.expires_at > now,
-    )
-
-
-def bounty_attempt_warnings(session: Session, bounty: Bounty, now: datetime) -> list[str]:
-    warnings: list[str] = []
-    awards_remaining = max(0, bounty.max_awards - bounty.awards_paid)
-    if bounty.status != "open":
-        warnings.append(f"bounty is {bounty.status}")
-        awards_remaining = 0
-    if awards_remaining <= 0:
-        warnings.append("bounty has no award slots remaining")
-    active_count = session.scalar(
-        select(func.count())
-        .select_from(BountyAttempt)
-        .where(*_active_attempt_conditions(bounty.id, now))
-    )
-    if active_count and active_count > 1:
-        warnings.append(f"bounty has {active_count} active attempts")
-    return warnings
-
-
-def expire_stale_bounty_attempts(
-    session: Session, bounty_id: int, now: datetime, submitter_account: str | None = None
-) -> None:
-    query = update(BountyAttempt).where(
-        BountyAttempt.bounty_id == bounty_id,
-        BountyAttempt.status == "active",
-        BountyAttempt.expires_at <= now,
-    )
-    if submitter_account is not None:
-        query = query.where(BountyAttempt.submitter_account == submitter_account)
-    session.execute(query.values(status="expired", updated_at=now))
 
 
 def _payout_response_from_proof(proof: Proof, *, status: str) -> dict[str, Any]:
@@ -680,7 +622,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 raise HTTPException(status_code=404, detail="bounty not found")
             query = select(BountyAttempt).where(BountyAttempt.bounty_id == bounty_id)
             if not include_expired:
-                query = query.where(*_active_attempt_conditions(bounty_id, now))
+                query = query.where(*active_attempt_conditions(bounty_id, now))
             attempts = session.scalars(
                 query.order_by(BountyAttempt.created_at.desc(), BountyAttempt.id.desc())
             ).all()
@@ -728,7 +670,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             existing = session.scalar(
                 select(BountyAttempt)
                 .where(
-                    *_active_attempt_conditions(bounty_id, now),
+                    *active_attempt_conditions(bounty_id, now),
                     BountyAttempt.submitter_account == submitter_account,
                 )
                 .order_by(BountyAttempt.created_at.desc(), BountyAttempt.id.desc())
@@ -761,7 +703,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 existing = session.scalar(
                     select(BountyAttempt)
                     .where(
-                        *_active_attempt_conditions(bounty_id, now),
+                        *active_attempt_conditions(bounty_id, now),
                         BountyAttempt.submitter_account == submitter_account,
                     )
                     .order_by(BountyAttempt.created_at.desc(), BountyAttempt.id.desc())
@@ -807,7 +749,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 raise HTTPException(status_code=404, detail="attempt not found")
             if attempt.submitter_account != submitter_account:
                 raise HTTPException(status_code=403, detail="submitter_account does not match")
-            effective_status = _attempt_effective_status(attempt, now)
+            effective_status = attempt_effective_status(attempt, now)
             if effective_status != "active":
                 return {
                     "status": f"already_{effective_status}",
@@ -1687,7 +1629,7 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
             now = _utc_now()
             attempt_query = select(BountyAttempt).where(BountyAttempt.bounty_id == bounty_id)
             if not optional_bool_arg("include_expired"):
-                attempt_query = attempt_query.where(*_active_attempt_conditions(bounty_id, now))
+                attempt_query = attempt_query.where(*active_attempt_conditions(bounty_id, now))
             attempts = session.scalars(
                 attempt_query.order_by(
                     BountyAttempt.created_at.desc(), BountyAttempt.id.desc()

--- a/tests/test_bounty_attempt_helpers.py
+++ b/tests/test_bounty_attempt_helpers.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+
+from app.bounty_attempts import (
+    attempt_effective_status,
+    bounty_attempt_to_dict,
+    bounty_attempt_warnings,
+    expire_stale_bounty_attempts,
+)
+from app.db import create_schema, session_scope
+from app.ledger.service import create_bounty, ensure_genesis
+from app.models import BountyAttempt
+
+
+def test_bounty_attempt_dict_reports_effective_expired_status() -> None:
+    now = datetime(2026, 5, 26, 12, 0, tzinfo=UTC)
+    attempt = BountyAttempt(
+        id=7,
+        bounty_id=3,
+        submitter_account="github:alice",
+        source_url="https://github.com/ramimbo/mergework/pull/700",
+        status="active",
+        expires_at=now - timedelta(minutes=1),
+        created_at=(now - timedelta(hours=1)).replace(tzinfo=None),
+        updated_at=now.replace(tzinfo=None),
+    )
+
+    assert attempt_effective_status(attempt, now) == "expired"
+    assert bounty_attempt_to_dict(attempt, now) == {
+        "id": 7,
+        "bounty_id": 3,
+        "submitter_account": "github:alice",
+        "source_url": "https://github.com/ramimbo/mergework/pull/700",
+        "status": "expired",
+        "expires_at": "2026-05-26T11:59:00+00:00",
+        "created_at": "2026-05-26T11:00:00+00:00",
+        "updated_at": "2026-05-26T12:00:00+00:00",
+    }
+
+
+def test_bounty_attempt_helpers_expire_stale_attempts_and_warn_on_overlap(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    now = datetime(2026, 5, 26, 12, 0, tzinfo=UTC)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=370,
+            issue_url="https://github.com/ramimbo/mergework/issues/370",
+            title="Attempt helper extraction",
+            reward_mrwk="100",
+            max_awards=2,
+            acceptance="Attempt helpers should stay consistent.",
+        )
+        session.add_all(
+            [
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account="github:alice",
+                    source_url=None,
+                    status="active",
+                    expires_at=now - timedelta(minutes=5),
+                    created_at=now - timedelta(hours=1),
+                    updated_at=now - timedelta(hours=1),
+                ),
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account="github:bob",
+                    source_url=None,
+                    status="active",
+                    expires_at=now + timedelta(hours=1),
+                    created_at=now,
+                    updated_at=now,
+                ),
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account="github:carol",
+                    source_url=None,
+                    status="active",
+                    expires_at=now + timedelta(hours=2),
+                    created_at=now,
+                    updated_at=now,
+                ),
+            ]
+        )
+        session.flush()
+
+        expire_stale_bounty_attempts(session, bounty.id, now, "github:alice")
+        statuses = dict(
+            session.execute(
+                select(BountyAttempt.submitter_account, BountyAttempt.status).where(
+                    BountyAttempt.bounty_id == bounty.id
+                )
+            ).all()
+        )
+
+        assert statuses == {
+            "github:alice": "expired",
+            "github:bob": "active",
+            "github:carol": "active",
+        }
+        assert bounty_attempt_warnings(session, bounty, now) == ["bounty has 2 active attempts"]


### PR DESCRIPTION
Refs #320

## Summary
- Move bounty-attempt reservation status, serialization, active-filter, warning, and stale-expiry helpers out of `app/main.py` into `app/bounty_attempts.py`.
- Keep API and MCP behavior unchanged while shrinking the route/API module.
- Add focused helper tests for effective expired status, UTC serialization, stale attempt expiry, and overlap warnings.

## Complexity reduced
`app/main.py` no longer owns the attempt-reservation helper logic used by both REST and MCP paths. The attempt-specific rules now live beside each other in a small module with direct tests, making future reservation behavior changes easier to review without scanning the main app wiring.

## Validation
- `python -m pytest` -> 337 passed
- `python -m ruff format --check .` -> 50 files already formatted
- `python -m ruff check .` -> All checks passed
- `python -m mypy app` -> Success: no issues found in 15 source files