### PR TITLE
Fix whitespace-only bounty sort defaults

### DIFF
--- a/app/bounty_sorting.py
+++ b/app/bounty_sorting.py
@@ -16,7 +16,9 @@ BOUNTY_SORT_ERROR = f"sort must be one of: {', '.join(BOUNTY_SORT_OPTIONS)}"
 
 
 def normalize_bounty_sort(sort: str | None) -> str:
-    normalized_sort = (sort or "newest").strip().lower()
+    normalized_sort = (sort or "").strip().lower()
+    if not normalized_sort:
+        return "newest"
     if normalized_sort not in BOUNTY_SORT_OPTIONS:
         raise ValueError(BOUNTY_SORT_ERROR)
     return normalized_sort

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -272,6 +272,9 @@ def test_bounties_page_and_api_sort_public_rows(sqlite_url: str) -> None:
     assert whitespace_sort_page.text.index(high_capacity.title) < whitespace_sort_page.text.index(
         high_reward.title
     )
+    assert whitespace_sort_page.text.index(high_reward.title) < whitespace_sort_page.text.index(
+        most_awards.title
+    )
     assert '<option value="newest" selected>Newest first</option>' in whitespace_sort_page.text
 
     invalid_sort = client.get("/api/v1/bounties?sort=bogus")

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -243,6 +243,10 @@ def test_bounties_page_and_api_sort_public_rows(sqlite_url: str) -> None:
     assert default_rows.status_code == 200
     assert [row["issue_number"] for row in default_rows.json()] == [71, 70, 69]
 
+    whitespace_sort_rows = client.get("/api/v1/bounties", params={"sort": "   "})
+    assert whitespace_sort_rows.status_code == 200
+    assert [row["issue_number"] for row in whitespace_sort_rows.json()] == [71, 70, 69]
+
     reward_rows = client.get("/api/v1/bounties?sort=reward")
     assert reward_rows.status_code == 200
     assert [row["issue_number"] for row in reward_rows.json()] == [70, 71, 69]
@@ -262,6 +266,13 @@ def test_bounties_page_and_api_sort_public_rows(sqlite_url: str) -> None:
     assert 'name="sort"' in available_page.text
     assert '<option value="available" selected>Most MRWK available</option>' in available_page.text
     assert 'href="/bounties?status=open&sort=available"' in available_page.text
+
+    whitespace_sort_page = client.get("/bounties", params={"sort": "   "})
+    assert whitespace_sort_page.status_code == 200
+    assert whitespace_sort_page.text.index(high_capacity.title) < whitespace_sort_page.text.index(
+        high_reward.title
+    )
+    assert '<option value="newest" selected>Newest first</option>' in whitespace_sort_page.text
 
     invalid_sort = client.get("/api/v1/bounties?sort=bogus")
     assert invalid_sort.status_code == 400


### PR DESCRIPTION
## Summary
- Treat whitespace-only bounty `sort` query values as omitted/default `newest`.
- Keep non-empty invalid sort values rejected with the existing `400` response.
- Add API and public page regression coverage for the blank-after-trim sort case.

Bounty #406

## Evidence
- Baseline regression failed before the normalizer change: `./.venv/bin/python -m pytest tests/test_bounty_pages.py::test_bounties_page_and_api_sort_public_rows -q` returned `400` for `/bounties` with a whitespace-only `sort` query.
- Live bounty preflight: `GET https://api.mrwk.ltclab.site/api/v1/bounties/66/attempts?include_expired=false` returned `attempts: []`.

## Validation
- `./.venv/bin/python -m pytest tests/test_bounty_pages.py::test_bounties_page_and_api_sort_public_rows -q` -> 1 passed
- `./.venv/bin/python -m pytest tests/test_bounty_pages.py tests/test_bounty_api_routes.py -q` -> 14 passed
- `./.venv/bin/python -m pytest -q` -> 414 passed
- `./.venv/bin/python -m ruff check .` -> passed
- `./.venv/bin/python -m ruff format --check .` -> 79 files already formatted
- `./.venv/bin/python -m mypy app` -> success
- `git diff --check` -> clean
- `gitleaks detect --no-banner --redact --source . --log-opts upstream/main..HEAD --exit-code 1` -> no leaks found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Whitespace-only sort parameters now default to "Newest first" instead of causing a validation error, so bounties sort correctly when extra spaces are included.

* **Tests**
  * Added API and UI tests to ensure whitespace-only sort values behave like the default "Newest first" ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->