### PR TITLE
Warn when active attempts fill bounty slots

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -83,7 +83,9 @@ def bounty_attempt_warnings(session: Session, bounty: Bounty, now: datetime) -> 
         .select_from(BountyAttempt)
         .where(*_active_attempt_conditions(bounty.id, now))
     )
-    if active_count and active_count >= awards_remaining:
+    if active_count and (
+        active_count > 1 or (awards_remaining > 0 and active_count >= awards_remaining)
+    ):
         attempt_label = "attempt" if active_count == 1 else "attempts"
         warnings.append(f"bounty has {active_count} active {attempt_label}")
     return warnings

--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -83,8 +83,9 @@ def bounty_attempt_warnings(session: Session, bounty: Bounty, now: datetime) -> 
         .select_from(BountyAttempt)
         .where(*_active_attempt_conditions(bounty.id, now))
     )
-    if active_count and active_count > 1:
-        warnings.append(f"bounty has {active_count} active attempts")
+    if active_count and active_count >= awards_remaining:
+        attempt_label = "attempt" if active_count == 1 else "attempts"
+        warnings.append(f"bounty has {active_count} active {attempt_label}")
     return warnings
 
 

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime, timedelta
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 
-from app.bounty_attempts import bounty_attempt_to_dict
+from app.bounty_attempts import bounty_attempt_to_dict, bounty_attempt_warnings
 from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import _signed_value, create_app
@@ -204,6 +204,37 @@ def test_single_award_bounty_warns_when_active_attempt_uses_available_slot(
     visible = client.get(f"/api/v1/bounties/{bounty.id}/attempts")
     assert visible.status_code == 200
     assert visible.json()["warnings"] == ["bounty has 1 active attempt"]
+
+
+def test_multi_award_bounty_still_warns_for_multiple_active_attempts(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    now = datetime.now(UTC)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=327,
+            issue_url="https://github.com/ramimbo/mergework/issues/327",
+            title="Multi award attempt warning",
+            reward_mrwk="50",
+            max_awards=3,
+            acceptance="Warn when multiple contributors have active attempts.",
+        )
+        for submitter in ("github:alice", "github:bob"):
+            session.add(
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account=submitter,
+                    status="active",
+                    expires_at=now + timedelta(hours=1),
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        session.flush()
+
+        assert bounty_attempt_warnings(session, bounty, now) == ["bounty has 2 active attempts"]
 
 
 def test_expired_bounty_attempt_is_visible_but_no_longer_blocks_submitter(

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -172,6 +172,40 @@ def test_bounty_attempts_accept_empty_body_defaults_to_login(sqlite_url: str, mo
     assert released.json()["attempt"]["status"] == "released"
 
 
+def test_single_award_bounty_warns_when_active_attempt_uses_available_slot(
+    sqlite_url: str, monkeypatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", COOKIE_SECRET)
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=326,
+            issue_url="https://github.com/ramimbo/mergework/issues/326",
+            title="Single award attempt warning",
+            reward_mrwk="50",
+            max_awards=1,
+            acceptance="Warn when the only award slot already has an active attempt.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _set_login(client, "alice")
+
+    created = client.post(
+        f"/api/v1/bounties/{bounty.id}/attempts",
+        json={"submitter_account": "github:alice", "ttl_seconds": 3600},
+    )
+
+    assert created.status_code == 201
+    assert created.json()["warnings"] == ["bounty has 1 active attempt"]
+
+    visible = client.get(f"/api/v1/bounties/{bounty.id}/attempts")
+    assert visible.status_code == 200
+    assert visible.json()["warnings"] == ["bounty has 1 active attempt"]
+
+
 def test_expired_bounty_attempt_is_visible_but_no_longer_blocks_submitter(
     sqlite_url: str,
     monkeypatch,


### PR DESCRIPTION
## Summary
- Warn when active bounty attempts already occupy all remaining award slots.
- Keep the existing multi-attempt warning behavior, with correct singular/plural wording.
- Add a regression test for single-award bounties so contributors see the warning before another overlapping attempt is opened.

Refs #406

## Evidence
- Reviewed `app/bounty_attempts.py` and confirmed the previous warning only fired when `active_count > 1`, so a single-award bounty with one active attempt returned no warning.
- Added `test_single_award_bounty_warns_when_active_attempt_uses_available_slot` to cover the affected API behavior.

## Validation
- `python -m pytest tests/test_bounty_attempts.py -q`
- `python -m pytest -q`
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy app`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Warning messages for active bounty attempts now correctly use singular ("1 active attempt") and plural ("X active attempts") forms when counting attempts that consume available award slots.

* **Tests**
  * Added tests covering single-award and multi-award bounty scenarios to ensure warning text and counting behave correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->