### PR TITLE
docs: clarify bounty submission hygiene

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@
 - Bounty capacity checked:
 - Active attempts/open PRs checked:
 - Intended scope and files:
+- Expected PR size:
 - Out of scope:
 
 ## Test Evidence

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,10 @@
 ## Evidence
 
 - Confusion, missing step, stale example, or bug this addresses:
+- Bounty capacity checked:
+- Active attempts/open PRs checked:
+- Intended scope and files:
+- Out of scope:
 
 ## Test Evidence
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -199,16 +199,34 @@ Tools:
 
 Use this checklist before opening a PR for `mrwk:bounty` issues:
 
-1. Confirm no active claim or duplicate PR already covers the same scope.
-2. When the bounty is active and has open award slots, register an advisory
+1. Confirm the bounty is still open and has award capacity with
+   `/api/v1/bounties/{id}`.
+2. Inspect active attempts with `/api/v1/bounties/{id}/attempts` and open PRs
+   for the same bounty issue. If another active attempt or PR already covers
+   your exact scope, pick a different scope or wait for maintainer direction.
+3. When the bounty is active and has open award slots, register an advisory
    attempt with `/api/v1/bounties/{id}/attempts` before opening a PR.
-3. Keep changes small and directly tied to one bounty issue.
-4. Include `Bounty #<issue>` or `Refs #<issue>` in PR body.
-5. Explain the exact user or maintainer pain point you fixed.
-6. Include evidence: command output, screenshot, or clear reproduction steps.
-7. Run the required checks from the issue text (for docs work, run
+4. Keep changes small and directly tied to one bounty issue.
+5. Include `Bounty #<issue>` or `Refs #<issue>` in PR body.
+6. Explain the exact user or maintainer pain point you fixed.
+7. Include evidence: command output, screenshot, or clear reproduction steps.
+8. Run the required checks from the issue text (for docs work, run
    `./.venv/bin/python scripts/docs_smoke.py`).
-8. Avoid private data, secret material, and speculative price claims.
+9. Avoid private data, secret material, and speculative price claims.
+
+Do not target exhausted, paid, closed, or stale bounty rounds unless a
+maintainer explicitly redirects the work. A stale round is one where the bounty
+text, latest maintainer comment, or open PR queue suggests the requested work is
+already handled or no longer being reviewed.
+
+For claim-window style bounties, keep the PR body precise enough that a
+maintainer can see the intended review window without reading the whole diff:
+
+- exact bounty issue and internal bounty id checked;
+- files or surfaces intentionally changed;
+- files or surfaces intentionally left alone;
+- expected PR size and why the scope is not a duplicate;
+- required evidence and checks for this bounty.
 
 Common rejection reasons: duplicate scope, style-only changes without user
 impact, missing evidence, or ignoring issue-specific acceptance criteria.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -219,7 +219,7 @@ maintainer explicitly redirects the work. A stale round is one where the bounty
 text, latest maintainer comment, or open PR queue suggests the requested work is
 already handled or no longer being reviewed.
 
-For claim-window style bounties, keep the PR body precise enough that a
+For claim-window-style bounties, keep the PR body precise enough that a
 maintainer can see the intended review window without reading the whole diff:
 
 - exact bounty issue and internal bounty id checked;

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -93,7 +93,7 @@ bounty state rather than relying on stale issue text:
 Good PR bodies make the claim window easy to review. Include the exact bounty
 reference, the intended files or surfaces, the test plan, and the evidence that
 shows the work satisfies the acceptance text. If another active attempt already
-covers the same exact scope, do not race it with a duplicate PR.
+covers the same scope, do not race it with a duplicate PR.
 
 Paid bounty links are tracked in
 [docs/paid-bounties.md](paid-bounties.md) and the public

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -80,6 +80,21 @@ PR bounty submissions should link the bounty issue with `Bounty #<issue>` or
 `Refs #<issue>`. Use a closing reference only when the issue should close after
 that PR.
 
+Before opening a bounty PR, contributors and agents should confirm the live
+bounty state rather than relying on stale issue text:
+
+- check the bounty still has `status: "open"` and `awards_remaining` above
+  zero;
+- check active attempts and open PRs for the same issue;
+- avoid exhausted, paid, closed, or stale rounds unless a maintainer explicitly
+  redirects the work;
+- keep one bounty target per PR unless the issue asks for a combined change.
+
+Good PR bodies make the claim window easy to review. Include the exact bounty
+reference, the intended files or surfaces, the test plan, and the evidence that
+shows the work satisfies the acceptance text. If another active attempt already
+covers the same exact scope, do not race it with a duplicate PR.
+
 Paid bounty links are tracked in
 [docs/paid-bounties.md](paid-bounties.md) and the public
 [GitHub discussion](https://github.com/ramimbo/mergework/discussions/16).


### PR DESCRIPTION
## Summary

- Tighten the agent checklist so contributors verify live bounty capacity, active attempts, and overlapping PRs before opening work.
- Add claim-window guidance in bounty rules: exact bounty reference, intended files/surfaces, test plan, evidence, and duplicate-scope avoidance.
- Extend the PR template with concrete preflight fields for capacity, attempts/open PRs, intended scope, and out-of-scope notes.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: Bounty #383 asks for short agent-facing guidance that reduces duplicate, stale, or mis-targeted bounty submissions.
- Bounty capacity checked: `GET https://api.mrwk.ltclab.site/api/v1/bounties/58` returned `status: "open"`, `awards_remaining: 2`.
- Active attempts/open PRs checked: `GET https://api.mrwk.ltclab.site/api/v1/bounties/58/attempts` returned no active attempts; open PR list did not show an existing #383 submission.
- Intended scope and files: `docs/agent-guide.md`, `docs/bounty-rules.md`, `.github/pull_request_template.md`.
- Out of scope: runtime code, API behavior, MCP behavior, payout logic, ledger behavior.

## Test Evidence

- [ ] `ruff format --check .`
- [ ] `ruff check .`
- [ ] `mypy app`
- [ ] `pytest`
- [x] `./.venv/bin/python scripts/docs_smoke.py` (docs smoke ok)
- [x] `git diff --check`

## MRWK

Bounty #383

No private keys, seed material, secrets, deployment credentials, private vulnerability details, payout credentials, or MRWK price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded bounty submission guidance: longer, specific checklists for confirming bounty capacity, scope, and PR size
  * Updated PR template to prompt checks for active attempts/open PRs and explicit in-scope/out-of-scope details
  * Clarified required PR body contents: exact bounty reference, affected files/surfaces, test plan, and evidence to match acceptance criteria

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->