### PR TITLE
Extract account route context

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from app.db import session_scope
+from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
+from app.models import Account, LedgerEntry, Proof
+from app.path_params import SQLITE_INTEGER_MAX
+from app.serializers import (
+    accepted_work_for_account,
+    account_accepted_summary,
+    ledger_to_dict,
+    safe_accepted_work_for_account,
+    safe_account_accepted_summary,
+)
+from app.wallets import WalletError, normalize_wallet_address
+
+GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+
+
+def normalized_wallet_address(address: str) -> str:
+    try:
+        return normalize_wallet_address(address)
+    except WalletError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def normalized_account(account: str) -> str:
+    if not account or not account.strip():
+        raise HTTPException(status_code=400, detail="account must not be empty")
+    if re.search(r"[\x00-\x1f\x7f]", account):
+        raise HTTPException(status_code=400, detail="account must not contain control characters")
+    clean = account.strip()
+    lower = clean.lower()
+    if lower == TREASURY_ACCOUNT:
+        return TREASURY_ACCOUNT
+    if lower.startswith("treasury:"):
+        raise HTTPException(status_code=400, detail="treasury account must be treasury:mrwk")
+    if lower.startswith("reserve:"):
+        reserve_prefix = "reserve:bounty:"
+        if not lower.startswith(reserve_prefix):
+            raise HTTPException(
+                status_code=400, detail="reserve account must use reserve:bounty:<id>"
+            )
+        bounty_id = lower.removeprefix(reserve_prefix)
+        try:
+            normalized_bounty_id = int(bounty_id) if bounty_id.isdigit() else 0
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="reserve bounty id is too large") from exc
+        if normalized_bounty_id <= 0:
+            raise HTTPException(status_code=400, detail="reserve bounty id must be positive")
+        if normalized_bounty_id > SQLITE_INTEGER_MAX:
+            raise HTTPException(status_code=400, detail="reserve bounty id is too large")
+        return f"{reserve_prefix}{normalized_bounty_id}"
+    if lower.startswith("mrwk1"):
+        return normalized_wallet_address(clean)
+    if lower.startswith("github:"):
+        login = clean.split(":", 1)[1].lower()
+        if not GITHUB_LOGIN_RE.fullmatch(login):
+            raise HTTPException(status_code=400, detail="github login must be valid")
+        return f"github:{login}"
+    return clean
+
+
+def github_login_from_account(account: str) -> str | None:
+    if not account.startswith("github:"):
+        return None
+    login = account.removeprefix("github:")
+    if not GITHUB_LOGIN_RE.fullmatch(login):
+        return None
+    return login
+
+
+def account_transfer_status(account: str) -> str:
+    if account.startswith("github:"):
+        return "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
+    if account.startswith(("treasury:", "reserve:")):
+        return (
+            "Internal ledger account. MRWK wallet transfers are only available "
+            "for registered mrwk1 addresses."
+        )
+    return "MRWK wallet transfers are enabled for registered mrwk1 addresses."
+
+
+def account_api_context(session: Session, account: str) -> dict[str, Any]:
+    account = normalized_account(account)
+    account_row = session.get(Account, account)
+    return {
+        "account": account,
+        "ledger_address": account,
+        "github_login": github_login_from_account(account),
+        "exists": account_row is not None,
+        "balance_mrwk": format_mrwk(get_balance(session, account)),
+        "transfer_status": account_transfer_status(account),
+        "accepted_work": safe_account_accepted_summary(session, account),
+    }
+
+
+def account_accepted_work_context(session: Session, account: str) -> dict[str, Any]:
+    account = normalized_account(account)
+    return {
+        "account": account,
+        "summary": account_accepted_summary(session, account),
+        "accepted_work": accepted_work_for_account(session, account),
+    }
+
+
+def _proof_hashes_by_sequence(session: Session, sequences: list[int]) -> dict[int, str]:
+    if not sequences:
+        return {}
+    rows = session.execute(
+        select(Proof.ledger_sequence, Proof.hash).where(Proof.ledger_sequence.in_(sequences))
+    ).all()
+    return {int(sequence): str(proof_hash) for sequence, proof_hash in rows}
+
+
+def account_page_context(session: Session, account: str) -> dict[str, Any]:
+    account = normalized_account(account)
+    entries = session.scalars(
+        select(LedgerEntry)
+        .where(or_(LedgerEntry.from_account == account, LedgerEntry.to_account == account))
+        .order_by(LedgerEntry.sequence.desc())
+        .limit(100)
+    ).all()
+    proofs = _proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
+    return {
+        "account": account_api_context(session, account),
+        "accepted_summary": safe_account_accepted_summary(session, account),
+        "accepted_work": safe_accepted_work_for_account(session, account),
+        "transactions": [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries],
+    }
+
+
+def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
+    @app.get("/api/v1/accounts/{account}")
+    def api_account(account: str) -> dict[str, Any]:
+        with session_scope(db_url) as session:
+            return account_api_context(session, account)
+
+    @app.get("/api/v1/accounts/{account}/accepted-work")
+    def api_account_accepted_work(account: str) -> dict[str, Any]:
+        with session_scope(db_url) as session:
+            return account_accepted_work_context(session, account)
+
+    @app.get("/accounts/{account}", response_class=HTMLResponse)
+    def account_page(request: Request, account: str) -> HTMLResponse:
+        with session_scope(db_url) as session:
+            context = account_page_context(session, account)
+        return templates.TemplateResponse(request, "account.html", context)

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-import re
 import secrets
 import time
 from pathlib import Path
