### PR TITLE
Add markdown output for PR queue health

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -103,18 +103,21 @@ Use the queue-health script before accepting busy bounty rounds:
 
 ```bash
 python scripts/pr_queue_health.py --repo ramimbo/mergework --format text
+python scripts/pr_queue_health.py --repo ramimbo/mergework --format markdown
 ```
 
 Live mode requires an authenticated GitHub CLI with access to the repository.
 The command only reads PRs and issues; it does not close PRs, label issues, or
 post comments. It reports missing bounty references, closed or exhausted bounty
 references, dirty or unknown merge state, `mrwk:needs-info`, and likely duplicate
-PR scope within the same bounty issue.
+PR scope within the same bounty issue. Use `--format markdown` for a pasteable
+GitHub issue, pull request, or discussion summary with tables.
 
 For offline checks, save fixture data and run:
 
 ```bash
 python scripts/pr_queue_health.py --input queue.json --format json --fail-on-issues
+python scripts/pr_queue_health.py --input queue.json --format markdown
 ```
 
 `--fail-on-issues` exits nonzero when queue-health problems are found, which lets

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -211,6 +211,69 @@ def format_text_report(report: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _format_markdown_issue(item: dict[str, Any]) -> str:
+    title = item["title"]
+    if item.get("url"):
+        title = f"[{title}]({item['url']})"
+    return f"| #{item['pull_request']} | {title} | {item['detail']} |"
+
+
+def _append_markdown_issue_section(
+    lines: list[str], report: dict[str, Any], title: str, key: str
+) -> None:
+    if not report[key]:
+        return
+    lines.extend(
+        [
+            "",
+            f"### {title}",
+            "",
+            "| PR | Title | Detail |",
+            "| --- | --- | --- |",
+        ]
+    )
+    lines.extend(_format_markdown_issue(item) for item in report[key])
+
+
+def format_markdown_report(report: dict[str, Any]) -> str:
+    lines = [
+        "# PR Queue Health",
+        "",
+        "## Summary",
+        "",
+        "| Metric | Count |",
+        "| --- | ---: |",
+    ]
+    for key, value in report["summary"].items():
+        lines.append(f"| {key.replace('_', ' ')} | {value} |")
+    if not has_queue_issues(report):
+        lines.extend(["", "No queue-health issues found."])
+        return "\n".join(lines)
+
+    lines.extend(["", "## Findings"])
+    for title, key in (
+        ("Closed or exhausted bounty references", "closed_bounty_references"),
+        ("Missing bounty references", "missing_bounty_references"),
+        ("Dirty or unstable merge state", "dirty_or_unstable_merge_state"),
+        ("Needs info", "needs_info"),
+    ):
+        _append_markdown_issue_section(lines, report, title, key)
+    if report["duplicate_scope_groups"]:
+        lines.extend(
+            [
+                "",
+                "### Likely duplicate bounty scope",
+                "",
+                "| Bounty | Scope | PRs |",
+                "| --- | --- | --- |",
+            ]
+        )
+        for item in report["duplicate_scope_groups"]:
+            prs = ", ".join(f"#{number}" for number in item["pull_requests"])
+            lines.append(f"| #{item['bounty']} | {item['scope']} | {prs} |")
+    return "\n".join(lines)
+
+
 def _run_gh_json(args: list[str]) -> Any:
     command = " ".join(args)
     try:
@@ -305,7 +368,7 @@ def main(argv: list[str] | None = None) -> int:
         "--repo",
         help="Collect live queue data with gh, for example ramimbo/mergework.",
     )
-    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--format", choices=["json", "markdown", "text"], default="text")
     parser.add_argument("--fail-on-issues", action="store_true")
     args = parser.parse_args(argv)
 
@@ -313,6 +376,8 @@ def main(argv: list[str] | None = None) -> int:
     report = analyze_queue(data)
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))
+    elif args.format == "markdown":
+        print(format_markdown_report(report))
     else:
         print(format_text_report(report))
     return 1 if args.fail_on_issues and has_queue_issues(report) else 0

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -6,7 +6,7 @@ import subprocess
 import pytest
 
 from scripts import pr_queue_health
-from scripts.pr_queue_health import analyze_queue, format_text_report, main
+from scripts.pr_queue_health import analyze_queue, format_markdown_report, format_text_report, main
 
 
 def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
@@ -105,6 +105,71 @@ def test_pr_queue_health_text_report_is_pasteable() -> None:
     assert "PR queue health summary" in text
     assert "pull requests: 1" in text
     assert "No queue-health issues found." in text
+
+
+def test_pr_queue_health_markdown_report_has_tables() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [
+                {"number": 292, "state": "OPEN", "awards_remaining": 1},
+                {"number": 293, "state": "CLOSED", "awards_remaining": 0},
+            ],
+            "pull_requests": [
+                {
+                    "number": 12,
+                    "title": "Update stale docs",
+                    "url": "https://github.com/ramimbo/mergework/pull/12",
+                    "body": "Refs #293",
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+                {
+                    "number": 13,
+                    "title": "Add queue report",
+                    "body": "",
+                    "merge_state": "dirty",
+                    "labels": ["mrwk:needs-info"],
+                },
+            ],
+        }
+    )
+
+    markdown = format_markdown_report(report)
+
+    assert markdown.startswith("# PR Queue Health")
+    assert "| Metric | Count |" in markdown
+    assert "| closed bounty references | 1 |" in markdown
+    assert "### Closed or exhausted bounty references" in markdown
+    assert "| #12 | [Update stale docs](https://github.com/ramimbo/mergework/pull/12)" in markdown
+    assert "### Missing bounty references" in markdown
+    assert "### Dirty or unstable merge state" in markdown
+    assert "### Needs info" in markdown
+
+
+def test_pr_queue_health_markdown_cli_output(tmp_path, capsys) -> None:
+    input_path = tmp_path / "queue.json"
+    input_path.write_text(
+        json.dumps(
+            {
+                "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 5}],
+                "pull_requests": [
+                    {
+                        "number": 8,
+                        "title": "Review open PRs",
+                        "body": "Refs #310",
+                        "merge_state": "clean",
+                        "labels": [],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(["--input", str(input_path), "--format", "markdown"])
+
+    assert exit_code == 0
+    assert "No queue-health issues found." in capsys.readouterr().out
 
 
 def test_pr_queue_health_wraps_gh_failures(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- Add `--format markdown` support to `scripts/pr_queue_health.py` with deterministic summary/finding tables.
- Add focused tests for markdown renderer and CLI output.
- Document markdown queue-health output in `docs/admin-runbook.md`.

Refs #409

## Evidence

- Bounty capacity checked: `/api/v1/bounties/69` is open for issue #409 with `awards_remaining: 1` during local verification.
- Intended files or surfaces: `scripts/pr_queue_health.py`, `tests/test_pr_queue_health.py`, `docs/admin-runbook.md`.
- Expected PR size: focused script/test/docs update.
- Out of scope: live GitHub mutation, queue-health semantics changes, label changes, or bot automation.

## Test Evidence

- [x] `pytest tests/test_pr_queue_health.py`
- [x] `python scripts/docs_smoke.py`

```bash
C:\Users\ADMIN\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m pytest tests\test_pr_queue_health.py
```

Result: `8 passed in 0.05s`

```bash
C:\Users\ADMIN\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe scripts\docs_smoke.py
```

Result: `docs smoke ok`

## MRWK

Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties): Refs #409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queue health reports can now be generated in markdown format, producing GitHub-ready summaries with metrics tables and findings.

* **Documentation**
  * Updated admin runbook to document the new markdown reporting capability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->