### PR TITLE
Add expected PR size bounty guidance [Bounty #383]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,10 @@
 ## Evidence
 
 - Confusion, missing step, stale example, or bug this addresses:
+- Bounty capacity and active attempts/open PRs checked:
+- Intended files or surfaces:
+- Expected PR size:
+- Out of scope:
 
 ## Test Evidence
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -202,13 +202,15 @@ Use this checklist before opening a PR for `mrwk:bounty` issues:
 1. Confirm no active claim or duplicate PR already covers the same scope.
 2. When the bounty is active and has open award slots, register an advisory
    attempt with `/api/v1/bounties/{id}/attempts` before opening a PR.
-3. Keep changes small and directly tied to one bounty issue.
-4. Include `Bounty #<issue>` or `Refs #<issue>` in PR body.
-5. Explain the exact user or maintainer pain point you fixed.
-6. Include evidence: command output, screenshot, or clear reproduction steps.
-7. Run the required checks from the issue text (for docs work, run
+3. Write the claim-window scope before coding: exact bounty, intended files or
+   surfaces, expected PR size, test plan, and what is out of scope.
+4. Keep changes small and directly tied to one bounty issue.
+5. Include `Bounty #<issue>` or `Refs #<issue>` in PR body.
+6. Explain the exact user or maintainer pain point you fixed.
+7. Include evidence: command output, screenshot, or clear reproduction steps.
+8. Run the required checks from the issue text (for docs work, run
    `./.venv/bin/python scripts/docs_smoke.py`).
-8. Avoid private data, secret material, and speculative price claims.
+9. Avoid private data, secret material, and speculative price claims.
 
 Common rejection reasons: duplicate scope, style-only changes without user
 impact, missing evidence, or ignoring issue-specific acceptance criteria.

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -80,6 +80,11 @@ PR bounty submissions should link the bounty issue with `Bounty #<issue>` or
 `Refs #<issue>`. Use a closing reference only when the issue should close after
 that PR.
 
+For bounty PRs, include the claim-window packet in the PR body: exact bounty
+reference, intended files or surfaces, expected PR size, test plan, evidence,
+and out-of-scope notes. If the diff grows beyond the expected size, split it or
+explain why the larger review remains focused.
+
 Paid bounty links are tracked in
 [docs/paid-bounties.md](paid-bounties.md) and the public
 [GitHub discussion](https://github.com/ramimbo/mergework/discussions/16).

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -64,14 +64,13 @@ def main() -> int:
         if "link the page, docs file, heading, command, or ui path" not in template:
             print("docs issue template location prompt must request actionable evidence")
             ok = False
-    if ok:
-        pr_template = ROOT / PR_TEMPLATE
-        if not pr_template.exists():
-            print(f"missing pull request template: {PR_TEMPLATE}")
-            ok = False
-        elif "expected pr size:" not in pr_template.read_text(encoding="utf-8").lower():
-            print("pull request template must ask for expected PR size")
-            ok = False
+    pr_template = ROOT / PR_TEMPLATE
+    if not pr_template.exists():
+        print(f"missing pull request template: {PR_TEMPLATE}")
+        ok = False
+    elif "expected pr size:" not in pr_template.read_text(encoding="utf-8").lower():
+        print("pull request template must ask for expected PR size")
+        ok = False
     if ok:
         print("docs smoke ok")
         return 0

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -24,6 +24,7 @@ BANNED_PUBLIC_PHRASES = [
 ]
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"
+PR_TEMPLATE = ".github/pull_request_template.md"
 
 
 def _local_target_exists(source: Path, target: str) -> bool:
@@ -62,6 +63,14 @@ def main() -> int:
             ok = False
         if "link the page, docs file, heading, command, or ui path" not in template:
             print("docs issue template location prompt must request actionable evidence")
+            ok = False
+    if ok:
+        pr_template = ROOT / PR_TEMPLATE
+        if not pr_template.exists():
+            print(f"missing pull request template: {PR_TEMPLATE}")
+            ok = False
+        elif "expected pr size:" not in pr_template.read_text(encoding="utf-8").lower():
+            print("pull request template must ask for expected PR size")
             ok = False
     if ok:
         print("docs smoke ok")


### PR DESCRIPTION
## Summary

- Add an explicit `Expected PR size:` prompt to the pull request template.
- Align the agent guide and bounty rules around the same claim-window packet: exact bounty, intended files/surfaces, expected PR size, test plan, evidence, and out-of-scope notes.
- Extend `scripts/docs_smoke.py` so the expected-size prompt is checked before future docs/template changes pass smoke.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: Bounty #383 asks for claim-window guidance, and PR #386 is held with `mrwk:needs-info` specifically because the PR template lacks an explicit `Expected PR size:` prompt.
- Bounty capacity and active attempts/open PRs checked: `GET https://api.mrwk.ltclab.site/api/v1/bounties/58` returned `status: open` and `awards_remaining: 1`; `GET https://api.mrwk.ltclab.site/api/v1/bounties/58/attempts` returned no active attempts. PR #387 is paid; PR #386 remains held on the missing expected-size prompt.
- Intended files or surfaces: `.github/pull_request_template.md`, `docs/agent-guide.md`, `docs/bounty-rules.md`, `scripts/docs_smoke.py`.
- Expected PR size: 4 focused files, docs/template plus one docs-smoke guard, about 26 added lines and 6 removed lines.
- Out of scope: runtime code, API behavior, MCP behavior, ledger behavior, payout logic, wallet logic, marketing copy, and broad docs rewrites.

## Test Evidence

- [x] `uv run --extra dev python -m ruff check .` -> passed.
- [x] `uv run --extra dev python -m ruff format --check .` -> 65 files already formatted.
- [x] `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- [x] `uv run --extra dev python -m pytest tests/test_docs_public_urls.py tests/test_check_agents.py tests/test_submission_quality_gate.py -q` -> 41 passed.
- [x] `uv run --extra dev python -m mypy app` -> success.
- [x] `uv run --extra dev python -m pytest -q` -> 377 passed.
- [x] `git diff --check` -> clean.

## MRWK

Bounty #383

No private keys, seed material, secrets, deployment credentials, private vulnerability details, payout credentials, or MRWK price claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated agent guide and bounty rules with a new bounty PR submission step requiring a written claim-window scope before coding
  * Introduced a "claim-window packet" format for PRs: bounty reference, intended files/surfaces, expected PR size, test plan, evidence, and out-of-scope items
  * Reordered checklist for clarity

* **Chores**
  * Added validation to enforce the new PR template requirements (including expected PR size)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->