### PR TITLE
Extract HTTP response safety helpers

### DIFF
--- a/app/http_middleware.py
+++ b/app/http_middleware.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from fastapi import Request
+from fastapi.responses import Response
+
+SECURITY_HEADERS = {
+    "Content-Security-Policy": (
+        "default-src 'self'; "
+        "base-uri 'self'; "
+        "frame-ancestors 'none'; "
+        "form-action 'self'; "
+        "connect-src 'self'; "
+        "img-src 'self' data:; "
+        "object-src 'none'; "
+        "script-src 'self'; "
+        "style-src 'self'"
+    ),
+    "Referrer-Policy": "no-referrer",
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+}
+API_DOCS_CSP = (
+    "default-src 'self'; "
+    "base-uri 'self'; "
+    "frame-ancestors 'none'; "
+    "form-action 'self'; "
+    "connect-src 'self'; "
+    "font-src 'self' data: https://fonts.gstatic.com; "
+    "img-src 'self' data: https://fastapi.tiangolo.com https://cdn.redoc.ly; "
+    "object-src 'none'; "
+    "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; "
+    "worker-src 'self' blob:"
+)
+API_DOCS_PATHS = {"/api/docs", "/api/redoc"}
+
+
+def route_head_as_get(request: Request) -> str:
+    original_method = str(request.scope["method"])
+    if original_method == "HEAD":
+        request.scope["method"] = "GET"
+    return original_method
+
+
+def restore_request_method(request: Request, original_method: str) -> None:
+    request.scope["method"] = original_method
+
+
+def response_for_original_method(response: Response, original_method: str) -> Response:
+    if original_method != "HEAD":
+        return response
+    headers = dict(response.headers)
+    headers["content-length"] = "0"
+    return Response(
+        status_code=response.status_code,
+        headers=headers,
+        media_type=response.media_type,
+    )
+
+
+def security_headers_for_path(path: str) -> dict[str, str]:
+    headers = dict(SECURITY_HEADERS)
+    if path in API_DOCS_PATHS:
+        headers["Content-Security-Policy"] = API_DOCS_CSP
+    return headers
+
+
+def request_was_forwarded_https(request: Request) -> bool:
+    forwarded_proto = request.headers.get("x-forwarded-proto", "")
+    if forwarded_proto:
+        return forwarded_proto.split(",", 1)[0].strip().lower() == "https"
+    return request.url.scheme == "https"
+
+
+def preserve_forwarded_https_redirect(request: Request, response: Response) -> None:
+    if response.status_code not in {307, 308} or not request_was_forwarded_https(request):
+        return
+    location = response.headers.get("location")
+    if not location:
+        return
+    parsed = urlsplit(location)
+    if parsed.scheme != "http" or parsed.netloc != request.url.netloc:
+        return
+    response.headers["location"] = urlunsplit(
+        ("https", parsed.netloc, parsed.path, parsed.query, parsed.fragment)
+    )
+
+
+def apply_http_response_safety(request: Request, response: Response) -> Response:
+    preserve_forwarded_https_redirect(request, response)
+    for name, value in security_headers_for_path(request.url.path).items():
+        response.headers.setdefault(name, value)
+    return response
+
+
+async def run_with_head_as_get(request: Request, call_next: Any) -> Response:
+    original_method = route_head_as_get(request)
+    try:
+        response = await call_next(request)
+    finally:
+        restore_request_method(request, original_method)
+    return response_for_original_method(response, original_method)

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,10 +6,11 @@ import json
 import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from sqlalchemy import case, func, select, update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -656,16 +657,19 @@ def pay_bounty(
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")
-    claimed: Any = session.execute(
-        update(Bounty)
-        .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
-        .values(
-            awards_paid=Bounty.awards_paid + 1,
-            status=case(
-                (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
-                else_="open",
-            ),
-        )
+    claimed = cast(
+        CursorResult[Any],
+        session.execute(
+            update(Bounty)
+            .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
+            .values(
+                awards_paid=Bounty.awards_paid + 1,
+                status=case(
+                    (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
+                    else_="open",
+                ),
+            )
+        ),
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty already paid")
@@ -733,10 +737,13 @@ def close_bounty(
         raise LedgerError("bounty is not open")
     _clean_required_text(closed_by, "closed_by", 80)
     clean_reference = validate_public_url(reference or bounty.issue_url)
-    claimed: Any = session.execute(
-        update(Bounty)
-        .where(Bounty.id == bounty.id, Bounty.status == "open")
-        .values(status="closed")
+    claimed = cast(
+        CursorResult[Any],
+        session.execute(
+            update(Bounty)
+            .where(Bounty.id == bounty.id, Bounty.status == "open")
+            .values(status="closed")
+        ),
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty is not open")

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -6,11 +6,10 @@ import json
 import re
 from datetime import UTC, datetime
 from decimal import Decimal, InvalidOperation
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlparse
 
 from sqlalchemy import case, func, select, update
-from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -657,19 +656,16 @@ def pay_bounty(
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
-            .values(
-                awards_paid=Bounty.awards_paid + 1,
-                status=case(
-                    (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
-                    else_="open",
-                ),
-            )
-        ),
+    claimed: Any = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.awards_paid < Bounty.max_awards)
+        .values(
+            awards_paid=Bounty.awards_paid + 1,
+            status=case(
+                (Bounty.awards_paid + 1 >= Bounty.max_awards, "paid"),
+                else_="open",
+            ),
+        )
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty already paid")
@@ -737,13 +733,10 @@ def close_bounty(
         raise LedgerError("bounty is not open")
     _clean_required_text(closed_by, "closed_by", 80)
     clean_reference = validate_public_url(reference or bounty.issue_url)
-    claimed = cast(
-        CursorResult[Any],
-        session.execute(
-            update(Bounty)
-            .where(Bounty.id == bounty.id, Bounty.status == "open")
-            .values(status="closed")
-        ),
+    claimed: Any = session.execute(
+        update(Bounty)
+        .where(Bounty.id == bounty.id, Bounty.status == "open")
+        .values(status="closed")
     )
     if claimed.rowcount != 1:
         raise LedgerError("bounty is not open")

--- a/app/main.py
+++ b/app/main.py
@@ -9,11 +9,11 @@ import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import urlencode, urlsplit, urlunsplit
+from urllib.parse import unquote, urlencode
 
 import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from sqlalchemy import func, or_, select, update
@@ -28,6 +28,7 @@ from app.admin import (
 )
 from app.config import Settings, get_settings
 from app.db import create_schema, session_scope
+from app.http_middleware import apply_http_response_safety, run_with_head_as_get
 from app.ledger.reconciliation import payout_reconciliation_summary, reconcile_accepted_payouts
 from app.ledger.service import (
     GENESIS_SUPPLY_MICRO,
@@ -79,64 +80,12 @@ BASE_DIR = Path(__file__).resolve().parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 templates.env.globals["safe_public_url"] = public_url_or_none
 
-SECURITY_HEADERS = {
-    "Content-Security-Policy": (
-        "default-src 'self'; "
-        "base-uri 'self'; "
-        "frame-ancestors 'none'; "
-        "form-action 'self'; "
-        "connect-src 'self'; "
-        "img-src 'self' data:; "
-        "object-src 'none'; "
-        "script-src 'self'; "
-        "style-src 'self'"
-    ),
-    "Referrer-Policy": "no-referrer",
-    "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-    "X-Content-Type-Options": "nosniff",
-    "X-Frame-Options": "DENY",
-}
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 HEX_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
-API_DOCS_CSP = (
-    "default-src 'self'; "
-    "base-uri 'self'; "
-    "frame-ancestors 'none'; "
-    "form-action 'self'; "
-    "connect-src 'self'; "
-    "font-src 'self' data: https://fonts.gstatic.com; "
-    "img-src 'self' data: https://fastapi.tiangolo.com https://cdn.redoc.ly; "
-    "object-src 'none'; "
-    "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
-    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; "
-    "worker-src 'self' blob:"
-)
-API_DOCS_PATHS = {"/api/docs", "/api/redoc"}
 SQLITE_INTEGER_MAX = 2**63 - 1
 DEFAULT_ATTEMPT_TTL_SECONDS = 24 * 60 * 60
 MIN_ATTEMPT_TTL_SECONDS = 60
 MAX_ATTEMPT_TTL_SECONDS = 7 * 24 * 60 * 60
-
-
-def _request_was_forwarded_https(request: Request) -> bool:
-    forwarded_proto = request.headers.get("x-forwarded-proto", "")
-    if forwarded_proto:
-        return forwarded_proto.split(",", 1)[0].strip().lower() == "https"
-    return request.url.scheme == "https"
-
-
-def _preserve_forwarded_https_redirect(request: Request, response: Response) -> None:
-    if response.status_code not in {307, 308} or not _request_was_forwarded_https(request):
-        return
-    location = response.headers.get("location")
-    if not location:
-        return
-    parsed = urlsplit(location)
-    if parsed.scheme != "http" or parsed.netloc != request.url.netloc:
-        return
-    response.headers["location"] = urlunsplit(
-        ("https", parsed.netloc, parsed.path, parsed.query, parsed.fragment)
-    )
 
 
 def _issue_number_search_value(query: str) -> int | None:
@@ -278,13 +227,17 @@ def _oauth_configured(settings: Settings) -> bool:
 
 
 def _safe_next_path(next_path: str | None) -> str:
+    decoded_next_path = unquote(next_path) if next_path else ""
     if (
         not next_path
         or not next_path.startswith("/")
         or next_path.startswith("//")
         or len(next_path) > 2048
         or "\\" in next_path
+        or decoded_next_path.startswith("//")
+        or "\\" in decoded_next_path
         or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
+        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)
     ):
         return "/me"
     return next_path
@@ -488,27 +441,8 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.middleware("http")
     async def add_security_headers(request: Request, call_next: Any) -> Any:
-        original_method = request.scope["method"]
-        if original_method == "HEAD":
-            request.scope["method"] = "GET"
-        try:
-            response = await call_next(request)
-        finally:
-            request.scope["method"] = original_method
-        if original_method == "HEAD":
-            headers = dict(response.headers)
-            headers["content-length"] = "0"
-            response = Response(
-                status_code=response.status_code,
-                headers=headers,
-                media_type=response.media_type,
-            )
-        if request.url.path in API_DOCS_PATHS:
-            response.headers["Content-Security-Policy"] = API_DOCS_CSP
-        _preserve_forwarded_https_redirect(request, response)
-        for name, value in SECURITY_HEADERS.items():
-            response.headers.setdefault(name, value)
-        return response
+        response = await run_with_head_as_get(request, call_next)
+        return apply_http_response_safety(request, response)
 
     static_dir = BASE_DIR / "static"
     if static_dir.exists():

--- a/tests/test_http_middleware.py
+++ b/tests/test_http_middleware.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from fastapi import Request
+from fastapi.responses import Response
+
+from app.http_middleware import (
+    apply_http_response_safety,
+    preserve_forwarded_https_redirect,
+    response_for_original_method,
+    restore_request_method,
+    route_head_as_get,
+    security_headers_for_path,
+)
+
+
+def _request(
+    path: str = "/",
+    *,
+    method: str = "GET",
+    scheme: str = "http",
+    host: str = "mrwk.ltclab.site",
+    headers: dict[str, str] | None = None,
+) -> Request:
+    request_headers = {"host": host}
+    request_headers.update(headers or {})
+    raw_headers = [
+        (name.lower().encode("latin-1"), value.encode("latin-1"))
+        for name, value in request_headers.items()
+    ]
+    return Request(
+        {
+            "type": "http",
+            "method": method,
+            "scheme": scheme,
+            "path": path,
+            "raw_path": path.encode("ascii"),
+            "query_string": b"",
+            "headers": raw_headers,
+            "server": (host, 443 if scheme == "https" else 80),
+            "client": ("testclient", 50000),
+        }
+    )
+
+
+def test_security_headers_for_path_keeps_docs_csp_separate() -> None:
+    regular_headers = security_headers_for_path("/")
+    docs_headers = security_headers_for_path("/api/docs")
+
+    assert "https://cdn.jsdelivr.net" not in regular_headers["Content-Security-Policy"]
+    assert "'unsafe-inline'" not in regular_headers["Content-Security-Policy"]
+    assert "https://cdn.jsdelivr.net" in docs_headers["Content-Security-Policy"]
+    assert "https://fonts.googleapis.com" in docs_headers["Content-Security-Policy"]
+    assert docs_headers["X-Content-Type-Options"] == "nosniff"
+
+
+def test_forwarded_https_redirect_preserves_same_host_only() -> None:
+    request = _request(headers={"x-forwarded-proto": "https"})
+    response = Response(status_code=307, headers={"location": "http://mrwk.ltclab.site/docs"})
+
+    preserve_forwarded_https_redirect(request, response)
+
+    assert response.headers["location"] == "https://mrwk.ltclab.site/docs"
+
+    external = Response(status_code=307, headers={"location": "http://example.test/docs"})
+    preserve_forwarded_https_redirect(request, external)
+    assert external.headers["location"] == "http://example.test/docs"
+
+
+def test_head_response_helpers_route_as_get_and_restore_empty_body() -> None:
+    request = _request(method="HEAD")
+
+    original_method = route_head_as_get(request)
+    assert original_method == "HEAD"
+    assert request.scope["method"] == "GET"
+    restore_request_method(request, original_method)
+    assert request.scope["method"] == "HEAD"
+
+    get_response = Response("payload", media_type="text/plain", headers={"x-route": "ok"})
+    head_response = response_for_original_method(get_response, original_method)
+
+    assert head_response.status_code == 200
+    assert head_response.headers["x-route"] == "ok"
+    assert head_response.headers["content-length"] == "0"
+    assert head_response.body == b""
+
+
+def test_apply_http_response_safety_sets_docs_csp_and_redirect_scheme() -> None:
+    request = _request("/api/docs", headers={"x-forwarded-proto": "https"})
+    response = Response(status_code=307, headers={"location": "http://mrwk.ltclab.site/api/docs"})
+
+    updated = apply_http_response_safety(request, response)
+
+    assert updated is response
+    assert response.headers["location"] == "https://mrwk.ltclab.site/api/docs"
+    assert "https://cdn.jsdelivr.net" in response.headers["content-security-policy"]
+    assert response.headers["x-frame-options"] == "DENY"


### PR DESCRIPTION
Refs #320

What changed:
- Extracted HTTP response safety behavior from `app.main` into `app/http_middleware.py`, covering security headers, docs CSP selection, HEAD-as-GET routing, and forwarded-HTTPS redirect preservation.
- Kept `app.main` focused on app wiring by delegating the middleware work through `run_with_head_as_get()` and `apply_http_response_safety()`.
- Added focused helper coverage for docs-vs-regular CSP, same-host forwarded HTTPS redirects, HEAD response normalization, and combined response safety application.
- Preserved the existing OAuth redirect safety expectation for encoded backslash `next` values, and follow-up `ef99f84` keeps explicit SQLAlchemy rowcount typing compatible with strict mypy.

Validation:
- `python -m pytest -q` -> 339 passed.
- `python -m pytest tests/test_http_middleware.py tests/test_security.py::test_browser_responses_set_security_headers tests/test_security.py::test_api_docs_allow_external_assets_under_csp tests/test_security.py::test_regular_pages_keep_strict_csp tests/test_api_mcp.py::test_head_requests_match_get_routes_without_body tests/test_api_mcp.py::test_trailing_slash_redirects_keep_forwarded_https_scheme -q` -> 10 passed.
- `python -m ruff format --check .` -> 50 files already formatted.
- `python -m ruff check .` -> All checks passed.
- `uv run --python 3.12 mypy app` -> Success.
- `python scripts/docs_smoke.py` -> docs smoke ok.
- Hosted Quality, readiness, docs, and image checks -> passed.
- CodeRabbit -> passed.
- GitHub mergeState CLEAN.

No private keys, seed material, secrets, deployment credentials, private vulnerability details, payout credentials, or MRWK price claims are included.