### PR TITLE
feat: add markdown PR queue health report

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -103,6 +103,7 @@ Use the queue-health script before accepting busy bounty rounds:
 
 ```bash
 python scripts/pr_queue_health.py --repo ramimbo/mergework --format text
+python scripts/pr_queue_health.py --repo ramimbo/mergework --format markdown
 ```
 
 Live mode requires an authenticated GitHub CLI with access to the repository.
@@ -115,6 +116,7 @@ For offline checks, save fixture data and run:
 
 ```bash
 python scripts/pr_queue_health.py --input queue.json --format json --fail-on-issues
+python scripts/pr_queue_health.py --input queue.json --format markdown
 ```
 
 `--fail-on-issues` exits nonzero when queue-health problems are found, which lets

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -211,6 +211,82 @@ def format_text_report(report: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _sort_by_pull_request(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(items, key=lambda item: item.get("pull_request", 0))
+
+
+def _pr_ref(item: dict[str, Any]) -> str:
+    url = item.get("url")
+    if isinstance(url, str) and url:
+        return f"[#{item['pull_request']}]({url})"
+    return f"#{item['pull_request']}"
+
+
+def format_markdown_report(report: dict[str, Any]) -> str:
+    lines = ["# PR Queue Health"]
+    lines.append("")
+    lines.append("## Summary")
+    for key, value in report["summary"].items():
+        lines.append(f"- {key.replace('_', ' ')}: `{value}`")
+
+    if not has_queue_issues(report):
+        lines.append("")
+        lines.append("## No queue-health issues found.")
+        return "\n".join(lines)
+
+    sections = [
+        (
+            "## Closed or exhausted bounty references",
+            "closed_bounty_references",
+            lambda item: f"{_pr_ref(item)}: {item['title']} ({item['detail']})",
+        ),
+        (
+            "## Missing bounty references",
+            "missing_bounty_references",
+            lambda item: f"{_pr_ref(item)}: {item['title']} ({item['detail']})",
+        ),
+        (
+            "## Dirty or unstable merge state",
+            "dirty_or_unstable_merge_state",
+            lambda item: f"{_pr_ref(item)}: {item['title']} ({item['detail']})",
+        ),
+        (
+            "## Needs info",
+            "needs_info",
+            lambda item: f"{_pr_ref(item)}: {item['title']} ({item['detail']})",
+        ),
+    ]
+
+    for title, key, formatter in sections:
+        issues = _sort_by_pull_request(report[key])
+        if issues:
+            lines.append("")
+            lines.append(title)
+            for item in issues:
+                lines.append(f"- {formatter(item)}")
+
+    duplicates = sorted(
+        report["duplicate_scope_groups"],
+        key=lambda item: (
+            item.get("bounty", 0),
+            item.get("scope", ""),
+            tuple(item.get("pull_requests", ())),
+        ),
+    )
+    if duplicates:
+        lines.append("")
+        lines.append("## Likely duplicate bounty scope")
+        for item in duplicates:
+            prs = ", ".join(
+                _pr_ref({"pull_request": number, "url": None})
+                for number in item["pull_requests"]
+            )
+            scope = item["scope"] or "(no scope)"
+            lines.append(f"- Bounty #{item['bounty']}: {scope} ({prs})")
+
+    return "\n".join(lines)
+
+
 def _run_gh_json(args: list[str]) -> Any:
     command = " ".join(args)
     try:
@@ -305,7 +381,7 @@ def main(argv: list[str] | None = None) -> int:
         "--repo",
         help="Collect live queue data with gh, for example ramimbo/mergework.",
     )
-    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--format", choices=["json", "text", "markdown"], default="text")
     parser.add_argument("--fail-on-issues", action="store_true")
     args = parser.parse_args(argv)
 
@@ -313,6 +389,8 @@ def main(argv: list[str] | None = None) -> int:
     report = analyze_queue(data)
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))
+    elif args.format == "markdown":
+        print(format_markdown_report(report))
     else:
         print(format_text_report(report))
     return 1 if args.fail_on_issues and has_queue_issues(report) else 0

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -278,8 +278,7 @@ def format_markdown_report(report: dict[str, Any]) -> str:
         lines.append("## Likely duplicate bounty scope")
         for item in duplicates:
             prs = ", ".join(
-                _pr_ref({"pull_request": number, "url": None})
-                for number in item["pull_requests"]
+                _pr_ref({"pull_request": number, "url": None}) for number in item["pull_requests"]
             )
             scope = item["scope"] or "(no scope)"
             lines.append(f"- Bounty #{item['bounty']}: {scope} ({prs})")

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -212,10 +212,12 @@ def format_text_report(report: dict[str, Any]) -> str:
 
 
 def _sort_by_pull_request(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return report items in stable pull-request order."""
     return sorted(items, key=lambda item: item.get("pull_request", 0))
 
 
 def _pr_ref(item: dict[str, Any]) -> str:
+    """Render a pull request reference as a Markdown link when possible."""
     url = item.get("url")
     if isinstance(url, str) and url:
         return f"[#{item['pull_request']}]({url})"
@@ -223,6 +225,7 @@ def _pr_ref(item: dict[str, Any]) -> str:
 
 
 def format_markdown_report(report: dict[str, Any]) -> str:
+    """Format a queue-health report as GitHub-pasteable Markdown."""
     lines = ["# PR Queue Health"]
     lines.append("")
     lines.append("## Summary")

--- a/tests/fixtures/queue_markdown_closed_exhausted.json
+++ b/tests/fixtures/queue_markdown_closed_exhausted.json
@@ -1,0 +1,16 @@
+{
+  "bounties": [
+    {"number": 1001, "state": "OPEN", "awards_remaining": 1},
+    {"number": 1002, "state": "CLOSED", "awards_remaining": 0}
+  ],
+  "pull_requests": [
+    {
+      "number": 111,
+      "title": "Fix queue status rendering",
+      "url": "https://github.com/ramimbo/mergework/pull/111",
+      "body": "Refs #1002",
+      "merge_state": "clean",
+      "labels": []
+    }
+  ]
+}

--- a/tests/fixtures/queue_markdown_dirty_merge.json
+++ b/tests/fixtures/queue_markdown_dirty_merge.json
@@ -1,0 +1,15 @@
+{
+  "bounties": [
+    {"number": 1201, "state": "OPEN", "awards_remaining": 4}
+  ],
+  "pull_requests": [
+    {
+      "number": 131,
+      "title": "Improve merge checks",
+      "url": "https://github.com/ramimbo/mergework/pull/131",
+      "body": "Refs #1201",
+      "merge_state": "dirty",
+      "labels": []
+    }
+  ]
+}

--- a/tests/fixtures/queue_markdown_duplicate_scope.json
+++ b/tests/fixtures/queue_markdown_duplicate_scope.json
@@ -1,0 +1,23 @@
+{
+  "bounties": [
+    {"number": 1501, "state": "OPEN", "awards_remaining": 2}
+  ],
+  "pull_requests": [
+    {
+      "number": 161,
+      "title": "Update queue checks",
+      "url": "https://github.com/ramimbo/mergework/pull/161",
+      "body": "Refs #1501",
+      "merge_state": "clean",
+      "labels": []
+    },
+    {
+      "number": 162,
+      "title": "Update queue checks",
+      "url": "https://github.com/ramimbo/mergework/pull/162",
+      "body": "Refs #1501",
+      "merge_state": "clean",
+      "labels": []
+    }
+  ]
+}

--- a/tests/fixtures/queue_markdown_missing_reference.json
+++ b/tests/fixtures/queue_markdown_missing_reference.json
@@ -1,0 +1,15 @@
+{
+  "bounties": [
+    {"number": 1401, "state": "OPEN", "awards_remaining": 3}
+  ],
+  "pull_requests": [
+    {
+      "number": 151,
+      "title": "Update queue checks",
+      "url": "https://github.com/ramimbo/mergework/pull/151",
+      "body": "",
+      "merge_state": "clean",
+      "labels": []
+    }
+  ]
+}

--- a/tests/fixtures/queue_markdown_needs_info.json
+++ b/tests/fixtures/queue_markdown_needs_info.json
@@ -1,0 +1,15 @@
+{
+  "bounties": [
+    {"number": 1101, "state": "OPEN", "awards_remaining": 2}
+  ],
+  "pull_requests": [
+    {
+      "number": 121,
+      "title": "Need extra evidence in submission",
+      "url": "https://github.com/ramimbo/mergework/pull/121",
+      "body": "Bounty #1101",
+      "merge_state": "clean",
+      "labels": ["mrwk:needs-info"]
+    }
+  ]
+}

--- a/tests/fixtures/queue_markdown_no_issues.json
+++ b/tests/fixtures/queue_markdown_no_issues.json
@@ -1,0 +1,15 @@
+{
+  "bounties": [
+    {"number": 1301, "state": "OPEN", "awards_remaining": 7}
+  ],
+  "pull_requests": [
+    {
+      "number": 141,
+      "title": "Update queue health docs",
+      "url": "https://github.com/ramimbo/mergework/pull/141",
+      "body": "Refs #1301",
+      "merge_state": "clean",
+      "labels": []
+    }
+  ]
+}

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -2,11 +2,20 @@ from __future__ import annotations
 
 import json
 import subprocess
+from pathlib import Path
 
 import pytest
 
 from scripts import pr_queue_health
-from scripts.pr_queue_health import analyze_queue, format_text_report, main
+from scripts.pr_queue_health import analyze_queue, format_markdown_report, format_text_report, main
+
+FIXTURES_DIR = Path(__file__).with_name("fixtures")
+
+
+def _load_fixture(name: str) -> dict:
+    path = FIXTURES_DIR / name
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
 
 
 def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
@@ -105,6 +114,62 @@ def test_pr_queue_health_text_report_is_pasteable() -> None:
     assert "PR queue health summary" in text
     assert "pull requests: 1" in text
     assert "No queue-health issues found." in text
+
+
+def test_pr_queue_health_markdown_report_includes_closed_exhausted_and_no_sections() -> None:
+    report = analyze_queue(_load_fixture("queue_markdown_closed_exhausted.json"))
+    output = format_markdown_report(report)
+
+    assert "## Summary" in output
+    assert "## Closed or exhausted bounty references" in output
+    assert "## No queue-health issues found." not in output
+
+
+def test_pr_queue_health_markdown_report_includes_needs_info_and_dirty_states() -> None:
+    needs_info = format_markdown_report(
+        analyze_queue(_load_fixture("queue_markdown_needs_info.json"))
+    )
+    dirty = format_markdown_report(analyze_queue(_load_fixture("queue_markdown_dirty_merge.json")))
+
+    assert "## Needs info" in needs_info
+    assert "## Dirty or unstable merge state" in dirty
+
+
+def test_pr_queue_health_markdown_report_includes_missing_sections() -> None:
+    output = format_markdown_report(
+        analyze_queue(_load_fixture("queue_markdown_missing_reference.json"))
+    )
+
+    assert "## Missing bounty references" in output
+    assert "No queue-health issues found" not in output
+
+
+def test_pr_queue_health_markdown_report_includes_duplicate_scope_section() -> None:
+    output = format_markdown_report(
+        analyze_queue(_load_fixture("queue_markdown_duplicate_scope.json"))
+    )
+
+    assert "## Likely duplicate bounty scope" in output
+
+
+def test_pr_queue_health_markdown_report_from_input_handles_no_issues(capsys) -> None:
+    no_issues = FIXTURES_DIR / "queue_markdown_no_issues.json"
+    exit_code = main(["--input", str(no_issues), "--format", "markdown"])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "## No queue-health issues found." in output
+    assert "## Closed or exhausted bounty references" not in output
+    assert "## Needs info" not in output
+    assert "## Dirty or unstable merge state" not in output
+
+
+def test_pr_queue_health_markdown_format_is_parseable_from_cli(capsys) -> None:
+    fixture = FIXTURES_DIR / "queue_markdown_no_issues.json"
+    exit_code = main(["--input", str(fixture), "--format", "markdown", "--fail-on-issues"])
+
+    assert exit_code == 0
+    assert capsys.readouterr().out.startswith("# PR Queue Health\n")
 
 
 def test_pr_queue_health_wraps_gh_failures(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- add `--format markdown` to `scripts/pr_queue_health.py`
- keep existing text and JSON output behavior intact
- render deterministic GitHub-pasteable sections for closed/exhausted bounty refs, missing bounty refs, dirty/unstable merge state, `mrwk:needs-info`, and likely duplicate scope groups
- add fixture-based tests for Markdown output and document the new command in the admin runbook

Bounty #409

## Evidence

The Markdown mode is read-only and uses the existing queue analysis result. It does not close PRs, apply labels, push branches, post comments, or mutate GitHub state.

Manual CLI smoke checks:

- `py -3.12 scripts\pr_queue_health.py --input tests\fixtures\queue_markdown_duplicate_scope.json --format markdown`
- `py -3.12 scripts\pr_queue_health.py --input tests\fixtures\queue_markdown_no_issues.json --format markdown --fail-on-issues` -> exit `0`
- `py -3.12 scripts\pr_queue_health.py --input tests\fixtures\queue_markdown_closed_exhausted.json --format markdown --fail-on-issues` -> exit `1`

## Validation

- `py -3.12 -m ruff check scripts/pr_queue_health.py tests/test_pr_queue_health.py` -> passed
- `py -3.12 -m pytest tests/test_pr_queue_health.py -q` -> `12 passed`
- `py -3.12 scripts\docs_smoke.py` -> `docs smoke ok`
- `py -3.12 -m pytest tests/test_docs_public_urls.py -q` -> `17 passed`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Markdown output for PR queue health; CLI now supports a markdown format alongside JSON and plain text.

* **Documentation**
  * Updated admin runbook with Markdown-format examples for queue health reporting.

* **Tests**
  * Added fixtures and tests covering Markdown report generation and CLI behavior across closed/exhausted, dirty/unstable, missing-reference, needs-info, duplicate-scope, and no-issues scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->