### PR TITLE
Clarify future portability docs copy

### DIFF
--- a/app/templates/docs.html
+++ b/app/templates/docs.html
@@ -31,5 +31,7 @@
   </ul>
   <h2>Payout access</h2>
   <p>MRWK balances can live on native <code>mrwk1</code> wallet addresses. A wallet signs transfer, GitHub-link, and claim payloads with its private key; the server verifies signatures and records accepted movements in the explorer.</p>
+  <h2>Future portability</h2>
+  <p>Future work can explore public snapshots and verifier-only claim designs. MergeWork does not currently operate a public bridge, exchange, off-ramp, liquidity path, fiat redemption route, or guaranteed external value path.</p>
 </section>
 {% endblock %}

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1545,6 +1545,8 @@ def test_docs_page_lists_live_ltclab_urls(sqlite_url: str) -> None:
     assert "OpenAPI docs" in docs
     assert 'href="/activity"' in docs
     assert 'href="/api/v1/activity"' in docs
+    assert "Future portability" in docs
+    assert "does not currently operate a public bridge, exchange, off-ramp" in docs
     assert "SwaggerUIBundle" in api_docs
 
 


### PR DESCRIPTION
## Summary

- Adds a docs-page `Future portability` section so the public docs no longer leave bridge/off-ramp status ambiguous.
- Clarifies that MergeWork does not currently operate a public bridge, exchange, off-ramp, liquidity path, fiat redemption route, or guaranteed external value path.
- Adds a focused regression assertion for the docs wording.

## Bounty

For #406.

This follows the docs-page wording gap reported in #405:
https://github.com/ramimbo/mergework/issues/405#issuecomment-4548338596

## Validation

- `python -m pytest tests/test_api_mcp.py::test_docs_page_lists_live_ltclab_urls -q`
- `ruff check app/status.py tests/test_status.py tests/test_api_mcp.py`
- `ruff format --check app/status.py tests/test_status.py tests/test_api_mcp.py`
- `python scripts/docs_smoke.py`
- `git diff --check`
