### PR TITLE
docs: update activity API example fields

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -182,9 +182,9 @@ curl -s "$API_HOST/api/v1/activity?q=p3xill"
 ```
 
 The optional `q` parameter filters activity rows by account, amount, submission
-URL, proof hash, internal bounty id, or GitHub issue number. The response groups
-matching proof-backed bounty payments into `totals`, contributor rollups, and
-the most recent payment rows:
+URL, proof hash, bounty repo, bounty issue URL, internal bounty id, or GitHub
+issue number. The response groups matching proof-backed bounty payments into
+`totals`, contributor rollups, and the most recent payment rows:
 
 ```json
 {
@@ -200,6 +200,9 @@ the most recent payment rows:
       "accepted_awards": 2,
       "accepted_mrwk": "115",
       "latest_submission_url": "https://github.com/ramimbo/mergework/pull/226#pullrequestreview-4354910919",
+      "latest_bounty_repo": "ramimbo/mergework",
+      "latest_bounty_issue_number": 219,
+      "latest_bounty_issue_url": "https://github.com/ramimbo/mergework/issues/219",
       "latest_proof_hash": "99f78d41b9a493ba2e6136cba0b0762f013a913c9d90c562976282e93d00b81f",
       "latest_proof_url": "/proofs/99f78d41b9a493ba2e6136cba0b0762f013a913c9d90c562976282e93d00b81f"
     }
@@ -212,8 +215,11 @@ the most recent payment rows:
       "submission_url": "https://github.com/ramimbo/mergework/pull/226#pullrequestreview-4354910919",
       "proof_hash": "99f78d41b9a493ba2e6136cba0b0762f013a913c9d90c562976282e93d00b81f",
       "proof_url": "/proofs/99f78d41b9a493ba2e6136cba0b0762f013a913c9d90c562976282e93d00b81f",
+      "bounty_repo": "ramimbo/mergework",
       "bounty_id": 37,
       "bounty_issue_number": 219,
+      "bounty_issue_url": "https://github.com/ramimbo/mergework/issues/219",
+      "bounty_url": "/bounties/37",
       "created_at": "2026-05-25T08:25:28.316705"
     }
   ]

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -224,9 +224,18 @@ def test_api_examples_document_activity_response_shape() -> None:
         '"latest_submission_url": "https://github.com/ramimbo/mergework/pull/226#pullrequestreview-4354910919"'
         in examples
     )
+    assert '"latest_bounty_repo": "ramimbo/mergework"' in examples
+    assert '"latest_bounty_issue_number": 219' in examples
+    assert (
+        '"latest_bounty_issue_url": "https://github.com/ramimbo/mergework/issues/219"' in examples
+    )
     assert '"recent": [' in examples
     assert '"ledger_sequence": 399' in examples
+    assert '"bounty_repo": "ramimbo/mergework"' in examples
     assert '"bounty_id": 37' in examples
     assert '"bounty_issue_number": 219' in examples
+    assert '"bounty_issue_url": "https://github.com/ramimbo/mergework/issues/219"' in examples
+    assert '"bounty_url": "/bounties/37"' in examples
+    assert "bounty repo, bounty issue URL" in examples
     assert "newest ledger sequence" in examples
     assert "/api/v1/proofs/<proof_hash>" in examples


### PR DESCRIPTION
Bounty #411

## Summary
- Update the public `/api/v1/activity` example so contributor rollups include latest bounty metadata.
- Update recent activity row examples with `bounty_repo`, `bounty_issue_url`, and `bounty_url` fields that the current serializer and live API return.
- Add docs regression assertions for the documented activity fields.

## Evidence
Compared `docs/api-examples.md` with current code in `app/serializers.py` and the live unauthenticated endpoint:

```bash
curl -s 'https://api.mrwk.ltclab.site/api/v1/activity?limit=1' | jq '{keys:keys, recent0:.recent[0]}'
```

Observed live `recent[0]` includes `bounty_repo`, `bounty_issue_url`, and `bounty_url` alongside `bounty_id` and `bounty_issue_number`. The old docs example only showed `bounty_id` and `bounty_issue_number`.

Expected PR size: small docs/test update.

## Tests
- `/Users/daneul.kim/Documents/New\ project/bounty-work/mergework/.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `/Users/daneul.kim/Documents/New\ project/bounty-work/mergework/.venv/bin/python -m pytest tests/test_docs_public_urls.py -q` -> 17 passed
- `/Users/daneul.kim/Documents/New\ project/bounty-work/mergework/.venv/bin/python -m ruff check docs/api-examples.md tests/test_docs_public_urls.py` -> passed
- `git diff --check` -> clean

No private keys, seed material, secrets, private vulnerability details, deployment credentials, price claims, investment claims, liquidity claims, bridge promises, exchange claims, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded activity API docs with additional query filter options to support filtering by bounty repository and bounty issue URL.
  * Updated example activity response to include richer bounty metadata: contributor-level latest bounty fields and bounty fields on recent activity entries (repo, issue number, issue URL, and bounty URL).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->