### PR TITLE
docs: clarify MRWK transfer and bridge status

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ MRWK wallets use Ed25519 public keys. The address is `mrwk1` plus the first
 Create or inspect wallets at `/wallets`, send MRWK at `/transfer`, and link a
 GitHub account at `/me`.
 
+Current MRWK movement is ledger-native: accepted work can pay a linked `mrwk1`
+wallet or a temporary `github:*` account, linked wallets can claim positive
+GitHub balances, and registered `mrwk1` wallets can send signed transfers to
+other registered `mrwk1` wallets. MergeWork does not currently operate a public
+BTC, USDC, fiat, bridge, exchange, or off-ramp; see
+[docs/ledger.md](docs/ledger.md#current-transfer-paths) for the current transfer
+paths and future bridge status.
+
 ## Reference Bounty Tiers
 
 | Tier | Work |

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -77,6 +77,12 @@ curl -s "$API_HOST/api/v1/accounts/treasury:mrwk"
 curl -s "$API_HOST/api/v1/wallets/mrwk1..."
 ```
 
+Before reporting payout or transfer status, check the ledger docs. Current MRWK
+movement is native to MergeWork: GitHub balance claims, linked `mrwk1` wallets,
+and signed wallet-to-wallet transfers between registered wallets. Do not imply a
+live BTC, USDC, fiat, bridge, exchange, or off-ramp unless maintainers publish
+one.
+
 Register a wallet public key. Keep the private key local; only the public key is
 sent to MergeWork:
 

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -1,7 +1,8 @@
 # MRWK Ledger
 
-MRWK starts as a native project coin on the MergeWork ledger. The ledger is
-designed for future public snapshots, bridges, and onchain claims.
+MRWK starts as a native project coin on the MergeWork ledger. The ledger keeps
+public balances and proofs that may support future snapshots, bridges, or
+onchain-claim experiments, but those paths are not live public off-ramps today.
 
 ## Units
 
@@ -41,6 +42,9 @@ the stored `entry_hash` must recompute from the entry payload.
 
 Public ledger state can be snapshotted for bridge or onchain-claim experiments.
 The public ledger and proof hashes are designed to make that process auditable.
+Any public bridge, chain claim, exchange, or redemption path requires separate
+maintainer and contributor discussion before implementation. The current public
+app does not operate a BTC, USDC, fiat, bridge, exchange, or off-ramp.
 
 ## Wallets and Sending
 
@@ -64,3 +68,21 @@ a wallet. A linked wallet can sign a claim payload to move the full positive
 
 Balances and proofs are inspectable in the explorer. The ledger remains the
 source of truth for spendable MRWK balances.
+
+## Current Transfer Paths
+
+MRWK transfer support is currently limited to native MergeWork ledger paths:
+
+1. Maintainer-approved work pays either a linked `mrwk1` wallet or a temporary
+   native `github:{login}` account.
+2. A contributor can link a registered `mrwk1` wallet with GitHub OAuth and a
+   wallet signature, then claim the full positive `github:{login}` balance into
+   that wallet.
+3. Registered `mrwk1` wallets can send signed wallet-to-wallet transfers to
+   other registered `mrwk1` wallets. The ledger verifies the Ed25519 signature,
+   source address, amount, and next nonce before recording the transfer.
+
+These are ledger-native transfers only. MergeWork does not currently provide a
+public BTC, USDC, fiat, bridge, exchange, or off-ramp. Treat future public
+snapshots, bridges, and onchain claims as separate design work until maintainers
+publish and accept an implementation plan.


### PR DESCRIPTION
## Summary
- Add `docs/ledger.md` current transfer paths for GitHub balance claims, linked `mrwk1` wallets, and registered wallet-to-wallet transfers.
- Clarify that MergeWork does not currently operate a public BTC, USDC, fiat, bridge, exchange, or off-ramp.
- Add a README pointer plus an agent-guide reminder so agents do not overstate liquidity or bridge status.

## Validation
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `./.venv/bin/python -m ruff check scripts/docs_smoke.py` -> passed
- `git diff --check` -> passed
- `./.venv/bin/python -m ruff format --check README.md docs/ledger.md docs/agent-guide.md` -> not applicable; Ruff reports Markdown formatting is experimental and requires preview mode

Bounty #395

No private keys, seed material, secrets, deployment credentials, private vulnerability details, payout credentials, price claims, or off-ramp promises are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified current MRWK transfer capabilities and limitations in README and ledger documentation
  * Documented supported transfer paths: work payments to linked wallets or temporary GitHub accounts, and wallet-to-wallet transfers with signature verification
  * Explicitly stated that non-native assets (BTC, USDC, fiat, bridges) are not currently supported

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->