### PR TITLE
[codex] Structure MCP work-proof selector errors

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1637,6 +1637,51 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
             ],
         }
 
+    def work_proof_selection_error_json(
+        *,
+        code: str,
+        message: str,
+        bounty_id: int | None = None,
+        issue_number: int | None = None,
+        matches: list[Bounty] | None = None,
+    ) -> dict[str, Any]:
+        matching_bounties = []
+        for match in matches or []:
+            bounty_data = bounty_to_dict(match)
+            matching_bounties.append(
+                {
+                    "bounty_id": bounty_data["id"],
+                    "issue_number": bounty_data["issue_number"],
+                    "repository": bounty_data["repo"],
+                    "issue_url": bounty_data["issue_url"],
+                    "title": bounty_data["title"],
+                    "status": bounty_data["status"],
+                    "awards_remaining": bounty_data["awards_remaining"],
+                }
+            )
+        return {
+            "bounty_id": bounty_id,
+            "issue_number": issue_number,
+            "status": code,
+            "availability": "unknown_without_bounty",
+            "can_submit": False,
+            "availability_warnings": [message],
+            "awards_remaining": None,
+            "reward_mrwk": None,
+            "repository": None,
+            "issue_url": None,
+            "acceptance": None,
+            "error": {"code": code, "message": message},
+            "matching_bounties": matching_bounties,
+            "submission_format": (
+                "Retry with an unambiguous bounty_id before preparing work-proof evidence."
+            ),
+            "safety_rules": [
+                "Do not include private keys, seed material, secrets, deployment "
+                "credentials, private vulnerability details, or price claims."
+            ],
+        }
+
     def optional_bool_arg(field: str, default: bool = False) -> bool:
         value = args.get(field, default)
         if value is None:
@@ -1759,8 +1804,15 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
             if has_bounty_id and has_issue_number:
                 raise ValueError("use bounty_id or issue_number, not both")
             if has_bounty_id:
-                bounty = session.get(Bounty, positive_int_arg("bounty_id"))
+                bounty_id = positive_int_arg("bounty_id")
+                bounty = session.get(Bounty, bounty_id)
                 if bounty is None:
+                    if output_format == "json":
+                        return work_proof_selection_error_json(
+                            code="bounty_not_found",
+                            message="bounty not found",
+                            bounty_id=bounty_id,
+                        )
                     return "bounty not found"
                 return (
                     work_proof_guidance_json(bounty)
@@ -1768,15 +1820,29 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
                     else work_proof_guidance(bounty)
                 )
             if has_issue_number:
+                issue_number = positive_int_arg("issue_number")
                 bounties = session.scalars(
                     select(Bounty)
-                    .where(Bounty.issue_number == positive_int_arg("issue_number"))
+                    .where(Bounty.issue_number == issue_number)
                     .order_by(Bounty.id.desc())
                     .limit(2)
                 ).all()
                 if not bounties:
+                    if output_format == "json":
+                        return work_proof_selection_error_json(
+                            code="bounty_not_found",
+                            message="bounty not found",
+                            issue_number=issue_number,
+                        )
                     return "bounty not found"
                 if len(bounties) > 1:
