### PR TITLE
Improve activity search empty state

### DIFF
--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -12,6 +12,9 @@
     {% if query %}<a href="/activity">Clear</a>{% endif %}
   </div>
 </form>
+{% if query %}
+<p class="notice">Showing accepted work matching “{{ query }}”.</p>
+{% endif %}
 
 <section class="grid">
   <article><strong>{{ totals.accepted_awards }}</strong><span>accepted awards</span></article>
@@ -54,7 +57,11 @@
     {% endfor %}
   </div>
   {% else %}
+  {% if query %}
+  <p>No contributors match this search.</p>
+  {% else %}
   <p>No accepted bounty payments yet.</p>
+  {% endif %}
   {% endif %}
 </section>
 
@@ -101,7 +108,12 @@
     {% endfor %}
   </div>
   {% else %}
+  {% if query %}
+  <p>No accepted work matches this search.</p>
+  <p><a href="/activity">Clear search</a></p>
+  {% else %}
   <p>No proof-backed accepted work rows yet.</p>
+  {% endif %}
   {% endif %}
 </section>
 {% endblock %}

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -219,4 +219,18 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
 
     assert filtered.status_code == 200
     assert 'value="bob"' in filtered.text
+    assert "Showing accepted work matching “bob”." in filtered.text
     assert 'href="/activity">Clear</a>' in filtered.text
+    assert "No contributors match this search." not in filtered.text
+    assert "No accepted work matches this search." not in filtered.text
+
+    no_match = client.get("/activity?q=alice")
+
+    assert no_match.status_code == 200
+    assert 'value="alice"' in no_match.text
+    assert "Showing accepted work matching “alice”." in no_match.text
+    assert "No contributors match this search." in no_match.text
+    assert "No accepted work matches this search." in no_match.text
+    assert "No accepted bounty payments yet." not in no_match.text
+    assert "No proof-backed accepted work rows yet." not in no_match.text
+    assert 'href="/activity">Clear search</a>' in no_match.text


### PR DESCRIPTION
## Summary

- Add a clear searched state to `/activity` so filtered views say what query is active.
- Show search-specific empty states for contributors and recent accepted work instead of the generic empty-ledger copy.
- Extend activity page tests to lock both matching and no-match search behavior.

Bounty #427

## Evidence

- The activity page already supports `q` search, but a no-match search currently renders the same copy as a completely empty ledger.
- This is distinct from the already-paid bounty-list empty-state work because it applies to accepted-work activity search and proof-backed contributor history.
- Touched surfaces are limited to `app/templates/activity.html` and `tests/test_activity.py`.
- Out of scope: activity serialization, ledger data, wallet behavior, proof records, price claims, liquidity claims, off-ramp claims, or broad redesign.

## Test Evidence

- `./.venv/bin/python -m pytest tests/test_activity.py -q` -> 3 passed
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `./.venv/bin/python -m ruff check .` -> passed
- `./.venv/bin/python -m ruff format --check .` -> 79 files already formatted
- `./.venv/bin/python -m mypy app` -> success
- `./.venv/bin/python -m pytest -q` -> 413 passed
- `git diff --check` -> passed

## MRWK

Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties): Bounty #427


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity page now displays search-aware empty-state messaging. When searches are applied, the page shows "Showing accepted work matching..." notices and query-specific "no match" messages for contributors and work sections. A "Clear search" option allows users to easily reset applied filters and view all content again.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->