### PR TITLE
test: validate issue template YAML in docs smoke

### DIFF
--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[1]
 REQUIRED = [
     "README.md",
@@ -55,6 +57,7 @@ REQUIRED_PUBLIC_PHRASES = {
     ],
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+ISSUE_TEMPLATE_DIR = ".github/ISSUE_TEMPLATE"
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"
 PR_TEMPLATE = ".github/pull_request_template.md"
 
@@ -68,6 +71,16 @@ def _local_target_exists(source: Path, target: str) -> bool:
 
 def _squash(text: str) -> str:
     return " ".join(text.split())
+
+
+def _load_yaml_mapping(path: Path) -> tuple[bool, str | None]:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        return False, f"invalid YAML: {exc}"
+    if not isinstance(data, dict):
+        return False, "must parse to a YAML mapping"
+    return True, None
 
 
 def main() -> int:
@@ -92,6 +105,17 @@ def main() -> int:
         for link in LINK_RE.findall(text):
             if not _local_target_exists(path, link):
                 print(f"broken local link in {relative}: {link}")
+                ok = False
+    issue_template_dir = ROOT / ISSUE_TEMPLATE_DIR
+    if not issue_template_dir.exists():
+        print(f"missing issue template directory: {ISSUE_TEMPLATE_DIR}")
+        ok = False
+    else:
+        for template_path in sorted(issue_template_dir.glob("*.yml")):
+            parsed, error = _load_yaml_mapping(template_path)
+            if not parsed:
+                relative = template_path.relative_to(ROOT)
+                print(f"invalid issue template YAML in {relative}: {error}")
                 ok = False
     docs_issue_template = ROOT / DOCS_ISSUE_TEMPLATE
     if not docs_issue_template.exists():

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.docs_smoke import REQUIRED
+from scripts.docs_smoke import REQUIRED, _load_yaml_mapping
 
 
 def test_readme_lists_live_ltclab_urls() -> None:
@@ -254,6 +254,27 @@ def test_agent_guide_explains_internal_bounty_ids() -> None:
 
 def test_docs_smoke_covers_public_api_examples() -> None:
     assert "docs/api-examples.md" in REQUIRED
+
+
+def test_docs_smoke_validates_issue_template_yaml(tmp_path: Path) -> None:
+    valid_template = Path(".github/ISSUE_TEMPLATE/bounty.yml")
+    parsed, error = _load_yaml_mapping(valid_template)
+    assert parsed is True
+    assert error is None
+
+    invalid_template = tmp_path / "broken.yml"
+    invalid_template.write_text(
+        "name: Broken\n"
+        "body:\n"
+        "  - type: textarea\n"
+        "    attributes:\n"
+        "      description: docs/bounty-rules.md: reward, max awards\n",
+        encoding="utf-8",
+    )
+    parsed, error = _load_yaml_mapping(invalid_template)
+    assert parsed is False
+    assert error is not None
+    assert "invalid YAML" in error
 
 
 def test_contributing_names_docs_smoke_for_public_docs_changes() -> None:


### PR DESCRIPTION
## Summary
- Parse all `.github/ISSUE_TEMPLATE/*.yml` files during `scripts/docs_smoke.py`
- Report invalid issue-template YAML before broken forms land
- Add regression coverage for an unquoted `:` in a template description

Bounty #406

## Evidence
This is motivated by a real current failure mode seen while reviewing PR #461: `.github/ISSUE_TEMPLATE/bounty.yml` can contain an unquoted description such as `docs/bounty-rules.md: reward`, which PyYAML rejects with `ScannerError: mapping values are not allowed here`. Before this change, `scripts/docs_smoke.py` checked docs issue-template text but did not parse the YAML for all issue templates, so that class of broken GitHub issue form could slip through docs checks.

The new regression test writes an invalid template with the same unquoted-colon pattern and verifies `_load_yaml_mapping` rejects it.

## Validation
```text
uv run --extra dev python scripts/docs_smoke.py
# docs smoke ok

uv run --extra dev python -m pytest tests/test_docs_public_urls.py -q
# 23 passed in 0.23s

uv run --extra dev ruff check scripts/docs_smoke.py tests/test_docs_public_urls.py
# All checks passed!

uv run --extra dev ruff format --check scripts/docs_smoke.py tests/test_docs_public_urls.py
# 2 files already formatted

git diff --check
# no output
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Implemented validation to ensure issue templates maintain proper YAML formatting standards.
* **Tests**
  * Added test coverage for issue template validation, verifying both valid and invalid template handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->