### PR TITLE
Extract ledger view helpers

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,10 +6,11 @@ import json
 import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from sqlalchemy import case, func, select, update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -656,16 +657,19 @@ def pay_bounty(
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")
-    claimed = session.execute(
-        update(Bounty)
-        .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
-        .values(
-            awards_paid=Bounty.awards_paid + 1,
-            status=case(
-                (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
-                else_="open",
-            ),
-        )
+    claimed = cast(
+        CursorResult[Any],
+        session.execute(
+            update(Bounty)
+            .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
+            .values(
+                awards_paid=Bounty.awards_paid + 1,
+                status=case(
+                    (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
+                    else_="open",
+                ),
+            )
+        ),
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty already paid")
@@ -733,10 +737,13 @@ def close_bounty(
         raise LedgerError("bounty is not open")
     _clean_required_text(closed_by, "closed_by", 80)
     clean_reference = validate_public_url(reference or bounty.issue_url)
-    claimed = session.execute(
-        update(Bounty)
-        .where(Bounty.id == bounty.id, Bounty.status == "open")
-        .values(status="closed")
+    claimed = cast(
+        CursorResult[Any],
+        session.execute(
+            update(Bounty)
+            .where(Bounty.id == bounty.id, Bounty.status == "open")
+            .values(status="closed")
+        ),
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty is not open")

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,11 +6,10 @@ import json
 import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlparse
 
 from sqlalchemy import case, func, select, update
-from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -657,19 +656,16 @@ def pay_bounty(
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
-            .values(
-                awards_paid=Bounty.awards_paid + 1,
-                status=case(
-                    (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
-                    else_="open",
-                ),
-            )
-        ),
+    claimed = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
+        .values(
+            awards_paid=Bounty.awards_paid + 1,
+            status=case(
+                (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
+                else_="open",
+            ),
+        )
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty already paid")
@@ -737,13 +733,10 @@ def close_bounty(
         raise LedgerError("bounty is not open")
     _clean_required_text(closed_by, "closed_by", 80)
     clean_reference = validate_public_url(reference or bounty.issue_url)
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.status == "open")
-            .values(status="closed")
-        ),
+    claimed = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.status == "open")
+        .values(status="closed")
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty is not open")

--- a/app/ledger_views.py
+++ b/app/ledger_views.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from app.models import LedgerEntry, Proof
+from app.serializers import ledger_to_dict
+
+
+def proof_hashes_by_sequence(session: Session, sequences: Sequence[int]) -> dict[int, str]:
+    if not sequences:
+        return {}
+    rows = session.execute(
+        select(Proof.ledger_sequence, Proof.hash).where(Proof.ledger_sequence.in_(sequences))
+    ).all()
+    return {int(sequence): str(proof_hash) for sequence, proof_hash in rows}
+
+
+def ledger_entries_to_dicts(
+    session: Session, entries: Sequence[LedgerEntry]
+) -> list[dict[str, Any]]:
+    proofs = proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
+    return [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
+
+
+def recent_ledger_entries(session: Session, limit: int) -> list[dict[str, Any]]:
+    entries = session.scalars(
+        select(LedgerEntry).order_by(LedgerEntry.sequence.desc()).limit(limit)
+    ).all()
+    return ledger_entries_to_dicts(session, entries)
+
+
+def ledger_entry_to_dict(session: Session, sequence: int) -> dict[str, Any] | None:
+    entry = session.get(LedgerEntry, sequence)
+    if entry is None:
+        return None
+    return ledger_entries_to_dicts(session, [entry])[0]
+
+
+def account_ledger_transactions(
+    session: Session, account: str, limit: int = 100
+) -> list[dict[str, Any]]:
+    entries = session.scalars(
+        select(LedgerEntry)
+        .where(or_(LedgerEntry.from_account == account, LedgerEntry.to_account == account))
+        .order_by(LedgerEntry.sequence.desc())
+        .limit(limit)
+    ).all()
+    return ledger_entries_to_dicts(session, entries)

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import urlencode, urlsplit, urlunsplit
+from urllib.parse import unquote, urlencode, urlsplit, urlunsplit
 
 import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
@@ -47,6 +47,11 @@ from app.ledger.service import (
     submit_github_claim,
     submit_wallet_transfer,
     validate_public_url,
+)
+from app.ledger_views import (
+    account_ledger_transactions,
+    ledger_entry_to_dict,
+    recent_ledger_entries,
 )
 from app.mcp import handle_mcp_request
 from app.models import (
@@ -260,15 +265,6 @@ def _is_ltc_lab_host(request: Request) -> bool:
     return _host_without_port(request) in {"ltclab.site", "www.ltclab.site"}
 
 
-def _proof_hashes_by_sequence(session: Session, sequences: list[int]) -> dict[int, str]:
-    if not sequences:
-        return {}
-    rows = session.execute(
-        select(Proof.ledger_sequence, Proof.hash).where(Proof.ledger_sequence.in_(sequences))
-    ).all()
-    return {int(sequence): str(proof_hash) for sequence, proof_hash in rows}
-
-
 def _oauth_configured(settings: Settings) -> bool:
     return bool(
         settings.github_oauth_client_id
@@ -278,13 +274,17 @@ def _oauth_configured(settings: Settings) -> bool:
 
 
 def _safe_next_path(next_path: str | None) -> str:
+    decoded_next_path = unquote(next_path) if next_path else ""
     if (
         not next_path
         or not next_path.startswith("/")
         or next_path.startswith("//")
         or len(next_path) > 2048
         or "\\" in next_path
+        or decoded_next_path.startswith("//")
+        or "\\" in decoded_next_path
         or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
+        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)
     ):
         return "/me"
     return next_path
@@ -1061,21 +1061,16 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     @app.get("/api/v1/ledger")
     def api_ledger(limit: Annotated[int, Query(ge=1, le=200)] = 50) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
-            entries = session.scalars(
-                select(LedgerEntry).order_by(LedgerEntry.sequence.desc()).limit(limit)
-            ).all()
-            proofs = _proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
-            return [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
+            return recent_ledger_entries(session, limit)
 
     @app.get("/api/v1/ledger/{sequence}")
     def api_ledger_entry(sequence: int) -> dict[str, Any]:
         sequence = _positive_ledger_sequence(sequence)
         with session_scope(db_url) as session:
-            entry = session.get(LedgerEntry, sequence)
+            entry = ledger_entry_to_dict(session, sequence)
             if entry is None:
                 raise HTTPException(status_code=404, detail="ledger entry not found")
-            proof = session.scalar(select(Proof).where(Proof.ledger_sequence == sequence).limit(1))
-            return ledger_to_dict(entry, proof.hash if proof else None)
+            return entry
 
     @app.get("/api/v1/proofs/{proof_hash}")
     def api_proof(proof_hash: str) -> dict[str, Any]:
@@ -1197,14 +1192,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         with session_scope(db_url) as session:
             account_data = api_account(account)
             accepted_summary = safe_account_accepted_summary(session, account)
-            entries = session.scalars(
-                select(LedgerEntry)
-                .where(or_(LedgerEntry.from_account == account, LedgerEntry.to_account == account))
-                .order_by(LedgerEntry.sequence.desc())
-                .limit(100)
-            ).all()
-            proofs = _proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
-            transactions = [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
+            transactions = account_ledger_transactions(session, account)
             accepted_work = safe_accepted_work_for_account(session, account)
         return templates.TemplateResponse(
             request,
@@ -1234,19 +1222,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             if wallet is None:
                 raise HTTPException(status_code=404, detail="wallet not found")
             wallet_data = wallet_to_dict(session, wallet)
-            entries = session.scalars(
-                select(LedgerEntry)
-                .where(
-                    or_(
-                        LedgerEntry.from_account == wallet.address,
-                        LedgerEntry.to_account == wallet.address,
-                    )
-                )
-                .order_by(LedgerEntry.sequence.desc())
-                .limit(100)
-            ).all()
-            proofs = _proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
-            transactions = [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
+            transactions = account_ledger_transactions(session, wallet.address)
         return templates.TemplateResponse(
             request,
             "wallet_detail.html",
@@ -1727,13 +1703,10 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
             )
             return json.dumps(wallet_transfer_to_dict(transfer))
         if name == "get_ledger_entry":
-            entry = session.get(LedgerEntry, positive_int_arg("sequence"))
+            entry = ledger_entry_to_dict(session, positive_int_arg("sequence"))
             if entry is None:
                 return "ledger entry not found"
-            proof = session.scalar(
-                select(Proof).where(Proof.ledger_sequence == entry.sequence).limit(1)
-            )
-            return json.dumps(ledger_to_dict(entry, proof.hash if proof else None))
+            return json.dumps(entry)
         if name == "get_proof":
             proof = session.get(Proof, _proof_hash_from_path(str_arg("hash")))
             if proof is None:

--- a/app/main.py
+++ b/app/main.py
@@ -282,6 +282,7 @@ def _safe_next_path(next_path: str | None) -> str:
         or len(next_path) > 2048
         or "\\" in next_path
         or decoded_next_path.startswith("//")
+        or len(decoded_next_path) > 2048
         or "\\" in decoded_next_path
         or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
         or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)

--- a/tests/test_ledger_views.py
+++ b/tests/test_ledger_views.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from app.db import create_schema, session_scope
+from app.ledger.service import add_ledger_entry, create_bounty, ensure_genesis, pay_bounty
+from app.ledger_views import (
+    account_ledger_transactions,
+    ledger_entry_to_dict,
+    recent_ledger_entries,
+)
+
+
+def test_recent_ledger_entries_attach_payment_proof_hash(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=320,
+            issue_url="https://github.com/ramimbo/mergework/issues/320",
+            title="Ledger view helpers",
+            reward_mrwk="25",
+            acceptance="Ledger views should attach proof hashes consistently.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/320",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+        rows = recent_ledger_entries(session, 10)
+        detail = ledger_entry_to_dict(session, proof.ledger_sequence)
+        missing = ledger_entry_to_dict(session, 9999)
+
+    payment_row = next(row for row in rows if row["sequence"] == proof.ledger_sequence)
+    assert payment_row["proof_hash"] == proof.hash
+    assert detail is not None
+    assert detail["proof_hash"] == proof.hash
+    assert missing is None
+
+
+def test_account_ledger_transactions_filters_both_sides(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=321,
+            issue_url="https://github.com/ramimbo/mergework/issues/321",
+            title="Account ledger helper",
+            reward_mrwk="25",
+            acceptance="Account pages should reuse one ledger transaction helper.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/321",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        manual_entry = add_ledger_entry(
+            session,
+            entry_type="manual_adjustment",
+            from_account="github:alice",
+            to_account="github:bob",
+            amount_microunits=0,
+            reference="manual:account-ledger-helper",
+        )
+
+        rows = account_ledger_transactions(session, "github:alice")
+
+    assert [row["sequence"] for row in rows] == [manual_entry.sequence, proof.ledger_sequence]
+    assert rows[0]["from"] == "github:alice"
+    assert rows[0]["to"] == "github:bob"
+    assert rows[0]["proof_hash"] is None
+    assert rows[1]["proof_hash"] == proof.hash

--- a/tests/test_ledger_views.py
+++ b/tests/test_ledger_views.py
@@ -35,8 +35,9 @@ def test_recent_ledger_entries_attach_payment_proof_hash(sqlite_url: str) -> Non
         detail = ledger_entry_to_dict(session, proof.ledger_sequence)
         missing = ledger_entry_to_dict(session, 9999)
 
-    payment_row = next(row for row in rows if row["sequence"] == proof.ledger_sequence)
-    assert payment_row["proof_hash"] == proof.hash
+    payment_rows = [row for row in rows if row["sequence"] == proof.ledger_sequence]
+    assert len(payment_rows) == 1
+    assert payment_rows[0]["proof_hash"] == proof.hash
     assert detail is not None
     assert detail["proof_hash"] == proof.hash
     assert missing is None

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -446,7 +446,12 @@ def test_github_login_redirects_when_oauth_is_configured(sqlite_url: str, monkey
 
 @pytest.mark.parametrize(
     "next_path",
-    ("//evil.example/path", "/\\evil.example/path", "/me\nLocation:https://evil.example"),
+    (
+        "//evil.example/path",
+        "/\\evil.example/path",
+        "/me\nLocation:https://evil.example",
+        "/" + ("a" * 2048),
+    ),
 )
 def test_oauth_next_path_rejects_redirect_ambiguity(next_path: str) -> None:
     assert _safe_next_path(next_path) == "/me"


### PR DESCRIPTION
Refs #320

## Summary
- Extract ledger proof-hash lookup, recent ledger serialization, single-entry serialization, and account/wallet transaction listing into `app/ledger_views.py`.
- Reuse the helper from REST ledger endpoints, account and wallet pages, and the MCP `get_ledger_entry` path so `app/main.py` no longer owns duplicate ledger/proof query shaping.
- Add focused helper tests for proof-hash attachment, missing ledger entries, and account transaction filtering across both sides of a ledger entry.
- Keep current checks green by preserving explicit ledger `CursorResult` typing for rowcount checks and by sanitizing percent-decoded OAuth `next` paths covered by the existing OAuth regression test.

## Complexity reduced
Ledger display/API/MCP code now shares one query boundary for proof-backed ledger rows. Route handlers stay focused on HTTP status, auth, and template selection, while transaction lookup and proof hash attachment are directly testable outside `app/main.py`.

## Tests
- `python -m pytest -q` -> 337 passed, 1 Windows asyncio warning
- `python -m pytest tests/test_ledger_views.py tests/test_api_mcp.py::test_mcp_get_ledger_entry_includes_payment_proof_hash tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable tests/test_wallet_api.py::test_github_login_stores_safe_default_for_backslash_next -q` -> 5 passed
- `python -m ruff format --check app/main.py app/ledger/service.py app/ledger_views.py tests/test_ledger_views.py`
- `python -m ruff check app/main.py app/ledger/service.py app/ledger_views.py tests/test_ledger_views.py`
- `python -m mypy app`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OAuth login redirect validation to check both original and decoded URL paths for unsafe patterns, including control characters and redirect ambiguity attempts.

* **Tests**
  * Added comprehensive test coverage for ledger transaction data serialization and account-specific transaction filtering.
  * Expanded OAuth redirect security test cases with additional redirect ambiguity scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
