### PR TITLE
feat: add bounty list sort controls

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from decimal import Decimal
 from typing import Annotated, Any
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
@@ -12,6 +11,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from app.admin import list_webhook_events, webhook_events_to_dict
+from app.bounty_sorting import BOUNTY_SORT_ERROR, normalize_bounty_sort, sort_bounties
 from app.config import Settings
 from app.db import session_scope
 from app.ledger.reconciliation import payout_reconciliation_summary, reconcile_accepted_payouts
@@ -32,9 +32,6 @@ from app.serializers import (
     bounty_to_dict,
     payout_reconciliation_to_dict,
 )
-
-BOUNTY_SORT_OPTIONS = ("newest", "reward", "available", "awards")
-BOUNTY_SORT_ERROR = "sort must be one of: newest, reward, available, awards"
 
 
 def _payout_response_from_proof(proof: Proof, *, status: str) -> dict[str, Any]:
@@ -85,37 +82,13 @@ def register_bounty_api_routes(
 ) -> dict[str, Any]:
     """Register bounty listing, CRUD, payment, close, and reconciliation routes."""
 
-    def _normalize_bounty_sort(sort: str | None) -> str:
-        normalized_sort = (sort or "newest").strip().lower()
-        if normalized_sort not in BOUNTY_SORT_OPTIONS:
-            raise HTTPException(status_code=400, detail=BOUNTY_SORT_ERROR)
-        return normalized_sort
-
-    def _sort_bounties(bounties: list[dict[str, Any]], sort: str) -> list[dict[str, Any]]:
-        if sort == "newest":
-            return sorted(bounties, key=lambda bounty: int(bounty["id"]), reverse=True)
-        if sort == "reward":
-            return sorted(
-                bounties,
-                key=lambda bounty: (Decimal(str(bounty["reward_mrwk"])), int(bounty["id"])),
-                reverse=True,
-            )
-        if sort == "available":
-            return sorted(
-                bounties,
-                key=lambda bounty: (Decimal(str(bounty["available_mrwk"])), int(bounty["id"])),
-                reverse=True,
-            )
-        return sorted(
-            bounties,
-            key=lambda bounty: (int(bounty["awards_remaining"]), int(bounty["id"])),
-            reverse=True,
-        )
-
     def _list_bounties_by_status(
         status: str | None = None, query_text: str | None = None, sort: str | None = None
     ) -> list[dict[str, Any]]:
-        normalized_sort = _normalize_bounty_sort(sort)
+        try:
+            normalized_sort = normalize_bounty_sort(sort)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=BOUNTY_SORT_ERROR) from exc
         with session_scope(db_url) as session:
             query = select(Bounty)
             if status is not None:
