### PR TITLE
docs(api): Document accepted-work bounty context

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -286,38 +286,40 @@ for registered `mrwk1` addresses.
 Read the proof-backed accepted-work list for a single account:
 
 ```bash
-curl -s "$API_HOST/api/v1/accounts/github:tatelyman/accepted-work"
+curl -s "$API_HOST/api/v1/accounts/github:carpedkm/accepted-work"
 ```
 
 The response includes the account summary plus the same accepted-work rows used
 by the public account page, so agents can inspect recent proof, ledger,
-submission, source issue, and maintainer acceptance details without scraping
-HTML:
+submission, source issue, internal bounty id and public bounty URL, and
+maintainer acceptance details without scraping HTML:
 
 ```json
 {
-  "account": "github:tatelyman",
+  "account": "github:carpedkm",
   "summary": {
-    "accepted_awards": 2,
-    "accepted_mrwk": "140",
-    "latest_ledger_sequence": 401,
-    "latest_submission_url": "https://github.com/ramimbo/mergework/pull/189",
-    "latest_proof_hash": "507413ce756056804e80d6782641222fda1444e8d541992d27b4ddd418792d68",
-    "latest_proof_url": "/proofs/507413ce756056804e80d6782641222fda1444e8d541992d27b4ddd418792d68"
+    "accepted_awards": 6,
+    "accepted_mrwk": "340",
+    "latest_ledger_sequence": 682,
+    "latest_submission_url": "https://github.com/ramimbo/mergework/issues/407#issuecomment-4545035155",
+    "latest_proof_hash": "cb7707861ca88447db67aa707d06ca51f4d6a1b382cbba33305b251f88fd1e80",
+    "latest_proof_url": "/proofs/cb7707861ca88447db67aa707d06ca51f4d6a1b382cbba33305b251f88fd1e80"
   },
   "accepted_work": [
     {
-      "ledger_sequence": 401,
-      "ledger_url": "/ledger/401",
-      "proof_hash": "507413ce756056804e80d6782641222fda1444e8d541992d27b4ddd418792d68",
-      "proof_url": "/proofs/507413ce756056804e80d6782641222fda1444e8d541992d27b4ddd418792d68",
-      "amount_mrwk": "100",
-      "submission_url": "https://github.com/ramimbo/mergework/pull/189",
-      "issue_url": "https://github.com/ramimbo/mergework/issues/291",
+      "ledger_sequence": 682,
+      "ledger_url": "/ledger/682",
+      "proof_hash": "cb7707861ca88447db67aa707d06ca51f4d6a1b382cbba33305b251f88fd1e80",
+      "proof_url": "/proofs/cb7707861ca88447db67aa707d06ca51f4d6a1b382cbba33305b251f88fd1e80",
+      "amount_mrwk": "50",
+      "submission_url": "https://github.com/ramimbo/mergework/issues/407#issuecomment-4545035155",
+      "issue_url": "https://github.com/ramimbo/mergework/issues/407",
       "repo": "ramimbo/mergework",
-      "issue_number": 291,
-      "accepted_by": "maintainer",
-      "created_at": "2026-05-25T20:12:59.000000"
+      "issue_number": 407,
+      "bounty_id": 67,
+      "bounty_url": "/bounties/67",
+      "accepted_by": "ramimbo",
+      "created_at": "2026-05-26T15:30:01.346962"
     }
   ]
 }

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -260,3 +260,12 @@ def test_api_examples_document_activity_response_shape() -> None:
     assert "bounty repo, bounty issue URL" in examples
     assert "newest ledger sequence" in examples
     assert "/api/v1/proofs/<proof_hash>" in examples
+
+
+def test_api_examples_document_accepted_work_bounty_context() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/accounts/github:carpedkm/accepted-work" in examples
+    assert '"bounty_id": 67' in examples
+    assert '"bounty_url": "/bounties/67"' in examples
+    assert "internal bounty id and public bounty URL" in examples


### PR DESCRIPTION
Bounty #411

Summary: update the public accepted-work API example with the current bounty
context fields returned by the live endpoint.

Update the public accepted-work API example in `docs/api-examples.md` so it
shows the current `bounty_id` and `bounty_url` fields returned by
`/api/v1/accounts/{account}/accepted-work`.

The live unauthenticated response for
`https://api.mrwk.ltclab.site/api/v1/accounts/github:carpedkm/accepted-work`
includes those fields on each accepted-work row. Documenting them helps agents
map accepted work back to the internal bounty detail page without scraping
HTML, while keeping the example grounded in public proof-backed ledger data.

This is distinct from the already-paid #411 examples for activity, MCP
ledger/wallet lookup, and `submit_work_proof`; it covers the per-account
accepted-work endpoint row shape.

Validation:
- `/Users/juliebush/mergework/.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `/Users/juliebush/mergework/.venv/bin/python -m pytest tests/test_docs_public_urls.py -q` -> 19 passed
- `/Users/juliebush/mergework/.venv/bin/ruff check tests/test_docs_public_urls.py` -> passed
- `/Users/juliebush/mergework/.venv/bin/ruff format --check tests/test_docs_public_urls.py` -> 1 file already formatted
- `git diff --check` -> passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API examples to show bounty context details, including bounty IDs and public URLs in accepted-work responses.

* **Tests**
  * Added validation to ensure API documentation includes complete bounty context information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->