### PR TITLE
Show active attempts on bounty detail pages

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -10,10 +10,11 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.accounts import normalized_wallet_address
+from app.bounty_attempts import list_bounty_attempts
 from app.bounty_sorting import BOUNTY_SORT_LABELS, normalize_bounty_sort
 from app.db import session_scope
 from app.ledger_views import account_ledger_transactions
-from app.models import Wallet
+from app.models import Bounty, Wallet
 from app.path_params import proof_hash_from_path
 from app.serializers import bounty_list_summary, wallet_to_dict
 
@@ -40,6 +41,13 @@ def public_bounties_context(
 def wallets_page_context(session: Session) -> dict[str, Any]:
     wallets = session.scalars(select(Wallet).order_by(Wallet.created_at.desc()).limit(100)).all()
     return {"wallets": [wallet_to_dict(session, wallet) for wallet in wallets]}
+
+
+def bounty_page_attempts_context(session: Session, bounty_id: int) -> dict[str, Any]:
+    bounty = session.get(Bounty, bounty_id)
+    if bounty is None:
+        raise HTTPException(status_code=404, detail="bounty not found")
+    return list_bounty_attempts(session, bounty, limit=5)
 
 
 def wallet_page_context(session: Session, address: str) -> dict[str, Any]:
@@ -80,8 +88,13 @@ def register_public_routes(
 
     @app.get("/bounties/{bounty_id}", response_class=HTMLResponse)
     def bounty_page(request: Request, bounty_id: int) -> HTMLResponse:
+        bounty = api_bounty(bounty_id)
+        with session_scope(db_url) as session:
+            attempts_context = bounty_page_attempts_context(session, bounty_id)
         return templates.TemplateResponse(
-            request, "bounty_detail.html", {"bounty": api_bounty(bounty_id)}
+            request,
+            "bounty_detail.html",
+            {"bounty": bounty, "attempts": attempts_context},
         )
 
     @app.get("/ledger", response_class=HTMLResponse)

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -45,6 +45,41 @@
     <h2 id="acceptance-heading">What has to be true</h2>
     <p>{{ bounty.acceptance }}</p>
   </section>
+
+  <section class="acceptance-card" aria-labelledby="attempts-heading">
+    <p class="eyebrow">Coordination</p>
+    <h2 id="attempts-heading">Active attempts</h2>
+    {% if attempts.warnings %}
+      <ul>
+        {% for warning in attempts.warnings %}
+          <li>{{ warning }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+    {% if attempts.attempts %}
+      <div class="ledger-list">
+        {% for attempt in attempts.attempts %}
+        <article class="ledger-row">
+          <div class="ledger-entry-card">
+            <div class="ledger-card-head">
+              <div class="ledger-card-title">
+                <strong>{{ attempt.submitter_account }}</strong>
+                <span class="ledger-type">{{ attempt.status }}</span>
+              </div>
+              <span>Expires {{ attempt.expires_at[:16] | replace("T", " ") }}</span>
+            </div>
+            {% set source_url = safe_public_url(attempt.source_url) %}
+            {% if source_url %}
+              <p><a href="{{ source_url }}">{{ attempt.source_url | replace("https://github.com/", "") }}</a></p>
+            {% endif %}
+          </div>
+        </article>
+        {% endfor %}
+      </div>
+    {% else %}
+      <p>No active attempts are registered for this bounty.</p>
+    {% endif %}
+  </section>
 </section>
 
 <section>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
+from app.models import BountyAttempt
 
 
 def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
@@ -308,6 +311,59 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert oversized_api_response.json()["detail"] == "bounty id is too large"
     oversized_page_response = client.get(f"/bounties/{oversized_bounty_id}")
     assert oversized_page_response.status_code == 400
+
+
+def test_bounty_detail_shows_active_attempt_coordination(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    now = datetime.now(UTC)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=427,
+            issue_url="https://github.com/ramimbo/mergework/issues/427",
+            title="Improve bounty coordination",
+            reward_mrwk="125",
+            max_awards=3,
+            acceptance="Bounty detail pages should make active attempts visible.",
+        )
+        session.add(
+            BountyAttempt(
+                bounty_id=bounty.id,
+                submitter_account="github:alice",
+                source_url="https://github.com/ramimbo/mergework/pull/451",
+                status="active",
+                expires_at=now + timedelta(hours=2),
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        session.add(
+            BountyAttempt(
+                bounty_id=bounty.id,
+                submitter_account="github:expired",
+                source_url="https://github.com/ramimbo/mergework/pull/999",
+                status="active",
+                expires_at=now - timedelta(minutes=1),
+                created_at=now - timedelta(hours=3),
+                updated_at=now - timedelta(hours=3),
+            )
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(f"/bounties/{bounty_id}")
+
+    assert response.status_code == 200
+    assert "Active attempts" in response.text
+    assert "github:alice" in response.text
+    assert "active" in response.text
+    assert 'href="https://github.com/ramimbo/mergework/pull/451"' in response.text
+    assert "github:expired" not in response.text
+    assert "https://github.com/ramimbo/mergework/pull/999" not in response.text
+    assert "No active attempts are registered for this bounty." not in response.text
 
 
 def test_bounty_detail_shows_accepted_award_history(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- show active attempt coordination on public bounty detail pages
- include active attempt submitter, status, expiry, and source link when available
- add regression coverage for active attempts on `/bounties/{id}`

Bounty #427

## Evidence
- Distinct from existing #427 work: #430 covers bounty cards/back nav, #434 covers filtered empty state, #440 covers wallet/private-key copy, #443 covers sorting, #444 covers contributor next steps, and #449 covers activity search empty states.
- Live public attempts API for bounty 73 returned `{"bounty_id":73,"warnings":[],"attempts":[]}` during preflight, but the public detail page did not surface active attempt coordination.
- This change reuses the existing `list_bounty_attempts` logic and keeps the public page limited to public attempt metadata.

## Validation
- `.venv/bin/python -m pytest tests/test_bounty_pages.py -q` -> 7 passed
- `.venv/bin/python -m pytest tests/test_bounty_attempts.py -q` -> 5 passed
- `.venv/bin/python -m ruff check app/public_routes.py tests/test_bounty_pages.py` -> passed
- `.venv/bin/python -m ruff format --check app/public_routes.py tests/test_bounty_pages.py` -> 2 files already formatted
- `.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `.venv/bin/python -m mypy app` -> success
- `git diff --check` -> passed

No wallet private keys, private data, price/off-ramp claims, liquidity claims, exchange claims, or fabricated payout claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounty detail pages add a "Coordination / Active attempts" section showing warnings (when present), active submitters, current status, expiration timestamps, and optional source links; shows a "No active attempts" fallback when none exist.

* **Tests**
  * Added test coverage verifying the coordination section displays active attempts, excludes expired attempts, and shows expected links and statuses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->