### PR TITLE
Validate malformed public URL hosts

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -40,6 +40,7 @@ SQLITE_INTEGER_MAX = 2**63 - 1
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 MRWK_AMOUNT_RE = re.compile(r"^-?\d+(?:\.\d+)?$")
+PUBLIC_DNS_LABEL_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$", re.I)
 
 
 class LedgerError(RuntimeError):
@@ -108,7 +109,16 @@ def validate_public_url(url: str) -> str:
     try:
         ip = ipaddress.ip_address(hostname)
     except ValueError:
-        pass
+        try:
+            ascii_hostname = hostname.encode("idna").decode("ascii").rstrip(".")
+        except UnicodeError as exc:
+            raise LedgerError("URL must include a valid host") from exc
+        if (
+            not ascii_hostname
+            or len(ascii_hostname) > 253
+            or not all(PUBLIC_DNS_LABEL_RE.fullmatch(label) for label in ascii_hostname.split("."))
+        ):
+            raise LedgerError("URL must include a valid host") from None
     else:
         if ip.is_multicast or not ip.is_global:
             raise LedgerError("URL must use a public host")

--- a/tests/test_security_url_validation.py
+++ b/tests/test_security_url_validation.py
@@ -53,12 +53,17 @@ def test_public_urls_reject_malformed_hosts_and_ports() -> None:
         "https://example.com:bad/path",
         "https://example.com:/path",
         "https://:443/path",
+        "https://api..example/path",
+        "https://bad_host.example/path",
+        "https://-bad.example/path",
+        "https://bad-.example/path",
     ):
         with pytest.raises(LedgerError, match="URL must include a valid host"):
             validate_public_url(url)
 
     assert public_url_or_none("https://[bad") is None
     assert public_url_or_none("https://:443/path") is None
+    assert public_url_or_none("https://bad_host.example/path") is None
 
 
 def test_bounty_urls_reject_embedded_credentials(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary

- Reject malformed DNS host labels in public URL validation, including empty labels, underscores, and leading/trailing hyphens.
- Keep existing IP literal handling intact: non-global IPs still fail with the public-host error.
- Add regression coverage for malformed public URL hosts and `public_url_or_none` fallback behavior.

Bounty #406

## Evidence

- Before this change, `validate_public_url` checked scheme, credentials, whitespace, ports, localhost, and IP globalness, but non-IP hostnames were otherwise accepted after `urlparse`.
- Hostnames such as `api..example`, `bad_host.example`, `-bad.example`, and `bad-.example` are malformed DNS names and should fail as invalid public URL hosts.
- Intended files or surfaces: `app/ledger/service.py`, `tests/test_security_url_validation.py`.
- Expected PR size: small validation fix with regression tests.
- Out of scope: changing allowed schemes, changing non-global IP behavior, private security disclosure, URL normalization rewrites.

## Test Evidence

- [x] `./.venv/Scripts/python.exe -m pytest tests/test_security_url_validation.py tests/test_security.py::test_public_url_or_none_omits_control_character_urls -q` -> 6 passed
- [x] `./.venv/Scripts/python.exe -m ruff check app/ledger/service.py tests/test_security_url_validation.py` -> passed
- [x] `./.venv/Scripts/python.exe -m ruff format --check app/ledger/service.py tests/test_security_url_validation.py` -> passed
- [x] `git diff --check` -> clean

## MRWK

Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties): Bounty #406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of public URLs to enforce stricter hostname requirements, including proper length constraints and label format validation.

* **Tests**
  * Added test coverage for additional malformed hostname patterns in URL validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->