### PR TITLE
Extract bounty attempt helpers

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import func, select, update
+from sqlalchemy.orm import Session
+
+from app.models import Bounty, BountyAttempt
+
+
+def as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def attempt_effective_status(attempt: BountyAttempt, now: datetime) -> str:
+    if attempt.status == "active" and as_utc(attempt.expires_at) <= now:
+        return "expired"
+    return attempt.status
+
+
+def bounty_attempt_to_dict(attempt: BountyAttempt, now: datetime) -> dict[str, Any]:
+    return {
+        "id": attempt.id,
+        "bounty_id": attempt.bounty_id,
+        "submitter_account": attempt.submitter_account,
+        "source_url": attempt.source_url,
+        "status": attempt_effective_status(attempt, now),
+        "expires_at": as_utc(attempt.expires_at).isoformat(),
+        "created_at": as_utc(attempt.created_at).isoformat(),
+        "updated_at": as_utc(attempt.updated_at).isoformat(),
+    }
+
+
+def active_attempt_conditions(bounty_id: int, now: datetime) -> tuple[Any, ...]:
+    return (
+        BountyAttempt.bounty_id == bounty_id,
+        BountyAttempt.status == "active",
+        BountyAttempt.expires_at > now,
+    )
+
+
+def bounty_attempt_warnings(session: Session, bounty: Bounty, now: datetime) -> list[str]:
+    warnings: list[str] = []
+    awards_remaining = max(0, bounty.max_awards - bounty.awards_paid)
+    if bounty.status != "open":
+        warnings.append(f"bounty is {bounty.status}")
+        awards_remaining = 0
+    if awards_remaining <= 0:
+        warnings.append("bounty has no award slots remaining")
+    active_count = session.scalar(
+        select(func.count())
+        .select_from(BountyAttempt)
+        .where(*active_attempt_conditions(bounty.id, now))
+    )
+    if active_count and active_count > 1:
+        warnings.append(f"bounty has {active_count} active attempts")
+    return warnings
+
+
+def expire_stale_bounty_attempts(
+    session: Session, bounty_id: int, now: datetime, submitter_account: str | None = None
+) -> None:
+    query = update(BountyAttempt).where(
+        BountyAttempt.bounty_id == bounty_id,
+        BountyAttempt.status == "active",
+        BountyAttempt.expires_at <= now,
+    )
+    if submitter_account is not None:
+        query = query.where(BountyAttempt.submitter_account == submitter_account)
+    session.execute(query.values(status="expired", updated_at=now))

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,11 +6,10 @@ import json
 import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlparse
 
 from sqlalchemy import case, func, select, update
-from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -657,19 +656,16 @@ def pay_bounty(
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
-            .values(
-                awards_paid=Bounty.awards_paid + 1,
-                status=case(
-                    (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
-                    else_="open",
-                ),
-            )
-        ),
+    claimed = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
+        .values(
+            awards_paid=Bounty.awards_paid + 1,
+            status=case(
+                (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
+                else_="open",
+            ),
+        )
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty already paid")
@@ -737,13 +733,10 @@ def close_bounty(
         raise LedgerError("bounty is not open")
     _clean_required_text(closed_by, "closed_by", 80)
     clean_reference = validate_public_url(reference or bounty.issue_url)
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.status == "open")
-            .values(status="closed")
-        ),
+    claimed = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.status == "open")
+        .values(status="closed")
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty is not open")

--- a/app/main.py
+++ b/app/main.py
@@ -9,14 +9,14 @@ import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import urlencode, urlsplit, urlunsplit
+from urllib.parse import unquote, urlencode, urlsplit, urlunsplit
 
 import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from sqlalchemy import func, or_, select, update
+from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -25,6 +25,13 @@ from app.admin import (
     normalize_webhook_status_filter,
     webhook_events_to_dict,
     webhook_status_summary,
+)
+from app.bounty_attempts import (
+    active_attempt_conditions,
+    attempt_effective_status,
+    bounty_attempt_to_dict,
+    bounty_attempt_warnings,
+    expire_stale_bounty_attempts,
 )
 from app.config import Settings, get_settings
 from app.db import create_schema, session_scope
@@ -153,71 +160,6 @@ def _utc_now() -> datetime:
     return datetime.now(UTC)
 
 
