### PR TITLE
Document agent-friendly bounty post template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -38,7 +38,7 @@ body:
 
         ## Work Needed
 
-
+        <Describe the useful accepted work.>
 
         Useful accepted work can include:
 
@@ -49,6 +49,26 @@ body:
         - Open a focused PR that links this issue with `Bounty #<issue number>` or `Refs #<issue number>`.
         - Existing checks pass.
         - One award per distinct useful submission. Duplicate, vague, misleading, or unrelated work does not qualify.
+
+        ## Evidence or Tests
+
+        <Describe required test output, commands, or screenshots. Remove if not needed.>
+
+        ## Out of Scope
+
+        <List work that will not be accepted even if technically related. Remove if not needed.>
+
+        ## Duplicate-Work Rules
+
+        Duplicate, vague, misleading, or superseded submissions do not qualify.
+
+        ## Stale-Work Rules
+
+        <State how long claims remain valid without activity. Remove if not needed.>
+
+        ## Public Artifact Cautions
+
+        Do not post private keys, seed material, secrets, private vulnerability details, deployment credentials, price claims, investment claims, liquidity claims, bridge promises, or fabricated payout claims.
 
         ## How To Submit
 

--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -7,7 +7,9 @@ body:
     id: reward
     attributes:
       label: Reward per award
-      description: MRWK amount per accepted award (e.g. 250). Also include this in the issue title.
+      description: >-
+        MRWK amount per accepted award (e.g. 250).
+        Also include this value in the issue title.
       placeholder: "250"
     validations:
       required: true
@@ -15,29 +17,43 @@ body:
     id: max_awards
     attributes:
       label: Max awards
-      description: Number of separate payouts allowed. Use 1 for a single-award bounty.
+      description: >-
+        Number of separate payouts allowed. Use 1 for a single-award bounty.
       placeholder: "1"
     validations:
       required: true
   - type: textarea
-    id: work
+    id: body
     attributes:
-      label: Work Needed
-      description: Describe the useful accepted work. List specific items that qualify.
-    validations:
-      required: true
-  - type: textarea
-    id: acceptance
-    attributes:
-      label: Acceptance Criteria
-      description: Explain what must be true before mrwk:accepted is applied. Mention evidence, tests, and checks.
-    validations:
-      required: true
-  - type: textarea
-    id: how_to_submit
-    attributes:
-      label: How To Submit
-      description: Explain whether to open a PR, comment with /claim, or use another path.
+      label: Bounty body
+      description: >-
+        Start with the canonical header block so parsers can read reward and
+        max awards directly from the issue body. Then fill in the sections below.
+        Keep the Reward and Max awards lines consistent with the inputs above.
+      value: |
+        ## MRWK Bounty
+
+        Reward: `250 MRWK per accepted award`
+        Max awards: `1`
+
+        ## Work Needed
+
+
+
+        Useful accepted work can include:
+
+        -
+
+        ## Acceptance Criteria
+
+        - Open a focused PR that links this issue with `Bounty #<issue number>` or `Refs #<issue number>`.
+        - Existing checks pass.
+        - One award per distinct useful submission. Duplicate, vague, misleading, or unrelated work does not qualify.
+
+        ## How To Submit
+
+        Open a focused PR with the required evidence. A maintainer must apply `mrwk:accepted` or record an admin payout before payment.
+      render: markdown
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -1,19 +1,13 @@
 name: MRWK bounty
 description: Propose work that may receive an MRWK bounty.
-title: "[bounty] "
+title: "MRWK bounty: "
 labels: ["mrwk:bounty"]
 body:
-  - type: textarea
-    id: work
-    attributes:
-      label: Work needed
-      description: Describe the useful accepted work.
-    validations:
-      required: true
   - type: input
     id: reward
     attributes:
-      label: Proposed MRWK per award
+      label: Reward per award
+      description: MRWK amount per accepted award (e.g. 250). Also include this in the issue title.
       placeholder: "250"
     validations:
       required: true
@@ -21,13 +15,35 @@ body:
     id: max_awards
     attributes:
       label: Max awards
+      description: Number of separate payouts allowed. Use 1 for a single-award bounty.
       placeholder: "1"
+    validations:
+      required: true
+  - type: textarea
+    id: work
+    attributes:
+      label: Work Needed
+      description: Describe the useful accepted work. List specific items that qualify.
     validations:
       required: true
   - type: textarea
     id: acceptance
     attributes:
