### PR TITLE
docs: document bounty sort and limit filters

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -15,7 +15,9 @@ Check service status and list bounties:
 curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
 curl -s "$API_HOST/api/v1/bounties?status=open"
+curl -s "$API_HOST/api/v1/bounties?status=open&sort=available&limit=5"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open&q=proof"
+curl -s "$API_HOST/api/v1/bounties/summary?status=open&sort=awards&limit=5"
 ```
 
 The bounties list returns public bounty rows. `status` can be omitted or set to
@@ -45,8 +47,14 @@ linking back to the source GitHub issue. Award counters can change as accepted
 work is paid; refresh concrete examples against the live API before relying on
 available slot counts.
 
-Use `/api/v1/bounties/summary` with the same optional `status` and `q`
-filters when an agent only needs capacity totals instead of full bounty rows:
+Use `sort` to choose the bounty order: `newest` is the default, `reward` sorts
+by per-award reward, `available` sorts by the remaining MRWK pool, and `awards`
+sorts by remaining award slots. Use `limit` from `1` to `200` to cap returned
+rows after filtering and sorting.
+
+Use `/api/v1/bounties/summary` with the same optional `status`, `q`, `sort`, and
+`limit` filters when an agent only needs capacity totals instead of full bounty
+rows:
 
 ```json
 {

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -96,8 +96,15 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 
     assert "/api/v1/bounties?status=open" in examples
+    assert "/api/v1/bounties?status=open&sort=available&limit=5" in examples
     assert "/api/v1/bounties/summary?status=open&q=proof" in examples
+    assert "/api/v1/bounties/summary?status=open&sort=awards&limit=5" in examples
     assert "status` can be omitted or set to" in examples
+    assert "`newest` is the default" in examples
+    assert "by per-award reward" in examples
+    assert "`available` sorts by the remaining MRWK pool" in examples
+    assert "remaining award slots" in examples
+    assert "Use `limit` from `1` to `200`" in examples
     assert '"id": 36' in examples
     assert '"repo": "ramimbo/mergework"' in examples
     assert '"issue_number": 164' in examples
@@ -110,7 +117,9 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert '"open_awards": 2' in examples
     assert '"open_pool_mrwk": "50"' in examples
     assert "Award counters can change" in examples
-    assert "capacity totals instead of full bounty rows" in examples
+    assert "capacity totals" in examples
+    assert "full bounty" in examples
+    assert "same optional `status`, `q`, `sort`, and" in examples
     assert "Use `id` for the single-bounty API path" in examples
 
 


### PR DESCRIPTION
/claim #426

Refs #426

## Summary
- Document the current `/api/v1/bounties` `sort` and `limit` query parameters in `docs/api-examples.md`.
- Add matching summary endpoint examples for `sort` and `limit`.
- Extend the existing docs regression test so the examples stay covered.

## Evidence
- `app/bounty_sorting.py` defines the current sort contract: `newest`, `reward`, `available`, and `awards`.
- `app/bounty_api.py` accepts `limit` from 1 to 200 and applies it after filtering/sorting for both list and summary responses.
- Existing open #426 PRs cover different docs areas: preflight quality gate, paid proof rows, and transfer-path copy. No open PR matched this sort/limit API examples scope during final collision check.

## Validation
- `python3 scripts/docs_smoke.py` -> docs smoke ok
- `uv run --extra dev python -m pytest tests/test_docs_public_urls.py::test_api_examples_document_bounty_list_response_shape -q` -> 1 passed
- `uv run --extra dev python -m pytest tests/test_docs_public_urls.py -q` -> 22 passed
- `uv run --extra dev python -m pytest -q` -> 413 passed
- `uv run --extra dev ruff check .` -> passed
- `uv run --extra dev ruff format --check .` -> 79 files already formatted
- `uv run --extra dev mypy app` -> success, no issues in 30 source files
- `git diff --check` -> clean
- `gitleaks detect --no-banner --redact --source . --exit-code 1` -> no leaks found

No private keys, wallet material, cookies, OAuth state, access tokens, signatures, secrets, price claims, liquidity claims, exchange claims, bridge promises, off-ramp promises, or fabricated payout claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Bounty API examples with additional query parameter details showing filtering, sorting, and limiting results. Documented all available sort options and valid limit ranges.

* **Tests**
  * Expanded test coverage for API documentation examples and query variants to ensure documentation accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->