### PR TITLE
Extract activity routes from app.main

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI, Query, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+from app.db import session_scope
+from app.serializers import activity_to_dict
+
+
+def activity_context(session: Session, query: str | None = None) -> dict[str, Any]:
+    return activity_to_dict(session, query)
+
+
+def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
+    @app.get("/api/v1/activity")
+    def api_activity(q: str | None = Query(None)) -> dict[str, Any]:
+        with session_scope(db_url) as session:
+            return activity_context(session, q)
+
+    @app.get("/activity", response_class=HTMLResponse)
+    def activity_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:
+        with session_scope(db_url) as session:
+            context = activity_context(session, q)
+        return templates.TemplateResponse(request, "activity.html", context)

--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,7 @@ from fastapi.templating import Jinja2Templates
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
+from app.activity import register_activity_routes
 from app.admin import (
     list_webhook_events,
     normalize_webhook_status_filter,
@@ -68,7 +69,6 @@ from app.path_params import (
 from app.serializers import (
     accepted_work_for_account,
     account_accepted_summary,
-    activity_to_dict,
     bounty_awards_to_dict,
     bounty_list_summary,
     bounty_to_dict,
@@ -826,10 +826,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 raise HTTPException(status_code=500, detail="invalid proof payload")
             return data
 
-    @app.get("/api/v1/activity")
-    def api_activity(q: str | None = Query(None)) -> dict[str, Any]:
-        with session_scope(db_url) as session:
-            return activity_to_dict(session, q)
+    register_activity_routes(app, db_url=db_url, templates=templates)
 
     @app.post("/webhooks/github")
     async def github_webhook(request: Request) -> JSONResponse:
@@ -923,10 +920,6 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         return templates.TemplateResponse(
             request, "ledger_entry.html", {"entry": api_ledger_entry(sequence)}
         )
-
-    @app.get("/activity", response_class=HTMLResponse)
-    def activity_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:
-        return templates.TemplateResponse(request, "activity.html", api_activity(q))
 
     @app.get("/accounts/{account}", response_class=HTMLResponse)
     def account_page(request: Request, account: str) -> HTMLResponse:

--- a/tests/test_activity_routes.py
+++ b/tests/test_activity_routes.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from app.activity import activity_context
+from app.db import create_schema, session_scope
+
+
+def test_activity_context_preserves_empty_feed_shape(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        assert activity_context(session) == {
+            "query": "",
+            "totals": {
+                "accepted_awards": 0,
+                "accepted_mrwk": "0",
+                "contributors": 0,
+            },
+            "contributors": [],
+            "recent": [],
+        }


### PR DESCRIPTION
Refs #377

## Summary
- Move the public activity API and HTML page route registration into app.activity
- Keep app.main responsible for wiring the route module instead of owning activity feed response handling
- Add focused coverage for the new activity_context boundary while preserving existing activity API/page behavior

## Validation
- uv run --extra dev python -m pytest tests/test_activity_routes.py tests/test_activity.py -q
- uv run --extra dev python -m pytest -q
- uv run --extra dev python -m ruff check app/main.py app/activity.py tests/test_activity_routes.py
- uv run --extra dev python -m ruff format --check app/main.py app/activity.py tests/test_activity_routes.py
- uv run --extra dev python -m mypy app/main.py app/activity.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON API endpoint at `/api/v1/activity` for retrieving activity data with optional query parameter support and filtering.
  * Added dedicated `/activity` HTML page for browser-based viewing of activity information.
  * Routes properly integrated into application initialization.

* **Tests**
  * Added test coverage for activity context functionality with validation of empty feed response structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/380?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->