-      label: Acceptance criteria
-      description: Explain what must be true before mrwk:accepted is applied.
+      label: Acceptance Criteria
+      description: Explain what must be true before mrwk:accepted is applied. Mention evidence, tests, and checks.
     validations:
       required: true
+  - type: textarea
+    id: how_to_submit
+    attributes:
+      label: How To Submit
+      description: Explain whether to open a PR, comment with /claim, or use another path.
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of Scope (optional)
+      description: List work that will not be accepted even if technically related.
+    validations:
+      required: false

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -2,14 +2,18 @@
 
 ## Post a Bounty
 
-1. Create or choose a GitHub issue.
-2. Decide the MRWK amount using the reference tiers.
-3. Add acceptance text that explains what counts as useful accepted work.
-4. Set `max_awards` to the number of separate payouts allowed. Use `1` for
+1. Create or choose a GitHub issue. Use the bounty issue template
+   (`.github/ISSUE_TEMPLATE/bounty.yml`) for a guided form, or follow the
+   canonical template in [Bounty Post Template](bounty-rules.md#bounty-post-template).
+2. Title the issue `MRWK bounty: <amount> MRWK - <short scope>` so the reward
+   is visible in lists and parseable by agents.
+3. Decide the MRWK amount using the reference tiers.
+4. Add acceptance text that explains what counts as useful accepted work.
+5. Set `max_awards` to the number of separate payouts allowed. Use `1` for
    a single-award bounty.
-5. Use `/admin` or `POST /api/v1/bounties` with an admin token.
+6. Use `/admin` or `POST /api/v1/bounties` with an admin token.
    Multi-award bounties reserve `reward_mrwk * max_awards`.
-6. Add `mrwk:bounty` to the GitHub issue.
+7. Add `mrwk:bounty` to the GitHub issue.
 
 ## Accept Work
 

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -56,6 +56,83 @@ After accepted work is paid, MergeWork records a public ledger proof. Public
 payment updates should point to those proofs and keep any private security or
 operational details out of public metadata.
 
+## Bounty Post Template
+
+Maintainers should use the following structure when posting a new bounty issue.
+The template is designed so both humans and agents can parse the scope, reward,
+award slots, acceptance criteria, evidence requirements, and out-of-scope rules
+without guessing.
+
+### Required Fields
+
+| Field | Where | Purpose |
+| --- | --- | --- |
+| Title | Issue title | Must follow `MRWK bounty: <amount> MRWK - <short scope>` so the reward is visible in lists |
+| Reward | Body, code block | `Reward: \`<amount> MRWK per accepted award\`` — repeated in body for API/MCP parsing |
+| Max awards | Body, code block | `Max awards: \`<number>\`` — controls reserve and payout cap |
+| Work Needed | Body heading | Describe the useful accepted work. Be specific about what qualifies. |
+| Acceptance Criteria | Body heading | List exact conditions for `mrwk:accepted`. Mention evidence, tests, and checks. |
+| How To Submit | Body heading | Explain whether to open a PR, comment with `/claim`, or use another path. |
+
+### Optional Fields
+
+| Field | Where | Purpose |
+| --- | --- | --- |
+| Out of Scope | Body heading | List work that will not be accepted even if technically related. |
+| Evidence or Tests | Body heading | Describe required test output, commands, or screenshots. |
+| Duplicate-Work Rules | Body heading | Explain how overlapping submissions are handled. |
+| Stale-Work Rules | Body heading | State how long claims remain valid without activity. |
+| Public Artifact Cautions | Body heading | Remind contributors not to post private keys, secrets, or price claims. |
+
+### Template
+
+Copy and fill in the sections that apply:
+
+```markdown
+## MRWK Bounty
+
+Reward: \`<amount> MRWK per accepted award\`
+Max awards: \`<number>\`
+
+## Work Needed
+
+<Describe the useful accepted work. Be specific about what qualifies.>
+
+Useful accepted work can include:
+
+- <item>
+- <item>
+
+## Acceptance Criteria
+
+- <criterion>
+- <criterion>
+- Existing checks pass.
+- One award per distinct useful submission. Duplicate, vague, misleading, or unrelated work does not qualify.
+
+## How To Submit
+
+<Open a focused PR / Comment with /claim / Other path>. A maintainer must apply \`mrwk:accepted\` or record an admin payout before payment.
+```
+
+### Agent-Readable Fields
+
+Agents consuming bounties through the GitHub API, REST API (`GET /api/v1/bounties`),
+or MCP (`list_bounties`, `get_bounty`) should read these fields:
+
+- **Reward and max awards**: parse from the body code blocks or from the API
+  response fields `reward_mrwk` and `max_awards`.
+- **Status**: use the `status` field from the API or the `mrwk:bounty` /
+  `mrwk:paid` labels on the GitHub issue.
+- **Available awards**: use `awards_remaining` or `available_mrwk` from the
+  API response.
+- **Work scope and acceptance criteria**: parse the `Work Needed` and
+  `Acceptance Criteria` headings from the issue body.
+
+The title format `MRWK bounty: <amount> MRWK - <short scope>` lets agents
+identify reward amounts without parsing the full body, which is useful when
+listing issues through GitHub search or the REST API summary endpoint.
+
 ## Submission Evidence Templates
 
 Use the smallest template that makes the claim reviewable. Delete fields that do

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -68,8 +68,8 @@ without guessing.
 | Field | Where | Purpose |
 | --- | --- | --- |
 | Title | Issue title | Must follow `MRWK bounty: <amount> MRWK - <short scope>` so the reward is visible in lists |
-| Reward | Body, code block | `Reward: \`<amount> MRWK per accepted award\`` — repeated in body for API/MCP parsing |
-| Max awards | Body, code block | `Max awards: \`<number>\`` — controls reserve and payout cap |
+| Reward | Body, inline code | `Reward: <amount> MRWK per accepted award` — repeated in body for API/MCP parsing |
+| Max awards | Body, inline code | `Max awards: <number>` — controls reserve and payout cap |
 | Work Needed | Body heading | Describe the useful accepted work. Be specific about what qualifies. |
 | Acceptance Criteria | Body heading | List exact conditions for `mrwk:accepted`. Mention evidence, tests, and checks. |
 | How To Submit | Body heading | Explain whether to open a PR, comment with `/claim`, or use another path. |
@@ -88,32 +88,35 @@ without guessing.
 
 Copy and fill in the sections that apply:
 
-```markdown
-## MRWK Bounty
+    ## MRWK Bounty
 
-Reward: \`<amount> MRWK per accepted award\`
-Max awards: \`<number>\`
+    Reward: `<amount> MRWK per accepted award`
+    Max awards: `<number>`
 
-## Work Needed
+    ## Work Needed
 
-<Describe the useful accepted work. Be specific about what qualifies.>
+    <Describe the useful accepted work. Be specific about what qualifies.>
 
-Useful accepted work can include:
+    Useful accepted work can include:
 
-- <item>
-- <item>
+    - <item>
+    - <item>
 
-## Acceptance Criteria
+    ## Acceptance Criteria
 
-- <criterion>
-- <criterion>
-- Existing checks pass.
-- One award per distinct useful submission. Duplicate, vague, misleading, or unrelated work does not qualify.
+    - <criterion>
+    - <criterion>
+    - Existing checks pass.
+    - One award per distinct useful submission. Duplicate, vague, misleading, or unrelated work does not qualify.
 
-## How To Submit
+    ## How To Submit
 
-<Open a focused PR / Comment with /claim / Other path>. A maintainer must apply \`mrwk:accepted\` or record an admin payout before payment.
-```
+    <Open a focused PR / Comment with /claim / Other path>. A maintainer must apply `mrwk:accepted` or record an admin payout before payment.
+
+> **Note**: When pasting into a GitHub issue body, wrap the template in a fenced
+> code block (triple backticks) only for display. The actual issue body should
+> contain the plain headings and inline code (single backticks), not the fence
+> markers.
 
 ### Agent-Readable Fields
 

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -109,6 +109,27 @@ Copy and fill in the sections that apply:
     - Existing checks pass.
     - One award per distinct useful submission. Duplicate, vague, misleading, or unrelated work does not qualify.
 
+    ## Evidence or Tests
+
+    <Describe required test output, commands, or screenshots. Remove if not needed.>
+
+    ## Out of Scope
+
+    - <List work that will not be accepted even if technically related.>
+    - <Remove this section if everything relevant is in scope.>
+
+    ## Duplicate-Work Rules
+
+    <How overlapping submissions are handled. Default: duplicate, vague, or superseded work does not qualify.>
+
+    ## Stale-Work Rules
+
+    <How long claims remain valid without activity. Remove if not needed.>
+
+    ## Public Artifact Cautions
+
+    Do not post private keys, seed material, secrets, private vulnerability details, deployment credentials, price claims, investment claims, liquidity claims, bridge promises, or fabricated payout claims.
+
     ## How To Submit
 
     <Open a focused PR / Comment with /claim / Other path>. A maintainer must apply `mrwk:accepted` or record an admin payout before payment.

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -54,11 +54,11 @@ REQUIRED_PUBLIC_PHRASES = {
         "Discussion or decision-support claim:",
         "Do not describe work as accepted, merged, or paid until the public GitHub label",
         "MRWK bounty: <amount> MRWK - <short scope>",
-        "Reward:",
-        "Max awards:",
-        "Work Needed",
-        "Acceptance Criteria",
-        "How To Submit",
+        "Reward: `<amount> MRWK per accepted award`",
+        "Max awards: `<number>`",
+        "## Work Needed",
+        "## Acceptance Criteria",
+        "## How To Submit",
     ],
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -58,6 +58,11 @@ REQUIRED_PUBLIC_PHRASES = {
         "Max awards: `<number>`",
         "## Work Needed",
         "## Acceptance Criteria",
+        "## Evidence or Tests",
+        "## Out of Scope",
+        "## Duplicate-Work Rules",
+        "## Stale-Work Rules",
+        "## Public Artifact Cautions",
         "## How To Submit",
     ],
 }

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -46,12 +46,19 @@ REQUIRED_PUBLIC_PHRASES = {
         ("creating or releasing an attempt requires the GitHub-authenticated browser session"),
     ],
     "docs/bounty-rules.md": [
+        "## Bounty Post Template",
         "## Submission Evidence Templates",
         "PR or fix claim:",
         "Review claim:",
         "Smoke-check or bug-report claim:",
         "Discussion or decision-support claim:",
         "Do not describe work as accepted, merged, or paid until the public GitHub label",
+        "MRWK bounty: <amount> MRWK - <short scope>",
+        "Reward:",
+        "Max awards:",
+        "Work Needed",
+        "Acceptance Criteria",
+        "How To Submit",
     ],
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")


