### PR TITLE
feat: add markdown PR queue health report

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -103,13 +103,15 @@ Use the queue-health script before accepting busy bounty rounds:
 
 ```bash
 python scripts/pr_queue_health.py --repo ramimbo/mergework --format text
+python scripts/pr_queue_health.py --repo ramimbo/mergework --format markdown
 ```
 
 Live mode requires an authenticated GitHub CLI with access to the repository.
 The command only reads PRs and issues; it does not close PRs, label issues, or
 post comments. It reports missing bounty references, closed or exhausted bounty
 references, dirty or unknown merge state, `mrwk:needs-info`, and likely duplicate
-PR scope within the same bounty issue.
+PR scope within the same bounty issue. Use `--format markdown` when you need a
+GitHub-ready report for an issue, PR comment, or payment-batch note.
 
 For offline checks, save fixture data and run:
 

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -211,6 +211,48 @@ def format_text_report(report: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _markdown_pr_link(item: dict[str, Any]) -> str:
+    label = f"PR #{item['pull_request']}"
+    if item.get("url"):
+        return f"[{label}]({item['url']})"
+    return label
+
+
+def format_markdown_report(report: dict[str, Any]) -> str:
+    lines = [
+        "## PR Queue Health Summary",
+        "",
+        "| Metric | Count |",
+        "| --- | ---: |",
+    ]
+    for key, value in report["summary"].items():
+        lines.append(f"| {key.replace('_', ' ').title()} | {value} |")
+    if not has_queue_issues(report):
+        lines.append("")
+        lines.append("No queue-health issues found.")
+        return "\n".join(lines)
+
+    sections = [
+        ("Closed or Exhausted Bounty References", "closed_bounty_references"),
+        ("Missing Bounty References", "missing_bounty_references"),
+        ("Dirty or Unstable Merge State", "dirty_or_unstable_merge_state"),
+        ("Needs Info", "needs_info"),
+    ]
+    for title, key in sections:
+        if report[key]:
+            lines.append("")
+            lines.append(f"### {title}")
+            for item in report[key]:
+                lines.append(f"- {_markdown_pr_link(item)}: {item['title']} ({item['detail']})")
+    if report["duplicate_scope_groups"]:
+        lines.append("")
+        lines.append("### Likely Duplicate Bounty Scope")
+        for item in report["duplicate_scope_groups"]:
+            prs = ", ".join(f"#{number}" for number in item["pull_requests"])
+            lines.append(f"- Bounty #{item['bounty']}: `{item['scope']}` ({prs})")
+    return "\n".join(lines)
+
+
 def _run_gh_json(args: list[str]) -> Any:
     command = " ".join(args)
     try:
@@ -305,7 +347,7 @@ def main(argv: list[str] | None = None) -> int:
         "--repo",
         help="Collect live queue data with gh, for example ramimbo/mergework.",
     )
-    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--format", choices=["json", "markdown", "text"], default="text")
     parser.add_argument("--fail-on-issues", action="store_true")
     args = parser.parse_args(argv)
 
@@ -313,6 +355,8 @@ def main(argv: list[str] | None = None) -> int:
     report = analyze_queue(data)
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))
+    elif args.format == "markdown":
+        print(format_markdown_report(report))
     else:
         print(format_text_report(report))
     return 1 if args.fail_on_issues and has_queue_issues(report) else 0

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -6,7 +6,7 @@ import subprocess
 import pytest
 
 from scripts import pr_queue_health
-from scripts.pr_queue_health import analyze_queue, format_text_report, main
+from scripts.pr_queue_health import analyze_queue, format_markdown_report, format_text_report, main
 
 
 def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
@@ -105,6 +105,90 @@ def test_pr_queue_health_text_report_is_pasteable() -> None:
     assert "PR queue health summary" in text
     assert "pull requests: 1" in text
     assert "No queue-health issues found." in text
