### PR TITLE
docs: document agent-friendly bounty post template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -65,6 +65,6 @@ body:
     attributes:
       label: Public artifact cautions
       description: Call out private data and MRWK wording boundaries.
-      placeholder: "No private keys, wallet seed material, private vulnerability details, signatures, credentials, price claims, liquidity claims, exchange claims, bridge promises, or fabricated payout claims."
+      placeholder: "No private keys, wallet seed material, private vulnerability details, signatures, credentials, investment claims, price claims, liquidity claims, exchange claims, bridge promises, or fabricated payout claims."
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -1,20 +1,28 @@
 name: MRWK bounty
 description: Propose work that may receive an MRWK bounty.
-title: "[bounty] "
+title: "MRWK bounty: <amount> MRWK - <short scope>"
 labels: ["mrwk:bounty"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Use the template in `docs/bounty-rules.md#agent-friendly-bounty-post-template`.
+        Keep reward, max awards, acceptance criteria, evidence, duplicate/stale
+        work rules, and public artifact cautions explicit enough for humans,
+        GitHub search, the public API, and MCP tools.
   - type: textarea
     id: work
     attributes:
       label: Work needed
-      description: Describe the useful accepted work.
+      description: Describe the useful accepted work and the concrete workflow it improves.
     validations:
       required: true
   - type: input
     id: reward
     attributes:
       label: Proposed MRWK per award
-      placeholder: "250"
+      description: Repeat the per-award amount in the body, for example `150 MRWK per accepted award`.
+      placeholder: "150 MRWK per accepted award"
     validations:
       required: true
   - type: input
@@ -28,6 +36,35 @@ body:
     id: acceptance
     attributes:
       label: Acceptance criteria
-      description: Explain what must be true before mrwk:accepted is applied.
+      description: Explain what must be true before `mrwk:accepted` is applied or an admin payout is recorded.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence required
+      description: Name required files, URLs, commands, tests, screenshots, API responses, MCP responses, or actionable findings.
+    validations:
+      required: true
+  - type: textarea
+    id: submit
+    attributes:
+      label: How to submit
+      description: State whether contributors should open a PR, post a report/comment, or use a discussion, and require `Bounty #<issue>` or `Refs #<issue>` where applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: List duplicate, broad, stale, style-only, speculative, private-security-detail, or unrelated work that does not qualify.
+    validations:
+      required: true
+  - type: textarea
+    id: artifact_cautions
+    attributes:
+      label: Public artifact cautions
+      description: Call out private data and MRWK wording boundaries.
+      placeholder: "No private keys, wallet seed material, private vulnerability details, signatures, credentials, price claims, liquidity claims, exchange claims, bridge promises, or fabricated payout claims."
     validations:
       required: true

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -4,12 +4,26 @@
 
 1. Create or choose a GitHub issue.
 2. Decide the MRWK amount using the reference tiers.
-3. Add acceptance text that explains what counts as useful accepted work.
-4. Set `max_awards` to the number of separate payouts allowed. Use `1` for
+3. Use the agent-friendly post template from
+   [docs/bounty-rules.md](bounty-rules.md#agent-friendly-bounty-post-template).
+   The issue title should be `MRWK bounty: <amount> MRWK - <short scope>`.
+4. Repeat the reward and max-awards values in the issue body.
+5. Add acceptance text that explains what counts as useful accepted work.
+6. Add evidence requirements, out-of-scope rules, duplicate-work rules,
+   stale-work rules, and public artifact cautions.
+7. Compare the draft against the GitHub bounty issue form, bounty rules, agent
+   guide, public API fields, and MCP bounty tools so agents can find the issue,
+   check award slots, inspect attempts, and submit evidence.
+8. Set `max_awards` to the number of separate payouts allowed. Use `1` for
    a single-award bounty.
-5. Use `/admin` or `POST /api/v1/bounties` with an admin token.
+9. Use `/admin` or `POST /api/v1/bounties` with an admin token.
    Multi-award bounties reserve `reward_mrwk * max_awards`.
-6. Add `mrwk:bounty` to the GitHub issue.
+10. Add `mrwk:bounty` to the GitHub issue.
+
+Before publishing, confirm the issue body includes these stable headings:
+`MRWK Bounty`, `Work Needed`, `Acceptance Criteria`, `Evidence Required`,
+`How To Submit`, `Out Of Scope`, `Duplicate and Stale Work`, and
+`Public Artifact Cautions`.
 
 ## Accept Work
 

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -34,6 +34,82 @@ MRWK uses work-based tiers at launch. The project does not publish a fiat peg.
 - `mrwk:rejected`: submission was not accepted.
 - `mrwk:needs-info`: maintainer needs more detail.
 
+## Agent-Friendly Bounty Post Template
+
+Use a stable bounty shape so humans, GitHub search, the public API, and MCP
+tools can read the same facts without guessing. Keep the title short and make
+the per-award amount visible:
+
+```text
+MRWK bounty: <amount> MRWK - <short scope>
+```
+
+Use this copy-paste body for new bounty issues:
+
+```text
+## MRWK Bounty
+
+Reward: `<amount> MRWK per accepted award`
+Max awards: `<number>`
+
+## Work Needed
+
+Describe the concrete user, maintainer, docs, API, MCP, or code workflow that
+needs useful work.
+
+Useful accepted work can include:
+
+- <specific useful outcome>
+- <specific useful outcome>
+
+## Acceptance Criteria
+
+- Link the PR, report, review, or discussion to this issue with
+  `Bounty #<issue number>` or `Refs #<issue number>`.
+- Keep the work focused to the named surfaces.
+- Include concrete evidence from files inspected, behavior checked, commands
+  run, screenshots, public URLs, API responses, MCP responses, or an actionable
+  finding.
+- Run the checks named for the touched files or explain why a check does not
+  apply.
+
+## Evidence Required
+
+- Files, pages, endpoints, tools, or commands inspected:
+- Expected behavior:
+- Observed behavior or change:
+- Validation commands and results:
+
+## How To Submit
+
+Open a focused PR or post the requested report/comment with the required
+evidence. A maintainer must apply `mrwk:accepted` or record an admin payout
+before payment.
+
+## Out Of Scope
+
+- <explicit non-goal>
+- <explicit non-goal>
+
+## Duplicate and Stale Work
+
+Duplicate, vague, misleading, self-review, superseded duplicate, stale-head,
+style-only, or unrelated submissions do not qualify. Re-check open PRs, active
+attempts, and recent bounty comments before submitting.
+
+## Public Artifact Cautions
+
+Do not include private keys, wallet seed material, private vulnerability
+details, signatures, credentials, investment claims, price claims, fabricated
+payout claims, liquidity claims, exchange claims, or bridge promises.
+```
+
+Agents need the GitHub issue number for `Bounty #<issue>` / `Refs #<issue>`
+references, the visible reward and max-awards values for award-slot decisions,
+the internal API bounty `id` from `/api/v1/bounties` or MCP `list_bounties` for
+attempt lookups, and explicit evidence requirements so quality gates and MCP
+`submit_work_proof` output can separate payable work from incomplete drafts.
+
 ## How Claims Are Reviewed
 
 Maintainers approve useful accepted work that matches the bounty text and has

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -146,6 +146,7 @@ def main() -> int:
             "bounty #<issue>",
             "refs #<issue>",
             "public artifact cautions",
+            "investment claims",
         ]
         for phrase in required_bounty_template_phrases:
             if phrase not in bounty_template:

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -46,6 +46,13 @@ REQUIRED_PUBLIC_PHRASES = {
         ("creating or releasing an attempt requires the GitHub-authenticated browser session"),
     ],
     "docs/bounty-rules.md": [
+        "## Agent-Friendly Bounty Post Template",
+        "MRWK bounty: <amount> MRWK - <short scope>",
+        "## Evidence Required",
+        "## Duplicate and Stale Work",
+        "## Public Artifact Cautions",
+        "Agents need the GitHub issue number",
+        "MCP `submit_work_proof`",
         "## Submission Evidence Templates",
         "PR or fix claim:",
         "Review claim:",
@@ -53,9 +60,18 @@ REQUIRED_PUBLIC_PHRASES = {
         "Discussion or decision-support claim:",
         "Do not describe work as accepted, merged, or paid until the public GitHub label",
     ],
+    "docs/admin-runbook.md": [
+        "agent-friendly post template",
+        "MRWK bounty: <amount> MRWK - <short scope>",
+        "GitHub bounty issue form",
+        "public API fields",
+        "MCP bounty tools",
+        "`Public Artifact Cautions`",
+    ],
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"
+BOUNTY_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/bounty.yml"
 PR_TEMPLATE = ".github/pull_request_template.md"
 
 
@@ -112,6 +128,29 @@ def main() -> int:
     elif "expected pr size:" not in pr_template.read_text(encoding="utf-8").lower():
         print("pull request template must ask for expected PR size")
         ok = False
+    bounty_issue_template = ROOT / BOUNTY_ISSUE_TEMPLATE
+    if not bounty_issue_template.exists():
+        print(f"missing bounty issue template: {BOUNTY_ISSUE_TEMPLATE}")
+        ok = False
+    else:
+        bounty_template = bounty_issue_template.read_text(encoding="utf-8").lower()
+        required_bounty_template_phrases = [
+            "mrwk bounty: <amount> mrwk - <short scope>",
+            "id: reward",
+            "id: max_awards",
+            "id: acceptance",
+            "id: evidence",
+            "id: submit",
+            "id: out_of_scope",
+            "id: artifact_cautions",
+            "bounty #<issue>",
+            "refs #<issue>",
+            "public artifact cautions",
+        ]
+        for phrase in required_bounty_template_phrases:
+            if phrase not in bounty_template:
+                print(f"bounty issue template missing required guidance: {phrase}")
+                ok = False
     if ok:
         print("docs smoke ok")
         return 0

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -263,6 +263,60 @@ def test_contributing_names_docs_smoke_for_public_docs_changes() -> None:
     assert "docs, templates, examples, or onboarding" in contributing
 
 
+def test_bounty_rules_document_agent_friendly_post_template() -> None:
+    rules = Path("docs/bounty-rules.md").read_text(encoding="utf-8")
+
+    assert "## Agent-Friendly Bounty Post Template" in rules
+    assert "MRWK bounty: <amount> MRWK - <short scope>" in rules
+    for heading in (
+        "## MRWK Bounty",
+        "## Work Needed",
+        "## Acceptance Criteria",
+        "## Evidence Required",
+        "## How To Submit",
+        "## Out Of Scope",
+        "## Duplicate and Stale Work",
+        "## Public Artifact Cautions",
+    ):
+        assert heading in rules
+    assert "GitHub issue number" in rules
+    assert "/api/v1/bounties" in rules
+    assert "MCP `list_bounties`" in rules
+    assert "`submit_work_proof`" in rules
+
+
+def test_bounty_issue_template_matches_agent_friendly_guidance() -> None:
+    template = Path(".github/ISSUE_TEMPLATE/bounty.yml").read_text(encoding="utf-8")
+
+    assert "MRWK bounty: <amount> MRWK - <short scope>" in template
+    for field in (
+        "id: work",
+        "id: reward",
+        "id: max_awards",
+        "id: acceptance",
+        "id: evidence",
+        "id: submit",
+        "id: out_of_scope",
+        "id: artifact_cautions",
+    ):
+        assert field in template
+    assert "Bounty #<issue>" in template
+    assert "Refs #<issue>" in template
+    assert "Public artifact cautions" in template
+
+
+def test_admin_runbook_points_maintainers_to_bounty_template() -> None:
+    runbook = Path("docs/admin-runbook.md").read_text(encoding="utf-8")
+
+    assert "bounty-rules.md#agent-friendly-bounty-post-template" in runbook
+    assert "MRWK bounty: <amount> MRWK - <short scope>" in runbook
+    assert "GitHub bounty issue form" in runbook
+    assert "public API fields" in runbook
+    assert "MCP bounty tools" in runbook
+    assert "`Evidence Required`" in runbook
+    assert "`Public Artifact Cautions`" in runbook
+
+
 def test_agent_guide_documents_activity_endpoint() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -303,6 +303,7 @@ def test_bounty_issue_template_matches_agent_friendly_guidance() -> None:
     assert "Bounty #<issue>" in template
     assert "Refs #<issue>" in template
     assert "Public artifact cautions" in template
+    assert "investment claims" in template
 
 
 def test_admin_runbook_points_maintainers_to_bounty_template() -> None:


### PR DESCRIPTION
## Summary

- Adds a canonical copy-pasteable agent-friendly bounty post template to `docs/bounty-rules.md`.
- Updates `docs/admin-runbook.md` and `.github/ISSUE_TEMPLATE/bounty.yml` so maintainers are guided toward the same title/body shape.
- Protects the template with `scripts/docs_smoke.py` and docs regression tests.

## Evidence

- Bounty #456 is open in the public API as internal bounty id 75 with `awards_remaining: 1`, `available_mrwk: "150"`, and `max_awards: 1`.
- Active attempts for bounty id 75 returned `warnings: []` and `attempts: []`.
- Open PR search found no existing PR body referencing `Bounty #456` / `Refs #456` and no open template PR for this scope before submission.
- Compared the requested surfaces: the existing bounty issue form asked only for work/reward/max awards/acceptance; `docs/bounty-rules.md` had claim evidence templates but no maintainer-facing bounty post template; `docs/admin-runbook.md` did not include stable heading/field checks; `docs/agent-guide.md` already documents issue refs, active attempts, API ids, MCP tools, and docs-smoke expectations; public bounty behavior exposes the GitHub issue number, internal bounty id, status, award slots, and attempt endpoint.
- Public MRWK wording stays within artifact hygiene: no investment, price, fabricated payout, liquidity, exchange, or bridge-promise claims.

## Test Evidence

- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --extra dev python -m pytest tests/test_docs_public_urls.py::test_bounty_rules_document_agent_friendly_post_template tests/test_docs_public_urls.py::test_bounty_issue_template_matches_agent_friendly_guidance tests/test_docs_public_urls.py::test_admin_runbook_points_maintainers_to_bounty_template -q` -> 3 passed
- `uv run --extra dev python -m pytest -q` -> 416 passed
- `uv run --extra dev ruff check .` -> passed
- `uv run --extra dev ruff format --check .` -> 79 files already formatted
- `uv run --extra dev mypy app` -> success
- `uv run --extra dev python - <<'PY' ... yaml.safe_load(...)` -> bounty issue template yaml ok
- `git diff --check` -> clean
- `uv run --extra dev python scripts/submission_quality_gate.py --input <fixture>` -> PASS

## Out of Scope

- No runtime, API, MCP, ledger, wallet, tokenomics, exchange, bridge, or payout behavior changes.
- No private security details or private data.

## MRWK

Bounty #456


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an agent-friendly bounty post template and expanded bounty rules with required headings, cautions, and evidence/submission guidance.
  * Updated admin runbook with step-by-step bounty publishing checklist and formatting requirements.

* **New Features**
  * Expanded bounty issue template to include acceptance criteria, evidence required, submission steps, out-of-scope guidance, and public-artifact cautions.

* **Tests**
  * Added cross-document validation tests to ensure consistency between bounty guidance, template, and admin runbook.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->