### PR TITLE
docs: add MCP lookup response examples

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -516,6 +516,58 @@ In that MCP payload, `bounty_id` is the internal MergeWork bounty id. The
 `proof.issue_number` value is the source GitHub issue number when the proof was
 created from a GitHub bounty claim.
 
+Call `get_ledger_entry` with the immutable ledger sequence returned by
+`/api/v1/ledger`, `/api/v1/activity`, `get_bounty` award rows, or `get_proof`.
+The MCP response wraps the same ledger-entry shape as
+`/api/v1/ledger/<sequence>` in `result.content[0].text`:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"get_ledger_entry","arguments":{"sequence":42}}}'
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 8,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"sequence\":42,\"type\":\"bounty_payment\",\"from\":\"reserve:bounty:11\",\"to\":\"github:tatelyman\",\"amount_mrwk\":\"75\",\"reference\":\"https://github.com/ramimbo/mergework/pull/183\",\"previous_hash\":\"248e1e38f90ac42897486a2b52a938ad51f31849250c4a979358e9721ec7c64e\",\"entry_hash\":\"d0c0e8f63ad11f2cc6e5f10dc1f61c45f943f3ab126c45761283c0ccf04cb276\",\"proof_hash\":\"a29b9cf54f2ea4734d58e9371b20234f85936e95bd8c45687f0644ad6a9e6871\",\"created_at\":\"2026-05-24T20:05:00\"}"
+      }
+    ]
+  }
+}
+```
+
+Call `get_wallet` with a registered `mrwk1` address when an agent needs wallet
+metadata through MCP. The response wraps the same public wallet shape as
+`/api/v1/wallets/<wallet_address>`; unknown but well-formed wallet addresses
+return `wallet not found`:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"get_wallet","arguments":{"address":"<wallet_address>"}}}'
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 9,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"address\":\"<wallet_address>\",\"public_key_hex\":\"<64 lowercase hex chars>\",\"label\":\"MCP wallet\",\"github_login\":null,\"balance_mrwk\":\"0\",\"nonce\":0,\"next_nonce\":1,\"created_at\":\"2026-05-24T20:00:00\"}"
+      }
+    ]
+  }
+}
+```
+
 ## Pre-Bounty Preflight Checks
 
 Before opening a PR or claiming a bounty, check the live API for award capacity and active attempts. These checks are read-only and do not create ledger entries, modify balances, or reserve awards.

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -186,6 +186,27 @@ def test_api_examples_document_mcp_wallet_transfer_response() -> None:
     assert '\\"memo\\":\\"agent payout consolidation\\"' in examples
 
 
+def test_api_examples_document_mcp_lookup_response_shapes() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert '"name":"get_ledger_entry"' in examples
+    assert '"arguments":{"sequence":42}' in examples
+    assert "same ledger-entry shape as" in examples
+    assert '\\"sequence\\":42' in examples
+    assert '\\"type\\":\\"bounty_payment\\"' in examples
+    assert (
+        '\\"proof_hash\\":\\"a29b9cf54f2ea4734d58e9371b20234f85936e95bd8c45687f0644ad6a9e6871\\"'
+        in examples
+    )
+    assert '"name":"get_wallet"' in examples
+    assert '"arguments":{"address":"<wallet_address>"}' in examples
+    assert "same public wallet shape as" in examples
+    assert "wallet not found" in examples
+    assert '\\"address\\":\\"<wallet_address>\\"' in examples
+    assert '\\"label\\":\\"MCP wallet\\"' in examples
+    assert '\\"next_nonce\\":1' in examples
+
+
 def test_agent_guide_explains_internal_bounty_ids() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- Add direct MCP examples for `get_ledger_entry` and `get_wallet`.
- Document that both tools wrap their JSON payloads in `result.content[0].text`.
- Add docs regression assertions for the command arguments and response-shape fields.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: `docs/agent-guide.md` lists these MCP tools and the app implements them, but `docs/api-examples.md` did not show direct calls or the wrapped response shapes agents receive from MCP.
- Bounty capacity and active attempts/open PRs checked: Bounty #411 is open; PR #412 covers `/api/v1/activity` examples, not these MCP lookup examples; a targeted open-PR search for `get_ledger_entry` / `get_wallet` found no matching open PR.
- Intended files or surfaces: `docs/api-examples.md`, `tests/test_docs_public_urls.py`.
- Expected PR size: small docs/test-only example update.
- Out of scope: no application behavior changes, no activity API docs changes, no wallet secret/private-key material, no MRWK price or investment claims.

## Test Evidence

- [x] `.venv/bin/python -m ruff format --check .`
- [x] `.venv/bin/python -m ruff check .`
- [x] `.venv/bin/python -m mypy app`
- [x] `.venv/bin/python -m pytest`
- [x] `.venv/bin/python scripts/docs_smoke.py` (docs, template, example, or onboarding changes)
- [x] `git diff --check`

## MRWK

Related bounty or issue: Bounty #411


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added MCP API example documentation with request and response patterns for ledger entry lookups and wallet address queries, including detailed response structure details.

* **Tests**
  * Added automated test to validate API documentation accuracy, ensuring examples contain required content fields and maintain expected response patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->