### PR TITLE
Extract security response helpers

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import urlencode, urlsplit, urlunsplit
+from urllib.parse import urlencode
 
 import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
@@ -58,6 +58,7 @@ from app.models import (
     Submission,
     Wallet,
 )
+from app.security import apply_security_headers
 from app.serializers import (
     accepted_work_for_account,
     account_accepted_summary,
@@ -79,64 +80,12 @@ BASE_DIR = Path(__file__).resolve().parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 templates.env.globals["safe_public_url"] = public_url_or_none
 
-SECURITY_HEADERS = {
-    "Content-Security-Policy": (
-        "default-src 'self'; "
-        "base-uri 'self'; "
-        "frame-ancestors 'none'; "
-        "form-action 'self'; "
-        "connect-src 'self'; "
-        "img-src 'self' data:; "
-        "object-src 'none'; "
-        "script-src 'self'; "
-        "style-src 'self'"
-    ),
-    "Referrer-Policy": "no-referrer",
-    "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-    "X-Content-Type-Options": "nosniff",
-    "X-Frame-Options": "DENY",
-}
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 HEX_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
-API_DOCS_CSP = (
-    "default-src 'self'; "
-    "base-uri 'self'; "
-    "frame-ancestors 'none'; "
-    "form-action 'self'; "
-    "connect-src 'self'; "
-    "font-src 'self' data: https://fonts.gstatic.com; "
-    "img-src 'self' data: https://fastapi.tiangolo.com https://cdn.redoc.ly; "
-    "object-src 'none'; "
-    "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
-    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; "
-    "worker-src 'self' blob:"
-)
-API_DOCS_PATHS = {"/api/docs", "/api/redoc"}
 SQLITE_INTEGER_MAX = 2**63 - 1
 DEFAULT_ATTEMPT_TTL_SECONDS = 24 * 60 * 60
 MIN_ATTEMPT_TTL_SECONDS = 60
 MAX_ATTEMPT_TTL_SECONDS = 7 * 24 * 60 * 60
-
-
-def _request_was_forwarded_https(request: Request) -> bool:
-    forwarded_proto = request.headers.get("x-forwarded-proto", "")
-    if forwarded_proto:
-        return forwarded_proto.split(",", 1)[0].strip().lower() == "https"
-    return request.url.scheme == "https"
-
-
-def _preserve_forwarded_https_redirect(request: Request, response: Response) -> None:
-    if response.status_code not in {307, 308} or not _request_was_forwarded_https(request):
-        return
-    location = response.headers.get("location")
-    if not location:
-        return
-    parsed = urlsplit(location)
-    if parsed.scheme != "http" or parsed.netloc != request.url.netloc:
-        return
-    response.headers["location"] = urlunsplit(
-        ("https", parsed.netloc, parsed.path, parsed.query, parsed.fragment)
-    )
 
 
 def _issue_number_search_value(query: str) -> int | None:
@@ -503,12 +452,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 headers=headers,
                 media_type=response.media_type,
             )
-        if request.url.path in API_DOCS_PATHS:
-            response.headers["Content-Security-Policy"] = API_DOCS_CSP
-        _preserve_forwarded_https_redirect(request, response)
-        for name, value in SECURITY_HEADERS.items():
-            response.headers.setdefault(name, value)
-        return response
+        return apply_security_headers(request, response)
 
     static_dir = BASE_DIR / "static"
     if static_dir.exists():

--- a/app/security.py
+++ b/app/security.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from urllib.parse import urlsplit, urlunsplit
+
+from fastapi import Request
+from fastapi.responses import Response
+
+SECURITY_HEADERS = {
+    "Content-Security-Policy": (
+        "default-src 'self'; "
+        "base-uri 'self'; "
+        "frame-ancestors 'none'; "
+        "form-action 'self'; "
+        "connect-src 'self'; "
+        "img-src 'self' data:; "
+        "object-src 'none'; "
+        "script-src 'self'; "
+        "style-src 'self'"
+    ),
+    "Referrer-Policy": "no-referrer",
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+}
+API_DOCS_CSP = (
+    "default-src 'self'; "
+    "base-uri 'self'; "
+    "frame-ancestors 'none'; "
+    "form-action 'self'; "
+    "connect-src 'self'; "
+    "font-src 'self' data: https://fonts.gstatic.com; "
+    "img-src 'self' data: https://fastapi.tiangolo.com https://cdn.redoc.ly; "
+    "object-src 'none'; "
+    "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+    "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; "
+    "worker-src 'self' blob:"
+)
+API_DOCS_PATHS = {"/api/docs", "/api/redoc"}
+
+
+def request_was_forwarded_https(request: Request) -> bool:
+    forwarded_proto = request.headers.get("x-forwarded-proto", "")
+    if forwarded_proto:
+        return forwarded_proto.split(",", 1)[0].strip().lower() == "https"
+    return request.url.scheme == "https"
+
+
+def preserve_forwarded_https_redirect(request: Request, response: Response) -> None:
+    if response.status_code not in {307, 308} or not request_was_forwarded_https(request):
+        return
+    location = response.headers.get("location")
+    if not location:
+        return
+    parsed = urlsplit(location)
+    if parsed.scheme != "http" or parsed.netloc != request.url.netloc:
+        return
+    response.headers["location"] = urlunsplit(
+        ("https", parsed.netloc, parsed.path, parsed.query, parsed.fragment)
+    )
+
+
+def apply_security_headers(request: Request, response: Response) -> Response:
+    if request.url.path in API_DOCS_PATHS:
+        response.headers["Content-Security-Policy"] = API_DOCS_CSP
+    preserve_forwarded_https_redirect(request, response)
+    for name, value in SECURITY_HEADERS.items():
+        response.headers.setdefault(name, value)
+    return response


### PR DESCRIPTION
Bounty #320. Refs #320.

## Summary
- Move CSP/security header constants and forwarded-HTTPS redirect handling out of app.main into app.security.
- Keep the middleware behavior unchanged while reducing the route-heavy main module.

## Tests
- .\\.venv\\Scripts\\python.exe -m pytest
- .\\.venv\\Scripts\\python.exe -m ruff format --check .
- .\\.venv\\Scripts\\python.exe -m ruff check .
- .\\.venv\\Scripts\\python.exe -m mypy app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized HTTP security header handling into a dedicated module for improved consistency and maintainability across the application.
  * Enhanced HTTPS redirect preservation when requests come through proxies.
  * Implemented stricter Content-Security-Policy enforcement for API documentation routes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->