### PR TITLE
docs: add missing public API endpoints to agent-guide.md (Bounty #426)

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -9,10 +9,12 @@ Submit small, reviewable work and include evidence.
 - `GET /api/v1/status`
 - `GET /api/v1/bounties`
 - `GET /api/v1/bounties/{id}`
+- `GET /api/v1/bounties/summary`
 - `GET /api/v1/bounties/{id}/attempts`
 - `GET /api/v1/accounts/{account}`
 - `GET /api/v1/wallets/{address}`
 - `GET /api/v1/ledger`
+- `GET /api/v1/ledger/{sequence}`
 - `GET /api/v1/activity`
 - `GET /api/v1/proofs/{hash}`
 - `POST /api/v1/wallets/register`
@@ -37,6 +39,15 @@ curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
 ```
 
+Get a lightweight counts-only bounty summary with optional status and search
+filters:
+
+```bash
+curl -s "$API_HOST/api/v1/bounties/summary"
+curl -s "$API_HOST/api/v1/bounties/summary?status=open"
+curl -s "$API_HOST/api/v1/bounties/summary?q=docs"
+```
+
 Inspect one bounty, accepted-work activity, a ledger page, and a proof:
 
 ```bash
@@ -45,6 +56,12 @@ curl -s "$API_HOST/api/v1/bounties/<bounty_id>/attempts"
 curl -s "$API_HOST/api/v1/activity"
 curl -s "$API_HOST/api/v1/ledger?limit=10"
 curl -s "$API_HOST/api/v1/proofs/<proof_hash>"
+```
+
+Look up a single ledger entry by sequence number:
+
+```bash
+curl -s "$API_HOST/api/v1/ledger/1"
 ```
 
 The `<bounty_id>` value is the internal MergeWork bounty id returned by


### PR DESCRIPTION
## Summary

Add two public API endpoints that exist in the live codebase but were missing from the agent guide documentation:

- `GET /api/v1/bounties/summary` — lightweight counts-only bounty summary with optional `status` and `q` filters (implemented in `app/bounty_api.py`)
- `GET /api/v1/ledger/{sequence}` — single ledger entry lookup by sequence number (implemented in `app/main.py`)

## Evidence

- `GET /api/v1/bounties/summary` is registered at `app/bounty_api.py` line with `@app.get("/api/v1/bounties/summary")`, accepts optional `status` and `q` query params, and calls `bounty_list_summary()`
- `GET /api/v1/ledger/{sequence}` is registered at `app/main.py` with `@app.get("/api/v1/ledger/{sequence}")`, uses `positive_ledger_sequence()` validation, and returns a single ledger entry dict via `ledger_entry_to_dict()`
- Both endpoints are public (no auth required) and return JSON responses

## Scope

- Only changes `docs/agent-guide.md`
- Adds the two endpoints to the Public API list
- Adds concise usage examples in the Public API Examples section
- No behavioral changes to any code

Bounty #426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documented public HTTP API endpoints with new bounty summary and ledger lookup capabilities.
  * Added examples for bounty summary queries and individual ledger entry retrieval.
  * Reorganized API endpoint listings for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->