### PR TITLE
docs: clarify attempt reservation authentication

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -51,10 +51,14 @@ The `<bounty_id>` value is the internal MergeWork bounty id returned by
 `/api/v1/bounties`, not the GitHub issue number.
 
 Before opening a bounty PR, sign in with GitHub and register a short-lived
-advisory attempt so other agents can see overlapping work:
+advisory attempt so other agents can see overlapping work. Public reads such as
+`GET /api/v1/bounties/{id}/attempts` do not require login, but creating or
+releasing an attempt requires the GitHub-authenticated browser session for the
+same `github:<login>` account:
 
 ```bash
 curl -s -X POST "$API_HOST/api/v1/bounties/<bounty_id>/attempts" \
+  -b "<browser-session-cookie>" \
   -H "Content-Type: application/json" \
   -d '{"submitter_account":"github:<login>","source_url":"https://github.com/<owner>/<repo>/tree/<branch>","ttl_seconds":86400}'
 ```
@@ -66,6 +70,7 @@ When you stop working, release your attempt:
 
 ```bash
 curl -s -X POST "$API_HOST/api/v1/bounty-attempts/<attempt_id>/release" \
+  -b "<browser-session-cookie>" \
   -H "Content-Type: application/json" \
   -d '{"submitter_account":"github:<login>"}'
 ```

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -41,6 +41,10 @@ REQUIRED_PUBLIC_PHRASES = {
         ),
         "require separate maintainer/contributor discussion before implementation",
     ],
+    "docs/agent-guide.md": [
+        ("Public reads such as `GET /api/v1/bounties/{id}/attempts` do not require login"),
+        ("creating or releasing an attempt requires the GitHub-authenticated browser session"),
+    ],
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"


### PR DESCRIPTION
## Summary
- Clarifies that public attempt listing is unauthenticated, while attempt create/release requires a GitHub-authenticated browser session for the matching `github:<login>` account.
- Adds browser session cookie placeholders to the POST examples.
- Extends `scripts/docs_smoke.py` so the auth distinction stays documented.

## Evidence
- `app/bounty_attempts.py` exposes `GET /api/v1/bounties/{id}/attempts` without a login dependency.
- `POST /api/v1/bounties/{id}/attempts` and `POST /api/v1/bounty-attempts/{attempt_id}/release` depend on `require_github_login` and validate the submitted account with `attempt_submitter_account`.

## Verification
- `./.venv/Scripts/python.exe scripts/docs_smoke.py`
- `./.venv/Scripts/python.exe -m pytest tests/test_bounty_attempts.py -q`
- `./.venv/Scripts/python.exe -m ruff check docs/agent-guide.md scripts/docs_smoke.py`
- `./.venv/Scripts/python.exe -m ruff format --check .`
- `git diff --check`

## Bounty Claim Packet
- Bounty reference: Refs #426 / MRWK bounty #72 documentation updates and improvements.
- Intended surfaces: `docs/agent-guide.md` attempt reservation API guidance and `scripts/docs_smoke.py` docs guard.
- Expected PR size: small docs-only patch, 2 files, currently +10/-1.
- Test plan: docs smoke, bounty attempt tests, ruff checks, format check, and diff whitespace check as listed above.
- Evidence: documented auth requirements match `app/bounty_attempts.py`; CodeRabbit pre-merge checks pass 6/6; human review approved after cross-checking the behavior.
- Out of scope: no API behavior changes, ledger/payment logic changes, wallet/claim-flow changes, price/cash-out claims, or unrelated docs churn.

Refs #426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified authentication for attempt operations: viewing attempts is publicly accessible without login; creating and releasing attempts require an authenticated GitHub browser session tied to the same account.
  * Updated API examples to show how to include the browser-session cookie when performing authenticated create/release requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->