-def _as_utc(value: datetime) -> datetime:
-    if value.tzinfo is None:
-        return value.replace(tzinfo=UTC)
-    return value.astimezone(UTC)
-
-
-def _attempt_effective_status(attempt: BountyAttempt, now: datetime) -> str:
-    if attempt.status == "active" and _as_utc(attempt.expires_at) <= now:
-        return "expired"
-    return attempt.status
-
-
-def bounty_attempt_to_dict(attempt: BountyAttempt, now: datetime | None = None) -> dict[str, Any]:
-    now = now or _utc_now()
-    return {
-        "id": attempt.id,
-        "bounty_id": attempt.bounty_id,
-        "submitter_account": attempt.submitter_account,
-        "source_url": attempt.source_url,
-        "status": _attempt_effective_status(attempt, now),
-        "expires_at": _as_utc(attempt.expires_at).isoformat(),
-        "created_at": _as_utc(attempt.created_at).isoformat(),
-        "updated_at": _as_utc(attempt.updated_at).isoformat(),
-    }
-
-
-def _active_attempt_conditions(bounty_id: int, now: datetime) -> tuple[Any, ...]:
-    return (
-        BountyAttempt.bounty_id == bounty_id,
-        BountyAttempt.status == "active",
-        BountyAttempt.expires_at > now,
-    )
-
-
-def bounty_attempt_warnings(session: Session, bounty: Bounty, now: datetime) -> list[str]:
-    warnings: list[str] = []
-    awards_remaining = max(0, bounty.max_awards - bounty.awards_paid)
-    if bounty.status != "open":
-        warnings.append(f"bounty is {bounty.status}")
-        awards_remaining = 0
-    if awards_remaining <= 0:
-        warnings.append("bounty has no award slots remaining")
-    active_count = session.scalar(
-        select(func.count())
-        .select_from(BountyAttempt)
-        .where(*_active_attempt_conditions(bounty.id, now))
-    )
-    if active_count and active_count > 1:
-        warnings.append(f"bounty has {active_count} active attempts")
-    return warnings
-
-
-def expire_stale_bounty_attempts(
-    session: Session, bounty_id: int, now: datetime, submitter_account: str | None = None
-) -> None:
-    query = update(BountyAttempt).where(
-        BountyAttempt.bounty_id == bounty_id,
-        BountyAttempt.status == "active",
-        BountyAttempt.expires_at <= now,
-    )
-    if submitter_account is not None:
-        query = query.where(BountyAttempt.submitter_account == submitter_account)
-    session.execute(query.values(status="expired", updated_at=now))
-
-
 def _payout_response_from_proof(proof: Proof, *, status: str) -> dict[str, Any]:
     data = json.loads(proof.public_json)
     if not isinstance(data, dict) or data.get("kind") != "bounty_payment":
@@ -278,13 +220,17 @@ def _oauth_configured(settings: Settings) -> bool:
 
 
 def _safe_next_path(next_path: str | None) -> str:
+    decoded_next_path = unquote(next_path) if next_path else ""
     if (
         not next_path
         or not next_path.startswith("/")
         or next_path.startswith("//")
         or len(next_path) > 2048
         or "\\" in next_path
+        or decoded_next_path.startswith("//")
+        or "\\" in decoded_next_path
         or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
+        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)
     ):
         return "/me"
     return next_path
@@ -680,7 +626,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 raise HTTPException(status_code=404, detail="bounty not found")
             query = select(BountyAttempt).where(BountyAttempt.bounty_id == bounty_id)
             if not include_expired:
-                query = query.where(*_active_attempt_conditions(bounty_id, now))
+                query = query.where(*active_attempt_conditions(bounty_id, now))
             attempts = session.scalars(
                 query.order_by(BountyAttempt.created_at.desc(), BountyAttempt.id.desc())
             ).all()
