### PR TITLE
Clarify live MRWK future path

### DIFF
--- a/app/status.py
+++ b/app/status.py
@@ -13,6 +13,21 @@ from app.ledger.service import (
 )
 from app.models import Bounty, LedgerEntry
 
+CURRENT_TRANSFER_PATHS = (
+    "github:* balance claims",
+    "linked mrwk1 wallet payouts",
+    "signed wallet-to-wallet transfers",
+)
+UNSUPPORTED_PUBLIC_PATHS = (
+    "public BTC/USDC/fiat bridge",
+    "exchange",
+    "off-ramp",
+)
+FUTURE_PATH_NOTE = (
+    "native ledger claims and transfers today; future public snapshots, bridges, "
+    "and onchain claims require separate maintainer/contributor discussion"
+)
+
 
 def ledger_height(session: Session) -> int:
     height = session.scalar(select(func.max(LedgerEntry.sequence))) or 0
@@ -40,5 +55,7 @@ def system_status(session: Session) -> dict[str, Any]:
         "ledger_height": ledger_height(session),
         "active_bounties": int(active_bounties or 0),
         "treasury_balance_mrwk": format_mrwk(treasury_balance),
-        "future_path": "public snapshots, bridges, and onchain claims",
+        "current_transfer_paths": list(CURRENT_TRANSFER_PATHS),
+        "unsupported_public_paths": list(UNSUPPORTED_PUBLIC_PATHS),
+        "future_path": FUTURE_PATH_NOTE,
     }

--- a/app/templates/hub.html
+++ b/app/templates/hub.html
@@ -21,7 +21,8 @@
 </section>
 <section>
   <h2>Future path</h2>
-  <p>MRWK starts as a native project coin on the MergeWork ledger. The ledger is designed for future public snapshots, bridges, and onchain claims.</p>
+  <p>MRWK starts as a native project coin on the MergeWork ledger. Supported paths today are GitHub balance claims, linked <code>mrwk1</code> wallet payouts, and signed wallet-to-wallet transfers.</p>
+  <p>MergeWork does not currently operate a public BTC, USDC, fiat, bridge, exchange, or off-ramp. Future public snapshots, bridges, and onchain claims require separate maintainer/contributor discussion before implementation.</p>
 </section>
 <section>
   <h2>Accounts and payouts</h2>

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -52,4 +52,6 @@ def test_hub_clarifies_current_and_future_transfer_paths(sqlite_url: str) -> Non
     assert "Supported paths today are GitHub balance claims" in response.text
     assert "linked <code>mrwk1</code> wallet payouts" in response.text
     assert "does not currently operate a public BTC, USDC, fiat, bridge" in response.text
+    assert "exchange, or off-ramp" in response.text
+    assert "Future public snapshots, bridges, and onchain claims" in response.text
     assert "separate maintainer/contributor discussion" in response.text

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from fastapi.testclient import TestClient
+
+from app.db import create_schema, session_scope
+from app.ledger.service import ensure_genesis
+from app.main import create_app
 from app.public_routes import public_bounties_context
 
 
@@ -32,3 +37,19 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
             "awards": "Most award slots",
         },
     }
+
+
+def test_hub_clarifies_current_and_future_transfer_paths(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "Supported paths today are GitHub balance claims" in response.text
+    assert "linked <code>mrwk1</code> wallet payouts" in response.text
+    assert "does not currently operate a public BTC, USDC, fiat, bridge" in response.text
+    assert "separate maintainer/contributor discussion" in response.text

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -72,4 +72,15 @@ def test_system_status_counts_only_open_bounties(sqlite_url: str) -> None:
     assert status["ledger_height"] == expected_height
     assert status["active_bounties"] == 1
     assert status["treasury_balance_mrwk"] == expected_treasury_balance
-    assert status["future_path"] == "public snapshots, bridges, and onchain claims"
+    assert status["current_transfer_paths"] == [
+        "github:* balance claims",
+        "linked mrwk1 wallet payouts",
+        "signed wallet-to-wallet transfers",
+    ]
+    assert status["unsupported_public_paths"] == [
+        "public BTC/USDC/fiat bridge",
+        "exchange",
+        "off-ramp",
+    ]
+    assert "native ledger claims and transfers today" in status["future_path"]
+    assert "separate maintainer/contributor discussion" in status["future_path"]


### PR DESCRIPTION
Summary:
- Clarifies the live `/api/v1/status` response by separating current supported transfer paths from unsupported public bridge/exchange/off-ramp paths.
- Updates the root page Future path copy to match the existing README and ledger-doc framing: native ledger claims/transfers are supported today, while future snapshots, bridges, and onchain claims require separate maintainer/contributor discussion.
- Adds focused regression coverage for the status payload and root page wording.

Bounty #406

Evidence:
- Public smoke report https://github.com/ramimbo/mergework/issues/405#issuecomment-4548338596 showed the live status API and root page mentioning bridges/onchain claims without nearby clarification that MergeWork does not currently operate public bridge, exchange, or off-ramp paths.
- Prior issue #395 / PR #397 clarified README and `docs/ledger.md`, but did not update `app/status.py` or `app/templates/hub.html`.
- Final duplicate/currentness checks found no same-scope open PR for the live status API/root page wording, and `/api/v1/bounties/66/attempts?include_expired=false` returned no active attempts.

Validation:
- `uv run --extra dev python -m pytest tests/test_status.py tests/test_public_routes.py tests/test_api_mcp.py::test_health_status_and_bounty_api -q` -> 5 passed
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --extra dev ruff check app/status.py tests/test_status.py tests/test_public_routes.py` -> passed
- `uv run --extra dev ruff format --check app/status.py tests/test_status.py tests/test_public_routes.py` -> 3 files already formatted
- `uv run --extra dev python -m mypy app` -> success
- `uv run --extra dev python -m pytest -q` -> 414 passed
- `git diff --check` -> clean
- diff-scoped `gitleaks detect --pipe --redact --no-banner --no-color` -> no leaks

No private keys, seed material, wallet JSON, browser storage, cookies, OAuth state, access tokens, signatures, deployment credentials, price claims, liquidity claims, exchange claims, off-ramp promises, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System status now exposes lists for current transfer paths and unsupported public paths, and uses a standardized future-path note.

* **Documentation**
  * Hub page clarifies supported transfer paths today and explicitly states which public transfer/bridge/on‑ramp features are not currently operated.

* **Tests**
  * Added a test verifying hub messaging about current/unsupported/future transfer paths; updated status tests to assert the new fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->