### PR TITLE
Extract wallet view helpers from app.main

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import urlencode, urlsplit, urlunsplit
+from urllib.parse import unquote, urlencode, urlsplit, urlunsplit
 
 import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
@@ -72,7 +72,7 @@ from app.serializers import (
     wallet_to_dict,
     wallet_transfer_to_dict,
 )
-from app.wallets import WalletError, normalize_wallet_address
+from app.wallet_views import wallet_address_from_path, wallet_detail_context, wallet_list_context
 from app.webhooks.github import handle_github_webhook
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -278,13 +278,17 @@ def _oauth_configured(settings: Settings) -> bool:
 
 
 def _safe_next_path(next_path: str | None) -> str:
+    decoded_next_path = unquote(next_path) if next_path else ""
     if (
         not next_path
         or not next_path.startswith("/")
         or next_path.startswith("//")
         or len(next_path) > 2048
         or "\\" in next_path
+        or decoded_next_path.startswith("//")
+        or "\\" in decoded_next_path
         or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
+        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)
     ):
         return "/me"
     return next_path
@@ -318,7 +322,7 @@ def _normalized_account(account: str) -> str:
             raise HTTPException(status_code=400, detail="reserve bounty id is too large")
         return f"{reserve_prefix}{normalized_bounty_id}"
     if lower.startswith("mrwk1"):
-        return _normalized_wallet_address(clean)
+        return wallet_address_from_path(clean)
     if lower.startswith("github:"):
         login = clean.split(":", 1)[1].lower()
         if not GITHUB_LOGIN_RE.fullmatch(login):
@@ -350,13 +354,6 @@ def _positive_ledger_sequence(sequence: int) -> int:
     if sequence > SQLITE_INTEGER_MAX:
         raise HTTPException(status_code=400, detail="ledger sequence is too large")
     return sequence
-
-
-def _normalized_wallet_address(address: str) -> str:
-    try:
-        return normalize_wallet_address(address)
-    except WalletError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 def _proof_hash_from_path(proof_hash: str) -> str:
@@ -997,7 +994,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/api/v1/wallets/{address}")
     def api_wallet(address: str) -> dict[str, Any]:
-        address = _normalized_wallet_address(address)
+        address = wallet_address_from_path(address)
         with session_scope(db_url) as session:
             wallet = session.get(Wallet, address)
             if wallet is None:
@@ -1219,38 +1216,14 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/wallets", response_class=HTMLResponse)
     def wallets_page(request: Request) -> HTMLResponse:
-        with session_scope(db_url) as session:
-            wallets = session.scalars(
-                select(Wallet).order_by(Wallet.created_at.desc()).limit(100)
-            ).all()
-            wallet_rows = [wallet_to_dict(session, wallet) for wallet in wallets]
-        return templates.TemplateResponse(request, "wallets.html", {"wallets": wallet_rows})
+        return templates.TemplateResponse(request, "wallets.html", wallet_list_context(db_url))
 
     @app.get("/wallets/{address}", response_class=HTMLResponse)
     def wallet_page(request: Request, address: str) -> HTMLResponse:
-        address = _normalized_wallet_address(address)
-        with session_scope(db_url) as session:
-            wallet = session.get(Wallet, address)
-            if wallet is None:
-                raise HTTPException(status_code=404, detail="wallet not found")
-            wallet_data = wallet_to_dict(session, wallet)
-            entries = session.scalars(
-                select(LedgerEntry)
-                .where(
-                    or_(
-                        LedgerEntry.from_account == wallet.address,
-                        LedgerEntry.to_account == wallet.address,
-                    )
-                )
-                .order_by(LedgerEntry.sequence.desc())
-                .limit(100)
-            ).all()
-            proofs = _proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
-            transactions = [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
         return templates.TemplateResponse(
             request,
             "wallet_detail.html",
-            {"wallet": wallet_data, "transactions": transactions},
+            wallet_detail_context(db_url, address),
         )
 
     @app.get("/transfer", response_class=HTMLResponse)
@@ -1711,7 +1684,7 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
             )
             return json.dumps(wallet_to_dict(session, wallet))
         if name == "get_wallet":
-            wallet_row = session.get(Wallet, _normalized_wallet_address(str_arg("address")))
+            wallet_row = session.get(Wallet, wallet_address_from_path(str_arg("address")))
             if wallet_row is None:
                 return "wallet not found"
             return json.dumps(wallet_to_dict(session, wallet_row))