@@ -728,7 +674,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             existing = session.scalar(
                 select(BountyAttempt)
                 .where(
-                    *_active_attempt_conditions(bounty_id, now),
+                    *active_attempt_conditions(bounty_id, now),
                     BountyAttempt.submitter_account == submitter_account,
                 )
                 .order_by(BountyAttempt.created_at.desc(), BountyAttempt.id.desc())
@@ -761,7 +707,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 existing = session.scalar(
                     select(BountyAttempt)
                     .where(
-                        *_active_attempt_conditions(bounty_id, now),
+                        *active_attempt_conditions(bounty_id, now),
                         BountyAttempt.submitter_account == submitter_account,
                     )
                     .order_by(BountyAttempt.created_at.desc(), BountyAttempt.id.desc())
@@ -807,7 +753,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 raise HTTPException(status_code=404, detail="attempt not found")
             if attempt.submitter_account != submitter_account:
                 raise HTTPException(status_code=403, detail="submitter_account does not match")
-            effective_status = _attempt_effective_status(attempt, now)
+            effective_status = attempt_effective_status(attempt, now)
             if effective_status != "active":
                 return {
                     "status": f"already_{effective_status}",
@@ -1687,7 +1633,7 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
             now = _utc_now()
             attempt_query = select(BountyAttempt).where(BountyAttempt.bounty_id == bounty_id)
             if not optional_bool_arg("include_expired"):
-                attempt_query = attempt_query.where(*_active_attempt_conditions(bounty_id, now))
+                attempt_query = attempt_query.where(*active_attempt_conditions(bounty_id, now))
             attempts = session.scalars(
                 attempt_query.order_by(
                     BountyAttempt.created_at.desc(), BountyAttempt.id.desc()

--- a/tests/test_bounty_attempt_helpers.py
+++ b/tests/test_bounty_attempt_helpers.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import select
+
+from app.bounty_attempts import (
+    attempt_effective_status,
+    bounty_attempt_to_dict,
+    bounty_attempt_warnings,
+    expire_stale_bounty_attempts,
+)
+from app.db import create_schema, session_scope
+from app.ledger.service import create_bounty, ensure_genesis, pay_bounty
+from app.models import BountyAttempt
+
+
+def test_bounty_attempt_dict_reports_expired_active_attempt(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    now = datetime(2026, 5, 26, 12, 0, tzinfo=UTC)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=320,
+            issue_url="https://github.com/ramimbo/mergework/issues/320",
+            title="Attempt helper extraction",
+            reward_mrwk="25",
+            acceptance="Attempt serializers should be testable outside app.main.",
+        )
+        attempt = BountyAttempt(
+            bounty_id=bounty.id,
+            submitter_account="github:alice",
+            source_url="https://github.com/ramimbo/mergework/pull/320",
+            status="active",
+            expires_at=now - timedelta(minutes=1),
+            created_at=now - timedelta(hours=1),
+            updated_at=now - timedelta(hours=1),
+        )
+        session.add(attempt)
+        session.flush()
+
+        payload = bounty_attempt_to_dict(attempt, now)
+
+    assert attempt_effective_status(attempt, now) == "expired"
+    assert payload["status"] == "expired"
+    assert payload["submitter_account"] == "github:alice"
+    assert payload["expires_at"] == "2026-05-26T11:59:00+00:00"
+
+
+def test_bounty_attempt_warnings_and_expiration_helpers(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    now = datetime(2026, 5, 26, 12, 0, tzinfo=UTC)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=321,
+            issue_url="https://github.com/ramimbo/mergework/issues/321",
+            title="Attempt warnings",
+            reward_mrwk="25",
+            max_awards=2,
+            acceptance="Attempt warnings should count active overlapping work.",
+        )
+        session.add_all(
+            [
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account="github:alice",
+                    source_url=None,
+                    status="active",
+                    expires_at=now + timedelta(hours=1),
+                    created_at=now - timedelta(minutes=5),
+                    updated_at=now - timedelta(minutes=5),
+                ),
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account="github:bob",
+                    source_url=None,
+                    status="active",
+                    expires_at=now - timedelta(minutes=1),
+                    created_at=now - timedelta(minutes=10),
+                    updated_at=now - timedelta(minutes=10),
+                ),
+            ]
+        )
+        session.flush()
+
+        expire_stale_bounty_attempts(session, bounty.id, now, "github:bob")
+        active_warning = bounty_attempt_warnings(session, bounty, now)
+        pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:winner",
+            submission_url="https://github.com/ramimbo/mergework/pull/321",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:second",
+            submission_url="https://github.com/ramimbo/mergework/pull/322",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        paid_warning = bounty_attempt_warnings(session, bounty, now)
+        bob_attempt = session.scalar(
+            select(BountyAttempt).where(BountyAttempt.submitter_account == "github:bob").limit(1)
+        )
+
+    assert active_warning == []
+    assert paid_warning == ["bounty is paid", "bounty has no award slots remaining"]
+    assert bob_attempt is not None
+    assert bob_attempt.status == "expired"


### PR DESCRIPTION
Refs #320

## Summary
- Extract bounty-attempt status, serialization, warning, active-condition, and stale-expiration helpers from `app/main.py` into `app/bounty_attempts.py`.
- Add focused helper tests for expired active attempts, warning generation, and stale attempt expiration.
- Keep checks green by removing redundant ledger casts reported by `mypy app` and by sanitizing percent-decoded OAuth `next` paths covered by the existing OAuth regression test.

## Complexity reduced
`app/main.py` no longer owns bounty-attempt serialization and query helper logic used by REST routes and MCP dispatch. Attempt behavior now lives in a small module with direct tests, leaving route handlers focused on auth, request parsing, and response status.

## Tests
- `python -m pytest -q` -> 337 passed
- `python -m pytest tests/test_bounty_attempt_helpers.py tests/test_bounty_attempts.py tests/test_api_mcp.py::test_mcp_list_bounty_attempts_reports_active_and_expired tests/test_ledger.py -q` -> 36 passed
- `python -m ruff format --check app/main.py app/ledger/service.py app/bounty_attempts.py tests/test_bounty_attempt_helpers.py`
- `python -m ruff check app/main.py app/ledger/service.py app/bounty_attempts.py tests/test_bounty_attempt_helpers.py`
- `python -m mypy app`