### PR TITLE
docs: add maintainer bounty post template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -1,13 +1,13 @@
 name: MRWK bounty
 description: Propose work that may receive an MRWK bounty.
-title: "[bounty] "
+title: "MRWK bounty: <amount> MRWK - "
 labels: ["mrwk:bounty"]
 body:
   - type: textarea
     id: work
     attributes:
       label: Work needed
-      description: Describe the useful accepted work.
+      description: Describe the focused work, affected surface, and why it is useful.
     validations:
       required: true
   - type: input
@@ -15,6 +15,7 @@ body:
     attributes:
       label: Proposed MRWK per award
       placeholder: "250"
+      description: Repeat the per-award amount from the issue title.
     validations:
       required: true
   - type: input
@@ -22,6 +23,7 @@ body:
     attributes:
       label: Max awards
       placeholder: "1"
+      description: Use 1 for a single accepted submission or a higher number for distinct awards.
     validations:
       required: true
   - type: textarea
@@ -31,3 +33,24 @@ body:
       description: Explain what must be true before mrwk:accepted is applied.
     validations:
       required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or tests
+      description: Name required commands, screenshots, live public URLs, or reproduction evidence.
+      placeholder: "Example: run python scripts/docs_smoke.py and relevant focused tests."
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: List broad rewrites, duplicate work, style-only changes, private security detail, or unrelated work that will not qualify.
+  - type: textarea
+    id: duplicate_stale
+    attributes:
+      label: Duplicate and stale work
+      description: Tell contributors to check open PRs, comments, active attempts, and accepted work before submitting.
+  - type: textarea
+    id: public_artifact_hygiene
+    attributes:
+      label: Public artifact hygiene
+      description: Remind contributors not to include secrets, private vulnerability details, price claims, liquidity claims, exchange claims, bridge promises, off-ramp promises, or fabricated payout claims.

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -4,12 +4,19 @@
 
 1. Create or choose a GitHub issue.
 2. Decide the MRWK amount using the reference tiers.
