### PR TITLE
docs(api): Document attempt-list response shape

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -82,6 +82,27 @@ List active attempts for a bounty:
 curl -s "$API_HOST/api/v1/bounties/<bounty_id>/attempts"
 ```
 
+The list response returns the bounty id, advisory warnings, and active attempt reservations:
+
+```json
+{
+  "bounty_id": 65,
+  "warnings": [],
+  "attempts": [
+    {
+      "id": 12,
+      "bounty_id": 65,
+      "submitter_account": "github:tatelyman",
+      "source_url": "https://github.com/ramimbo/mergework/tree/attempt-bounty-321",
+      "status": "active",
+      "expires_at": "2026-05-26T22:07:00+00:00",
+      "created_at": "2026-05-25T22:07:00+00:00",
+      "updated_at": "2026-05-25T22:07:00+00:00"
+    }
+  ]
+}
+```
+
 Include expired or released attempts when auditing abandoned work:
 
 ```bash
@@ -617,20 +638,25 @@ Before registering a new attempt or opening a PR, inspect existing active attemp
 curl -s "$API_HOST/api/v1/bounties/<bounty_id>/attempts"
 ```
 
-The response lists active attempt reservations:
+The response returns the same wrapper object used by the active-attempts API:
 
 ```json
-[
-  {
-    "id": 12,
-    "bounty_id": 53,
-    "submitter_account": "github:tatelyman",
-    "source_url": "https://github.com/ramimbo/mergework/tree/attempt-bounty-321",
-    "status": "active",
-    "expires_at": "2026-05-26T22:07:00+00:00",
-    "created_at": "2026-05-25T22:07:00+00:00"
-  }
-]
+{
+  "bounty_id": 65,
+  "warnings": [],
+  "attempts": [
+    {
+      "id": 12,
+      "bounty_id": 65,
+      "submitter_account": "github:tatelyman",
+      "source_url": "https://github.com/ramimbo/mergework/tree/attempt-bounty-321",
+      "status": "active",
+      "expires_at": "2026-05-26T22:07:00+00:00",
+      "created_at": "2026-05-25T22:07:00+00:00",
+      "updated_at": "2026-05-25T22:07:00+00:00"
+    }
+  ]
+}
 ```
 
 If another active attempt already covers your exact intended scope, pick a different scope or bounty rather than racing with a duplicate PR. Expired or released attempts can be included for abandoned-work audit:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -104,6 +104,16 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert "Use `id` for the single-bounty API path" in examples
 
 
+def test_api_examples_document_attempt_list_response_shape() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/bounties/<bounty_id>/attempts" in examples
+    assert "returns the bounty id, advisory warnings, and active attempt reservations" in examples
+    assert '"bounty_id": 65' in examples
+    assert '"warnings": []' in examples
+    assert '"attempts": [' in examples
+
+
 def test_api_examples_document_wallet_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Summary: Document the `GET /api/v1/bounties/<bounty_id>/attempts` list response as the wrapper object returned by the live public API, including `bounty_id`, `warnings`, and `attempts`.

Evidence: The existing public examples showed the preflight active-attempts response as a bare JSON array, but the live endpoint returns an object wrapper; `GET https://api.mrwk.ltclab.site/api/v1/bounties/65/attempts?include_expired=false` returned `{"bounty_id":65,"warnings":[],"attempts":[]}` during preflight.

Validation: `python -m pytest tests/test_docs_public_urls.py::test_api_examples_document_attempt_list_response_shape -q`, `python scripts/docs_smoke.py`, `python -m pytest tests/test_docs_public_urls.py -q`, `ruff check tests/test_docs_public_urls.py`, `ruff format --check tests/test_docs_public_urls.py`, and `git diff --check` passed locally. GitHub Actions and CodeRabbit also pass on this PR.

This is a focused public documentation accuracy fix. It was originally submitted while #411 was active; #411 is now paid/full, so this remaining open docs PR is linked to the general documentation bounty.

Bounty #426