### PR TITLE
Extract admin route registration [Bounty #390]

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -68,7 +68,6 @@ def register_admin_routes(
 
     @app.post("/admin/bounties")
     def admin_create_bounty(
-        request: Request,
         repo: str = Form(...),
         issue_number: int = Form(...),
         issue_url: str = Form(...),
@@ -79,7 +78,6 @@ def register_admin_routes(
         csrf_token_value: str | None = Form(None, alias="csrf_token"),
         admin_login: str = Depends(require_admin),
     ) -> RedirectResponse:
-        del request
         if admin_login != "api-token" and not verify_csrf_token(
             csrf_token_value,
             action="admin-bounty",

--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Annotated, Any
+
+from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from app.admin import admin_page_context, create_admin_bounty_from_form
+from app.config import Settings
+from app.db import session_scope
+from app.ledger.service import LedgerError
+
+
+def register_admin_routes(
+    app: FastAPI,
+    *,
+    db_url: str,
+    settings: Settings,
+    templates: Jinja2Templates,
+    admin_login_from_request: Callable[[Request], str | None],
+    require_admin: Callable[[Request], str],
+    oauth_configured: Callable[[Settings], bool],
+    csrf_token: Callable[[str, str, str], str],
+    verify_csrf_token: Callable[..., bool],
+) -> None:
+    @app.get("/admin/login")
+    def admin_login() -> RedirectResponse:
+        return RedirectResponse("/auth/github/login?next=/admin", status_code=302)
+
+    @app.get("/admin/callback")
+    async def admin_callback(request: Request) -> RedirectResponse:
+        suffix = f"?{request.url.query}" if request.url.query else ""
+        return RedirectResponse(f"/auth/github/callback{suffix}", status_code=302)
+
+    @app.post("/admin/logout")
+    def admin_logout() -> RedirectResponse:
+        response = RedirectResponse("/", status_code=303)
+        response.delete_cookie("mrwk_admin")
+        response.delete_cookie("mrwk_user")
+        return response
+
+    @app.get("/admin", response_class=HTMLResponse)
+    def admin_page(
+        request: Request,
+        webhook_status: str | None = Query(None),
+        webhook_limit: Annotated[int, Query(ge=1, le=100)] = 25,
+    ) -> Any:
+        login = admin_login_from_request(request)
+        if login is None:
+            if oauth_configured(settings):
+                return RedirectResponse("/auth/github/login?next=/admin", status_code=302)
+            raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
+        with session_scope(db_url) as session:
+            context = admin_page_context(
+                session,
+                login=login,
+                csrf_token=csrf_token("admin-bounty", login, settings.cookie_secret),
+                webhook_status=webhook_status,
+                webhook_limit=webhook_limit,
+            )
+        return templates.TemplateResponse(
+            request,
+            "admin.html",
+            context,
+        )
+
+    @app.post("/admin/bounties")
+    def admin_create_bounty(
+        request: Request,
+        repo: str = Form(...),
+        issue_number: int = Form(...),
+        issue_url: str = Form(...),
+        title: str = Form(...),
+        reward_mrwk: str = Form(...),
+        max_awards: int = Form(1),
+        acceptance: str = Form(...),
+        csrf_token_value: str | None = Form(None, alias="csrf_token"),
+        admin_login: str = Depends(require_admin),
+    ) -> RedirectResponse:
+        del request
+        if admin_login != "api-token" and not verify_csrf_token(
+            csrf_token_value,
+            action="admin-bounty",
+            login=admin_login,
+            secret=settings.cookie_secret,
+        ):
+            raise HTTPException(status_code=403, detail="invalid CSRF token")
+        with session_scope(db_url) as session:
+            try:
+                bounty_id = create_admin_bounty_from_form(
+                    session,
+                    repo=repo,
+                    issue_number=issue_number,
+                    issue_url=issue_url,
+                    title=title,
+                    reward_mrwk=reward_mrwk,
+                    max_awards=max_awards,
+                    acceptance=acceptance,
+                )
+            except LedgerError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return RedirectResponse(f"/bounties/{bounty_id}", status_code=303)

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any
 from urllib.parse import unquote, urlencode, urlsplit, urlunsplit
 
 import httpx
-from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -19,12 +19,8 @@ from sqlalchemy.orm import Session
 
 from app.accounts import normalized_account, normalized_wallet_address, register_account_routes
 from app.activity import register_activity_routes
-from app.admin import (
-    admin_page_context,
-    create_admin_bounty_from_form,
-    list_webhook_events,
-    webhook_events_to_dict,
-)
+from app.admin import list_webhook_events, webhook_events_to_dict
+from app.admin_routes import register_admin_routes
 from app.bounty_attempts import (
     list_bounty_attempts,
     register_bounty_attempt_routes,
@@ -915,15 +911,6 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         response.delete_cookie("mrwk_oauth_state")
         return response
 
-    @app.get("/admin/login")
-    def admin_login() -> RedirectResponse:
-        return RedirectResponse("/auth/github/login?next=/admin", status_code=302)
-
-    @app.get("/admin/callback")
-    async def admin_callback(request: Request) -> RedirectResponse:
-        suffix = f"?{request.url.query}" if request.url.query else ""
-        return RedirectResponse(f"/auth/github/callback{suffix}", status_code=302)
-
     @app.post("/auth/logout")
     def auth_logout() -> RedirectResponse:
         response = RedirectResponse("/", status_code=303)
@@ -942,74 +929,17 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             context,
         )
 
-    @app.post("/admin/logout")
-    def admin_logout() -> RedirectResponse:
-        response = RedirectResponse("/", status_code=303)
-        response.delete_cookie("mrwk_admin")
-        response.delete_cookie("mrwk_user")
-        return response
-
-    @app.get("/admin", response_class=HTMLResponse)
-    def admin_page(
-        request: Request,
-        webhook_status: str | None = Query(None),
-        webhook_limit: Annotated[int, Query(ge=1, le=100)] = 25,
-    ) -> Any:
-        login = admin_login_from_request(request)
-        if login is None:
-            if _oauth_configured(settings):
-                return RedirectResponse("/auth/github/login?next=/admin", status_code=302)
-            raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
-        with session_scope(db_url) as session:
-            context = admin_page_context(
-                session,
-                login=login,
-                csrf_token=_csrf_token("admin-bounty", login, settings.cookie_secret),
-                webhook_status=webhook_status,
-                webhook_limit=webhook_limit,
-            )
-        return templates.TemplateResponse(
-            request,
-            "admin.html",
-            context,
-        )
-
-    @app.post("/admin/bounties")
-    def admin_create_bounty(
-        request: Request,
-        repo: str = Form(...),
-        issue_number: int = Form(...),
-        issue_url: str = Form(...),
-        title: str = Form(...),
-        reward_mrwk: str = Form(...),
-        max_awards: int = Form(1),
-        acceptance: str = Form(...),
-        csrf_token: str | None = Form(None),
-        admin_login: str = Depends(require_admin),
-    ) -> RedirectResponse:
-        del request
-        if admin_login != "api-token" and not _verify_csrf_token(
-            csrf_token,
-            action="admin-bounty",
-            login=admin_login,
-            secret=settings.cookie_secret,
-        ):
-            raise HTTPException(status_code=403, detail="invalid CSRF token")
-        with session_scope(db_url) as session:
-            try:
-                bounty_id = create_admin_bounty_from_form(
-                    session,
-                    repo=repo,
-                    issue_number=issue_number,
-                    issue_url=issue_url,
-                    title=title,
-                    reward_mrwk=reward_mrwk,
-                    max_awards=max_awards,
-                    acceptance=acceptance,
-                )
-            except LedgerError as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
-        return RedirectResponse(f"/bounties/{bounty_id}", status_code=303)
+    register_admin_routes(
+        app,
+        db_url=db_url,
+        settings=settings,
+        templates=templates,
+        admin_login_from_request=admin_login_from_request,
+        require_admin=require_admin,
+        oauth_configured=_oauth_configured,
+        csrf_token=_csrf_token,
+        verify_csrf_token=_verify_csrf_token,
+    )
 
     return app
 

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+
+def test_admin_login_callback_and_logout_routes_remain_registered(sqlite_url: str) -> None:
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+
+    login = client.get("/admin/login", follow_redirects=False)
+    callback = client.get("/admin/callback?code=abc&state=xyz", follow_redirects=False)
+    client.cookies.set("mrwk_admin", "admin-cookie")
+    client.cookies.set("mrwk_user", "user-cookie")
+    logout = client.post("/admin/logout", follow_redirects=False)
+
+    assert login.status_code == 302
+    assert login.headers["location"] == "/auth/github/login?next=/admin"
+    assert callback.status_code == 302
+    assert callback.headers["location"] == "/auth/github/callback?code=abc&state=xyz"
+    assert logout.status_code == 303
+    assert logout.headers["location"] == "/"
+    set_cookie = logout.headers.get_list("set-cookie")
+    assert any(cookie.startswith("mrwk_admin=") and "Max-Age=0" in cookie for cookie in set_cookie)
+    assert any(cookie.startswith("mrwk_user=") and "Max-Age=0" in cookie for cookie in set_cookie)
+
+
+def test_admin_page_requires_oauth_config_before_redirect(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/admin", follow_redirects=False)
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "GitHub OAuth is not configured"


### PR DESCRIPTION
## Summary

- Move `/admin/login`, `/admin/callback`, `/admin/logout`, `/admin`, and `/admin/bounties` route registration out of `app/main.py` into `app/admin_routes.py`.
- Keep `app/main.py` focused on app wiring while passing the existing auth, OAuth, CSRF, settings, database, and template dependencies into the admin route boundary.
- Add route-level regression coverage for admin login/callback/logout wiring and the unauthenticated admin page fallback.

## Complexity reduced

`app/main.py` no longer owns the admin HTML/form route bodies or admin-specific redirect/logout wiring. Admin page and form routing now live beside the existing admin context/form helpers, while `app/main.py` only registers the boundary with shared dependencies. Public admin behavior, CSRF checks, OAuth redirect behavior, and bounty creation responses are preserved.

## Validation

- `uv run --extra dev python -m ruff check .` -> passed.
- `uv run --extra dev python -m ruff format --check .` -> 67 files already formatted.
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `uv run --extra dev python -m mypy app` -> success.
- `uv run --extra dev python -m pytest -q` -> 379 passed.
- `git diff --check` -> clean.

## MRWK

Bounty #390

No private keys, seed material, secrets, deployment credentials, private vulnerability details, payout credentials, or MRWK price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin authentication with GitHub OAuth: login, callback, and logout flows.
  * Added an admin dashboard for viewing and managing admin operations.
  * Enabled admins to create bounties via the admin panel with CSRF-protected forms.

* **Tests**
  * Added integration tests for admin login/callback/logout, cookie clearing, and behavior when OAuth is not configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->