### PR TITLE
Document agent-friendly bounty template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -1,13 +1,13 @@
 name: MRWK bounty
 description: Propose work that may receive an MRWK bounty.
-title: "[bounty] "
+title: "MRWK bounty: <amount> MRWK - <short scope>"
 labels: ["mrwk:bounty"]
 body:
   - type: textarea
     id: work
     attributes:
       label: Work needed
-      description: Describe the useful accepted work.
+      description: "Use stable headings from docs/bounty-rules.md: reward, max awards, scope, acceptance criteria, evidence/tests, out of scope, duplicate/stale rules."
     validations:
       required: true
   - type: input
@@ -29,5 +29,20 @@ body:
     attributes:
       label: Acceptance criteria
       description: Explain what must be true before mrwk:accepted is applied.
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence / tests
+      description: List commands, screenshots, proof links, or docs-review evidence expected from submissions.
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope and duplicate rules
+      description: Name non-qualifying work and how duplicate or stale attempts are handled.
     validations:
       required: true

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -56,6 +56,119 @@ After accepted work is paid, MergeWork records a public ledger proof. Public
 payment updates should point to those proofs and keep any private security or
 operational details out of public metadata.
 
+
+## Agent-Friendly Bounty Post Template
+
+Use this short, stable shape when posting new bounties so humans, agents, the
+GitHub API, and MCP clients can parse the same fields without guessing. Keep the
+reward visible in both the title and body.
+
+Title:
+
+```text
+MRWK bounty: <amount> MRWK - <short scope>
+```
+
+Body:
+
+```text
+## MRWK Bounty
+
+Reward: `<amount> MRWK per accepted award>`
+Max awards: `<number>`
+
+## Work Needed
+
+<Concrete scope. Name the files, pages, commands, or behavior to change.>
+
+## Acceptance Criteria
+
+- <Objective result required before mrwk:accepted can be applied.>
+- <Evidence or test output the reviewer must see.>
+- <Compatibility, accessibility, docs, or security requirement if relevant.>
+
+## How To Submit
+
+Open a focused PR, issue comment, or proof link that includes `Bounty #<issue>`
+or `Refs #<issue>`, plus a short summary, evidence, tests, and out-of-scope
+notes. Use `Closes #<issue>` only when one accepted award should close the
+issue.
+
+## Evidence / Tests
+
+Run `<command>` if touched files affect code or examples. For docs-only work,
+quote the reviewed files and explain why no runtime test applies.
+
+## Out Of Scope
+
+- Duplicate, broad rewrite, typo-only, style-only, speculative tokenomics, or
+  unrelated changes.
+- Public claims about MRWK price, liquidity, exchange support, bridge support,
+  accepted status, or payout status unless a maintainer label/comment/proof
+  already exists.
+
+## Duplicate And Stale Work Rules
+
+Check existing comments, PRs, and active attempt reservations before starting.
+If someone else already submitted equivalent work, add review evidence instead
+of opening a duplicate PR. If your reservation or draft goes stale, release it
+or comment with current status before continuing.
+```
+
+Agents rely on these exact fields to rank safe work, avoid duplicate claims,
+choose the right submission path, and attach proof that maintainers can review
+from GitHub, API responses, or MCP tools. Maintainers should avoid hiding award
+amounts in prose, changing heading names per issue, or asking for private
+security details in public bounty posts.
+
+## Submission Evidence Templates
+
+Use the smallest template that makes the claim reviewable. Delete fields that do
+not apply, but keep the evidence specific enough that a maintainer can reproduce
+the work without reading unrelated context.
+
+PR or fix claim:
+
+```text
+Summary:
+Linked bounty:
+Changed files:
+Evidence:
+Tests:
+Out of scope:
+```
+
+Review claim:
+
+```text
+Reviewed PR:
+Head commit:
+Files inspected:
+Verdict:
+Validation:
+```
+
+Smoke-check or bug-report claim:
+
+```text
+Checked URL or command:
+Expected:
+Observed:
+Concise note:
+```
+
+Discussion or decision-support claim:
+
+```text
+Discussion URL:
+Category:
+Maintainer decision this supports:
+Non-goals:
+```
+
+Do not describe work as accepted, merged, or paid until the public GitHub label,
+maintainer comment, or MRWK proof exists.
+
 ## Payout Flow
 
 1. A maintainer posts a bounty and MRWK is reserved from treasury.
@@ -79,6 +192,11 @@ links a wallet and signs a claim. Manual payouts can target a registered
 PR bounty submissions should link the bounty issue with `Bounty #<issue>` or
 `Refs #<issue>`. Use a closing reference only when the issue should close after
 that PR.
+
+For bounty PRs, include the claim-window packet in the PR body: exact bounty
+reference, intended files or surfaces, expected PR size, test plan, evidence,
+and out-of-scope notes. If the diff grows beyond the expected size, split it or
+explain why the larger review remains focused.
 
 Paid bounty links are tracked in
 [docs/paid-bounties.md](paid-bounties.md) and the public


### PR DESCRIPTION
Bounty #456

Summary:
- Add a copy-pasteable agent-friendly bounty post template with stable headings.
- Document required fields for reward, max awards, scope, acceptance criteria, evidence/tests, out-of-scope, duplicate-work, and stale-work rules.
- Update the bounty issue template title/fields so new issues expose amount and review evidence up front.

Evidence / comparison:
- Compared against docs/bounty-rules.md, docs/admin-runbook.md, docs/agent-guide.md, and .github/ISSUE_TEMPLATE/bounty.yml.
- Existing docs already require PR bodies to link `Bounty #<issue>` or `Refs #<issue>` and warn against public accepted/paid claims without labels/proofs; this PR consolidates those requirements into a maintainer-facing post template.
- Public MRWK wording avoids price, liquidity, exchange, bridge, or fabricated payout claims.

Tests:
- `python3 scripts/docs_smoke.py`

Out of scope:
- No tokenomics, payout logic, API, ledger, or private-security workflow changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an agent-friendly bounty post guide with a stable, parseable format and required sections: reward, work needed, acceptance criteria, submission instructions, evidence/tests, out-of-scope, and duplicate/stale rules.
  * Updated payout guidance to require a claim-window packet in bounty PRs (bounty reference, intended surfaces, expected size, test plan, evidence, out-of-scope notes).

* **Chores**
  * Standardized bounty issue title format and added required fields for evidence/tests and out-of-scope/duplicate rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->