### PR TITLE
Treat blank bounty status filters as unfiltered

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -96,11 +96,12 @@ def register_bounty_api_routes(
             query = select(Bounty)
             if status is not None:
                 normalized_status = status.strip().lower()
-                if normalized_status not in {"open", "paid", "closed"}:
+                if normalized_status and normalized_status not in {"open", "paid", "closed"}:
                     raise HTTPException(
                         status_code=400, detail="status must be one of: open, paid, closed"
                     )
-                query = query.where(Bounty.status == normalized_status)
+                if normalized_status:
+                    query = query.where(Bounty.status == normalized_status)
             if query_text is not None:
                 normalized_query = query_text.strip()
                 if normalized_query:

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -23,7 +23,8 @@ def public_bounties_context(
     q: str | None,
     sort: str | None = None,
 ) -> dict[str, Any]:
-    selected_status = status.strip().lower() if status is not None else None
+    normalized_status = status.strip().lower() if status is not None else ""
+    selected_status = normalized_status or None
     query_text = q.strip() if q is not None else ""
     selected_sort = normalize_bounty_sort(sort)
     return {

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -72,6 +72,12 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert "Open public bounty" not in paid_rows_uppercase.text
     assert 'href="/bounties?status=paid" aria-current="page"' in paid_rows_uppercase.text
 
+    blank_status_rows = client.get("/bounties?status=")
+    assert blank_status_rows.status_code == 200
+    assert "Open public bounty" in blank_status_rows.text
+    assert "Paid public bounty" in blank_status_rows.text
+    assert 'href="/bounties" aria-current="page"' in blank_status_rows.text
+
 
 def test_bounties_summary_api_matches_public_list_filters(sqlite_url: str) -> None:
     create_schema(sqlite_url)
@@ -113,6 +119,9 @@ def test_bounties_summary_api_matches_public_list_filters(sqlite_url: str) -> No
         "open_awards": 2,
         "open_pool_mrwk": "50",
     }
+
+    blank_status_summary = client.get("/api/v1/bounties/summary?status=&q=discovery").json()
+    assert blank_status_summary == summary
 
     paid_summary = client.get("/api/v1/bounties/summary?status=paid&q=discovery").json()
     assert paid_summary == {

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -32,3 +32,8 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
             "awards": "Most award slots",
         },
     }
+
+    blank_context = public_bounties_context(bounties, status="   ", q=None)
+
+    assert blank_context["selected_status"] is None
+    assert blank_context["query_text"] == ""


### PR DESCRIPTION
Bounty #406

## Summary
- Treat blank `status` query values as no bounty status filter.
- Normalize the public bounty page context so blank status keeps the All filter selected.
- Add regression coverage for the public bounty page, summary API, and context helper.

## Why
Copied or form-generated URLs can include `?status=`. Before this change, that empty value was stripped and then validated as an invalid status, producing a `400` instead of showing the unfiltered bounty list. Non-empty invalid status values still return the existing validation error.

## Validation
- `./.venv312/bin/python -m pytest -q` -> 413 passed
- `./.venv312/bin/python -m ruff format --check .` -> 79 files already formatted
- `./.venv312/bin/python -m ruff check .` -> All checks passed
- `./.venv312/bin/python -m mypy app` -> Success: no issues found in 30 source files
- `git diff --check` -> clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed status filtering to handle empty or whitespace-only values gracefully. Empty status parameters (e.g., `?status=`) now behave like no filter is applied instead of returning a validation error. Valid status values (open, paid, closed) remain validated and filter results correctly.

* **Tests**
  * Added test coverage for blank status filter behavior across bounty listing pages and API summary endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->