@@ -18,6 +17,7 @@ from fastapi.templating import Jinja2Templates
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
+from app.accounts import normalized_account, normalized_wallet_address, register_account_routes
 from app.admin import (
     list_webhook_events,
     normalize_webhook_status_filter,
@@ -32,7 +32,6 @@ from app.config import Settings, get_settings
 from app.db import create_schema, session_scope
 from app.ledger.reconciliation import payout_reconciliation_summary, reconcile_accepted_payouts
 from app.ledger.service import (
-    TREASURY_ACCOUNT,
     LedgerError,
     close_bounty,
     create_bounty,
@@ -51,7 +50,6 @@ from app.ledger.service import (
 from app.mcp import handle_mcp_request
 from app.me import me_page_context
 from app.models import (
-    Account,
     Bounty,
     LedgerEntry,
     Proof,
@@ -66,21 +64,16 @@ from app.path_params import (
     proof_hash_from_path,
 )
 from app.serializers import (
-    accepted_work_for_account,
-    account_accepted_summary,
     activity_to_dict,
     bounty_awards_to_dict,
     bounty_list_summary,
     bounty_to_dict,
     ledger_to_dict,
     payout_reconciliation_to_dict,
-    safe_accepted_work_for_account,
-    safe_account_accepted_summary,
     wallet_to_dict,
     wallet_transfer_to_dict,
 )
 from app.status import health_status, system_status
-from app.wallets import WalletError, normalize_wallet_address
 from app.webhooks.github import handle_github_webhook
 
 BASE_DIR = Path(__file__).resolve().parent
@@ -104,7 +97,6 @@ SECURITY_HEADERS = {
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
 }
-GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 API_DOCS_CSP = (
     "default-src 'self'; "
     "base-uri 'self'; "
@@ -212,59 +204,6 @@ def _safe_next_path(next_path: str | None) -> str:
     ):
         return "/me"
     return next_path
-
-
-def _normalized_account(account: str) -> str:
-    if not account or not account.strip():
-        raise HTTPException(status_code=400, detail="account must not be empty")
-    if re.search(r"[\x00-\x1f\x7f]", account):
-        raise HTTPException(status_code=400, detail="account must not contain control characters")
-    clean = account.strip()
-    lower = clean.lower()
-    if lower == TREASURY_ACCOUNT:
-        return TREASURY_ACCOUNT
-    if lower.startswith("treasury:"):
-        raise HTTPException(status_code=400, detail="treasury account must be treasury:mrwk")
-    if lower.startswith("reserve:"):
-        reserve_prefix = "reserve:bounty:"
-        if not lower.startswith(reserve_prefix):
-            raise HTTPException(
-                status_code=400, detail="reserve account must use reserve:bounty:<id>"
-            )
-        bounty_id = lower.removeprefix(reserve_prefix)
-        try:
-            normalized_bounty_id = int(bounty_id) if bounty_id.isdigit() else 0
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail="reserve bounty id is too large") from exc
-        if normalized_bounty_id <= 0:
-            raise HTTPException(status_code=400, detail="reserve bounty id must be positive")
-        if normalized_bounty_id > SQLITE_INTEGER_MAX:
-            raise HTTPException(status_code=400, detail="reserve bounty id is too large")
-        return f"{reserve_prefix}{normalized_bounty_id}"
-    if lower.startswith("mrwk1"):
-        return _normalized_wallet_address(clean)
-    if lower.startswith("github:"):
-        login = clean.split(":", 1)[1].lower()
-        if not GITHUB_LOGIN_RE.fullmatch(login):
-            raise HTTPException(status_code=400, detail="github login must be valid")
-        return f"github:{login}"
-    return clean
-
-
-def _github_login_from_account(account: str) -> str | None:
-    if not account.startswith("github:"):
-        return None
-    login = account.removeprefix("github:")
-    if not GITHUB_LOGIN_RE.fullmatch(login):
-        return None
-    return login
-
-
-def _normalized_wallet_address(address: str) -> str:
-    try:
-        return normalize_wallet_address(address)
-    except WalletError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 def _signed_value(value: str, secret: str) -> str:
@@ -553,10 +492,12 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         json_object=_json_object,
         required_str=_required_str,
         optional_int=_optional_int,
-        normalized_account=_normalized_account,
+        normalized_account=normalized_account,
         positive_bounty_id=positive_bounty_id,
         sqlite_integer_max=SQLITE_INTEGER_MAX,
     )
+
+    register_account_routes(app, db_url=db_url, templates=templates)
 
     @app.get("/api/v1/reconciliation/payouts")
     def api_payout_reconciliation(
@@ -667,44 +608,6 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 "ledger_sequence": release.sequence if release else None,
             }
 
-    @app.get("/api/v1/accounts/{account}")
-    def api_account(account: str) -> dict[str, Any]:
-        account = _normalized_account(account)
-        github_login = _github_login_from_account(account)
-        if account.startswith("github:"):
-            transfer_status = (
-                "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
-            )
-        elif account.startswith(("treasury:", "reserve:")):
-            transfer_status = (
-                "Internal ledger account. MRWK wallet transfers are only available "
-                "for registered mrwk1 addresses."
-            )
-        else:
-            transfer_status = "MRWK wallet transfers are enabled for registered mrwk1 addresses."
-        with session_scope(db_url) as session:
-            account_row = session.get(Account, account)
-            accepted_work = safe_account_accepted_summary(session, account)
-            return {
-                "account": account,
-                "ledger_address": account,
-                "github_login": github_login,
-                "exists": account_row is not None,
-                "balance_mrwk": format_mrwk(get_balance(session, account)),
-                "transfer_status": transfer_status,
-                "accepted_work": accepted_work,
-            }
-
-    @app.get("/api/v1/accounts/{account}/accepted-work")
-    def api_account_accepted_work(account: str) -> dict[str, Any]:
-        account = _normalized_account(account)
-        with session_scope(db_url) as session:
-            return {
-                "account": account,
-                "summary": account_accepted_summary(session, account),
-                "accepted_work": accepted_work_for_account(session, account),
-            }
-
     @app.get("/api/v1/auth/me")
     def api_auth_me(request: Request) -> dict[str, Any]:
         login = github_login_from_request(request)
@@ -734,7 +637,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/api/v1/wallets/{address}")
     def api_wallet(address: str) -> dict[str, Any]:
-        address = _normalized_wallet_address(address)
+        address = normalized_wallet_address(address)
         with session_scope(db_url) as session:
             wallet = session.get(Wallet, address)
             if wallet is None:
@@ -928,32 +831,6 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     def activity_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:
         return templates.TemplateResponse(request, "activity.html", api_activity(q))
 
-    @app.get("/accounts/{account}", response_class=HTMLResponse)
-    def account_page(request: Request, account: str) -> HTMLResponse:
-        account = _normalized_account(account)
-        with session_scope(db_url) as session:
-            account_data = api_account(account)
-            accepted_summary = safe_account_accepted_summary(session, account)
-            entries = session.scalars(
-                select(LedgerEntry)
-                .where(or_(LedgerEntry.from_account == account, LedgerEntry.to_account == account))
-                .order_by(LedgerEntry.sequence.desc())
-                .limit(100)
-            ).all()
-            proofs = _proof_hashes_by_sequence(session, [entry.sequence for entry in entries])
-            transactions = [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
-            accepted_work = safe_accepted_work_for_account(session, account)
-        return templates.TemplateResponse(
-            request,
-            "account.html",
-            {
-                "account": account_data,
-                "accepted_summary": accepted_summary,
-                "accepted_work": accepted_work,
-                "transactions": transactions,
-            },
-        )
-
     @app.get("/wallets", response_class=HTMLResponse)
     def wallets_page(request: Request) -> HTMLResponse:
         with session_scope(db_url) as session:
@@ -965,7 +842,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/wallets/{address}", response_class=HTMLResponse)
     def wallet_page(request: Request, address: str) -> HTMLResponse:
-        address = _normalized_wallet_address(address)
+        address = normalized_wallet_address(address)
         with session_scope(db_url) as session:
             wallet = session.get(Wallet, address)
             if wallet is None:
@@ -1517,7 +1394,7 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
                 "attempts": attempt_listing["attempts"],
             }
         if name == "get_balance":
-            account = _normalized_account(str_arg("account"))
+            account = normalized_account(str_arg("account"))
             return f"{account}: {format_mrwk(get_balance(session, account))} MRWK"
         if name == "register_wallet":
             wallet = register_wallet(
@@ -1527,7 +1404,7 @@ def _call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | 
             )
             return json.dumps(wallet_to_dict(session, wallet))
         if name == "get_wallet":
-            wallet_row = session.get(Wallet, _normalized_wallet_address(str_arg("address")))
+            wallet_row = session.get(Wallet, normalized_wallet_address(str_arg("address")))
             if wallet_row is None:
                 return "wallet not found"
             return json.dumps(wallet_to_dict(session, wallet_row))

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.accounts import account_api_context, account_page_context, normalized_account
+from app.db import create_schema, session_scope
+from app.ledger.service import create_bounty, ensure_genesis, pay_bounty
+from app.main import create_app
+
+
+def test_account_contexts_include_balance_status_and_proof_backed_rows(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=177,
+            issue_url="https://github.com/ramimbo/mergework/issues/177",
+            title="Account route extraction",
+            reward_mrwk="40",
+            acceptance="Account context should preserve accepted work and transaction rows.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/177",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+        api_context = account_api_context(session, "GitHub:Alice")
+        page_context = account_page_context(session, "github:alice")
+
+    assert api_context["account"] == "github:alice"
+    assert api_context["github_login"] == "alice"
+    assert api_context["balance_mrwk"] == "40"
+    assert api_context["transfer_status"].startswith("Claim GitHub balances")
+    assert api_context["accepted_work"]["accepted_awards"] == 1
+    assert api_context["accepted_work"]["latest_proof_hash"] == proof.hash
+
+    assert page_context["account"]["account"] == "github:alice"
+    assert page_context["accepted_summary"]["accepted_mrwk"] == "40"
+    assert page_context["accepted_work"][0]["proof_hash"] == proof.hash
+    assert page_context["transactions"][0]["proof_hash"] == proof.hash
+    assert page_context["transactions"][0]["to"] == "github:alice"
+
+
+def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=178,
+            issue_url="https://github.com/ramimbo/mergework/issues/178",
+            title="Account page route",
+            reward_mrwk="25",
+            acceptance="Account routes should render accepted work after extraction.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:bob",
+            submission_url="https://github.com/ramimbo/mergework/pull/178",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    api_response = client.get("/api/v1/accounts/GitHub:Bob")
+    accepted_response = client.get("/api/v1/accounts/github:bob/accepted-work")
+    page_response = client.get("/accounts/github:bob")
+
+    assert api_response.status_code == 200
+    assert api_response.json()["account"] == "github:bob"
+    assert api_response.json()["accepted_work"]["latest_proof_hash"] == proof.hash
+    assert accepted_response.status_code == 200
+    assert accepted_response.json()["summary"]["accepted_mrwk"] == "25"
+    assert accepted_response.json()["accepted_work"][0]["submission_url"].endswith("/pull/178")
+    assert page_response.status_code == 200
+    assert "github:bob" in page_response.text
+    assert "25 MRWK" in page_response.text
+    assert f'href="/proofs/{proof.hash}"' in page_response.text
+
+
+def test_normalized_account_keeps_existing_account_validation_boundaries() -> None:
+    assert normalized_account(" Reserve:Bounty:001 ") == "reserve:bounty:1"
+    assert normalized_account("MRWK1" + ("A" * 40)) == "mrwk1" + ("a" * 40)


### PR DESCRIPTION
## Summary

- Extract account normalization, account API context, accepted-work context, and account page context from `app/main.py` into `app/accounts.py`.
- Register account API/page routes through one focused account-route boundary.
- Keep wallet, bounty, ledger, MCP, and page behavior unchanged while continuing to reuse the account normalizer from MCP and bounty-attempt wiring.

Refs #377

## Complexity reduced

`app/main.py` no longer owns account-specific validation, transfer-status text, accepted-work account summaries, account transaction proof lookup, or account page route registration. The account surface can now be reviewed and tested independently from wallet, admin, bounty, activity, MCP, and webhook routing.

## Validation

- `uv run --extra dev python -m pytest tests/test_account_routes.py tests/test_account_validation.py tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows -q` -> 29 passed.
- `uv run --extra dev python -m pytest -q` -> 356 passed.
- `uv run --extra dev ruff check .` -> passed.
- `uv run --extra dev ruff format --check .` -> 57 files already formatted.
- `uv run --extra dev python -m mypy app` -> success.
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.

## MRWK

Bounty #377

No private keys, seed material, secrets, deployment credentials, private vulnerability details, payout credentials, or MRWK price claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account pages now display transaction history, balance status, and accepted work information
  * New API endpoints provide account context and accepted-work data
  * Improved account and wallet address validation with enhanced normalization

* **Tests**
  * Added comprehensive test coverage for account pages and API endpoints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->