+                    if output_format == "json":
+                        return work_proof_selection_error_json(
+                            code="ambiguous_issue_number",
+                            message="issue_number matches multiple bounties",
+                            issue_number=issue_number,
+                            matches=list(bounties),
+                        )
                     raise ValueError("issue_number matches multiple bounties")
                 return (
                     work_proof_guidance_json(bounties[0])

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -184,6 +184,10 @@ Tools:
 - `get_proof`
 - `submit_work_proof`
 
+`submit_work_proof` accepts optional `bounty_id`, `issue_number`, and `format`
+arguments. Use `format: "json"` when an agent needs `structuredContent`,
+including machine-readable guidance for unknown or ambiguous bounty selectors.
+
 ## Contribution Rules
 
 - Read `AGENTS.md` before starting.

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1542,6 +1542,54 @@ def test_mcp_submit_work_proof_reports_unknown_bounty(sqlite_url: str) -> None:
     assert result["result"]["content"][0]["text"] == "bounty not found"
 
 
+def test_mcp_submit_work_proof_structures_unknown_bounty_selector(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_work_proof",
+                "arguments": {"issue_number": 999, "format": "json"},
+            },
+        },
+    ).json()["result"]
+
+    structured = response["structuredContent"]
+    assert json.loads(response["content"][0]["text"]) == structured
+    assert structured == {
+        "bounty_id": None,
+        "issue_number": 999,
+        "status": "bounty_not_found",
+        "availability": "unknown_without_bounty",
+        "can_submit": False,
+        "availability_warnings": ["bounty not found"],
+        "awards_remaining": None,
+        "reward_mrwk": None,
+        "repository": None,
+        "issue_url": None,
+        "acceptance": None,
+        "error": {"code": "bounty_not_found", "message": "bounty not found"},
+        "matching_bounties": [],
+        "submission_format": (
+            "Retry with an unambiguous bounty_id before preparing work-proof evidence."
+        ),
+        "safety_rules": [
+            "Do not include private keys, seed material, secrets, deployment "
+            "credentials, private vulnerability details, or price claims."
+        ],
+    }
+
+
 @pytest.mark.parametrize(
     ("arguments", "request_id"),
     [
@@ -1622,6 +1670,77 @@ def test_mcp_submit_work_proof_rejects_ambiguous_issue_number(sqlite_url: str) -
         "id": 26,
         "error": {"code": -32602, "message": "invalid tool arguments"},
     }
+
+
+def test_mcp_submit_work_proof_structures_ambiguous_issue_number(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        first = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=284,
+            issue_url="https://github.com/ramimbo/mergework/issues/284",
+            title="First bounty",
+            reward_mrwk="100",
+            acceptance="First acceptance.",
+        )
+        second = create_bounty(
+            session,
+            repo="example/mergework",
+            issue_number=284,
+            issue_url="https://github.com/example/mergework/issues/284",
+            title="Second bounty",
+            reward_mrwk="100",
+            acceptance="Second acceptance.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 26,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_work_proof",
+                "arguments": {"issue_number": 284, "format": "json"},
+            },
+        },
+    ).json()["result"]
+
+    structured = response["structuredContent"]
+    assert json.loads(response["content"][0]["text"]) == structured
+    assert structured["status"] == "ambiguous_issue_number"
+    assert structured["issue_number"] == 284
+    assert structured["can_submit"] is False
+    assert structured["error"] == {
+        "code": "ambiguous_issue_number",
+        "message": "issue_number matches multiple bounties",
+    }
+    assert structured["matching_bounties"] == [
+        {
+            "bounty_id": second.id,
+            "issue_number": 284,
+            "repository": "example/mergework",
+            "issue_url": "https://github.com/example/mergework/issues/284",
+            "title": "Second bounty",
+            "status": "open",
+            "awards_remaining": 1,
+        },
+        {
+            "bounty_id": first.id,
+            "issue_number": 284,
+            "repository": "ramimbo/mergework",
+            "issue_url": "https://github.com/ramimbo/mergework/issues/284",
+            "title": "First bounty",
+            "status": "open",
+            "awards_remaining": 1,
+        },
+    ]
 
 
 def test_host_specific_homepages(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary

- Return JSON `structuredContent` for `submit_work_proof(format: "json")` when a bounty selector is unknown or ambiguous.
- Preserve existing text-mode behavior and the existing JSON-RPC invalid-argument path for invalid selector types/values.
- Include machine-readable error codes and matching bounty summaries for ambiguous issue-number lookups so agents can retry with a concrete `bounty_id` instead of scraping prose.

## Why this is distinct

Bounty #315 already has accepted work for the core JSON guidance path and availability fields. This PR targets the remaining selector failure path: JSON callers can now handle missing or ambiguous bounty selectors with structured fields instead of plain text or generic tool errors.

## Validation

- `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_mcp_submit_work_proof_structures_unknown_bounty_selector tests/test_api_mcp.py::test_mcp_submit_work_proof_structures_ambiguous_issue_number tests/test_api_mcp.py::test_mcp_submit_work_proof_reports_unknown_bounty tests/test_api_mcp.py::test_mcp_submit_work_proof_rejects_ambiguous_issue_number -q` -> 4 passed.
- `uv run --extra dev python -m pytest tests/test_api_mcp.py -q` -> 78 passed.
- `uv run --extra dev python -m pytest -q` -> 337 passed.
- `uv run --extra dev ruff check .` -> passed.
- `uv run --extra dev ruff format --check .` -> 48 files already formatted.
- `uv run --extra dev python -m mypy app` -> success.
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.

Bounty #315

No private keys, seed material, secrets, deployment credentials, private vulnerability details, payout credentials, or MRWK price claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Work proof submission tool now returns structured JSON error responses with error codes and context information when bounty selection fails or is ambiguous.

* **Documentation**
  * Updated work proof submission tool documentation to clarify optional parameters and provide guidance on using JSON format for machine-readable error handling.

* **Tests**
  * Added test coverage for structured error responses in work proof submission scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->