--- a/app/wallet_views.py
+++ b/app/wallet_views.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from app.db import session_scope
+from app.models import LedgerEntry, Proof, Wallet
+from app.serializers import ledger_to_dict, wallet_to_dict
+from app.wallets import WalletError, normalize_wallet_address
+
+
+def wallet_address_from_path(address: str) -> str:
+    try:
+        return normalize_wallet_address(address)
+    except WalletError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def wallet_list_context(database_url: str, limit: int = 100) -> dict[str, Any]:
+    with session_scope(database_url) as session:
+        wallets = session.scalars(
+            select(Wallet).order_by(Wallet.created_at.desc()).limit(limit)
+        ).all()
+        return {"wallets": [wallet_to_dict(session, wallet) for wallet in wallets]}
+
+
+def wallet_detail_context(database_url: str, address: str, limit: int = 100) -> dict[str, Any]:
+    address = wallet_address_from_path(address)
+    with session_scope(database_url) as session:
+        wallet = session.get(Wallet, address)
+        if wallet is None:
+            raise HTTPException(status_code=404, detail="wallet not found")
+        return {
+            "wallet": wallet_to_dict(session, wallet),
+            "transactions": wallet_transaction_rows(session, wallet.address, limit),
+        }
+
+
+def wallet_transaction_rows(
+    session: Session, wallet_address: str, limit: int = 100
+) -> list[dict[str, Any]]:
+    entries = session.scalars(
+        select(LedgerEntry)
+        .where(
+            or_(
+                LedgerEntry.from_account == wallet_address,
+                LedgerEntry.to_account == wallet_address,
+            )
+        )
+        .order_by(LedgerEntry.sequence.desc())
+        .limit(limit)
+    ).all()
+    proofs = proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
+    return [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
+
+
+def proof_hashes_by_sequence(session: Session, sequences: list[int]) -> dict[int, str]:
+    if not sequences:
+        return {}
+    rows = session.execute(
+        select(Proof.ledger_sequence, Proof.hash).where(Proof.ledger_sequence.in_(sequences))
+    ).all()
+    return {int(sequence): str(proof_hash) for sequence, proof_hash in rows}

--- a/tests/test_wallet_views.py
+++ b/tests/test_wallet_views.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.db import create_schema, session_scope
+from app.ledger.service import TREASURY_ACCOUNT, add_ledger_entry, ensure_genesis, register_wallet
+from app.models import Proof
+from app.wallet_views import wallet_address_from_path, wallet_detail_context, wallet_list_context
+from app.wallets import address_from_public_key_hex
+
+
+def test_wallet_list_context_serializes_registered_wallet(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    public_key_hex = "11" * 32
+    address = address_from_public_key_hex(public_key_hex)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        register_wallet(session, public_key_hex=public_key_hex, label="Main wallet")
+
+    context = wallet_list_context(sqlite_url)
+
+    assert context["wallets"][0]["address"] == address
+    assert context["wallets"][0]["label"] == "Main wallet"
+    assert context["wallets"][0]["balance_mrwk"] == "0"
+
+
+def test_wallet_detail_context_includes_transactions_and_proof_hash(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    public_key_hex = "22" * 32
+    address = address_from_public_key_hex(public_key_hex)
+    proof_hash = "a" * 64
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        register_wallet(session, public_key_hex=public_key_hex, label="Funded wallet")
+        entry = add_ledger_entry(
+            session,
+            entry_type="test_funding",
+            from_account=TREASURY_ACCOUNT,
+            to_account=address,
+            amount_microunits=2_500_000,
+            reference="test funding",
+        )
+        session.add(
+            Proof(
+                hash=proof_hash,
+                ledger_sequence=entry.sequence,
+                bounty_id=None,
+                submission_id=None,
+                kind="test_proof",
+                public_json="{}",
+            )
+        )
+
+    context = wallet_detail_context(sqlite_url, address.upper())
+
+    assert context["wallet"]["address"] == address
+    assert context["wallet"]["balance_mrwk"] == "2.5"
+    assert context["transactions"][0]["sequence"] == entry.sequence
+    assert context["transactions"][0]["proof_hash"] == proof_hash
+
+
+def test_wallet_detail_context_reports_invalid_or_missing_wallet(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with pytest.raises(HTTPException) as invalid:
+        wallet_address_from_path("not-a-wallet")
+    assert invalid.value.status_code == 400
+    assert invalid.value.detail == "invalid MRWK wallet address"
+
+    missing_address = "mrwk1" + ("0" * 40)
+    with pytest.raises(HTTPException) as missing:
+        wallet_detail_context(sqlite_url, missing_address)
+    assert missing.value.status_code == 404
+    assert missing.value.detail == "wallet not found"


### PR DESCRIPTION
Refs #320

## Summary
- Move wallet page address validation, wallet list context, wallet detail context, transaction row lookup, and proof-hash mapping into `app.wallet_views`.
- Keep `/wallets` and `/wallets/{address}` route handlers in `app.main` as thin template renderers.
- Reuse the shared wallet address path validator from account/API/MCP wallet lookups.
- Add direct wallet view helper tests for list serialization, detail transactions with proof hashes, invalid addresses, and missing wallets.
- Preserve the existing OAuth encoded-backslash next-path safety expectation required by the test suite.

## Complexity reduced
- `app.main` no longer owns wallet page query composition or wallet route address normalization. Wallet HTML view data can now be reviewed and tested independently from the broader app wiring, API routes, MCP dispatch, and admin flows.

## Tests
- `python -m pytest tests\test_wallet_views.py tests\test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows tests\test_wallet_api.py::test_github_login_stores_safe_default_for_backslash_next -q`
- `python -m pytest -q`
- `python -m ruff check .`
- `git diff --check`