### PR TITLE
fix: honor bounty API limit

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -82,7 +82,7 @@ def register_bounty_api_routes(
     """Register bounty listing, CRUD, payment, close, and reconciliation routes."""
 
     def _list_bounties_by_status(
-        status: str | None = None, query_text: str | None = None
+        status: str | None = None, query_text: str | None = None, limit: int | None = None
     ) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
             query = select(Bounty)
@@ -112,20 +112,27 @@ def register_bounty_api_routes(
                     if issue_number is not None:
                         text_filter = or_(text_filter, Bounty.issue_number == issue_number)
                     query = query.where(text_filter)
-            bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
+            query = query.order_by(Bounty.id.desc())
+            if limit is not None:
+                query = query.limit(limit)
+            bounties = session.scalars(query).all()
             return [bounty_to_dict(bounty) for bounty in bounties]
 
     @app.get("/api/v1/bounties")
     def api_bounties(
-        status: str | None = Query(None), q: str | None = Query(None)
+        status: str | None = Query(None),
+        q: str | None = Query(None),
+        limit: Annotated[int | None, Query(ge=1, le=200)] = None,
     ) -> list[dict[str, Any]]:
-        return _list_bounties_by_status(status, q)
+        return _list_bounties_by_status(status, q, limit)
 
     @app.get("/api/v1/bounties/summary")
     def api_bounties_summary(
-        status: str | None = Query(None), q: str | None = Query(None)
+        status: str | None = Query(None),
+        q: str | None = Query(None),
+        limit: Annotated[int | None, Query(ge=1, le=200)] = None,
     ) -> dict[str, Any]:
-        return bounty_list_summary(_list_bounties_by_status(status, q))
+        return bounty_list_summary(_list_bounties_by_status(status, q, limit))
 
     @app.get("/api/v1/admin/webhook-events")
     def api_admin_webhook_events(

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -257,3 +257,59 @@ def test_bounty_api_filters_by_status(sqlite_url: str) -> None:
     invalid = client.get("/api/v1/bounties?status=bogus")
     assert invalid.status_code == 400
     assert invalid.json()["detail"] == "status must be one of: open, paid, closed"
+
+
+def test_bounty_api_limit_caps_filtered_rows(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        first = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=50,
+            issue_url="https://github.com/ramimbo/mergework/issues/50",
+            title="Old open bounty",
+            reward_mrwk="5",
+            acceptance="Older open bounty.",
+        )
+        second = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=51,
+            issue_url="https://github.com/ramimbo/mergework/issues/51",
+            title="Middle open bounty",
+            reward_mrwk="5",
+            acceptance="Middle open bounty.",
+        )
+        third = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=52,
+            issue_url="https://github.com/ramimbo/mergework/issues/52",
+            title="Newest open bounty",
+            reward_mrwk="5",
+            acceptance="Newest open bounty.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    limited = client.get("/api/v1/bounties?status=open&limit=2")
+    summary = client.get("/api/v1/bounties/summary?status=open&limit=2")
+
+    assert [item["id"] for item in limited.json()] == [third.id, second.id]
+    assert summary.json()["bounties_shown"] == 2
+    assert summary.json()["open_awards"] == 2
+    assert first.id not in [item["id"] for item in limited.json()]
+
+
+def test_bounty_api_limit_rejects_out_of_range_values(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    assert client.get("/api/v1/bounties?limit=0").status_code == 422
+    assert client.get("/api/v1/bounties?limit=201").status_code == 422
+    assert client.get("/api/v1/bounties/summary?limit=0").status_code == 422
+    assert client.get("/api/v1/bounties/summary?limit=201").status_code == 422


### PR DESCRIPTION
## Summary
- Adds optional `limit` support to the public REST bounty listing endpoint.
- Applies the same limit to `/api/v1/bounties/summary` so summaries match the visible limited result set.
- Adds regression coverage for capped rows and out-of-range limit validation.

## Evidence
- Live public check before the fix: `GET https://api.mrwk.ltclab.site/api/v1/bounties?status=open&limit=1` returned 7 open rows instead of 1.
- Live public summary check before the fix: `GET https://api.mrwk.ltclab.site/api/v1/bounties/summary?status=open&limit=1` reported `bounties_shown=7`.
- MCP `list_bounties` already has validated limit behavior; this makes the REST API consistent for agents using the public HTTP endpoint.

## Verification
- Added regression test first and confirmed it failed before the route change: `2 failed` for ignored `limit` and unvalidated out-of-range values.
- `.\.venv\Scripts\python.exe -m pytest tests/test_bounty_api_routes.py::test_bounty_api_limit_caps_filtered_rows tests/test_bounty_api_routes.py::test_bounty_api_limit_rejects_out_of_range_values -q` -> 2 passed
- `.\.venv\Scripts\python.exe -m pytest tests/test_bounty_api_routes.py tests/test_bounty_api.py tests/test_bounty_pages.py tests/test_mcp_tools.py -q` -> 31 passed
- `.\.venv\Scripts\python.exe -m pytest tests/test_api_mcp.py::test_mcp_list_bounties_filters_status_query_and_limit tests/test_api_mcp.py::test_mcp_list_bounties_rejects_invalid_filters -q` -> 6 passed
- `.\.venv\Scripts\python.exe -m ruff check app\bounty_api.py tests\test_bounty_api_routes.py` -> passed
- `.\.venv\Scripts\python.exe -m ruff format --check app\bounty_api.py tests\test_bounty_api_routes.py` -> passed
- `.\.venv\Scripts\python.exe -m mypy app` -> passed
- `git diff --check` -> clean

## Bounty Claim Packet
- Bounty reference: Refs #406 / MRWK bounty #66 useful bug reports and small fixes.
- Intended surfaces: `app/bounty_api.py` public REST bounty list and summary routes; `tests/test_bounty_api_routes.py` regression coverage.
- Expected PR size: small focused fix, 2 files.
- Out of scope: no payout, ledger, wallet, MCP behavior, auth, private data, or price/off-ramp claims.

Refs #406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `limit` query parameter to bounty listing and summary endpoints (valid range: 1–200) so users can cap results. Results are ordered with newest bounties first when limited.

* **Tests**
  * Added tests covering limit behavior, including correct truncation of results and rejection of out-of-range values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->