### PR TITLE
docs: add MCP work-proof structured example

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -574,6 +574,66 @@ curl -s -X POST "$MCP_HOST/mcp" \
 }
 ```
 
+Call `submit_work_proof` with `format:"json"` when an agent needs
+machine-readable bounty submission guidance. Use either internal `bounty_id` or
+GitHub `issue_number`; include `repo` with `issue_number` when the issue number
+could exist in more than one repository:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"submit_work_proof","arguments":{"issue_number":404,"repo":"ramimbo/mergework","format":"json"}}}'
+```
+
+Structured responses include both a JSON-string copy in
+`result.content[0].text` and the parsed object in `result.structuredContent`.
+Read `availability`, `can_submit`, `availability_warnings`,
+`submission_requirements.reference_formats`, and
+`submission_requirements.next_actions` before opening or claiming work:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 10,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"bounty_id\":64,\"issue_number\":404,\"status\":\"open\",\"availability\":\"open_for_submissions\",\"can_submit\":true,\"availability_warnings\":[],\"awards_remaining\":8,\"max_awards\":30,\"awards_paid\":22,\"reward_mrwk\":\"40\",\"available_mrwk\":\"320\",\"repository\":\"ramimbo/mergework\",\"issue_url\":\"https://github.com/ramimbo/mergework/issues/404\",\"title\":\"MRWK bounty: review open MergeWork PRs with evidence, round 11\",\"submission_requirements\":{\"reference_formats\":[\"Bounty #404\",\"Refs #404\"],\"claim_command\":\"/claim\",\"attempt_endpoint\":\"/api/v1/bounties/64/attempts\",\"next_actions\":[{\"id\":\"confirm_award_slot\",\"required\":true,\"text\":\"Confirm this bounty is open and has at least one award slot remaining.\"}]}}"
+      }
+    ],
+    "structuredContent": {
+      "bounty_id": 64,
+      "issue_number": 404,
+      "status": "open",
+      "availability": "open_for_submissions",
+      "can_submit": true,
+      "availability_warnings": [],
+      "awards_remaining": 8,
+      "max_awards": 30,
+      "awards_paid": 22,
+      "reward_mrwk": "40",
+      "available_mrwk": "320",
+      "repository": "ramimbo/mergework",
+      "issue_url": "https://github.com/ramimbo/mergework/issues/404",
+      "title": "MRWK bounty: review open MergeWork PRs with evidence, round 11",
+      "submission_requirements": {
+        "reference_formats": ["Bounty #404", "Refs #404"],
+        "claim_command": "/claim",
+        "attempt_endpoint": "/api/v1/bounties/64/attempts",
+        "next_actions": [
+          {
+            "id": "confirm_award_slot",
+            "required": true,
+            "text": "Confirm this bounty is open and has at least one award slot remaining."
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
 ## Pre-Bounty Preflight Checks
 
 Before opening a PR or claiming a bounty, check the live API for award capacity and active attempts. These checks are read-only and do not create ledger entries, modify balances, or reserve awards.

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -207,6 +207,24 @@ def test_api_examples_document_mcp_lookup_response_shapes() -> None:
     assert '\\"next_nonce\\":1' in examples
 
 
+def test_api_examples_document_mcp_submit_work_proof_structured_response() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert '"name":"submit_work_proof"' in examples
+    assert '"issue_number":404' in examples
+    assert '"repo":"ramimbo/mergework"' in examples
+    assert '"format":"json"' in examples
+    assert "result.structuredContent" in examples
+    assert "result.content[0].text" in examples
+    assert '"structuredContent": {' in examples
+    assert '"availability": "open_for_submissions"' in examples
+    assert '"can_submit": true' in examples
+    assert '"availability_warnings": []' in examples
+    assert '"reference_formats": ["Bounty #404", "Refs #404"]' in examples
+    assert '"attempt_endpoint": "/api/v1/bounties/64/attempts"' in examples
+    assert '"id": "confirm_award_slot"' in examples
+
+
 def test_agent_guide_explains_internal_bounty_ids() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- Add a public MCP `submit_work_proof` example using `format:json`.
- Document the actual JSON-RPC response shape with `result.content[0].text` plus `result.structuredContent`.
- Add a docs test that keeps the structured guidance fields visible in `docs/api-examples.md`.

Bounty #411

## Evidence

- Compared against `app/mcp.py`, where dict tool results are returned as both `content[0].text` and `structuredContent`.
- Compared against `app/mcp_work_proof.py`, which emits `availability`, `can_submit`, `availability_warnings`, `submission_requirements.reference_formats`, `attempt_endpoint`, and `next_actions`.
- Intended files or surfaces: `docs/api-examples.md`, `tests/test_docs_public_urls.py`.
- Expected PR size: focused API/MCP example update.
- Out of scope: activity examples, MCP ledger/wallet lookup examples, route behavior changes.

## Test Evidence

- [x] `./.venv/Scripts/python.exe scripts/docs_smoke.py` -> docs smoke ok
- [x] `./.venv/Scripts/python.exe -m pytest tests/test_docs_public_urls.py -q` -> 19 passed
- [x] `./.venv/Scripts/python.exe -m ruff check tests/test_docs_public_urls.py` -> passed
- [x] `./.venv/Scripts/python.exe -m ruff format --check tests/test_docs_public_urls.py` -> passed
- [x] `git diff --check` -> clean

## MRWK

Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties): Bounty #411

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new API usage example for work proof submissions, demonstrating how to handle structured responses and properly interpret availability status, submission requirements, and reference format specifications.

* **Tests**
  * Added automated test to validate API documentation accuracy and completeness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->