### PR TITLE
docs: add bounty evidence templates

### DIFF
--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -56,6 +56,54 @@ After accepted work is paid, MergeWork records a public ledger proof. Public
 payment updates should point to those proofs and keep any private security or
 operational details out of public metadata.
 
+## Submission Evidence Templates
+
+Use the smallest template that makes the claim reviewable. Delete fields that do
+not apply, but keep the evidence specific enough that a maintainer can reproduce
+the work without reading unrelated context.
+
+PR or fix claim:
+
+```text
+Summary:
+Linked bounty:
+Changed files:
+Evidence:
+Tests:
+Out of scope:
+```
+
+Review claim:
+
+```text
+Reviewed PR:
+Head commit:
+Files inspected:
+Verdict:
+Validation:
+```
+
+Smoke-check or bug-report claim:
+
+```text
+Checked URL or command:
+Expected:
+Observed:
+Concise note:
+```
+
+Discussion or decision-support claim:
+
+```text
+Discussion URL:
+Category:
+Maintainer decision this supports:
+Non-goals:
+```
+
+Do not describe work as accepted, merged, or paid until the public GitHub label,
+maintainer comment, or MRWK proof exists.
+
 ## Payout Flow
 
 1. A maintainer posts a bounty and MRWK is reserved from treasury.

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -41,6 +41,13 @@ REQUIRED_PUBLIC_PHRASES = {
         ),
         "require separate maintainer/contributor discussion before implementation",
     ],
+    "docs/bounty-rules.md": [
+        "## Submission Evidence Templates",
+        "PR or fix claim:",
+        "Review claim:",
+        "Smoke-check or bug-report claim:",
+        "Discussion or decision-support claim:",
+    ],
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -47,6 +47,7 @@ REQUIRED_PUBLIC_PHRASES = {
         "Review claim:",
         "Smoke-check or bug-report claim:",
         "Discussion or decision-support claim:",
+        "Do not describe work as accepted, merged, or paid until the public GitHub label",
     ],
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")


### PR DESCRIPTION
## Summary

- Add reusable evidence templates for PR/fix claims, review claims, smoke reports, and decision-support claims in `docs/bounty-rules.md`.
- Extend `scripts/docs_smoke.py` so the new evidence-template section remains covered by docs smoke checks.

Refs #426

## Evidence

- Compared against current bounty rules and recent review/smoke/discussion bounty formats.
- Intended files or surfaces: `docs/bounty-rules.md`, `scripts/docs_smoke.py`.
- Expected PR size: small docs + docs smoke guard.
- Out of scope: API/MCP examples, attempt-auth docs, payout mechanics, price/off-ramp claims.

## Test Evidence

- [x] `./.venv/Scripts/python.exe scripts/docs_smoke.py` -> docs smoke ok
- [x] `./.venv/Scripts/python.exe -m ruff check scripts/docs_smoke.py` -> passed
- [x] `./.venv/Scripts/python.exe -m ruff format --check scripts/docs_smoke.py` -> passed
- [x] `git diff --check` -> clean

## MRWK

Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties): Refs #426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Submission Evidence Templates" section with three template formats (PR/fix, review, smoke-check/bug-report) and guidance to choose the smallest suitable template.
  * Added instruction not to describe work as accepted/merged/paid until a public label, maintainer comment, or specified proof is present.

* **Tests**
  * Extended smoke-test validation to require the new heading text, prompt lines, and the explicit constraint about describing work status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/433?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->