### PR TITLE
Extract me page context from app.main

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -39,7 +39,6 @@ from app.ledger.service import (
     format_mrwk,
     get_balance,
     link_wallet_to_github,
-    linked_wallet_for_github,
     pay_bounty,
     public_url_or_none,
     register_wallet,
@@ -49,6 +48,7 @@ from app.ledger.service import (
     validate_public_url,
 )
 from app.mcp import handle_mcp_request
+from app.me import me_page_context
 from app.models import (
     Account,
     Bounty,
@@ -1371,22 +1371,12 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     @app.get("/me", response_class=HTMLResponse)
     def me_page(request: Request) -> HTMLResponse:
         login = github_login_from_request(request)
-        github_balance_mrwk = "0"
-        linked_wallet_address = ""
-        if login:
-            with session_scope(db_url) as session:
-                github_balance_mrwk = format_mrwk(get_balance(session, f"github:{login}"))
-                linked_wallet = linked_wallet_for_github(session, login)
-                if linked_wallet:
-                    linked_wallet_address = linked_wallet.address
+        with session_scope(db_url) as session:
+            context = me_page_context(session, login)
         return templates.TemplateResponse(
             request,
             "me.html",
-            {
-                "github_login": login,
-                "github_balance_mrwk": github_balance_mrwk,
-                "linked_wallet_address": linked_wallet_address,
-            },
+            context,
         )
 
     @app.post("/admin/logout")

--- a/app/me.py
+++ b/app/me.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.ledger.service import format_mrwk, get_balance, linked_wallet_for_github
+
+
+def me_page_context(session: Session, login: str | None) -> dict[str, Any]:
+    github_balance_mrwk = "0"
+    linked_wallet_address = ""
+    if login:
+        github_balance_mrwk = format_mrwk(get_balance(session, f"github:{login}"))
+        linked_wallet = linked_wallet_for_github(session, login)
+        if linked_wallet:
+            linked_wallet_address = linked_wallet.address
+    return {
+        "github_login": login,
+        "github_balance_mrwk": github_balance_mrwk,
+        "linked_wallet_address": linked_wallet_address,
+    }

--- a/tests/test_me_page.py
+++ b/tests/test_me_page.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from app.db import create_schema, session_scope
+from app.ledger.service import TREASURY_ACCOUNT, add_ledger_entry, ensure_genesis, register_wallet
+from app.me import me_page_context
+from app.wallets import address_from_public_key_hex
+
+
+def _wallet_public_hex() -> str:
+    private_key = Ed25519PrivateKey.generate()
+    return (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        .hex()
+    )
+
+
+def test_me_page_context_defaults_for_anonymous_user(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+        context = me_page_context(session, None)
+
+    assert context == {
+        "github_login": None,
+        "github_balance_mrwk": "0",
+        "linked_wallet_address": "",
+    }
+
+
+def test_me_page_context_reports_balance_and_linked_wallet(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    public_hex = _wallet_public_hex()
+    address = address_from_public_key_hex(public_hex)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        add_ledger_entry(
+            session,
+            entry_type="test_github_balance",
+            from_account=TREASURY_ACCOUNT,
+            to_account="github:alice",
+            amount_microunits=4_000_000,
+            reference="test-github-balance",
+        )
+        register_wallet(session, public_key_hex=public_hex, github_login="alice")
+
+        context = me_page_context(session, "alice")
+
+    assert context == {
+        "github_login": "alice",
+        "github_balance_mrwk": "4",
+        "linked_wallet_address": address,
+    }


### PR DESCRIPTION
Bounty #320

## Summary
- Extract the `/me` page data assembly from `app.main` into a focused `app.me.me_page_context()` helper.
- Keep the route handler as template wiring while the helper owns GitHub claim balance and linked-wallet lookup context.
- Add direct helper regressions for anonymous users and signed-in users with both GitHub balance and linked wallet state.

## Complexity reduced
`app.main` no longer owns the `/me` page balance/link lookup details. The signed-in account page context is now reviewable and testable independently from OAuth/session handling, wallet APIs, wallet pages, admin flows, ledger views, and MCP dispatch.

## Test evidence
- `uv run --extra dev python -m pytest tests/test_me_page.py tests/test_wallet_api.py::test_me_page_shows_signed_in_github_claim_balance tests/test_wallet_api.py::test_me_page_prefills_claim_address_for_linked_wallet tests/test_wallet_api.py::test_wallet_pages_do_not_require_manual_nonce -q` -> 5 passed
- `uv run --extra dev python -m pytest -q` -> 337 passed
- `uv run --extra dev python -m ruff check .` -> passed
- `uv run --extra dev python -m ruff format --check .` -> 50 files already formatted
- `uv run --extra dev python -m mypy app/main.py app/me.py` -> success
- `git diff --check` -> clean

No private keys, seed material, secrets, deployment credentials, private vulnerability details, payout credentials, or MRWK price claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization for the account settings page by consolidating related business logic.

* **Tests**
  * Added test coverage for account context generation, including anonymous and authenticated user scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->