### PR TITLE
Split MCP bounty attempt tests

### DIFF
--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime, timedelta
 
 import pytest
 from fastapi.testclient import TestClient
@@ -9,7 +8,7 @@ from fastapi.testclient import TestClient
 from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
-from app.models import BountyAttempt, Proof
+from app.models import Proof
 
 
 def test_health_status_and_bounty_api(sqlite_url: str) -> None:
@@ -456,136 +455,6 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     ).json()
     assert balance["result"]["content"][0]["type"] == "text"
     assert "100000000" in balance["result"]["content"][0]["text"]
-
-
-def test_mcp_list_bounty_attempts_reports_active_and_expired(sqlite_url: str) -> None:
-    create_schema(sqlite_url)
-    now = datetime.now(UTC)
-    with session_scope(sqlite_url) as session:
-        ensure_genesis(session)
-        bounty = create_bounty(
-            session,
-            repo="ramimbo/mergework",
-            issue_number=321,
-            issue_url="https://github.com/ramimbo/mergework/issues/321",
-            title="Attempt reservations",
-            reward_mrwk="250",
-            max_awards=2,
-            acceptance="Agents should inspect active attempts before opening work.",
-        )
-        session.add_all(
-            [
-                BountyAttempt(
-                    bounty_id=bounty.id,
-                    submitter_account="github:alice",
-                    source_url="https://github.com/ramimbo/mergework/pull/501",
-                    status="active",
-                    expires_at=now + timedelta(hours=1),
-                    created_at=now - timedelta(minutes=2),
-                    updated_at=now - timedelta(minutes=2),
-                ),
-                BountyAttempt(
-                    bounty_id=bounty.id,
-                    submitter_account="github:bob",
-                    source_url="https://github.com/ramimbo/mergework/pull/502",
-                    status="active",
-                    expires_at=now + timedelta(hours=2),
-                    created_at=now - timedelta(minutes=1),
-                    updated_at=now - timedelta(minutes=1),
-                ),
-                BountyAttempt(
-                    bounty_id=bounty.id,
-                    submitter_account="github:carol",
-                    source_url="https://github.com/ramimbo/mergework/pull/503",
-                    status="active",
-                    expires_at=now - timedelta(minutes=1),
-                    created_at=now - timedelta(minutes=3),
-                    updated_at=now - timedelta(minutes=3),
-                ),
-            ]
-        )
-
-    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
-
-    active_result = client.post(
-        "/mcp",
-        json={
-            "jsonrpc": "2.0",
-            "id": 21,
-            "method": "tools/call",
-            "params": {
-                "name": "list_bounty_attempts",
-                "arguments": {"bounty_id": bounty.id},
-            },
-        },
-    ).json()["result"]
-
-    active_payload = active_result["structuredContent"]
-    assert active_payload["bounty_id"] == bounty.id
-    assert active_payload["issue_number"] == 321
-    assert active_payload["warnings"] == ["bounty has 2 active attempts"]
-    assert [attempt["submitter_account"] for attempt in active_payload["attempts"]] == [
-        "github:bob",
-        "github:alice",
-    ]
-
-    all_result = client.post(
-        "/mcp",
-        json={
-            "jsonrpc": "2.0",
-            "id": 22,
-            "method": "tools/call",
-            "params": {
-                "name": "list_bounty_attempts",
-                "arguments": {"bounty_id": bounty.id, "include_expired": True, "limit": 3},
-            },
-        },
-    ).json()["result"]
-
-    all_payload = all_result["structuredContent"]
-    assert [attempt["status"] for attempt in all_payload["attempts"]] == [
-        "active",
-        "active",
-        "expired",
-    ]
-
-
-def test_mcp_list_bounty_attempts_rejects_invalid_arguments(sqlite_url: str) -> None:
-    create_schema(sqlite_url)
-    with session_scope(sqlite_url) as session:
-        ensure_genesis(session)
-        bounty = create_bounty(
-            session,
-            repo="ramimbo/mergework",
-            issue_number=321,
-            issue_url="https://github.com/ramimbo/mergework/issues/321",
-            title="Attempt reservations",
-            reward_mrwk="250",
-            acceptance="Agents should inspect attempts before opening work.",
-        )
-        bounty_id = bounty.id
-
-    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
-
-    response = client.post(
-        "/mcp",
-        json={
-            "jsonrpc": "2.0",
-            "id": 23,
-            "method": "tools/call",
-            "params": {
-                "name": "list_bounty_attempts",
-                "arguments": {"bounty_id": bounty_id, "include_expired": "yes"},
-            },
-        },
-    )
-
-    assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 23,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
 
 
 def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> None:

