### PR TITLE
fix: honor MCP bounty sort argument

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -14,7 +14,7 @@ MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
-        "description": "List MRWK bounties with optional status, q, and limit filters",
+        "description": "List MRWK bounties with optional status, q, sort, and limit filters",
     },
     {
         "name": "get_bounty",

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -7,6 +7,7 @@ from sqlalchemy import func, or_, select
 
 from app.accounts import normalized_account, normalized_wallet_address
 from app.bounty_attempts import list_bounty_attempts
+from app.bounty_sorting import normalize_bounty_sort, sort_bounties
 from app.db import session_scope
 from app.ledger.service import format_mrwk, get_balance, register_wallet, submit_wallet_transfer
 from app.ledger_views import ledger_entry_to_dict
@@ -135,10 +136,11 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 if issue_number is not None:
                     text_filter = or_(text_filter, Bounty.issue_number == issue_number)
                 query = query.where(text_filter)
-            bounties = session.scalars(
-                query.order_by(Bounty.id.desc()).limit(list_limit_arg())
-            ).all()
-            return json.dumps([bounty_to_dict(bounty) for bounty in bounties])
+            sort = normalize_bounty_sort(optional_clean_str_arg("sort"))
+            limit = list_limit_arg()
+            bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
+            sorted_bounties = sort_bounties([bounty_to_dict(bounty) for bounty in bounties], sort)
+            return json.dumps(sorted_bounties[:limit])
         if name == "get_bounty":
             bounty = session.get(Bounty, positive_int_arg("id"))
             if bounty is None:

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -138,6 +138,11 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 query = query.where(text_filter)
             sort = normalize_bounty_sort(optional_clean_str_arg("sort"))
             limit = list_limit_arg()
+            if sort == "newest":
+                newest_bounties = session.scalars(
+                    query.order_by(Bounty.id.desc()).limit(limit)
+                ).all()
+                return json.dumps([bounty_to_dict(bounty) for bounty in newest_bounties])
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             sorted_bounties = sort_bounties([bounty_to_dict(bounty) for bounty in bounties], sort)
             return json.dumps(sorted_bounties[:limit])

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -495,6 +495,18 @@ def test_mcp_list_bounties_honors_sort_argument(sqlite_url: str) -> None:
     payload = json.loads(result["result"]["content"][0]["text"])
     assert [item["id"] for item in payload] == [large_bounty.id, small_bounty.id]
 
+    limited = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "tools/call",
+            "params": {"name": "list_bounties", "arguments": {"sort": "reward", "limit": 1}},
+        },
+    ).json()
+    limited_payload = json.loads(limited["result"]["content"][0]["text"])
+    assert [item["id"] for item in limited_payload] == [large_bounty.id]
+
 
 @pytest.mark.parametrize(
     ("arguments", "request_id"),
@@ -504,6 +516,7 @@ def test_mcp_list_bounties_honors_sort_argument(sqlite_url: str) -> None:
         ({"q": 284}, 33),
         ({"limit": 0}, 34),
         ({"limit": 101}, 35),
+        ({"sort": "invalid"}, 36),
     ],
 )
 def test_mcp_list_bounties_rejects_invalid_filters(

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -173,7 +173,7 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
 
     tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()
     assert tools["result"]["tools"][0]["name"] == "list_bounties"
-    assert "status, q, and limit filters" in tools["result"]["tools"][0]["description"]
+    assert "status, q, sort, and limit filters" in tools["result"]["tools"][0]["description"]
     submit_tool = next(
         tool for tool in tools["result"]["tools"] if tool["name"] == "submit_work_proof"
     )
@@ -456,6 +456,44 @@ def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> No
     ).json()
     digit_limit_payload = json.loads(digit_limit_result["result"]["content"][0]["text"])
     assert digit_limit_payload == []
+
+
+def test_mcp_list_bounties_honors_sort_argument(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        large_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=301,
+            issue_url="https://github.com/ramimbo/mergework/issues/301",
+            title="Large MCP bounty",
+            reward_mrwk="100",
+            acceptance="Agents can sort this higher reward bounty first.",
+        )
+        small_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=302,
+            issue_url="https://github.com/ramimbo/mergework/issues/302",
+            title="Small MCP bounty",
+            reward_mrwk="25",
+            acceptance="Agents can list this lower reward bounty.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": {"name": "list_bounties", "arguments": {"sort": "reward"}},
+        },
+    ).json()
+
+    payload = json.loads(result["result"]["content"][0]["text"])
+    assert [item["id"] for item in payload] == [large_bounty.id, small_bounty.id]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Honor the `sort` argument for MCP `list_bounties` calls using the shared bounty sorting helper
- Update the MCP tool description to document the sort filter
- Add coverage proving MCP reward sorting differs from default newest sorting

## Test plan
- `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_mcp_list_bounties_honors_sort_argument -q`
- `uv run --extra dev python -m pytest tests/test_api_mcp.py -q`
- `uv run --extra dev ruff check .`
- `uv run --extra dev python -m pytest -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `sort` filter for the bounties list so users can order results (e.g., by reward or newest) and combine sorting with `limit`.
* **Documentation**
  * Updated the bounties tool description to reference the new `sort` option alongside existing filters.
* **Tests**
  * Added tests to verify sorting behavior, sort+limit interaction, and invalid `sort` handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->