### PR TITLE
docs(ledger): Clarify current MRWK transfer paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 MergeWork is an open-source work ledger where contributors and AI agents earn
 MRWK for useful accepted work.
 
-MRWK starts as a native project coin on the MergeWork ledger. The ledger is
-designed for future public snapshots, bridges, and onchain claims.
+MRWK is native to the MergeWork ledger. The ledger is the source of truth for
+current balances, transfers, and payout proofs.
 
 ## How Earning Works
 
@@ -33,6 +33,13 @@ MRWK wallets use Ed25519 public keys. The address is `mrwk1` plus the first
 
 Create or inspect wallets at `/wallets`, send MRWK at `/transfer`, and link a
 GitHub account at `/me`.
+
+The supported paths today are `github:*` balance claims, linked `mrwk1` wallet
+payouts, and signed wallet-to-wallet transfers between registered wallets.
+MergeWork does not currently operate a public BTC, USDC, fiat, bridge,
+exchange, or off-ramp. Future public snapshots, bridges, and onchain claims
+require separate maintainer/contributor discussion before implementation. See
+[docs/ledger.md](docs/ledger.md#current-transfer-paths) for details.
 
 ## Reference Bounty Tiers
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -112,6 +112,9 @@ Submit the transfer with:
 GitHub link and claim actions require GitHub OAuth login plus a wallet signature.
 The public app flow is `/auth/github/login?next=/me`.
 
+Before describing payout or transfer behavior, check the current transfer paths
+in [docs/ledger.md](ledger.md#current-transfer-paths).
+
 ## MCP Endpoint
 
 The MCP JSON-RPC endpoint is `POST /mcp`.

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -1,7 +1,7 @@
 # MRWK Ledger
 
-MRWK starts as a native project coin on the MergeWork ledger. The ledger is
-designed for future public snapshots, bridges, and onchain claims.
+MRWK is native to the MergeWork ledger. The ledger is the source of truth for
+current balances, transfers, and payout proofs.
 
 ## Units
 
@@ -37,10 +37,27 @@ Each ledger entry hashes canonical JSON containing:
 Entries must be sequential, each `previous_hash` must match the prior entry, and
 the stored `entry_hash` must recompute from the entry payload.
 
+## Current Transfer Paths
+
+The supported MRWK transfer paths today are:
+
+- `github:*` balance claims into a linked wallet.
+- Payouts to linked `mrwk1` wallets.
+- Signed wallet-to-wallet transfers between registered wallets.
+
+A `github:*` account is a native ledger account for contributors who were paid
+before linking a wallet. A linked wallet can sign a claim payload to move that
+GitHub balance into the wallet.
+
+MergeWork does not currently operate a public BTC, USDC, fiat, bridge,
+exchange, or off-ramp. Future public snapshots, bridges, and onchain claims
+require separate maintainer/contributor discussion before implementation.
+
 ## Future Snapshot Path
 
-Public ledger state can be snapshotted for bridge or onchain-claim experiments.
-The public ledger and proof hashes are designed to make that process auditable.
+Public ledger state and proof hashes make future snapshot, bridge, or
+onchain-claim experiments auditable if maintainers and contributors decide to
+explore them.
 
 ## Wallets and Sending
 
@@ -57,10 +74,6 @@ Transfer payloads use this shape:
 ```json
 {"type":"mrwk_transfer_v1","from_address":"mrwk1...","to_address":"mrwk1...","amount_microunits":1000000,"nonce":1,"memo":"optional"}
 ```
-
-GitHub payout accounts still exist for contributors who were paid before linking
-a wallet. A linked wallet can sign a claim payload to move the full positive
-`github:{login}` balance into the wallet.
 
 Balances and proofs are inspectable in the explorer. The ledger remains the
 source of truth for spendable MRWK balances.

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -22,6 +22,26 @@ BANNED_PUBLIC_PHRASES = [
     "promised convertibility",
     "1 MRWK = $",
 ]
+REQUIRED_PUBLIC_PHRASES = {
+    "README.md": [
+        "supported paths today are `github:*` balance claims",
+        (
+            "MergeWork does not currently operate a public BTC, USDC, fiat, "
+            "bridge, exchange, or off-ramp."
+        ),
+        "require separate maintainer/contributor discussion before implementation",
+    ],
+    "docs/ledger.md": [
+        "## Current Transfer Paths",
+        "`github:*` balance claims into a linked wallet.",
+        "Signed wallet-to-wallet transfers between registered wallets.",
+        (
+            "MergeWork does not currently operate a public BTC, USDC, fiat, "
+            "bridge, exchange, or off-ramp."
+        ),
+        "require separate maintainer/contributor discussion before implementation",
+    ],
+}
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"
 
@@ -31,6 +51,10 @@ def _local_target_exists(source: Path, target: str) -> bool:
     if not clean or clean.startswith(("http://", "https://", "mailto:")):
         return True
     return (source.parent / clean).resolve().exists()
+
+
+def _squash(text: str) -> str:
+    return " ".join(text.split())
 
 
 def main() -> int:
@@ -46,6 +70,11 @@ def main() -> int:
         for phrase in BANNED_PUBLIC_PHRASES:
             if phrase.lower() in lowered:
                 print(f"banned public phrase in {relative}: {phrase}")
+                ok = False
+        squashed = _squash(text)
+        for phrase in REQUIRED_PUBLIC_PHRASES.get(relative, []):
+            if _squash(phrase) not in squashed:
+                print(f"missing required public phrase in {relative}: {phrase}")
                 ok = False
         for link in LINK_RE.findall(text):
             if not _local_target_exists(path, link):


### PR DESCRIPTION
Summary: Clarifies MRWK current transfer support in the ledger docs and README.

This keeps public docs clear that MRWK currently lives on the MergeWork ledger: GitHub balance claims, linked `mrwk1` payouts, and signed transfers between registered wallets are supported today, while public BTC, USDC, fiat, bridge, exchange, or off-ramp support is not currently operated by MergeWork. It also points agents to the ledger docs before describing payout behavior.

The docs smoke script now checks that the README and ledger docs retain the current-transfer-path language and the maintainer/contributor discussion boundary.

Bounty #395

Evidence:
- `./.venv/bin/python scripts/docs_smoke.py` -> `docs smoke ok`
- `./.venv/bin/python -m ruff format --check .` -> `65 files already formatted`
- `./.venv/bin/python -m ruff check .` -> `All checks passed!`
- `./.venv/bin/python -m pytest tests/test_docs_public_urls.py -q` -> `17 passed`
- `./.venv/bin/python -m pytest -q` -> `377 passed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified MRWK as a native coin on the MergeWork ledger, serving as the source of truth for balances, transfers, and payout proofs.
  * Documented currently supported transfer paths: GitHub balance claims, linked wallet payouts, and wallet-to-wallet transfers.
  * Added clarity on unsupported paths (public BTC/USDC/fiat/bridge/exchange/off-ramp) with details in updated ledger documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->