### PR TITLE
Extract GitHub OAuth auth boundary

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+import time
+from urllib.parse import unquote, urlencode
+
+import httpx
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import RedirectResponse
+
+from app.config import Settings
+
+
+def oauth_configured(settings: Settings) -> bool:
+    return bool(
+        settings.github_oauth_client_id
+        and settings.github_oauth_client_secret
+        and settings.cookie_secret
+    )
+
+
+def safe_next_path(next_path: str | None) -> str:
+    decoded_next_path = unquote(next_path) if next_path else ""
+    if (
+        not next_path
+        or not next_path.startswith("/")
+        or next_path.startswith("//")
+        or len(next_path) > 2048
+        or "\\" in next_path
+        or decoded_next_path.startswith("//")
+        or len(decoded_next_path) > 2048
+        or "\\" in decoded_next_path
+        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
+        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)
+    ):
+        return "/me"
+    return next_path
+
+
+def signed_value(value: str, secret: str) -> str:
+    timestamp = str(int(time.time()))
+    body = f"{value}|{timestamp}"
+    signature = hmac.new(secret.encode(), body.encode(), hashlib.sha256).hexdigest()
+    return f"{body}|{signature}"
+
+
+def verified_value(token: str | None, secret: str, max_age_seconds: int) -> str | None:
+    if not token or not secret:
+        return None
+    try:
+        value, timestamp, signature = token.rsplit("|", 2)
+        age = int(time.time()) - int(timestamp)
+    except ValueError:
+        return None
+    if age < 0 or age > max_age_seconds:
+        return None
+    expected = hmac.new(
+        secret.encode(), f"{value}|{timestamp}".encode(), hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(signature, expected):
+        return None
+    return value
+
+
+class AuthService:
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+
+    def admin_login_from_request(self, request: Request) -> str | None:
+        token = request.headers.get("x-mergework-admin-token", "")
+        if self._settings.admin_token and hmac.compare_digest(token, self._settings.admin_token):
+            return "api-token"
+        login = verified_value(
+            request.cookies.get("mrwk_admin"), self._settings.cookie_secret, 86_400
+        )
+        if login and login.lower() in self._settings.admin_logins:
+            return login.lower()
+        return None
+
+    def github_login_from_request(self, request: Request) -> str | None:
+        login = verified_value(
+            request.cookies.get("mrwk_user"), self._settings.cookie_secret, 604_800
+        )
+        return login.lower() if login else None
+
+    def require_github_login(self, request: Request) -> str:
+        login = self.github_login_from_request(request)
+        if login is None:
+            raise HTTPException(status_code=401, detail="github login required")
+        return login
+
+    def require_admin(self, request: Request) -> str:
+        login = self.admin_login_from_request(request)
+        if login is None:
+            raise HTTPException(status_code=401, detail="admin authentication required")
+        return login
+
+    def require_admin_token(self, request: Request) -> str:
+        token = request.headers.get("x-mergework-admin-token", "")
+        if self._settings.admin_token and hmac.compare_digest(token, self._settings.admin_token):
+            return "api-token"
+        raise HTTPException(status_code=401, detail="admin token required")
+
+
+def register_auth_routes(app: FastAPI, *, settings: Settings) -> AuthService:
+    auth = AuthService(settings)
+
+    @app.get("/auth/github/login")
+    def auth_github_login(next_path: str | None = Query(None, alias="next")) -> RedirectResponse:
+        if not oauth_configured(settings):
+            raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
+        safe_next = safe_next_path(next_path)
+        state_value = f"{secrets.token_urlsafe(24)},{safe_next}"
+        state = signed_value(state_value, settings.cookie_secret)
+        query = urlencode(
+            {
+                "client_id": settings.github_oauth_client_id,
+                "redirect_uri": f"{settings.public_base_url}/auth/github/callback",
+                "scope": "read:user",
+                "state": state,
+            }
+        )
+        response = RedirectResponse(
+            f"https://github.com/login/oauth/authorize?{query}", status_code=302
+        )
+        response.set_cookie(
+            "mrwk_oauth_state", state, httponly=True, secure=True, samesite="lax", max_age=600
+        )
+        return response
+
+    @app.get("/auth/github/callback")
+    async def auth_github_callback(request: Request, code: str, state: str) -> RedirectResponse:
+        if not oauth_configured(settings):
+            raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
+        cookie_state = request.cookies.get("mrwk_oauth_state")
+        if not cookie_state or not hmac.compare_digest(cookie_state, state):
+            raise HTTPException(status_code=401, detail="invalid OAuth state")
+        state_value = verified_value(state, settings.cookie_secret, 600)
+        if state_value is None:
+            raise HTTPException(status_code=401, detail="expired OAuth state")
+        try:
+            _, next_path = state_value.split(",", 1)
+        except ValueError as exc:
+            raise HTTPException(status_code=401, detail="invalid OAuth state") from exc
+        next_path = safe_next_path(next_path)
+        async with httpx.AsyncClient(timeout=10) as client:
+            token_response = await client.post(
+                "https://github.com/login/oauth/access_token",
+                headers={"Accept": "application/json"},
+                data={
+                    "client_id": settings.github_oauth_client_id,
+                    "client_secret": settings.github_oauth_client_secret,
+                    "code": code,
+                    "redirect_uri": f"{settings.public_base_url}/auth/github/callback",
+                },
+            )
+            token_response.raise_for_status()
+            access_token = token_response.json().get("access_token")
+            if not access_token:
+                raise HTTPException(status_code=401, detail="GitHub OAuth token exchange failed")
+            user_response = await client.get(
+                "https://api.github.com/user",
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": f"Bearer {access_token}",
+                },
+            )
+            user_response.raise_for_status()
+            login = str(user_response.json().get("login", "")).lower()
+            if not login:
+                raise HTTPException(status_code=401, detail="GitHub OAuth user lookup failed")
+        response = RedirectResponse(next_path, status_code=302)
+        response.set_cookie(
+            "mrwk_user",
+            signed_value(login, settings.cookie_secret),
+            httponly=True,
+            secure=True,
+            samesite="lax",
+            max_age=604_800,
+        )
+        if login in settings.admin_logins:
+            response.set_cookie(
+                "mrwk_admin",
+                signed_value(login, settings.cookie_secret),
+                httponly=True,
+                secure=True,
+                samesite="lax",
+                max_age=86_400,
+            )
+        response.delete_cookie("mrwk_oauth_state")
+        return response
+
+    @app.post("/auth/logout")
+    def auth_logout() -> RedirectResponse:
+        response = RedirectResponse("/", status_code=303)
+        response.delete_cookie("mrwk_user")
+        response.delete_cookie("mrwk_admin")
+        return response
+
+    return auth

