### PR TITLE
docs: clarify wallet private key storage

### DIFF
--- a/app/templates/me.html
+++ b/app/templates/me.html
@@ -25,7 +25,7 @@
   <form data-action="link-github">
     <label>Wallet address <input name="address" placeholder="mrwk1..." required></label>
     <label>Private key <textarea name="private_key_hex" rows="5" autocomplete="off" autocapitalize="none" spellcheck="false" required></textarea></label>
-    <p class="notice">Use the private key for this wallet address; a different key will be rejected. Clear this field after use. Never share your private key.</p>
+    <p class="notice">Use the private key for this wallet address; a different key will be rejected. The server never stores this key. Clear this field after use.</p>
     <p class="notice" data-link-nonce-status>Transaction number is handled automatically.</p>
     <button type="submit">Sign and link</button>
   </form>
@@ -35,7 +35,7 @@
   <form data-action="claim-github">
     <label>Wallet address <input name="address" placeholder="mrwk1..." value="{{ linked_wallet_address or '' }}" required></label>
     <label>Private key <textarea name="private_key_hex" rows="5" autocomplete="off" autocapitalize="none" spellcheck="false" required></textarea></label>
-    <p class="notice">Claim works only after this GitHub account is linked to the wallet. Clear this field after use. Never share your private key.</p>
+    <p class="notice">Claim works only after this GitHub account is linked to the wallet. The server never stores this key. Clear this field after use.</p>
     {% if linked_wallet_address %}
     <p class="notice">Claim form is prefilled with your linked wallet.</p>
     {% endif %}

--- a/app/templates/wallets.html
+++ b/app/templates/wallets.html
@@ -19,8 +19,8 @@
     <label>Private key <textarea id="wallet-private-key" name="private_key_hex" rows="5" readonly autocomplete="off" autocapitalize="none" spellcheck="false"></textarea></label>
     <button type="submit">Register public key</button>
   </form>
-  <p class="notice">Private key stays in this browser. Store it yourself; the server cannot recover it.</p>
-  <p class="notice">If you lose the private key, generate a new wallet and register that public key instead.</p>
+  <p class="notice">Registering saves only the public key. Copy the private key to your own password manager or encrypted note before leaving this page.</p>
+  <p class="notice">The server cannot recover private keys. If you lose one, generate a new wallet and register that public key instead.</p>
   <pre class="result" data-wallet-result></pre>
 </section>
 

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -524,8 +524,9 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     me = client.get("/me").text
 
     assert "Generate wallet" in wallets
-    assert "Private key stays in this browser" in wallets
-    assert "If you lose the private key" in wallets
+    assert "Registering saves only the public key" in wallets
+    assert "password manager or encrypted note" in wallets
+    assert "The server cannot recover private keys" in wallets
     assert (
         'id="wallet-private-key" name="private_key_hex" rows="5" readonly autocomplete="off"'
         in wallets
@@ -589,7 +590,7 @@ def test_wallet_pages_do_not_require_manual_nonce(sqlite_url: str, monkeypatch) 
     assert 'name="private_key_hex" rows="5" autocomplete="off"' in transfer
     assert me.count('name="private_key_hex" rows="5" autocomplete="off"') == 2
     assert "Clear this field after use. Never share your private key." in transfer
-    assert "Clear this field after use. Never share your private key." in me
+    assert "The server never stores this key. Clear this field after use." in me
 
 
 def test_github_wallet_actions_clear_private_key_after_submit_attempt() -> None:


### PR DESCRIPTION
## Summary

- Clarify on `/wallets` that registration saves only the public key and users must copy the private key before leaving the page.
- Clarify on `/me` link/claim forms that the server never stores the private key.
- Update wallet page tests to lock the private-key storage/recovery guidance.

Bounty #427

## Evidence

- Current wallet generation UI shows address/public/private key fields and says the private key stays in the browser, but users can still miss the important operational step: registering only saves the public key, and the private key must be stored by the user before leaving the page.
- `app/static/wallet.js` fills `wallet-private-key` client-side and `app/wallet_api.py` registers only `public_key_hex`; the server verifies later signed actions but does not store private keys.
- `README.md` and `docs/ledger.md` describe public-key registration and signed wallet actions; this PR makes the live wallet/account forms match that model more explicitly.
- Bounty #427 has open award capacity and no active attempts at `/api/v1/bounties/73/attempts?include_expired=false` when checked.
- Open #427 PRs checked: #430 covers bounty status card styling/back nav, #434 covers filtered bounty empty states. This PR is a distinct wallet/private-key clarity improvement.
- Intended files or surfaces: `/wallets`, `/me`, wallet page tests.
- Expected PR size: small UX copy/test update.
- Out of scope: wallet cryptography, transfer behavior, account linking logic, broad redesign, price/off-ramp claims.

## Test Evidence

- [x] `./.venv/bin/python -m pytest tests/test_wallet_api.py -q` -> 32 passed
- [x] `./.venv/bin/python -m ruff check tests/test_wallet_api.py` -> passed
- [x] `./.venv/bin/python -m ruff format --check tests/test_wallet_api.py` -> passed
- [x] `git diff --check` -> passed

## MRWK

Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties): Bounty #427


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated wallet form and account page notices with clearer security guidance, clarifying that the server never stores private keys and recommending users clear fields after use.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->