-3. Add acceptance text that explains what counts as useful accepted work.
-4. Set `max_awards` to the number of separate payouts allowed. Use `1` for
+3. Use the maintainer bounty post template in
+   [bounty rules](bounty-rules.md#maintainer-bounty-post-template). The issue
+   title should follow `MRWK bounty: <amount> MRWK - <short scope>` so the
+   reward is visible in lists, notifications, the API, and MCP tools.
+4. Add acceptance text that explains what counts as useful accepted work, which
+   evidence or tests are required, and what is out of scope.
+5. Set `max_awards` to the number of separate payouts allowed. Use `1` for
    a single-award bounty.
-5. Use `/admin` or `POST /api/v1/bounties` with an admin token.
+6. Include duplicate-work, stale-work, and public artifact hygiene rules when
+   the bounty could attract overlapping agent submissions.
+7. Use `/admin` or `POST /api/v1/bounties` with an admin token.
    Multi-award bounties reserve `reward_mrwk * max_awards`.
-6. Add `mrwk:bounty` to the GitHub issue.
+8. Add `mrwk:bounty` to the GitHub issue.
 
 ## Accept Work
 

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -34,6 +34,66 @@ MRWK uses work-based tiers at launch. The project does not publish a fiat peg.
 - `mrwk:rejected`: submission was not accepted.
 - `mrwk:needs-info`: maintainer needs more detail.
 
+## Maintainer Bounty Post Template
+
+Use stable headings so humans, agents, the public API, and MCP tools can parse a
+bounty without guessing. Put the reward in the issue title:
+
+```text
+MRWK bounty: <amount> MRWK - <short scope>
+```
+
+Copy this body and replace the placeholders:
+
+```text
+## MRWK Bounty
+
+Reward: `<amount> MRWK per accepted award`
+Max awards: `<number>`
+
+## Work Needed
+
+Describe the focused work, affected page, workflow, docs area, code path, or
+review target.
+
+## Acceptance Criteria
+
+- List the exact conditions that must be true before work can be accepted.
+- Include required commands, screenshots, links, or reproduction evidence.
+- State any bounty-specific constraints such as one award per distinct scope.
+
+## How To Submit
+
+Open a focused PR, review, issue comment, or discussion post with `Bounty
+#<issue number>` or `Refs #<issue number>` unless this bounty asks for a
+different reference.
+
+## Evidence Or Tests
+
+Name the checks expected for this bounty, such as `python scripts/docs_smoke.py`,
+focused tests for touched code, live public URLs checked, or screenshots for UI
+changes.
+
+## Out Of Scope
+
+List work that does not qualify, including broad rewrites, typo-only edits,
+style-only changes, unrelated refactors, private security details, or claims
+outside the stated scope.
+
+## Duplicate And Stale Work
+
+Submissions must check current open PRs, issue comments, active attempts, and
+accepted work. Duplicate, superseded, or stale work does not qualify unless the
+bounty text explicitly allows a distinct follow-up.
+
+## Public Artifact Hygiene
+
+Do not include private keys, seed material, credentials, private vulnerability
+details, deployment secrets, price claims, investment claims, liquidity claims,
+exchange claims, bridge promises, off-ramp promises, or fabricated payout
+claims.
+```
+
 ## How Claims Are Reviewed
 
 Maintainers approve useful accepted work that matches the bounty text and has

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -52,10 +52,16 @@ REQUIRED_PUBLIC_PHRASES = {
         "Smoke-check or bug-report claim:",
         "Discussion or decision-support claim:",
         "Do not describe work as accepted, merged, or paid until the public GitHub label",
+        "## Maintainer Bounty Post Template",
+        "MRWK bounty: <amount> MRWK - <short scope>",
+        "## Evidence Or Tests",
+        "## Duplicate And Stale Work",
+        "## Public Artifact Hygiene",
     ],
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"
+BOUNTY_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/bounty.yml"
 PR_TEMPLATE = ".github/pull_request_template.md"
 
 
@@ -105,6 +111,21 @@ def main() -> int:
         if "link the page, docs file, heading, command, or ui path" not in template:
             print("docs issue template location prompt must request actionable evidence")
             ok = False
+    bounty_issue_template = ROOT / BOUNTY_ISSUE_TEMPLATE
+    if not bounty_issue_template.exists():
+        print(f"missing bounty issue template: {BOUNTY_ISSUE_TEMPLATE}")
+        ok = False
+    else:
+        bounty_template = bounty_issue_template.read_text(encoding="utf-8").lower()
+        for phrase in [
+            "mrwk bounty: <amount> mrwk -",
+            "evidence or tests",
+            "duplicate and stale work",
+            "public artifact hygiene",
+        ]:
+            if phrase not in bounty_template:
+                print(f"bounty issue template missing required guidance: {phrase}")
+                ok = False
     pr_template = ROOT / PR_TEMPLATE
     if not pr_template.exists():
         print(f"missing pull request template: {PR_TEMPLATE}")


### PR DESCRIPTION
## Summary

- Add a copy-pasteable maintainer bounty post template with stable headings in `docs/bounty-rules.md`.
- Point the admin runbook's bounty-posting checklist at that template and the amount-in-title format.
- Align `.github/ISSUE_TEMPLATE/bounty.yml` with the same evidence, out-of-scope, duplicate/stale, and public artifact hygiene prompts, then guard the headings in docs smoke.

Refs #456

## Evidence

- Current `docs/bounty-rules.md` already has contributor submission evidence templates from merged PR #433, but it did not document a maintainer-facing bounty post template.
- Current `docs/admin-runbook.md` only had a short "Post a Bounty" checklist without stable heading or amount-in-title guidance.
- Current `.github/ISSUE_TEMPLATE/bounty.yml` used the title prefix `[bounty] ` and required only work, reward, max awards, and acceptance fields.
- Live MRWK bounty API shows issue #456 / internal bounty id 75 is open, reward 150 MRWK, max awards 1, awards paid 0, awards remaining 1, and active attempts `[]`.
- Public duplicate checks for `agent-friendly bounty post template`, `bounty post template`, `stable headings`, and `amount-in-title` found no same-scope open PR or claim. Adjacent PR #457 is #426 API docs, and owner draft PR #458 is governance proposal work, not this template.

## Validation

- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --extra dev python -m pytest tests/test_docs_public_urls.py -q` -> 22 passed
- `uv run --extra dev ruff check scripts/docs_smoke.py` -> passed
- `uv run --extra dev ruff format --check scripts/docs_smoke.py` -> already formatted
- `uv run --extra dev ruff check .` -> passed
- `uv run --extra dev ruff format --check .` -> 79 files already formatted
- `uv run --extra dev python -m mypy app` -> success
- `uv run --extra dev python -m pytest -q` -> 413 passed
- `git diff --check` -> clean
- Diff-scoped `gitleaks detect --pipe --redact --no-banner --no-color --exit-code 1` -> no leaks found

## MRWK

Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties): Refs #456

No private keys, seed material, credentials, private vulnerability details, deployment secrets, price claims, investment claims, liquidity claims, exchange claims, bridge promises, off-ramp promises, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Standardized bounty issue template with updated title format and expanded guidance fields
  * Created comprehensive bounty post template documentation covering reward details, work scope, acceptance criteria, evidence/testing requirements, out-of-scope items, and duplicate/stale work handling

* **Chores**
  * Enhanced documentation validation to ensure bounty template consistency and compliance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->