--- a/app/main.py
+++ b/app/main.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
-import hashlib
-import hmac
 import json
-import secrets
-import time
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import unquote, urlencode, urlsplit, urlunsplit
+from urllib.parse import urlsplit, urlunsplit
 
-import httpx
 from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
@@ -17,6 +12,7 @@ from fastapi.templating import Jinja2Templates
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
+from app import auth as auth_module
 from app.accounts import normalized_account, normalized_wallet_address, register_account_routes
 from app.activity import register_activity_routes
 from app.admin import (
@@ -29,7 +25,7 @@ from app.bounty_attempts import (
     list_bounty_attempts,
     register_bounty_attempt_routes,
 )
-from app.config import Settings, get_settings
+from app.config import get_settings
 from app.db import create_schema, session_scope
 from app.hub import is_ltc_lab_host, ltc_lab_context, mergework_hub_context
 from app.ledger.reconciliation import payout_reconciliation_summary, reconcile_accepted_payouts
@@ -89,6 +85,19 @@ from app.webhooks.github import handle_github_webhook
 BASE_DIR = Path(__file__).resolve().parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 templates.env.globals["safe_public_url"] = public_url_or_none
+
+_oauth_configured = auth_module.oauth_configured
+_safe_next_path = auth_module.safe_next_path
+_signed_value = auth_module.signed_value
+_verified_value = auth_module.verified_value
+
+__all__ = [
+    "_oauth_configured",
+    "_safe_next_path",
+    "_signed_value",
+    "_verified_value",
+    "create_app",
+]
 
 SECURITY_HEADERS = {
     "Content-Security-Policy": (
@@ -176,57 +185,6 @@ def _existing_payout_proof_for_submission(
         .where(Proof.submission_id == submission.id, Proof.kind == "bounty_payment")
         .limit(1)
     )
-
-
-def _oauth_configured(settings: Settings) -> bool:
-    return bool(
-        settings.github_oauth_client_id
-        and settings.github_oauth_client_secret
-        and settings.cookie_secret
-    )
-
-
-def _safe_next_path(next_path: str | None) -> str:
-    decoded_next_path = unquote(next_path) if next_path else ""
-    if (
-        not next_path
-        or not next_path.startswith("/")
-        or next_path.startswith("//")
-        or len(next_path) > 2048
-        or "\\" in next_path
-        or decoded_next_path.startswith("//")
-        or len(decoded_next_path) > 2048
-        or "\\" in decoded_next_path
-        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in next_path)
-        or any(ord(char) < 32 or 127 <= ord(char) < 160 for char in decoded_next_path)
-    ):
-        return "/me"
-    return next_path
-
-
-def _signed_value(value: str, secret: str) -> str:
-    timestamp = str(int(time.time()))
-    body = f"{value}|{timestamp}"
-    signature = hmac.new(secret.encode(), body.encode(), hashlib.sha256).hexdigest()
-    return f"{body}|{signature}"
-
-
-def _verified_value(token: str | None, secret: str, max_age_seconds: int) -> str | None:
-    if not token or not secret:
-        return None
-    try:
-        value, timestamp, signature = token.rsplit("|", 2)
-        age = int(time.time()) - int(timestamp)
-    except ValueError:
-        return None
-    if age < 0 or age > max_age_seconds:
-        return None
-    expected = hmac.new(
-        secret.encode(), f"{value}|{timestamp}".encode(), hashlib.sha256
-    ).hexdigest()
-    if not hmac.compare_digest(signature, expected):
-        return None
-    return value
 
 
 async def _json_object(request: Request) -> dict[str, Any]:
@@ -350,36 +308,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     if static_dir.exists():
         app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
-    def admin_login_from_request(request: Request) -> str | None:
-        token = request.headers.get("x-mergework-admin-token", "")
-        if settings.admin_token and hmac.compare_digest(token, settings.admin_token):
-            return "api-token"
-        login = _verified_value(request.cookies.get("mrwk_admin"), settings.cookie_secret, 86_400)
-        if login and login.lower() in settings.admin_logins:
-            return login.lower()
-        return None
-
-    def github_login_from_request(request: Request) -> str | None:
-        login = _verified_value(request.cookies.get("mrwk_user"), settings.cookie_secret, 604_800)
-        return login.lower() if login else None
-
-    def require_github_login(request: Request) -> str:
-        login = github_login_from_request(request)
-        if login is None:
-            raise HTTPException(status_code=401, detail="github login required")
-        return login
-
-    def require_admin(request: Request) -> str:
-        login = admin_login_from_request(request)
-        if login is None:
-            raise HTTPException(status_code=401, detail="admin authentication required")
-        return login
-
-    def require_admin_token(request: Request) -> str:
-        token = request.headers.get("x-mergework-admin-token", "")
-        if settings.admin_token and hmac.compare_digest(token, settings.admin_token):
-            return "api-token"
-        raise HTTPException(status_code=401, detail="admin token required")
+    auth = auth_module.register_auth_routes(app, settings=settings)
 
     @app.get("/health")
     def health() -> dict[str, Any]:
@@ -441,7 +370,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     def api_admin_webhook_events(
         status: str | None = Query(None),
         limit: Annotated[int, Query(ge=1, le=200)] = 50,
-        admin_login: str = Depends(require_admin_token),
+        admin_login: str = Depends(auth.require_admin_token),
     ) -> list[dict[str, Any]]:
         del admin_login
         with session_scope(db_url) as session:
@@ -449,7 +378,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.post("/api/v1/bounties")
     async def api_create_bounty(
-        request: Request, admin_login: str = Depends(require_admin_token)
+        request: Request, admin_login: str = Depends(auth.require_admin_token)
     ) -> dict[str, Any]:
         data = await _json_object(request)
         with session_scope(db_url) as session:
@@ -486,7 +415,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     register_bounty_attempt_routes(
         app,
         db_url=db_url,
-        require_github_login=require_github_login,
+        require_github_login=auth.require_github_login,
         json_object=_json_object,
         required_str=_required_str,
         optional_int=_optional_int,
@@ -499,7 +428,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/api/v1/reconciliation/payouts")
     def api_payout_reconciliation(
-        admin_login: str = Depends(require_admin_token),
+        admin_login: str = Depends(auth.require_admin_token),
     ) -> dict[str, Any]:
         with session_scope(db_url) as session:
             checks = reconcile_accepted_payouts(session)
@@ -513,7 +442,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     async def api_pay_bounty(
         bounty_id: int,
         request: Request,
-        admin_login: str = Depends(require_admin_token),
+        admin_login: str = Depends(auth.require_admin_token),
     ) -> Any:
         bounty_id = positive_bounty_id(bounty_id)
         data = await _json_object(request)
@@ -583,7 +512,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     async def api_close_bounty(
         bounty_id: int,
         request: Request,
-        admin_login: str = Depends(require_admin_token),
+        admin_login: str = Depends(auth.require_admin_token),
     ) -> dict[str, Any]:
         bounty_id = positive_bounty_id(bounty_id)
         data = await _json_object(request)
@@ -608,7 +537,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/api/v1/auth/me")
     def api_auth_me(request: Request) -> dict[str, Any]:
-        login = github_login_from_request(request)
+        login = auth.github_login_from_request(request)
         return {"authenticated": login is not None, "github_login": login}
 
     @app.post("/api/v1/wallets/register")
@@ -644,7 +573,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.post("/api/v1/wallets/link-github")
     async def api_link_wallet_github(
-        request: Request, github_login: str = Depends(require_github_login)
+        request: Request, github_login: str = Depends(auth.require_github_login)
     ) -> dict[str, Any]:
         data = await _json_object(request)
         with session_scope(db_url) as session:
@@ -662,7 +591,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.post("/api/v1/github/claim")
     async def api_github_claim(
-        request: Request, github_login: str = Depends(require_github_login)
+        request: Request, github_login: str = Depends(auth.require_github_login)
     ) -> dict[str, Any]:
         data = await _json_object(request)
         with session_scope(db_url) as session:
@@ -830,91 +759,6 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     def docs_page(request: Request) -> HTMLResponse:
         return templates.TemplateResponse(request, "docs.html")
 
-    @app.get("/auth/github/login")
-    def auth_github_login(next_path: str | None = Query(None, alias="next")) -> RedirectResponse:
-        if not _oauth_configured(settings):
-            raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
-        safe_next = _safe_next_path(next_path)
-        state_value = f"{secrets.token_urlsafe(24)},{safe_next}"
-        state = _signed_value(state_value, settings.cookie_secret)
-        query = urlencode(
-            {
-                "client_id": settings.github_oauth_client_id,
-                "redirect_uri": f"{settings.public_base_url}/auth/github/callback",
-                "scope": "read:user",
-                "state": state,
-            }
-        )
-        response = RedirectResponse(
-            f"https://github.com/login/oauth/authorize?{query}", status_code=302
-        )
-        response.set_cookie(
-            "mrwk_oauth_state", state, httponly=True, secure=True, samesite="lax", max_age=600
-        )
-        return response
-
-    @app.get("/auth/github/callback")
-    async def auth_github_callback(request: Request, code: str, state: str) -> RedirectResponse:
-        if not _oauth_configured(settings):
-            raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
-        cookie_state = request.cookies.get("mrwk_oauth_state")
-        if not cookie_state or not hmac.compare_digest(cookie_state, state):
-            raise HTTPException(status_code=401, detail="invalid OAuth state")
-        state_value = _verified_value(state, settings.cookie_secret, 600)
-        if state_value is None:
-            raise HTTPException(status_code=401, detail="expired OAuth state")
-        try:
-            _, next_path = state_value.split(",", 1)
-        except ValueError as exc:
-            raise HTTPException(status_code=401, detail="invalid OAuth state") from exc
-        next_path = _safe_next_path(next_path)
-        async with httpx.AsyncClient(timeout=10) as client:
-            token_response = await client.post(
-                "https://github.com/login/oauth/access_token",
-                headers={"Accept": "application/json"},
-                data={
-                    "client_id": settings.github_oauth_client_id,
-                    "client_secret": settings.github_oauth_client_secret,
-                    "code": code,
-                    "redirect_uri": f"{settings.public_base_url}/auth/github/callback",
-                },
-            )
-            token_response.raise_for_status()
-            access_token = token_response.json().get("access_token")
-            if not access_token:
-                raise HTTPException(status_code=401, detail="GitHub OAuth token exchange failed")
-            user_response = await client.get(
-                "https://api.github.com/user",
-                headers={
-                    "Accept": "application/vnd.github+json",
-                    "Authorization": f"Bearer {access_token}",
-                },
-            )
-            user_response.raise_for_status()
-            login = str(user_response.json().get("login", "")).lower()
-            if not login:
-                raise HTTPException(status_code=401, detail="GitHub OAuth user lookup failed")
-        response = RedirectResponse(next_path, status_code=302)
-        response.set_cookie(
-            "mrwk_user",
-            _signed_value(login, settings.cookie_secret),
-            httponly=True,
-            secure=True,
-            samesite="lax",
-            max_age=604_800,
-        )
-        if login in settings.admin_logins:
-            response.set_cookie(
-                "mrwk_admin",
-                _signed_value(login, settings.cookie_secret),
-                httponly=True,
-                secure=True,
-                samesite="lax",
-                max_age=86_400,
-            )
-        response.delete_cookie("mrwk_oauth_state")
-        return response
-
     @app.get("/admin/login")
     def admin_login() -> RedirectResponse:
         return RedirectResponse("/auth/github/login?next=/admin", status_code=302)
@@ -924,16 +768,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         suffix = f"?{request.url.query}" if request.url.query else ""
         return RedirectResponse(f"/auth/github/callback{suffix}", status_code=302)
 
-    @app.post("/auth/logout")
-    def auth_logout() -> RedirectResponse:
-        response = RedirectResponse("/", status_code=303)
-        response.delete_cookie("mrwk_user")
-        response.delete_cookie("mrwk_admin")
-        return response
-
     @app.get("/me", response_class=HTMLResponse)
     def me_page(request: Request) -> HTMLResponse:
-        login = github_login_from_request(request)
+        login = auth.github_login_from_request(request)
         with session_scope(db_url) as session:
             context = me_page_context(session, login)
         return templates.TemplateResponse(
@@ -955,7 +792,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         webhook_status: str | None = Query(None),
         webhook_limit: Annotated[int, Query(ge=1, le=100)] = 25,
     ) -> Any:
-        login = admin_login_from_request(request)
+        login = auth.admin_login_from_request(request)
         if login is None:
             if _oauth_configured(settings):
                 return RedirectResponse("/auth/github/login?next=/admin", status_code=302)
@@ -985,7 +822,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         max_awards: int = Form(1),
         acceptance: str = Form(...),
         csrf_token: str | None = Form(None),
-        admin_login: str = Depends(require_admin),
+        admin_login: str = Depends(auth.require_admin),
     ) -> RedirectResponse:
         del request
         if admin_login != "api-token" and not _verify_csrf_token(


### PR DESCRIPTION
Bounty #390

## Summary
- Extract GitHub OAuth, signed-cookie session helpers, and `/auth/*` route registration into `app/auth.py`.
- Keep admin page/form routes, wallet APIs, bounty APIs, public pages, and MCP tools outside this PR to avoid overlap with active claims.
- Preserve existing compatibility imports from `app.main` for tests and callers using `_signed_value`, `_verified_value`, `_safe_next_path`, or `_oauth_configured`.

## Tests
- `uv run --extra dev pytest -q` -> 377 passed
- `uv run --extra dev ruff check app/auth.py app/main.py tests/test_security.py tests/test_wallet_api.py tests/test_bounty_attempts.py`
- `uv run --extra dev ruff format --check app/auth.py app/main.py`
- `uv run --extra dev mypy app`
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check`

## Security
- OAuth state signing, signed session cookie verification, safe redirect validation, and constant-time comparisons remain unchanged and are now isolated in one auth boundary.
- No broader behavior changes to API, wallet, ledger, MCP, webhook, admin, or public page logic.

Prepared with AI assistance and manually reviewed before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented GitHub OAuth authentication with complete login and logout workflows
  * Added admin access control system with token-based authentication support
  * Integrated secure signed cookie handling for protected user sessions
  * Added OAuth state validation with sanitized redirect path handling for enhanced security

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->