### PR TITLE
Add PR queue health markdown output

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -105,6 +105,13 @@ Use the queue-health script before accepting busy bounty rounds:
 python scripts/pr_queue_health.py --repo ramimbo/mergework --format text
 ```
 
+For a report that can be pasted directly into a GitHub issue, PR comment, or
+payment-batch note, use Markdown output:
+
+```bash
+python scripts/pr_queue_health.py --repo ramimbo/mergework --format markdown
+```
+
 Live mode requires an authenticated GitHub CLI with access to the repository.
 The command only reads PRs and issues; it does not close PRs, label issues, or
 post comments. It reports missing bounty references, closed or exhausted bounty

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -211,6 +211,48 @@ def format_text_report(report: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _single_line(value: Any) -> str:
+    return " ".join(str(value or "").split())
+
+
+def _markdown_pr_issue(item: dict[str, Any]) -> str:
+    pr_label = f"PR #{item['pull_request']}"
+    url = item.get("url")
+    if isinstance(url, str) and url:
+        pr_label = f"[{pr_label}]({url})"
+    return f"- {pr_label}: {_single_line(item['title'])} ({_single_line(item['detail'])})"
+
+
+def format_markdown_report(report: dict[str, Any]) -> str:
+    lines = ["## PR Queue Health Summary", ""]
+    for key, value in report["summary"].items():
+        lines.append(f"- **{key.replace('_', ' ')}**: {value}")
+    if not has_queue_issues(report):
+        lines.append("")
+        lines.append("No queue-health issues found.")
+        return "\n".join(lines)
+
+    sections = [
+        ("Closed or exhausted bounty references", "closed_bounty_references"),
+        ("Missing bounty references", "missing_bounty_references"),
+        ("Dirty or unstable merge state", "dirty_or_unstable_merge_state"),
+        ("Needs info", "needs_info"),
+    ]
+    for title, key in sections:
+        if report[key]:
+            lines.append("")
+            lines.append(f"### {title}")
+            for item in report[key]:
+                lines.append(_markdown_pr_issue(item))
+    if report["duplicate_scope_groups"]:
+        lines.append("")
+        lines.append("### Likely duplicate bounty scope")
+        for item in report["duplicate_scope_groups"]:
+            prs = ", ".join(f"#{number}" for number in item["pull_requests"])
+            lines.append(f"- Bounty #{item['bounty']}: {_single_line(item['scope'])} ({prs})")
+    return "\n".join(lines)
+
+
 def _run_gh_json(args: list[str]) -> Any:
     command = " ".join(args)
     try:
@@ -305,7 +347,7 @@ def main(argv: list[str] | None = None) -> int:
         "--repo",
         help="Collect live queue data with gh, for example ramimbo/mergework.",
     )
-    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--format", choices=["json", "markdown", "text"], default="text")
     parser.add_argument("--fail-on-issues", action="store_true")
     args = parser.parse_args(argv)
 
@@ -313,6 +355,8 @@ def main(argv: list[str] | None = None) -> int:
     report = analyze_queue(data)
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))
+    elif args.format == "markdown":
+        print(format_markdown_report(report))
     else:
         print(format_text_report(report))
     return 1 if args.fail_on_issues and has_queue_issues(report) else 0

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -6,7 +6,7 @@ import subprocess
 import pytest
 
 from scripts import pr_queue_health
-from scripts.pr_queue_health import analyze_queue, format_text_report, main
+from scripts.pr_queue_health import analyze_queue, format_markdown_report, format_text_report, main
 
 
 def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
@@ -105,6 +105,97 @@ def test_pr_queue_health_text_report_is_pasteable() -> None:
     assert "PR queue health summary" in text
     assert "pull requests: 1" in text
     assert "No queue-health issues found." in text
+
+
+def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [
+                {"number": 292, "state": "OPEN", "awards_remaining": 13},
+                {"number": 293, "state": "CLOSED", "awards_remaining": 0},
+            ],
+            "pull_requests": [
+                {
+                    "number": 1,
+                    "title": "Add public bounty summary API",
+                    "url": "https://github.com/ramimbo/mergework/pull/1",
+                    "body": "Refs #293",
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+                {
+                    "number": 2,
+                    "title": "Improve bounty filters",
+                    "url": "https://github.com/ramimbo/mergework/pull/2",
+                    "body": "",
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+                {
+                    "number": 3,
+                    "title": "Guard MCP bounty search oversized numeric query",
+                    "url": "https://github.com/ramimbo/mergework/pull/3",
+                    "body": "Bounty #292",
+                    "merge_state": "dirty",
+                    "labels": ["mrwk:needs-info"],
+                },
+                {
+                    "number": 4,
+                    "title": "Guard MCP bounty search oversized numeric query",
+                    "url": "https://github.com/ramimbo/mergework/pull/4",
+                    "body": "Refs #292",
+                    "merge_state": "unknown",
+                    "labels": [],
+                },
+            ],
+        }
+    )
+
+    markdown = format_markdown_report(report)
+
+    assert markdown.startswith("## PR Queue Health Summary")
+    assert "- **pull requests**: 4" in markdown
+    assert "### Closed or exhausted bounty references" in markdown
+    assert (
+        "- [PR #1](https://github.com/ramimbo/mergework/pull/1): "
+        "Add public bounty summary API (Referenced bounty #293 is not payable)"
+    ) in markdown
+    assert "### Missing bounty references" in markdown
+    assert (
+        "- [PR #2](https://github.com/ramimbo/mergework/pull/2): "
+        "Improve bounty filters (No Bounty #<issue> or Refs #<issue> found)"
+    ) in markdown
+    assert "### Dirty or unstable merge state" in markdown
+    assert "Merge state is dirty" in markdown
+    assert "### Needs info" in markdown
+    assert "PR has mrwk:needs-info label" in markdown
+    assert "### Likely duplicate bounty scope" in markdown
+    assert "- Bounty #292: guard mcp bounty search oversized numeric query (#3, #4)" in markdown
+
+
+def test_pr_queue_health_markdown_no_issues_output_is_pasteable(tmp_path, capsys) -> None:
+    fixture = {
+        "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 5}],
+        "pull_requests": [
+            {
+                "number": 8,
+                "title": "Review open PRs",
+                "body": "Refs #310",
+                "merge_state": "clean",
+                "labels": [],
+            }
+        ],
+    }
+    input_path = tmp_path / "queue.json"
+    input_path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    exit_code = main(["--input", str(input_path), "--format", "markdown"])
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert output.startswith("## PR Queue Health Summary")
+    assert "- **pull requests**: 1" in output
+    assert "No queue-health issues found." in output
 
 
 def test_pr_queue_health_wraps_gh_failures(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- Add a deterministic `--format markdown` output mode for `scripts/pr_queue_health.py`.
- Keep existing text and JSON behavior stable while adding GitHub-pasteable Markdown sections for queue-health findings.
- Document the Markdown command in the admin runbook.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: maintainers can currently emit text or JSON queue-health reports, but not a clean Markdown report for GitHub comments or payment-batch notes.
- Bounty capacity and active attempts/open PRs checked: `Bounty #409` is open; before implementation I checked current PRs for `409` / markdown queue-health work and found no matching PR.
- Intended files or surfaces: `scripts/pr_queue_health.py`, `tests/test_pr_queue_health.py`, `docs/admin-runbook.md`.
- Expected PR size: small, format-only feature with fixture coverage.
- Out of scope: no GitHub mutation behavior, no report schema rewrite, no text/JSON output changes.

## Test Evidence

- [x] `ruff format --check .`
- [x] `ruff check .`
- [x] `mypy app`
- [x] `pytest`
- [x] `python scripts/docs_smoke.py` (docs, template, example, or onboarding changes)

## MRWK

Related bounty or issue: Bounty #409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* PR queue health reports can now be generated in Markdown format, enabling reports to be directly pasted into GitHub issues, pull request comments, and other documentation without reformatting.

## Documentation
* Updated Admin Runbook with instructions for generating Markdown-formatted queue health reports.

## Tests
* Added comprehensive test coverage for Markdown report generation, including validation of section headers and required content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->