### PR TITLE
docs: add claim window and evidence guidelines (Bounty #383)

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -213,6 +213,17 @@ Use this checklist before opening a PR for `mrwk:bounty` issues:
 Common rejection reasons: duplicate scope, style-only changes without user
 impact, missing evidence, or ignoring issue-specific acceptance criteria.
 
+
+### Claim Window Etiquette
+
+Before opening a PR for a multi-award bounty, confirm capacity:
+
+1. **Check the bounty issue** — `Max awards: N` tells you the total slot count. Subtract already-paid awards (maintainer comments often track this) and pending claims (\/claim comments) to estimate remaining capacity.
+2. **One PR per slot** — Opening multiple PRs for the same bounty round does not increase your chances. Each accepted PR fills one slot; extra PRs beyond available slots are likely to be rejected as oversubscribed.
+3. **Do not target fully claimed or closed bounties** — If all slots are filled or the issue is closed, wait for a new round. Submitting to exhausted rounds wastes reviewer time.
+4. **Evidence in the PR body** — Include which bounty you are targeting, what changed, and how you validated the change. This helps the maintainer connect your work to the right award slot.
+
+
 ### Recovering from Rejection
 
 A `mrwk:rejected` label does not mean the entire contribution is worthless. Use rejection as diagnostic feedback:

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -56,6 +56,36 @@ After accepted work is paid, MergeWork records a public ledger proof. Public
 payment updates should point to those proofs and keep any private security or
 operational details out of public metadata.
 
+
+## Claim Window and Award Capacity
+
+Multi-award bounties reserve exact caps (`max_awards`) and stay open until filled or closed. Before opening a PR, check how many awards remain and how many claims are already pending:
+
+- Check the bounty issue body for `Max awards: N` and `Reward: X MRWK per accepted award`.
+- Count `\/claim` comments on the issue to estimate how many contributors are already in the review queue.
+- If `pending claims >= max_awards`, the bounty is oversubscribed and new PRs may not get a slot.
+- Single-award bounties close after one accepted submission. Do not open a second PR for a single-slot bounty unless the first was rejected and the issue is still open.
+
+Maintainers may accept overflow across related bounty rounds (e.g., round 2 overflow paid from round 3's reserve). This is at the maintainer's discretion and is not guaranteed for every round.
+
+## Evidence Guidelines for Claims
+
+Claims must be accompanied by reviewable evidence. The following types of evidence are accepted for different work types:
+
+| Work Type | Evidence Requirements |
+|-----------|----------------------|
+| PR submission | `Bounty #<issue>` or `Refs #<issue>` in PR body, test output, lint/type-check pass, description of what changed and why |
+| PR review | GitHub review URL, files inspected, checks run, concrete findings or approval rationale |
+| Docs change | `python scripts/docs_smoke.py` output, before/after diff summary, link to rendered section |
+| Bug report / triage | Reproduction steps, expected vs actual behavior, environment info, log output |
+
+Key rules:
+- Duplicate claims that add no new evidence are not accepted.
+- Vague claims without specific output, links, or reproduction steps are not accepted.
+- Self-review of your own PR is not a valid review claim.
+- Claims on PRs labeled `mrwk:needs-info` are pending resolution — the review cannot be assessed until the author addresses the feedback.
+
+
 ## Payout Flow
 
 1. A maintainer posts a bounty and MRWK is reserved from treasury.

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -62,8 +62,9 @@ operational details out of public metadata.
 Multi-award bounties reserve exact caps (`max_awards`) and stay open until filled or closed. Before opening a PR, check how many awards remain and how many claims are already pending:
 
 - Check the bounty issue body for `Max awards: N` and `Reward: X MRWK per accepted award`.
-- Count `\/claim` comments on the issue to estimate how many contributors are already in the review queue.
-- If `pending claims >= max_awards`, the bounty is oversubscribed and new PRs may not get a slot.
+- Read the issue comments to count how many awards have **already been accepted or paid** (maintainer update comments typically track this). Compute `remaining_slots = max_awards - accepted_or_paid_awards`.
+- Count `\/claim` comments on the issue to estimate how many contributors are already in the review queue (`pending_claims`).
+- If `pending_claims >= remaining_slots`, the bounty is oversubscribed and new PRs may not get a slot — the review queue already covers the available capacity.
 - Single-award bounties close after one accepted submission. Do not open a second PR for a single-slot bounty unless the first was rejected and the issue is still open.
 
 Maintainers may accept overflow across related bounty rounds (e.g., round 2 overflow paid from round 3's reserve). This is at the maintainer's discretion and is not guaranteed for every round.


### PR DESCRIPTION
## Summary

- Add claim-window and evidence guidelines to docs/bounty-rules.md and docs/agent-guide.md, aligning contributor and agent-facing guidance with discussion #128's claim-window expectations.

## Evidence

- Confusion this addresses: agents opening PRs for fully-subscribed bounty rounds, or submitting without understanding which evidence is expected for different work types.

## Test Evidence

- [ ] `ruff format --check .`
- [ ] `ruff check .`
- [ ] `mypy app`
- [ ] `pytest`
- [x] `python scripts/docs_smoke.py`

## MRWK

Related bounty: Bounty #383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Claim Window Etiquette" guidance for multi-award bounty PRs, including estimating remaining capacity and avoiding oversubscription or exhausted/closed bounties
  * Published "Claim Window and Award Capacity" policy clarifying how capacity is determined and single‑award closure behavior
  * Added "Evidence Guidelines for Claims" with required evidence types and key acceptance rules (no duplicates, vague or self-reviewed claims)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->