+
+
+def test_pr_queue_health_markdown_report_includes_actionable_sections() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [
+                {"number": 292, "state": "OPEN", "awards_remaining": 1},
+                {"number": 293, "state": "CLOSED", "awards_remaining": 0},
+            ],
+            "pull_requests": [
+                {
+                    "number": 1,
+                    "title": "Closed bounty target",
+                    "url": "https://github.com/ramimbo/mergework/pull/1",
+                    "body": "Refs #293",
+                    "merge_state": "dirty",
+                    "labels": ["mrwk:needs-info"],
+                },
+                {
+                    "number": 2,
+                    "title": "Missing bounty target",
+                    "url": "https://github.com/ramimbo/mergework/pull/2",
+                    "body": "",
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+                {
+                    "number": 3,
+                    "title": "Duplicate cleanup scope",
+                    "url": "https://github.com/ramimbo/mergework/pull/3",
+                    "body": "Bounty #292",
+                    "merge_state": "unknown",
+                    "labels": [],
+                },
+                {
+                    "number": 4,
+                    "title": "Duplicate cleanup scope",
+                    "url": "https://github.com/ramimbo/mergework/pull/4",
+                    "body": "Refs #292",
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+            ],
+        }
+    )
+
+    markdown = format_markdown_report(report)
+
+    assert markdown.startswith("## PR Queue Health Summary")
+    assert "| Closed Bounty References | 1 |" in markdown
+    assert "### Closed or Exhausted Bounty References" in markdown
+    assert "[PR #1](https://github.com/ramimbo/mergework/pull/1)" in markdown
+    assert "### Missing Bounty References" in markdown
+    assert "[PR #2](https://github.com/ramimbo/mergework/pull/2)" in markdown
+    assert "### Dirty or Unstable Merge State" in markdown
+    assert "Merge state is dirty" in markdown
+    assert "### Needs Info" in markdown
+    assert "PR has mrwk:needs-info label" in markdown
+    assert "### Likely Duplicate Bounty Scope" in markdown
+    assert "Bounty #292: `duplicate cleanup scope` (#3, #4)" in markdown
+
+
+def test_pr_queue_health_markdown_report_handles_no_issues() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 5}],
+            "pull_requests": [
+                {
+                    "number": 8,
+                    "title": "Review open PRs",
+                    "body": "Refs #310",
+                    "merge_state": "clean",
+                    "labels": [],
+                }
+            ],
+        }
+    )
+
+    markdown = format_markdown_report(report)
+
+    assert "## PR Queue Health Summary" in markdown
+    assert "| Pull Requests | 1 |" in markdown
+    assert "No queue-health issues found." in markdown
+    assert "### Closed or Exhausted Bounty References" not in markdown
 
 
 def test_pr_queue_health_wraps_gh_failures(monkeypatch) -> None:


### PR DESCRIPTION
Bounty #409

Summary:
- Add a deterministic `--format markdown` output for `scripts/pr_queue_health.py`.
- Keep the existing JSON and text output paths unchanged.
- Include GitHub-ready sections for closed/exhausted bounty refs, missing refs, dirty/unstable merge state, needs-info, and likely duplicate scope groups.
- Document the markdown format in the admin runbook.

Validation:
- `python -m pytest tests/test_pr_queue_health.py -q` -> 8 passed
- `python scripts/docs_smoke.py` -> docs smoke ok
- `python -m ruff check scripts/pr_queue_health.py tests/test_pr_queue_health.py docs/admin-runbook.md` -> all checks passed
- `git diff --check` -> clean

Expected PR size: 3 files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR Queue Health tool now supports Markdown output format via `--format markdown`, enabling generation of GitHub-ready reports suitable for pull request comments, issues, and payment batch notes with properly formatted bounty scope details.

* **Documentation**
  * Updated admin runbook with example commands demonstrating how to generate PR Queue Health reports in Markdown format for use in GitHub comments and notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->