### PR TITLE
Improve filtered bounty empty state

### DIFF
--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -49,7 +49,12 @@
     <p>{{ bounty.acceptance }}</p>
   </article>
   {% else %}
+  {% if query_text or selected_status %}
+  <p>No bounties match these filters.</p>
+  <p><a href="/bounties">Clear filters</a></p>
+  {% else %}
   <p>No bounties yet.</p>
+  {% endif %}
   {% endfor %}
 </div>
 {% endblock %}

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -182,7 +182,13 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
 
     oversized_issue_page = client.get("/bounties", params={"q": "9" * 40})
     assert oversized_issue_page.status_code == 200
-    assert "No bounties yet." in oversized_issue_page.text
+    assert "No bounties match these filters." in oversized_issue_page.text
+    assert 'href="/bounties">Clear filters</a>' in oversized_issue_page.text
+
+    empty_status_page = client.get("/bounties?status=paid&q=proof")
+    assert empty_status_page.status_code == 200
+    assert "No bounties match these filters." in empty_status_page.text
+    assert 'href="/bounties">Clear filters</a>' in empty_status_page.text
 
     percent_search = client.get("/api/v1/bounties?q=%25")
     assert percent_search.status_code == 200


### PR DESCRIPTION
## Summary

- Make the `/bounties` empty state distinguish a filtered/search-empty result from a truly empty bounty list.
- Add a clear-filters link when search or status filters produce no matching rows.
- Cover query-only and status-plus-query empty states in `tests/test_bounty_pages.py`.

Bounty #427

## Evidence

- Current page used `No bounties yet.` even when bounties existed but the active search/status filter matched nothing.
- Intended files or surfaces: public `/bounties` template and focused bounty page tests.
- Expected PR size: small UX empty-state change.
- Out of scope: bounty card restyling, status pill work, API response shape changes, broad redesign.

## Test Evidence

- [x] `./.venv/Scripts/python.exe -m pytest tests/test_bounty_pages.py -q` -> 6 passed
- [x] `./.venv/Scripts/python.exe -m ruff check tests/test_bounty_pages.py` -> passed
- [x] `./.venv/Scripts/python.exe -m ruff format --check tests/test_bounty_pages.py` -> passed
- [x] `git diff --check` -> clean

## MRWK

Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties): Bounty #427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced empty-state messaging for bounties search results. When search filters are active, users now see "No bounties match these filters." with a convenient "Clear filters" link. Without filters, the message displays "No bounties yet."

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->