--- a/tests/test_api_mcp_attempts.py
+++ b/tests/test_api_mcp_attempts.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+from app.db import create_schema, session_scope
+from app.ledger.service import create_bounty, ensure_genesis
+from app.main import create_app
+from app.models import BountyAttempt
+
+
+def test_mcp_list_bounty_attempts_reports_active_and_expired(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    now = datetime.now(UTC)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=321,
+            issue_url="https://github.com/ramimbo/mergework/issues/321",
+            title="Attempt reservations",
+            reward_mrwk="250",
+            max_awards=2,
+            acceptance="Agents should inspect active attempts before opening work.",
+        )
+        session.add_all(
+            [
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account="github:alice",
+                    source_url="https://github.com/ramimbo/mergework/pull/501",
+                    status="active",
+                    expires_at=now + timedelta(hours=1),
+                    created_at=now - timedelta(minutes=2),
+                    updated_at=now - timedelta(minutes=2),
+                ),
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account="github:bob",
+                    source_url="https://github.com/ramimbo/mergework/pull/502",
+                    status="active",
+                    expires_at=now + timedelta(hours=2),
+                    created_at=now - timedelta(minutes=1),
+                    updated_at=now - timedelta(minutes=1),
+                ),
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account="github:carol",
+                    source_url="https://github.com/ramimbo/mergework/pull/503",
+                    status="active",
+                    expires_at=now - timedelta(minutes=1),
+                    created_at=now - timedelta(minutes=3),
+                    updated_at=now - timedelta(minutes=3),
+                ),
+            ]
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    active_result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 21,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounty_attempts",
+                "arguments": {"bounty_id": bounty.id},
+            },
+        },
+    ).json()["result"]
+
+    active_payload = active_result["structuredContent"]
+    assert active_payload["bounty_id"] == bounty.id
+    assert active_payload["issue_number"] == 321
+    assert active_payload["warnings"] == ["bounty has 2 active attempts"]
+    assert [attempt["submitter_account"] for attempt in active_payload["attempts"]] == [
+        "github:bob",
+        "github:alice",
+    ]
+
+    all_result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 22,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounty_attempts",
+                "arguments": {"bounty_id": bounty.id, "include_expired": True, "limit": 3},
+            },
+        },
+    ).json()["result"]
+
+    all_payload = all_result["structuredContent"]
+    assert [attempt["status"] for attempt in all_payload["attempts"]] == [
+        "active",
+        "active",
+        "expired",
+    ]
+
+
+def test_mcp_list_bounty_attempts_rejects_invalid_arguments(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=321,
+            issue_url="https://github.com/ramimbo/mergework/issues/321",
+            title="Attempt reservations",
+            reward_mrwk="250",
+            acceptance="Agents should inspect attempts before opening work.",
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 23,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounty_attempts",
+                "arguments": {"bounty_id": bounty_id, "include_expired": "yes"},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 23,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }


### PR DESCRIPTION
## Summary

- Split the MCP bounty-attempt tests out of oversized `tests/test_api_mcp.py`.
- Added `tests/test_api_mcp_attempts.py` as the focused module for active/expired attempt listing and invalid argument coverage.
- Removed now-unused attempt/time imports from `tests/test_api_mcp.py`.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: large MCP test module targeted by bounty #410.
- Bounty capacity and active attempts/open PRs checked: bounty allows up to 3 awards; no conflicting PR found for this exact split.
- Intended files or surfaces: `tests/test_api_mcp.py`, `tests/test_api_mcp_attempts.py`.
- Expected PR size: focused test-only split.
- Out of scope: production behavior changes.

## Test Evidence

- [x] `./.venv/bin/python -m pytest tests/test_api_mcp_attempts.py tests/test_api_mcp.py`
- [x] `./.venv/bin/python -m ruff format --check .`
- [x] `./.venv/bin/python -m ruff check .`
- [x] `./.venv/bin/python -m pytest`
- [x] `./.venv/bin/python -m mypy app`

## MRWK

Refs #410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the MCP `list_bounty_attempts` method, validating proper reporting of active and expired attempts with correct ordering and warning messages
  * Added input validation tests to ensure the API correctly rejects invalid arguments and returns appropriate error responses
  * Reorganized test suite structure for improved maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->