### PR TITLE
docs: document internal ledger account responses

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -304,6 +304,37 @@ For `treasury:` and `reserve:` accounts, `github_login` is `null` and
 `transfer_status` explains that direct MRWK wallet transfers are only available
 for registered `mrwk1` addresses.
 
+Internal ledger accounts use the same account response shape. The treasury
+account is useful when checking public reserve movements, but it is not a
+wallet account:
+
+```bash
+curl -s "$API_HOST/api/v1/accounts/treasury:mrwk"
+```
+
+```json
+{
+  "account": "treasury:mrwk",
+  "ledger_address": "treasury:mrwk",
+  "github_login": null,
+  "exists": true,
+  "balance_mrwk": "99959140",
+  "transfer_status": "Internal ledger account. MRWK wallet transfers are only available for registered mrwk1 addresses.",
+  "accepted_work": {
+    "accepted_awards": 0,
+    "accepted_mrwk": "0",
+    "latest_ledger_sequence": null,
+    "latest_submission_url": null,
+    "latest_proof_hash": null,
+    "latest_proof_url": null
+  }
+}
+```
+
+Treasury and reserve balances change as bounties are reserved, paid, and
+released. Treat the `balance_mrwk` value as a live snapshot, not a fixed
+account invariant.
+
 Read the proof-backed accepted-work list for a single account:
 
 ```bash

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -53,6 +53,10 @@ REQUIRED_PUBLIC_PHRASES = {
         "Discussion or decision-support claim:",
         "Do not describe work as accepted, merged, or paid until the public GitHub label",
     ],
+    "docs/api-examples.md": [
+        "Internal ledger accounts use the same account response shape",
+        ("Treasury and reserve balances change as bounties are reserved, paid, and released."),
+    ],
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -55,6 +55,7 @@ def test_api_examples_document_mcp_get_proof_response_shape() -> None:
 
 def test_api_examples_document_account_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+    squashed = " ".join(examples.split())
 
     assert "/api/v1/accounts/treasury:mrwk" in examples
     assert '"ledger_address": "github:tatelyman"' in examples
@@ -64,6 +65,13 @@ def test_api_examples_document_account_response_shape() -> None:
     assert "Claim GitHub balances from /me" in examples
     assert "treasury:" in examples
     assert "registered `mrwk1` addresses" in examples
+    assert "Internal ledger accounts use the same account response shape" in examples
+    assert '"account": "treasury:mrwk"' in examples
+    assert '"github_login": null' in examples
+    assert (
+        "Treasury and reserve balances change as bounties are reserved, paid, and released"
+        in squashed
+    )
 
 
 def test_api_examples_document_ledger_response_shape() -> None:


### PR DESCRIPTION
## Summary
- Document the public account API shape for internal ledger accounts such as `treasury:mrwk`
- Clarify that treasury/reserve balances are live snapshots, not fixed invariants
- Add docs smoke/test coverage for the new internal-account wording

Bounty #426

## Evidence
Compared against live unauthenticated production behavior on 2026-05-26:

```bash
curl -i 'https://api.mrwk.ltclab.site/api/v1/accounts/treasury:mrwk'
curl -i 'https://mrwk.ltclab.site/accounts/treasury:mrwk'
```

Observed API response included `ledger_address: "treasury:mrwk"`, `github_login: null`, `exists: true`, `balance_mrwk: "99959140"`, and transfer status explaining that internal ledger accounts cannot send direct wallet transfers.

## Validation
```text
uv run --extra dev python scripts/docs_smoke.py
# docs smoke ok

uv run --extra dev python -m pytest tests/test_docs_public_urls.py -q
# 22 passed in 0.19s

uv run --extra dev ruff check scripts/docs_smoke.py tests/test_docs_public_urls.py
# All checks passed!

uv run --extra dev ruff format --check scripts/docs_smoke.py tests/test_docs_public_urls.py
# 2 files already formatted

git diff --check
# no output
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced API documentation with clarification on internal ledger accounts and their response format
  * Added detailed examples showing treasury account structures and field values
  * Clarified that treasury and reserve balances are snapshots that update as bounties are reserved, paid, or released

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->