### PR DESCRIPTION
## Problem

Bounty #456 asked for a canonical agent-friendly bounty post template so humans and agents can parse scope, reward, award slots, acceptance criteria, and evidence requirements without guessing.

Before this PR, bounty posts relied on convention rather than documented structure. The issue template (`bounty.yml`) did not enforce key fields like How To Submit or Out of Scope.

## Changes

- **docs/bounty-rules.md**: Added a "Bounty Post Template" section with:
  - Required fields table (title format, reward, max awards, work needed, acceptance criteria, how to submit)
  - Optional fields table (out of scope, evidence/tests, duplicate-work rules, stale-work rules, public artifact cautions)
  - Copy-pasteable markdown template
  - Agent-readable fields guide explaining which fields agents need for GitHub, REST API, and MCP bounty workflows

- **docs/admin-runbook.md**: Updated "Post a Bounty" steps to reference the documented template and require the `MRWK bounty: <amount> MRWK - <short scope>` title format.

- **.github/ISSUE_TEMPLATE/bounty.yml**: Restructured to match the documented template — added How To Submit and Out of Scope fields, reordered to put Reward and Max Awards first.

- **scripts/docs_smoke.py**: Added checks for the new template section headings and key phrases.

## Evidence

```
$ ./.venv/bin/python scripts/docs_smoke.py
docs smoke ok

$ ./.venv/bin/python -m pytest tests/ -q
414 passed in 53.37s

$ ./.venv/bin/python -m ruff format --check .
79 files already formatted

$ ./.venv/bin/python -m ruff check .
All checks passed!

$ ./.venv/bin/python -m mypy app
Success: no issues found in 30 source files
```

Compared the proposed template against existing bounty issues (#405, #406, #427, #456, #459) — all already follow this structure, confirming the template matches real-world usage.

## Out of Scope

- No changes to app code, database models, or API endpoints
- No public artifact cautions beyond what existing docs already state
- No investment/price/liquidity claims

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated bounty issue template: new title prefix "MRWK bounty:", consolidated required body with canonical sections (Reward, Max awards, Work Needed, Acceptance Criteria, Evidence/Tests, Out of Scope, Duplicate/Stale-Work Rules, Public Artifact Cautions, How To Submit).
  * Clarified "Reward per award" and max-awards guidance; instruct title to include MRWK amount.
  * Expanded runbook and automated checks to reference and enforce the canonical template.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->