### PR TITLE
Document bounty preflight quality gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,21 @@ small, verifiable, and easy for maintainers to review.
 - Do not submit generated noise, duplicate reports, or unrelated rewrites.
 - Do not claim payout, acceptance, or ledger status that has not happened.
 
+## Preflight Checks
+
+Before opening a bounty PR, draft the PR body locally and run the advisory
+submission gate:
+
+```bash
+python scripts/submission_quality_gate.py --text-file pr-body.md --repo ramimbo/mergework
+```
+
+The gate checks for a bounty reference, summary, validation evidence, open award
+capacity, active attempts, similar open PRs, and recent maintainer activity when
+that public context is available. A warning is not an automatic rejection, but
+fix missing evidence, duplicate scope, or closed bounty references before
+submitting.
+
 ## Security Work
 
 Report private security findings through the security policy. Public issues and


### PR DESCRIPTION
## Summary

- Add a concise contributor-facing preflight section to `CONTRIBUTING.md` for bounty PR authors.
- Document the existing `scripts/submission_quality_gate.py --text-file ... --repo ...` advisory workflow and what it checks.
- Replaces the same focused docs scope from PR #429, which is currently held because required project CI is not present/green on that inaccessible PR head.

Refs #426

## Evidence

- Compared against `scripts/submission_quality_gate.py`, which checks bounty references, summary/evidence signals, payability, active attempts, similar open PRs, and maintainer activity when available.
- `docs/agent-guide.md` already documents this gate for agents; this PR adds the same contributor-facing preflight guidance to the main contributor entrypoint.
- Current diff against `origin/main` is one file: `CONTRIBUTING.md`, 15 insertions.
- Out of scope: API/MCP examples, behavior changes, broad docs rewrite, payout/price claims, or payment status claims.

## Test Evidence

- `python scripts/check_agents.py` -> AGENTS.md ok
- `python scripts/docs_smoke.py` -> docs smoke ok
- `python -m pytest` -> 413 passed
- `python -m ruff check .` -> passed
- `python -m ruff format --check .` -> 79 files already formatted
- `python -m mypy app` -> success
- `python scripts/check_deploy_ready.py` with CI env values -> passed
- `docker build -t mergework:ci .` -> passed
- `git diff --check origin/main...HEAD` -> passed

## MRWK

Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties): Refs #426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guide with a new "Preflight Checks" section describing a local validation workflow for bounty pull requests. Includes verification of bounty references, required evidence fields, capacity/attempt status, and detection of similar open or closed pull requests before submission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->