### PR TITLE
fix: recognize claim bounty references

### DIFF
--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -8,7 +8,7 @@ import sys
 from collections import defaultdict
 from typing import Any
 
-BOUNTY_REF_RE = re.compile(r"(?:bounty|refs?|fixes|closes)\s+#(\d+)", re.IGNORECASE)
+BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+#(\d+)", re.IGNORECASE)
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
 UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
 GH_TIMEOUT_SECONDS = 30
@@ -113,7 +113,11 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
     for pr in normalized_prs:
         if not pr["refs"]:
             missing_bounty_references.append(
-                _issue(pr, "missing_bounty_reference", "No Bounty #<issue> or Refs #<issue> found")
+                _issue(
+                    pr,
+                    "missing_bounty_reference",
+                    "No Bounty #<issue>, Refs #<issue>, or /claim #<issue> found",
+                )
             )
         for ref in pr["refs"]:
             bounty = bounties.get(ref)

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -11,7 +11,7 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
-BOUNTY_REF_RE = re.compile(r"(?:bounty|refs?|fixes|closes)\s+#(\d+)", re.IGNORECASE)
+BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+#(\d+)", re.IGNORECASE)
 EVIDENCE_RE = re.compile(
     r"\b(pytest|ruff|mypy|validation|verified|test evidence|checks? passed)\b",
     re.IGNORECASE,
@@ -220,7 +220,7 @@ def evaluate_submission(data: dict[str, Any]) -> dict[str, Any]:
             _check(
                 "bounty_reference",
                 "fail",
-                "submission text must include Bounty #<issue> or Refs #<issue>",
+                "submission text must include Bounty #<issue>, Refs #<issue>, or /claim #<issue>",
             )
         )
     else:

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -107,6 +107,26 @@ def test_pr_queue_health_text_report_is_pasteable() -> None:
     assert "No queue-health issues found." in text
 
 
+def test_pr_queue_health_accepts_claim_command_reference() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [
+                {
+                    "number": 8,
+                    "title": "Harden bounty submission checks",
+                    "body": "/claim #310",
+                    "merge_state": "clean",
+                    "labels": [],
+                }
+            ],
+        }
+    )
+
+    assert report["summary"]["missing_bounty_references"] == 0
+    assert report["missing_bounty_references"] == []
+
+
 def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     report = analyze_queue(
         {
@@ -163,7 +183,7 @@ def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     assert "### Missing bounty references" in markdown
     assert (
         "- [PR #2](https://github.com/ramimbo/mergework/pull/2): "
-        "Improve bounty filters (No Bounty #<issue> or Refs #<issue> found)"
+        "Improve bounty filters (No Bounty #<issue>, Refs #<issue>, or /claim #<issue> found)"
     ) in markdown
     assert "### Dirty or unstable merge state" in markdown
     assert "Merge state is dirty" in markdown

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -40,6 +40,32 @@ def test_submission_quality_gate_passes_open_bounty_with_evidence(capsys, tmp_pa
     assert json.loads(capsys.readouterr().out)["status"] == "pass"
 
 
+def test_submission_quality_gate_accepts_claim_command_reference() -> None:
+    result = evaluate_submission(
+        {
+            "submission_text": """
+            Summary:
+            Harden the bounty submission checks.
+
+            /claim #319
+
+            Validation:
+            - pytest passed.
+            """,
+            "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [],
+        }
+    )
+
+    assert result["status"] == "pass"
+    assert result["bounty_reference"] == 319
+    assert {
+        "name": "bounty_reference",
+        "status": "pass",
+        "message": "found bounty reference #319",
+    } in result["checks"]
+
+
 def test_submission_quality_gate_fails_missing_reference() -> None:
     result = evaluate_submission(
         {
@@ -53,7 +79,9 @@ def test_submission_quality_gate_fails_missing_reference() -> None:
     assert result["checks"][0] == {
         "name": "bounty_reference",
         "status": "fail",
-        "message": "submission text must include Bounty #<issue> or Refs #<issue>",
+        "message": (
+            "submission text must include Bounty #<issue>, Refs #<issue>, or /claim #<issue>"
+        ),
     }
 
 


### PR DESCRIPTION
## Summary

- Recognize `/claim #N` as a bounty reference in `scripts/submission_quality_gate.py` and `scripts/pr_queue_health.py`.
- Update missing-reference guidance so contributors see `/claim #<issue>` as an accepted reference format.

Refs #406

## Evidence

- A submission body containing `/claim #N` previously failed the quality gate as missing a bounty reference.
- This is distinct from open PR #436, which handles public URL host validation.
- Intended files or surfaces: `scripts/submission_quality_gate.py`, `scripts/pr_queue_health.py`, and focused regression tests.
- Expected PR size: small script/test fix.
- Out of scope: URL validation, payout mechanics, broad docs rewrite, or price/off-ramp claims.

## Test Evidence

- [x] `./.venv/bin/python -m pytest` -> 404 passed
- [x] `./.venv/bin/python -m ruff format --check .` -> 78 files already formatted
- [x] `./.venv/bin/python -m ruff check .` -> All checks passed
- [x] `./.venv/bin/python -m mypy app` -> Success: no issues found in 29 source files
- [x] `git diff --check HEAD~1 HEAD` -> clean

## MRWK

Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties): Refs #406


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bounty references can now be expressed using `/claim #<issue>` format alongside existing `Bounty #` and `Refs #` formats for enhanced flexibility.

* **Tests**
  * Added comprehensive test coverage to verify `/claim` command reference recognition across quality gate systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/438?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->