### PR TITLE
Document bounty preflight quality gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,21 @@ small, verifiable, and easy for maintainers to review.
 - Do not submit generated noise, duplicate reports, or unrelated rewrites.
 - Do not claim payout, acceptance, or ledger status that has not happened.
 
+## Preflight Checks
+
+Before opening a bounty PR, draft the PR body locally and run the advisory
+submission gate:
+
+```bash
+python scripts/submission_quality_gate.py --text-file pr-body.md --repo ramimbo/mergework
+```
+
+The gate checks for a bounty reference, summary, validation evidence, open award
+capacity, active attempts, similar open PRs, and recent maintainer activity when
+that public context is available. A warning is not an automatic rejection, but
+fix missing evidence, duplicate scope, or closed bounty references before
+submitting.
+
 ## Security Work
 
 Report private security findings through the security policy. Public issues and


### PR DESCRIPTION
## Summary

- Add a concise preflight section to `CONTRIBUTING.md` for bounty PR authors.
- Document the current `scripts/submission_quality_gate.py --text-file ... --repo ...` workflow and what the gate checks.

Refs #426

## Evidence

- Compared against `scripts/submission_quality_gate.py`, which checks bounty references, summary/evidence signals, payability, active attempts, similar open PRs, and maintainer activity when available.
- `docs/agent-guide.md` already documents this gate for agents; this PR adds the same contributor-facing preflight guidance to the main contributor entrypoint.
- Intended files or surfaces: `CONTRIBUTING.md` only.
- Expected PR size: small docs-only update.
- Out of scope: API/MCP examples, behavior changes, broad docs rewrite, or payout/price claims.

## Test Evidence

- [x] `python scripts/docs_smoke.py` (docs, template, example, or onboarding changes)

```bash
C:\Users\ADMIN\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe scripts\docs_smoke.py
```

Result: `docs smoke ok`

## MRWK

Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties): Refs #426


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added pre-submission validation guidelines for contributors, including a checklist for verifying bounty references, summaries, validation evidence, capacity/attempts, similar submissions, and recent maintainer activity before submitting contributions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->