@@ -145,7 +118,7 @@ def register_bounty_api_routes(
                         text_filter = or_(text_filter, Bounty.issue_number == issue_number)
                     query = query.where(text_filter)
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
-            return _sort_bounties([bounty_to_dict(bounty) for bounty in bounties], normalized_sort)
+            return sort_bounties([bounty_to_dict(bounty) for bounty in bounties], normalized_sort)
 
     @app.get("/api/v1/bounties")
     def api_bounties(

--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 from typing import Annotated, Any
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
@@ -31,6 +32,9 @@ from app.serializers import (
     bounty_to_dict,
     payout_reconciliation_to_dict,
 )
+
+BOUNTY_SORT_OPTIONS = ("newest", "reward", "available", "awards")
+BOUNTY_SORT_ERROR = "sort must be one of: newest, reward, available, awards"
 
 
 def _payout_response_from_proof(proof: Proof, *, status: str) -> dict[str, Any]:
@@ -81,9 +85,37 @@ def register_bounty_api_routes(
 ) -> dict[str, Any]:
     """Register bounty listing, CRUD, payment, close, and reconciliation routes."""
 
+    def _normalize_bounty_sort(sort: str | None) -> str:
+        normalized_sort = (sort or "newest").strip().lower()
+        if normalized_sort not in BOUNTY_SORT_OPTIONS:
+            raise HTTPException(status_code=400, detail=BOUNTY_SORT_ERROR)
+        return normalized_sort
+
+    def _sort_bounties(bounties: list[dict[str, Any]], sort: str) -> list[dict[str, Any]]:
+        if sort == "newest":
+            return sorted(bounties, key=lambda bounty: int(bounty["id"]), reverse=True)
+        if sort == "reward":
+            return sorted(
+                bounties,
+                key=lambda bounty: (Decimal(str(bounty["reward_mrwk"])), int(bounty["id"])),
+                reverse=True,
+            )
+        if sort == "available":
+            return sorted(
+                bounties,
+                key=lambda bounty: (Decimal(str(bounty["available_mrwk"])), int(bounty["id"])),
+                reverse=True,
+            )
+        return sorted(
+            bounties,
+            key=lambda bounty: (int(bounty["awards_remaining"]), int(bounty["id"])),
+            reverse=True,
+        )
+
     def _list_bounties_by_status(
-        status: str | None = None, query_text: str | None = None
+        status: str | None = None, query_text: str | None = None, sort: str | None = None
     ) -> list[dict[str, Any]]:
+        normalized_sort = _normalize_bounty_sort(sort)
         with session_scope(db_url) as session:
             query = select(Bounty)
             if status is not None:
@@ -113,13 +145,15 @@ def register_bounty_api_routes(
                         text_filter = or_(text_filter, Bounty.issue_number == issue_number)
                     query = query.where(text_filter)
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
-            return [bounty_to_dict(bounty) for bounty in bounties]
+            return _sort_bounties([bounty_to_dict(bounty) for bounty in bounties], normalized_sort)
 
     @app.get("/api/v1/bounties")
     def api_bounties(
-        status: str | None = Query(None), q: str | None = Query(None)
+        status: str | None = Query(None),
+        q: str | None = Query(None),
+        sort: str | None = Query(None),
     ) -> list[dict[str, Any]]:
-        return _list_bounties_by_status(status, q)
+        return _list_bounties_by_status(status, q, sort)
 
     @app.get("/api/v1/bounties/summary")
     def api_bounties_summary(

--- a/app/bounty_sorting.py
+++ b/app/bounty_sorting.py
@@ -1,0 +1,45 @@
+"""Shared bounty list sorting contract."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+BOUNTY_SORT_LABELS = {
+    "newest": "Newest first",
+    "reward": "Highest per-award reward",
+    "available": "Most MRWK available",
+    "awards": "Most award slots",
+}
+BOUNTY_SORT_OPTIONS = tuple(BOUNTY_SORT_LABELS)
+BOUNTY_SORT_ERROR = f"sort must be one of: {', '.join(BOUNTY_SORT_OPTIONS)}"
+
+
+def normalize_bounty_sort(sort: str | None) -> str:
+    normalized_sort = (sort or "newest").strip().lower()
+    if normalized_sort not in BOUNTY_SORT_OPTIONS:
+        raise ValueError(BOUNTY_SORT_ERROR)
+    return normalized_sort
+
+
+def sort_bounties(bounties: list[dict[str, Any]], sort: str | None) -> list[dict[str, Any]]:
+    normalized_sort = normalize_bounty_sort(sort)
+    if normalized_sort == "newest":
+        return sorted(bounties, key=lambda bounty: int(bounty["id"]), reverse=True)
+    if normalized_sort == "reward":
+        return sorted(
+            bounties,
+            key=lambda bounty: (Decimal(str(bounty["reward_mrwk"])), int(bounty["id"])),
+            reverse=True,
+        )
+    if normalized_sort == "available":
+        return sorted(
+            bounties,
+            key=lambda bounty: (Decimal(str(bounty["available_mrwk"])), int(bounty["id"])),
+            reverse=True,
+        )
+    return sorted(
+        bounties,
+        key=lambda bounty: (int(bounty["awards_remaining"]), int(bounty["id"])),
+        reverse=True,
+    )

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -10,17 +10,11 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.accounts import normalized_wallet_address
+from app.bounty_sorting import BOUNTY_SORT_LABELS, normalize_bounty_sort
 from app.db import session_scope
 from app.ledger_views import account_ledger_transactions
 from app.models import Wallet
 from app.serializers import bounty_list_summary, wallet_to_dict
-
-BOUNTY_SORT_LABELS = {
-    "newest": "Newest first",
-    "reward": "Highest per-award reward",
-    "available": "Most MRWK available",
-    "awards": "Most award slots",
-}
 
 
 def public_bounties_context(
@@ -31,7 +25,7 @@ def public_bounties_context(
 ) -> dict[str, Any]:
     selected_status = status.strip().lower() if status is not None else None
     query_text = q.strip() if q is not None else ""
-    selected_sort = (sort or "newest").strip().lower()
+    selected_sort = normalize_bounty_sort(sort)
     return {
         "bounties": bounties,
         "summary": bounty_list_summary(bounties),

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -15,17 +15,30 @@ from app.ledger_views import account_ledger_transactions
 from app.models import Wallet
 from app.serializers import bounty_list_summary, wallet_to_dict
 
+BOUNTY_SORT_LABELS = {
+    "newest": "Newest first",
+    "reward": "Highest per-award reward",
+    "available": "Most MRWK available",
+    "awards": "Most award slots",
+}
+
 
 def public_bounties_context(
-    bounties: list[dict[str, Any]], status: str | None, q: str | None
+    bounties: list[dict[str, Any]],
+    status: str | None,
+    q: str | None,
+    sort: str | None = None,
 ) -> dict[str, Any]:
     selected_status = status.strip().lower() if status is not None else None
     query_text = q.strip() if q is not None else ""
+    selected_sort = (sort or "newest").strip().lower()
     return {
         "bounties": bounties,
         "summary": bounty_list_summary(bounties),
         "selected_status": selected_status,
         "query_text": query_text,
+        "selected_sort": selected_sort,
+        "sort_options": BOUNTY_SORT_LABELS,
     }
 
 
@@ -50,7 +63,7 @@ def register_public_routes(
     *,
     db_url: str,
     templates: Jinja2Templates,
-    list_bounties_by_status: Callable[[str | None, str | None], list[dict[str, Any]]],
+    list_bounties_by_status: Callable[[str | None, str | None, str | None], list[dict[str, Any]]],
     api_bounty: Callable[[int], dict[str, Any]],
     api_ledger: Callable[[], list[dict[str, Any]]],
     api_ledger_entry: Callable[[int], dict[str, Any]],
@@ -58,13 +71,16 @@ def register_public_routes(
 ) -> None:
     @app.get("/bounties", response_class=HTMLResponse)
     def bounties_page(
-        request: Request, status: str | None = Query(None), q: str | None = Query(None)
+        request: Request,
+        status: str | None = Query(None),
+        q: str | None = Query(None),
+        sort: str | None = Query(None),
     ) -> HTMLResponse:
-        bounties = list_bounties_by_status(status, q)
+        bounties = list_bounties_by_status(status, q, sort)
         return templates.TemplateResponse(
             request,
             "bounties.html",
-            public_bounties_context(bounties, status, q),
+            public_bounties_context(bounties, status, q, sort),
         )
 
     @app.get("/bounties/{bounty_id}", response_class=HTMLResponse)

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -6,14 +6,20 @@
   {% if selected_status %}<input type="hidden" name="status" value="{{ selected_status }}">{% endif %}
   <label for="bounty-search">Search bounties</label>
   <input id="bounty-search" name="q" type="search" value="{{ query_text }}" placeholder="repo, title, issue number, or acceptance text">
+  <label for="bounty-sort">Sort</label>
+  <select id="bounty-sort" name="sort">
+    {% for sort_value, sort_label in sort_options.items() %}
+    <option value="{{ sort_value }}"{% if selected_sort == sort_value %} selected{% endif %}>{{ sort_label }}</option>
+    {% endfor %}
+  </select>
   <button type="submit">Search</button>
-  {% if query_text %}<a href="/bounties{% if selected_status %}?status={{ selected_status }}{% endif %}">Clear search</a>{% endif %}
+  {% if query_text %}<a href="/bounties{% if selected_status or selected_sort != "newest" %}?{% if selected_status %}status={{ selected_status }}{% endif %}{% if selected_status and selected_sort != "newest" %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% endif %}">Clear search</a>{% endif %}
 </form>
 <nav aria-label="Bounty status filters">
-  <a href="/bounties{% if query_text %}?q={{ query_text | urlencode }}{% endif %}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
-  <a href="/bounties?status=open{% if query_text %}&q={{ query_text | urlencode }}{% endif %}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
-  <a href="/bounties?status=paid{% if query_text %}&q={{ query_text | urlencode }}{% endif %}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
-  <a href="/bounties?status=closed{% if query_text %}&q={{ query_text | urlencode }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
+  <a href="/bounties{% if query_text or selected_sort != "newest" %}?{% if query_text %}q={{ query_text | urlencode }}{% endif %}{% if query_text and selected_sort != "newest" %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% endif %}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
+  <a href="/bounties?status=open{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
+  <a href="/bounties?status=paid{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
+  <a href="/bounties?status=closed{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
 </nav>
 {% if query_text %}<p>Showing matches for “{{ query_text }}”.</p>{% endif %}
 <section class="bounty-list-summary" aria-label="Bounty list summary">

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -201,6 +201,16 @@ def test_bounties_page_and_api_sort_public_rows(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
         ensure_genesis(session)
+        most_awards = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=69,
+            issue_url="https://github.com/ramimbo/mergework/issues/69",
+            title="Eight slot bounty",
+            reward_mrwk="10",
+            max_awards=8,
+            acceptance="Most remaining award slots should sort first by awards.",
+        )
         high_reward = create_bounty(
             session,
             repo="ramimbo/mergework",
@@ -225,16 +235,23 @@ def test_bounties_page_and_api_sort_public_rows(sqlite_url: str) -> None:
 
     default_rows = client.get("/api/v1/bounties")
     assert default_rows.status_code == 200
-    assert [row["issue_number"] for row in default_rows.json()] == [71, 70]
+    assert [row["issue_number"] for row in default_rows.json()] == [71, 70, 69]
 
     reward_rows = client.get("/api/v1/bounties?sort=reward")
     assert reward_rows.status_code == 200
-    assert [row["issue_number"] for row in reward_rows.json()] == [70, 71]
+    assert [row["issue_number"] for row in reward_rows.json()] == [70, 71, 69]
+
+    awards_rows = client.get("/api/v1/bounties?sort=awards")
+    assert awards_rows.status_code == 200
+    assert [row["issue_number"] for row in awards_rows.json()] == [69, 71, 70]
 
     available_page = client.get("/bounties?sort=available")
     assert available_page.status_code == 200
     assert available_page.text.index(high_capacity.title) < available_page.text.index(
         high_reward.title
+    )
+    assert available_page.text.index(high_reward.title) < available_page.text.index(
+        most_awards.title
     )
     assert 'name="sort"' in available_page.text
     assert '<option value="available" selected>Most MRWK available</option>' in available_page.text

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -197,6 +197,54 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     assert [row["issue_number"] for row in backslash_search.json()] == [66]
 
 
+def test_bounties_page_and_api_sort_public_rows(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        high_reward = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=70,
+            issue_url="https://github.com/ramimbo/mergework/issues/70",
+            title="High reward single slot",
+            reward_mrwk="90",
+            acceptance="Large per-award payout should sort first by reward.",
+        )
+        high_capacity = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=71,
+            issue_url="https://github.com/ramimbo/mergework/issues/71",
+            title="Many smaller award slots",
+            reward_mrwk="25",
+            max_awards=5,
+            acceptance="More remaining capacity should sort first by available pool.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    default_rows = client.get("/api/v1/bounties")
+    assert default_rows.status_code == 200
+    assert [row["issue_number"] for row in default_rows.json()] == [71, 70]
+
+    reward_rows = client.get("/api/v1/bounties?sort=reward")
+    assert reward_rows.status_code == 200
+    assert [row["issue_number"] for row in reward_rows.json()] == [70, 71]
+
+    available_page = client.get("/bounties?sort=available")
+    assert available_page.status_code == 200
+    assert available_page.text.index(high_capacity.title) < available_page.text.index(
+        high_reward.title
+    )
+    assert 'name="sort"' in available_page.text
+    assert '<option value="available" selected>Most MRWK available</option>' in available_page.text
+    assert 'href="/bounties?status=open&sort=available"' in available_page.text
+
+    invalid_sort = client.get("/api/v1/bounties?sort=bogus")
+    assert invalid_sort.status_code == 400
+    assert invalid_sort.json()["detail"] == "sort must be one of: newest, reward, available, awards"
+
+
 def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -13,7 +13,7 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
         }
     ]
 
-    context = public_bounties_context(bounties, status=" OPEN ", q=" proof ")
+    context = public_bounties_context(bounties, status=" OPEN ", q=" proof ", sort=" Reward ")
 
     assert context == {
         "bounties": bounties,
@@ -24,7 +24,7 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
         },
         "selected_status": "open",
         "query_text": "proof",
-        "selected_sort": "newest",
+        "selected_sort": "reward",
         "sort_options": {
             "newest": "Newest first",
             "reward": "Highest per-award reward",

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -24,4 +24,11 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
         },
         "selected_status": "open",
         "query_text": "proof",
+        "selected_sort": "newest",
+        "sort_options": {
+            "newest": "Newest first",
+            "reward": "Highest per-award reward",
+            "available": "Most MRWK available",
+            "awards": "Most award slots",
+        },
     }


### PR DESCRIPTION
## Summary
- Add public sort options for bounty rows: newest, highest per-award reward, most MRWK available, and most award slots.
- Preserve the selected sort across the search form and status filter links on `/bounties`.
- Add API support for `sort=` on `/api/v1/bounties`, including a clear 400 for unsupported values.

Bounty #427

## Evidence
- The public bounty list already had search, status filters, and summary totals, but contributors could not prioritize rows by reward size, total available pool, or remaining award capacity.
- This is distinct from open #427 PRs I checked before starting: #430 covers status/card styling, #434 covers filtered empty states, and #440 covers wallet/private-key copy.
- The page and API now produce the same sorted row order, and status filter links keep the selected sort.

## Validation
- `./.venv/bin/python -m pytest -q` -> 403 passed
- `./.venv/bin/python -m ruff check .` -> passed
- `./.venv/bin/python -m ruff format --check .` -> passed
- `./.venv/bin/python -m mypy app` -> passed
- `git diff --check HEAD~1 HEAD` -> passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sorting to bounties: sort by newest, reward, availability, or awards (UI selector added).
  * Sort choice is preserved when filtering by status or performing searches.
  * API and page listing support the sort parameter and validate input (invalid values return an error).

* **Tests**
  * Added tests to verify consistent sorting between the JSON API and HTML page, control state, and invalid-sort handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->