### PR TITLE
feat: add bounty detail contributor next steps

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -203,7 +203,8 @@ code.hash { overflow-wrap: anywhere; }
   margin: 28px 0;
 }
 .bounty-summary article,
-.acceptance-card {
+.acceptance-card,
+.next-steps-card {
   border: 1px solid var(--line);
   background: var(--panel);
   border-radius: 8px;
@@ -260,6 +261,30 @@ code.hash { overflow-wrap: anywhere; }
 }
 .acceptance-card h2 {
   margin: 0 0 10px;
+}
+.next-steps-card {
+  margin-top: 16px;
+}
+.next-steps-card h2 {
+  margin: 0 0 10px;
+}
+.next-steps-card ol {
+  margin: 0;
+  padding-left: 22px;
+}
+.next-steps-card li + li {
+  margin-top: 8px;
+}
+.next-steps-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 16px;
+}
+.next-steps-actions a {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 8px 12px;
 }
 .acceptance-card p:last-child {
   margin-bottom: 0;

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -45,6 +45,26 @@
     <h2 id="acceptance-heading">What has to be true</h2>
     <p>{{ bounty.acceptance }}</p>
   </section>
+
+  <section class="next-steps-card" aria-labelledby="bounty-next-steps-heading">
+    <p class="eyebrow">Contributor next steps</p>
+    <h2 id="bounty-next-steps-heading">Before you start</h2>
+    <ol>
+      <li>Confirm the source issue is still open and your change is not already covered by another PR.</li>
+      <li>Keep the PR focused, link <strong>Bounty #{{ bounty.issue_number }}</strong>, and include test or smoke-check evidence.</li>
+      <li>
+        {% if bounty.awards_remaining %}
+          {{ bounty.awards_remaining }} award{% if bounty.awards_remaining != 1 %}s{% endif %} still open for distinct accepted work.
+        {% else %}
+          No awards remain; treat new work as unpaid unless maintainers reopen the bounty.
+        {% endif %}
+      </li>
+    </ol>
+    <div class="next-steps-actions" aria-label="Bounty action links">
+      {% if issue_url %}<a href="{{ issue_url }}" rel="nofollow noopener">Open source issue</a>{% endif %}
+      <a href="/api/v1/bounties/{{ bounty.id }}">View JSON details</a>
+    </div>
+  </section>
 </section>
 
 <section>

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -51,7 +51,7 @@
     <h2 id="bounty-next-steps-heading">Before you start</h2>
     <ol>
       <li>Confirm the source issue is still open and your change is not already covered by another PR.</li>
-      <li>Keep the PR focused, link <strong>Bounty #{{ bounty.id }}</strong>, and include test or smoke-check evidence.</li>
+      <li>Keep the PR focused, link the source issue as <strong>Bounty #{{ bounty.issue_number }}</strong>, and include test or smoke-check evidence.</li>
       <li>
         {% if bounty.awards_remaining %}
           {{ bounty.awards_remaining }} award{% if bounty.awards_remaining != 1 %}s{% endif %} still open for distinct accepted work.

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -51,7 +51,7 @@
     <h2 id="bounty-next-steps-heading">Before you start</h2>
     <ol>
       <li>Confirm the source issue is still open and your change is not already covered by another PR.</li>
-      <li>Keep the PR focused, link <strong>Bounty #{{ bounty.issue_number }}</strong>, and include test or smoke-check evidence.</li>
+      <li>Keep the PR focused, link <strong>Bounty #{{ bounty.id }}</strong>, and include test or smoke-check evidence.</li>
       <li>
         {% if bounty.awards_remaining %}
           {{ bounty.awards_remaining }} award{% if bounty.awards_remaining != 1 %}s{% endif %} still open for distinct accepted work.

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -228,7 +228,7 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert "Contributor next steps" in response.text
     assert "Before you start" in response.text
     assert "Confirm the source issue is still open" in response.text
-    assert "Bounty #4" in response.text
+    assert f"Bounty #{bounty.id}" in response.text
     assert "1 award still open for distinct accepted work." in response.text
     assert (
         'href="https://github.com/ramimbo/mergework/issues/4" rel="nofollow noopener"'

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -228,7 +228,8 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert "Contributor next steps" in response.text
     assert "Before you start" in response.text
     assert "Confirm the source issue is still open" in response.text
-    assert f"Bounty #{bounty.id}" in response.text
+    assert bounty.id != bounty.issue_number
+    assert "link the source issue as <strong>Bounty #4</strong>" in response.text
     assert "1 award still open for distinct accepted work." in response.text
     assert (
         'href="https://github.com/ramimbo/mergework/issues/4" rel="nofollow noopener"'

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -225,6 +225,16 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert "100 MRWK" in response.text
     assert "What has to be true" in response.text
     assert "Focused PR improves status, reward, issue link, and acceptance text." in response.text
+    assert "Contributor next steps" in response.text
+    assert "Before you start" in response.text
+    assert "Confirm the source issue is still open" in response.text
+    assert "Bounty #4" in response.text
+    assert "1 award still open for distinct accepted work." in response.text
+    assert (
+        'href="https://github.com/ramimbo/mergework/issues/4" rel="nofollow noopener"'
+        in response.text
+    )
+    assert f'href="/api/v1/bounties/{bounty.id}"' in response.text
 
     missing_response = client.get("/api/v1/bounties/999")
     assert missing_response.status_code == 404
@@ -237,6 +247,40 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert oversized_api_response.json()["detail"] == "bounty id is too large"
     oversized_page_response = client.get(f"/bounties/{oversized_bounty_id}")
     assert oversized_page_response.status_code == 400
+
+
+def test_bounty_detail_warns_when_no_awards_remain(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=5,
+            issue_url="https://github.com/ramimbo/mergework/issues/5",
+            title="One-shot bounty",
+            reward_mrwk="25",
+            max_awards=1,
+            acceptance="Only one accepted award should be paid.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:contributor",
+            submission_url="https://github.com/ramimbo/mergework/pull/5",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(f"/bounties/{bounty.id}")
+
+    assert response.status_code == 200
+    assert (
+        "No awards remain; treat new work as unpaid unless maintainers reopen the bounty."
+        in response.text
+    )
 
 
 def test_bounty_detail_shows_accepted_award_history(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- Adds a contributor next-steps panel to bounty detail pages.
- Links the source issue and JSON detail endpoint from the detail page.
- Shows whether award slots remain, including a warning once awards are exhausted.

Bounty #427

## Test Plan
- `python3 -m pytest tests/test_bounty_pages.py tests/test_public_routes.py -q`

## Evidence
- Preflight: #427 is open with awards remaining; existing #427 submissions cover list card styling, empty states, wallet copy, and sort controls. This PR is a distinct bounty-detail workflow improvement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Contributor next steps" card on bounty detail pages with before-you-start guidance, conditional messaging when no awards remain, and action links to open the source issue and view bounty JSON.

* **Style**
  * Extended card styling to the new next-steps card and added spacing, list, heading, and responsive action-link layout.

* **Tests**
  * Added/updated tests to verify the new guidance, conditional warning when awards are exhausted, and presence of action links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->