### PR TITLE
chore: tune CodeRabbit review style

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,108 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+tone_instructions: "Be concise, direct, evidence-backed, and human. No hype, jokes, poems, emojis, or MRWK price/cash-out claims. Put blockers first."
+early_access: false
+enable_free_tier: true
+inheritance: false
+
+reviews:
+  profile: assertive
+  request_changes_workflow: false
+  review_status: true
+  review_details: false
+  collapse_walkthrough: true
+  changed_files_summary: true
+  high_level_summary: true
+  high_level_summary_in_walkthrough: false
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  suggested_labels: false
+  suggested_reviewers: false
+  auto_apply_labels: false
+  auto_assign_reviewers: false
+  related_issues: true
+  related_prs: true
+  poem: false
+  in_progress_fortune: false
+  enable_prompt_for_ai_agents: false
+
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: false
+
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
+    title:
+      mode: warning
+      requirements: "Use a short, concrete title that names the changed surface."
+    description:
+      mode: warning
+    issue_assessment:
+      mode: warning
+    custom_checks:
+      - name: MergeWork public artifact hygiene
+        mode: warning
+        instructions: "For README, docs, PR descriptions, and public comments, flag investment claims, price claims, cash-out/off-ramp claims, fabricated payout claims, or private security details. MRWK should be described as a native project coin that may support future snapshots, bridges, and onchain claims."
+      - name: Bounty PR focus
+        mode: warning
+        instructions: "When a PR references Bounty #N or Refs #N, check that the diff matches the stated files or surfaces, includes evidence and test output where relevant, and avoids unrelated scope."
+
+  path_instructions:
+    - path: "README.md"
+      instructions: "Keep public wording conservative and direct. MRWK is native to the MergeWork ledger today. Do not imply a current fiat, BTC, USDC, bridge, exchange, off-ramp, cash-out, price, or investment path."
+    - path: "docs/**/*.md"
+      instructions: "Review docs for short, concrete prose. Flag speculative MRWK claims, private security details, stale workflow instructions, and missing command or endpoint evidence."
+    - path: ".github/pull_request_template.md"
+      instructions: "Preserve the Summary, Evidence, Test Evidence, and MRWK sections. Do not require a bounty reference for maintainer or repository-maintenance PRs."
+    - path: "app/ledger/**"
+      instructions: "Prioritize supply conservation, hash-chain continuity, payout idempotency, proof metadata, and duplicate-payment prevention."
+    - path: "app/wallets.py"
+      instructions: "Prioritize canonical payloads, Ed25519 signatures, nonce ordering, replay protection, and spend validation."
+    - path: "app/webhooks/**"
+      instructions: "Prioritize GitHub signature verification, replay/idempotency, label and payment side effects, and redacted security metadata."
+    - path: "tests/**/*.py"
+      instructions: "Do not request docstrings. Focus on whether tests prove the changed behavior and include negative, replay, boundary, or regression cases where relevant."
+
+chat:
+  art: false
+  auto_reply: true
+
+knowledge_base:
+  web_search:
+    enabled: true
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - AGENTS.md
+      - docs/AGENTS.md
+      - .github/pull_request_template.md
+      - docs/bounty-rules.md
+
+code_generation:
+  docstrings:
+    language: en-US
+    path_instructions: []
+  unit_tests:
+    path_instructions: []
+
+issue_enrichment:
+  auto_enrich:
+    enabled: false
+  planning:
+    enabled: true
+    auto_planning:
+      enabled: false
+      labels: []
+  labeling:
+    auto_apply_labels: false
+    labeling_instructions: []


### PR DESCRIPTION
## Summary

- Add a version-controlled CodeRabbit configuration at `.coderabbit.yaml`.
- Keep reviews assertive, but reduce noisy walkthrough extras and align review guidance with MergeWork's public artifact rules.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: recent CodeRabbit reviews used Repository UI configuration and produced useful findings, but also noisy label/reviewer suggestions, docstring warnings on docs/tests, finishing-touch prompts, and prose that does not fully match MergeWork's short, direct public style.
- Bounty capacity and active attempts/open PRs checked: no bounty claimed; repository-maintenance PR only.
- Intended files or surfaces: `.coderabbit.yaml` only.
- Expected PR size: one config file.
- Out of scope: changing application behavior, CI, bounty rules, or existing GitHub labels.

## Test Evidence

- [x] `./.venv/bin/python - <<'PY' ... jsonschema.validate(...) ... PY` (CodeRabbit schema validation)
- [x] `./.venv/bin/python -m pytest`
- [x] `./.venv/bin/python -m ruff format --check .`
- [x] `./.venv/bin/python -m ruff check .`
- [x] `./.venv/bin/python -m mypy app`
- [x] `./.venv/bin/python scripts/docs_smoke.py`
- [x] `git diff --check`

## MRWK

No bounty claimed. This is a repository-maintenance PR for review configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured CodeRabbit to enable automated code review with pre-merge checks and customized review settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->