### PR TITLE
fix: normalize proof hash on proof page

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -14,6 +14,7 @@ from app.bounty_sorting import BOUNTY_SORT_LABELS, normalize_bounty_sort
 from app.db import session_scope
 from app.ledger_views import account_ledger_transactions
 from app.models import Wallet
+from app.path_params import proof_hash_from_path
 from app.serializers import bounty_list_summary, wallet_to_dict
 
 
@@ -111,8 +112,11 @@ def register_public_routes(
 
     @app.get("/proofs/{proof_hash}", response_class=HTMLResponse)
     def proof_page(request: Request, proof_hash: str) -> HTMLResponse:
+        normalized_proof_hash = proof_hash_from_path(proof_hash)
         return templates.TemplateResponse(
-            request, "proof.html", {"proof": api_proof(proof_hash), "proof_hash": proof_hash}
+            request,
+            "proof.html",
+            {"proof": api_proof(normalized_proof_hash), "proof_hash": normalized_proof_hash},
         )
 
     @app.get("/docs", response_class=HTMLResponse)

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -434,6 +434,11 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert f'href="/bounties/{bounty.id}"' in proof_page.text
     assert f'href="/ledger/{payment_sequence}"' in proof_page.text
 
+    uppercase_proof_page = client.get(f"/proofs/{proof_hash.upper()}")
+    assert uppercase_proof_page.status_code == 200
+    assert f'<code class="hash">{proof_hash}</code>' in uppercase_proof_page.text
+    assert f'<code class="hash">{proof_hash.upper()}</code>' not in uppercase_proof_page.text
+
     missing_proof = client.get(f"/api/v1/proofs/{'0' * 64}")
     assert missing_proof.status_code == 404
     assert client.get("/api/v1/proofs/not-a-proof-hash").status_code == 400


### PR DESCRIPTION
Focused Bounty #406 small fix: the HTML proof page now displays the canonical lowercase proof hash when a mixed-case proof URL is requested, matching the API proof lookup and stored proof hash.

Refs #406

Validation:
- Added a regression test first and confirmed it failed before the route change.
- `./.venv/bin/python -m pytest tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable tests/test_path_params.py -q` -> 6 passed
- `./.venv/bin/python -m pytest -q` -> 413 passed
- `./.venv/bin/python -m ruff format --check .` -> 79 files already formatted
- `./.venv/bin/python -m ruff check .` -> All checks passed
- `./.venv/bin/python -m mypy app` -> Success: no issues found in 30 source files
- `git diff --check` -> clean

Live bounty preflight:
- `GET https://api.mrwk.ltclab.site/api/v1/bounties/66/attempts?include_expired=false` -> no active attempts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed proof hash URL handling to normalize different casing variants, ensuring consistent access to proofs regardless of letter case.

* **Tests**
  * Added test coverage for case-insensitive proof hash endpoint access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/455?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->