### PR TITLE
docs: surface current MRWK transfer paths on public pages

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -15,6 +15,11 @@ from app.db import session_scope
 from app.ledger_views import account_ledger_transactions
 from app.models import Wallet
 from app.serializers import bounty_list_summary, wallet_to_dict
+from app.status import (
+    CURRENT_TRANSFER_PATHS,
+    FUTURE_PATH_BOUNDARY,
+    UNSUPPORTED_PUBLIC_PATHS_SUMMARY,
+)
 
 
 def public_bounties_context(
@@ -117,4 +122,12 @@ def register_public_routes(
 
     @app.get("/docs", response_class=HTMLResponse)
     def docs_page(request: Request) -> HTMLResponse:
-        return templates.TemplateResponse(request, "docs.html")
+        return templates.TemplateResponse(
+            request,
+            "docs.html",
+            {
+                "current_transfer_paths": CURRENT_TRANSFER_PATHS,
+                "future_path_boundary": FUTURE_PATH_BOUNDARY,
+                "unsupported_public_paths_summary": UNSUPPORTED_PUBLIC_PATHS_SUMMARY,
+            },
+        )

--- a/app/status.py
+++ b/app/status.py
@@ -13,6 +13,20 @@ from app.ledger.service import (
 )
 from app.models import Bounty, LedgerEntry
 
+CURRENT_TRANSFER_PATHS = (
+    "github:* balance claims into a linked wallet",
+    "payouts to linked mrwk1 wallets",
+    "signed wallet-to-wallet transfers between registered wallets",
+)
+UNSUPPORTED_PUBLIC_PATHS = ("BTC", "USDC", "fiat", "bridge", "exchange", "off-ramp")
+UNSUPPORTED_PUBLIC_PATHS_SUMMARY = (
+    "MergeWork does not currently operate a public BTC, USDC, fiat, bridge, exchange, or off-ramp."
+)
+FUTURE_PATH_BOUNDARY = (
+    "Future public snapshots, bridges, and onchain claims require separate "
+    "maintainer/contributor discussion before implementation."
+)
+
 
 def ledger_height(session: Session) -> int:
     height = session.scalar(select(func.max(LedgerEntry.sequence))) or 0
@@ -40,5 +54,9 @@ def system_status(session: Session) -> dict[str, Any]:
         "ledger_height": ledger_height(session),
         "active_bounties": int(active_bounties or 0),
         "treasury_balance_mrwk": format_mrwk(treasury_balance),
+        "current_transfer_paths": list(CURRENT_TRANSFER_PATHS),
+        "unsupported_public_paths": list(UNSUPPORTED_PUBLIC_PATHS),
+        "unsupported_public_paths_summary": UNSUPPORTED_PUBLIC_PATHS_SUMMARY,
         "future_path": "public snapshots, bridges, and onchain claims",
+        "future_path_boundary": FUTURE_PATH_BOUNDARY,
     }

--- a/app/templates/docs.html
+++ b/app/templates/docs.html
@@ -29,6 +29,15 @@
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/api-examples.md">Public API examples</a></li>
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/ledger.md">Ledger details</a></li>
   </ul>
+  <h2>Current transfer paths</h2>
+  <p>Supported MRWK transfer paths today are:</p>
+  <ul>
+    {% for path in current_transfer_paths %}
+    <li>{{ path }}</li>
+    {% endfor %}
+  </ul>
+  <p>{{ unsupported_public_paths_summary }}</p>
+  <p>{{ future_path_boundary }}</p>
   <h2>Payout access</h2>
   <p>MRWK balances can live on native <code>mrwk1</code> wallet addresses. A wallet signs transfer, GitHub-link, and claim payloads with its private key; the server verifies signatures and records accepted movements in the explorer.</p>
 </section>

--- a/app/templates/hub.html
+++ b/app/templates/hub.html
@@ -20,8 +20,15 @@
   <article><strong>{{ status.treasury_balance_mrwk }}</strong><span>treasury MRWK</span></article>
 </section>
 <section>
-  <h2>Future path</h2>
-  <p>MRWK starts as a native project coin on the MergeWork ledger. The ledger is designed for future public snapshots, bridges, and onchain claims.</p>
+  <h2>Current transfer paths</h2>
+  <p>MRWK starts as a native project coin on the MergeWork ledger. Supported paths today are:</p>
+  <ul>
+    {% for path in status.current_transfer_paths %}
+    <li>{{ path }}</li>
+    {% endfor %}
+  </ul>
+  <p>{{ status.unsupported_public_paths_summary }}</p>
+  <p>{{ status.future_path_boundary }}</p>
 </section>
 <section>
   <h2>Accounts and payouts</h2>

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -76,6 +76,29 @@ def test_head_requests_match_get_routes_without_body(sqlite_url: str) -> None:
     assert post_only.headers["allow"] == "POST"
 
 
+def test_public_pages_clarify_current_transfer_paths(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    for path in ("/", "/docs"):
+        response = client.get(path)
+        assert response.status_code == 200
+        assert "github:* balance claims into a linked wallet" in response.text
+        assert "payouts to linked mrwk1 wallets" in response.text
+        assert "signed wallet-to-wallet transfers between registered wallets" in response.text
+        assert (
+            "MergeWork does not currently operate a public BTC, USDC, fiat, "
+            "bridge, exchange, or off-ramp."
+        ) in response.text
+        assert (
+            "Future public snapshots, bridges, and onchain claims require separate "
+            "maintainer/contributor discussion before implementation."
+        ) in response.text
+
+
 def test_trailing_slash_redirects_keep_forwarded_https_scheme(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -72,4 +72,25 @@ def test_system_status_counts_only_open_bounties(sqlite_url: str) -> None:
     assert status["ledger_height"] == expected_height
     assert status["active_bounties"] == 1
     assert status["treasury_balance_mrwk"] == expected_treasury_balance
+    assert status["current_transfer_paths"] == [
+        "github:* balance claims into a linked wallet",
+        "payouts to linked mrwk1 wallets",
+        "signed wallet-to-wallet transfers between registered wallets",
+    ]
+    assert status["unsupported_public_paths"] == [
+        "BTC",
+        "USDC",
+        "fiat",
+        "bridge",
+        "exchange",
+        "off-ramp",
+    ]
+    assert status["unsupported_public_paths_summary"] == (
+        "MergeWork does not currently operate a public BTC, USDC, fiat, bridge, "
+        "exchange, or off-ramp."
+    )
     assert status["future_path"] == "public snapshots, bridges, and onchain claims"
+    assert status["future_path_boundary"] == (
+        "Future public snapshots, bridges, and onchain claims require separate "
+        "maintainer/contributor discussion before implementation."
+    )


### PR DESCRIPTION
Bounty #426

## Summary
- Adds the current MRWK transfer-path boundary to the public Hub and Docs pages.
- Extends `/api/v1/status` with explicit current transfer paths and unsupported public paths so clients do not have to infer that from the future-path string.
- Adds regression coverage that `/` and `/docs` both render the supported paths, the no public BTC/USDC/fiat/bridge/exchange/off-ramp boundary, and the separate future-discussion boundary.

## Evidence
- `docs/ledger.md` and `README.md` already document that MRWK currently supports `github:*` balance claims, linked `mrwk1` payouts, and signed registered wallet-to-wallet transfers, while public BTC, USDC, fiat, bridge, exchange, and off-ramp paths are not currently operated.
- Before this PR, `app/templates/hub.html` only said the ledger is designed for future public snapshots, bridges, and onchain claims, and `app/templates/docs.html` did not surface the same current-path boundary.
- `curl https://api.mrwk.ltclab.site/api/v1/status` currently returns `future_path: public snapshots, bridges, and onchain claims` without current transfer-path or unsupported-path fields.
- Live bounty preflight: `GET https://api.mrwk.ltclab.site/api/v1/bounties/72` returned issue `#426`, status `open`, `awards_remaining: 4`; `GET /api/v1/bounties/72/attempts?include_expired=false` returned no active attempts.
- This is distinct from PR #397 / issue #395, which updated repository docs only; this PR makes the live public pages and status JSON carry the same boundary.

## Validation
- `/Users/mx/Money/worktrees/mergework-pr451-review/.venv/bin/python -m pytest tests/test_api_mcp.py::test_public_pages_clarify_current_transfer_paths tests/test_status.py tests/test_public_routes.py -q` -> `4 passed`
- `python3 scripts/docs_smoke.py` -> `docs smoke ok`
- `/Users/mx/Money/worktrees/mergework-pr451-review/.venv/bin/python -m ruff check app/status.py app/public_routes.py tests/test_api_mcp.py tests/test_status.py` -> `All checks passed!`
- `/Users/mx/Money/worktrees/mergework-pr451-review/.venv/bin/python -m ruff format --check app/status.py app/public_routes.py tests/test_api_mcp.py tests/test_status.py` -> `4 files already formatted`
- `/Users/mx/Money/worktrees/mergework-pr451-review/.venv/bin/python -m mypy app` -> `Success: no issues found in 30 source files`
- `/Users/mx/Money/worktrees/mergework-pr451-review/.venv/bin/python -m pytest -q` -> `414 passed`
- `git diff --check` -> passed
- `gitleaks detect --no-banner --redact --source . --exit-code 1` -> no leaks found

No private keys, seed material, secrets, deployment credentials, price claims, investment claims, liquidity claims, exchange claims, bridge promises, off-ramp promises, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced documentation and public pages with clarification about currently supported transfer paths, unsupported bridging/off-ramping options, and future path boundaries.
  * Hub page updated to display current transfer paths and related restrictions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->