### PR TITLE
Extract GitHub webhook route

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,11 +6,10 @@ import json
 import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlparse
 
 from sqlalchemy import case, func, select, update
-from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -657,19 +656,16 @@ def pay_bounty(
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
-            .values(
-                awards_paid=Bounty.awards_paid + 1,
-                status=case(
-                    (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
-                    else_="open",
-                ),
-            )
-        ),
+    claimed = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
+        .values(
+            awards_paid=Bounty.awards_paid + 1,
+            status=case(
+                (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
+                else_="open",
+            ),
+        )
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty already paid")
@@ -737,13 +733,10 @@ def close_bounty(
         raise LedgerError("bounty is not open")
     _clean_required_text(closed_by, "closed_by", 80)
     clean_reference = validate_public_url(reference or bounty.issue_url)
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.status == "open")
-            .values(status="closed")
-        ),
+    claimed = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.status == "open")
+        .values(status="closed")
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty is not open")

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import urlencode, urlsplit, urlunsplit
+from urllib.parse import unquote, urlencode, urlsplit, urlunsplit
 
 import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
@@ -73,7 +73,7 @@ from app.serializers import (
     wallet_transfer_to_dict,
 )
 from app.wallets import WalletError, normalize_wallet_address
-from app.webhooks.github import handle_github_webhook
+from app.webhooks.routes import register_github_webhook_route
 
 BASE_DIR = Path(__file__).resolve().parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
@@ -278,13 +278,17 @@ def _oauth_configured(settings: Settings) -> bool:
 
 
 def _safe_next_path(next_path: str | None) -> str:
+    decoded_next_path = unquote(next_path) if next_path else ""
     if (
         not next_path
         or not next_path.startswith("/")
         or next_path.startswith("//")
         or len(next_path) > 2048
         or "\\" in next_path
+        or decoded_next_path.startswith("//")
+        or "\\" in decoded_next_path
         or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
+        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)
     ):
         return "/me"
     return next_path
@@ -1094,20 +1098,12 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         with session_scope(db_url) as session:
             return activity_to_dict(session, q)
 
-    @app.post("/webhooks/github")
-    async def github_webhook(request: Request) -> JSONResponse:
-        body = await request.body()
-        headers = {key: value for key, value in request.headers.items()}
-        normalized = {
-            "X-GitHub-Delivery": headers.get("x-github-delivery", ""),
-            "X-GitHub-Event": headers.get("x-github-event", ""),
-            "X-Hub-Signature-256": headers.get("x-hub-signature-256", ""),
-        }
-        result = handle_github_webhook(
-            db_url, normalized, body, secret, settings.github_accepted_labelers
-        )
-        code = 401 if result["status"] == "unauthorized" else 200
-        return JSONResponse(result, status_code=code)
+    register_github_webhook_route(
+        app,
+        database_url=db_url,
+        webhook_secret=secret,
+        accepted_labelers=settings.github_accepted_labelers,
+    )
 
     @app.post("/mcp")
     async def mcp(request: Request) -> Any:

--- a/app/webhooks/routes.py
+++ b/app/webhooks/routes.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from app.webhooks.github import handle_github_webhook
+
+GITHUB_WEBHOOK_HEADERS = {
+    "X-GitHub-Delivery": "x-github-delivery",
+    "X-GitHub-Event": "x-github-event",
+    "X-Hub-Signature-256": "x-hub-signature-256",
+}
+
+
+def github_webhook_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    normalized = {key.lower(): value for key, value in headers.items()}
+    return {
+        canonical: normalized.get(header_name, "")
+        for canonical, header_name in GITHUB_WEBHOOK_HEADERS.items()
+    }
+
+
+def github_webhook_status_code(result: Mapping[str, Any]) -> int:
+    return 401 if result.get("status") == "unauthorized" else 200
+
+
+def register_github_webhook_route(
+    app: FastAPI,
+    *,
+    database_url: str,
+    webhook_secret: str,
+    accepted_labelers: tuple[str, ...] = (),
+) -> None:
+    @app.post("/webhooks/github")
+    async def github_webhook(request: Request) -> JSONResponse:
+        body = await request.body()
+        result = handle_github_webhook(
+            database_url,
+            github_webhook_headers(request.headers),
+            body,
+            webhook_secret,
+            accepted_labelers,
+        )
+        return JSONResponse(result, status_code=github_webhook_status_code(result))

--- a/tests/test_webhook_routes.py
+++ b/tests/test_webhook_routes.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+from fastapi.testclient import TestClient
+
+from app.db import session_scope
+from app.main import create_app
+from app.models import WebhookEvent
+
+
+def _signature(secret: str, body: bytes) -> str:
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def test_github_webhook_route_normalizes_headers(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    body = b'{"action":"opened"}'
+
+    response = client.post(
+        "/webhooks/github",
+        content=body,
+        headers={
+            "X-GitHub-Delivery": "delivery-route-ignored",
+            "X-GitHub-Event": "issues",
+            "X-Hub-Signature-256": _signature("secret", body),
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ignored"}
+    with session_scope(sqlite_url) as session:
+        event = session.get(WebhookEvent, "delivery-route-ignored")
+        assert event is not None
+        assert event.event_type == "issues"
+        assert event.processed_status == "ignored"
+
+
+def test_github_webhook_route_returns_401_for_bad_signature(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/webhooks/github",
+        content=b'{"action":"opened"}',
+        headers={
+            "X-GitHub-Delivery": "delivery-bad-signature",
+            "X-GitHub-Event": "issues",
+            "X-Hub-Signature-256": "sha256=bad",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"status": "unauthorized"}


### PR DESCRIPTION
Refs #320

## Summary
- Extract the `/webhooks/github` FastAPI route wiring into `app/webhooks/routes.py`.
- Move GitHub webhook header normalization and unauthorized-to-401 status mapping behind focused helpers while preserving the existing core `handle_github_webhook` behavior.
- Add route-level regression tests for canonical GitHub headers, ignored signed events, persisted webhook status, and bad-signature 401 responses.
- Keep current checks green by removing redundant ledger casts reported by `mypy app` and by sanitizing percent-decoded OAuth `next` paths covered by the existing OAuth regression test.

## Complexity reduced
`app/main.py` no longer owns the GitHub webhook HTTP adapter details. The webhook domain handler stays in `app/webhooks/github.py`, while request header shaping, FastAPI route registration, and HTTP status response mapping live in a small webhook routes module with direct tests.

## Tests
- `python -m pytest -q` -> 337 passed
- `python -m pytest tests/test_webhook_routes.py tests/test_webhooks.py::test_github_signature_verification tests/test_webhooks.py::test_accepted_label_pays_bounty_once tests/test_wallet_api.py::test_github_login_stores_safe_default_for_backslash_next -q` -> 5 passed
- `python -m ruff format --check app/main.py app/ledger/service.py app/webhooks/routes.py tests/test_webhook_routes.py`
- `python -m ruff check app/main.py app/ledger/service.py app/webhooks/routes.py tests/test_webhook_routes.py`
- `python -m mypy app`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security by validating redirect paths more strictly, checking both raw and decoded forms for unsafe patterns.

* **Refactor**
  * Reorganized GitHub webhook handling into a dedicated routing module with improved structure.
  * Removed unused typing imports from ledger service.

* **Tests**
  * Added webhook route tests verifying signature validation and proper header handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->