### PR TITLE
Extract hub page context from app.main

### DIFF
--- a/app/hub.py
+++ b/app/hub.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any
+
+LTC_LAB_HOSTS = {"ltclab.site", "www.ltclab.site"}
+LTC_LAB_PROJECTS = (
+    {
+        "name": "MergeWork",
+        "tagline": "MRWK from LTC Lab",
+        "href": "https://mrwk.ltclab.site",
+        "status": "live",
+    },
+    {
+        "name": "MergeWork API",
+        "tagline": "Public MRWK status, bounty, ledger, and proof endpoints",
+        "href": "https://api.mrwk.ltclab.site",
+        "status": "live",
+    },
+    {
+        "name": "MergeWork MCP",
+        "tagline": "Tool endpoint for bounty and ledger queries",
+        "href": "https://mcp.mrwk.ltclab.site",
+        "status": "live",
+    },
+)
+
+
+def host_without_port(host_header: str) -> str:
+    return host_header.split(":", 1)[0].lower()
+
+
+def is_ltc_lab_host(host_header: str) -> bool:
+    return host_without_port(host_header) in LTC_LAB_HOSTS
+
+
+def ltc_lab_context() -> dict[str, Any]:
+    return {
+        "site_context": "ltc_lab",
+        "projects": [dict(project) for project in LTC_LAB_PROJECTS],
+    }
+
+
+def mergework_hub_context(status: dict[str, Any], public_base_url: str) -> dict[str, Any]:
+    return {
+        "status": status,
+        "public_base_url": public_base_url,
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.bounty_attempts import (
 )
 from app.config import Settings, get_settings
 from app.db import create_schema, session_scope
+from app.hub import is_ltc_lab_host, ltc_lab_context, mergework_hub_context
 from app.ledger.reconciliation import payout_reconciliation_summary, reconcile_accepted_payouts
 from app.ledger.service import (
     TREASURY_ACCOUNT,
@@ -174,14 +175,6 @@ def _existing_payout_proof_for_submission(
         .where(Proof.submission_id == submission.id, Proof.kind == "bounty_payment")
         .limit(1)
     )
-
-
-def _host_without_port(request: Request) -> str:
-    return request.headers.get("host", "").split(":", 1)[0].lower()
-
-
-def _is_ltc_lab_host(request: Request) -> bool:
-    return _host_without_port(request) in {"ltclab.site", "www.ltclab.site"}
 
 
 def _proof_hashes_by_sequence(session: Session, sequences: list[int]) -> dict[int, str]:
@@ -852,42 +845,17 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/", response_class=HTMLResponse)
     def hub(request: Request) -> HTMLResponse:
-        if _is_ltc_lab_host(request):
+        if is_ltc_lab_host(request.headers.get("host", "")):
             return templates.TemplateResponse(
                 request,
                 "ltc_lab.html",
-                {
-                    "site_context": "ltc_lab",
-                    "projects": [
-                        {
-                            "name": "MergeWork",
-                            "tagline": "MRWK from LTC Lab",
-                            "href": "https://mrwk.ltclab.site",
-                            "status": "live",
-                        },
-                        {
-                            "name": "MergeWork API",
-                            "tagline": "Public MRWK status, bounty, ledger, and proof endpoints",
-                            "href": "https://api.mrwk.ltclab.site",
-                            "status": "live",
-                        },
-                        {
-                            "name": "MergeWork MCP",
-                            "tagline": "Tool endpoint for bounty and ledger queries",
-                            "href": "https://mcp.mrwk.ltclab.site",
-                            "status": "live",
-                        },
-                    ],
-                },
+                ltc_lab_context(),
             )
         status_data = api_status()
         return templates.TemplateResponse(
             request,
             "hub.html",
-            {
-                "status": status_data,
-                "public_base_url": settings.public_base_url,
-            },
+            mergework_hub_context(status_data, settings.public_base_url),
         )
 
     @app.get("/bounties", response_class=HTMLResponse)

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from app.hub import (
+    host_without_port,
+    is_ltc_lab_host,
+    ltc_lab_context,
+    mergework_hub_context,
+)
+
+
+def test_host_without_port_normalizes_host_headers() -> None:
+    assert host_without_port("LtcLab.Site:443") == "ltclab.site"
+    assert host_without_port("www.ltclab.site") == "www.ltclab.site"
+    assert host_without_port("") == ""
+
+
+def test_is_ltc_lab_host_matches_root_domain_only() -> None:
+    assert is_ltc_lab_host("ltclab.site")
+    assert is_ltc_lab_host("www.ltclab.site:8443")
+    assert not is_ltc_lab_host("mrwk.ltclab.site")
+    assert not is_ltc_lab_host("api.mrwk.ltclab.site")
+
+
+def test_ltc_lab_context_lists_projects_without_shared_mutation() -> None:
+    context = ltc_lab_context()
+
+    assert context["site_context"] == "ltc_lab"
+    assert [project["name"] for project in context["projects"]] == [
+        "MergeWork",
+        "MergeWork API",
+        "MergeWork MCP",
+    ]
+    assert {project["status"] for project in context["projects"]} == {"live"}
+    assert "https://api.mrwk.ltclab.site" in {project["href"] for project in context["projects"]}
+
+    context["projects"][0]["status"] = "changed"
+
+    assert ltc_lab_context()["projects"][0]["status"] == "live"
+
+
+def test_mergework_hub_context_preserves_status_and_base_url() -> None:
+    status = {"ledger_height": 7, "active_bounties": 2}
+
+    context = mergework_hub_context(status, "https://mrwk.ltclab.site")
+
+    assert context == {
+        "status": status,
+        "public_base_url": "https://mrwk.ltclab.site",
+    }


### PR DESCRIPTION
Refs #377

## Summary
- Move root homepage host matching and template context construction into app.hub
- Keep app.main focused on route registration and response selection
- Add direct coverage for LTC Lab host matching, project context immutability, and MergeWork hub context shape

## Validation
- uv run --extra dev python -m pytest tests/test_hub.py tests/test_api_mcp.py::test_host_specific_homepages -q
- uv run --extra dev python -m pytest -q
- uv run --extra dev python -m ruff check app/main.py app/hub.py tests/test_hub.py
- uv run --extra dev python -m ruff format --check app/main.py app/hub.py tests/test_hub.py
- uv run --extra dev python -m mypy app/main.py app/hub.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure**
  * Reorganized hub configuration handling to improve support for different host types (LTC Lab and MergeWork projects).
  * Enhanced host detection and hub context building for better configuration management.

* **Tests**
  * Added test coverage for hub configuration utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/379?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->