### PR TITLE
Document submit_work_proof repo schema dependency

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -61,7 +61,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
                 "repo": {
                     "type": "string",
                     "maxLength": 200,
-                    "description": "Optional owner/name repository scope for issue_number lookups.",
+                    "description": "Owner/name repository scope. Only valid with issue_number.",
                 },
                 "format": {
                     "type": "string",
@@ -71,6 +71,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
                 },
             },
             "additionalProperties": False,
+            "dependentRequired": {"repo": ["issue_number"]},
             "not": {"required": ["bounty_id", "issue_number"]},
         },
     },

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -185,6 +185,7 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert submit_schema["properties"]["bounty_id"]["minimum"] == 1
     assert submit_schema["properties"]["issue_number"]["minimum"] == 1
     assert submit_schema["properties"]["repo"]["maxLength"] == 200
+    assert submit_schema["dependentRequired"] == {"repo": ["issue_number"]}
     assert submit_schema["not"] == {"required": ["bounty_id", "issue_number"]}
     bounty_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_bounty")
     assert "accepted awards" in bounty_tool["description"]


### PR DESCRIPTION
Bounty #406

Summary:
- Add `dependentRequired: {"repo": ["issue_number"]}` to the public MCP `submit_work_proof` input schema.
- Update the `repo` field description so `tools/list` advertises the same selector contract enforced by the handler.
- Add regression coverage in `test_mcp_tools_list_and_call`.

Evidence:
- The current handler rejects `submit_work_proof` arguments that provide `repo` without `issue_number` with `repo can only be used with issue_number`.
- Before this PR, `tools/list` allowed `repo` as an independent optional field, so agent-side schema validation could suggest an invalid call shape.
- Public preflight for internal bounty 66 showed #406 open with 15 award slots and no active attempts, and an open-PR search found no matching `submit_work_proof`/inputSchema fix.

Validation:
- `/home/kali/money/mergework/.venv/bin/python -m pytest tests/test_api_mcp.py::test_mcp_tools_list_and_call tests/test_api_mcp.py::test_mcp_submit_work_proof_rejects_invalid_bounty_selectors -q` -> 12 passed
- `/home/kali/money/mergework/.venv/bin/python -m pytest -q` -> 414 passed
- `/home/kali/money/mergework/.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `/home/kali/money/mergework/.venv/bin/python -m ruff check app/mcp.py tests/test_api_mcp.py` -> passed
- `/home/kali/money/mergework/.venv/bin/python -m ruff format --check app/mcp.py tests/test_api_mcp.py` -> 2 files already formatted
- `/home/kali/money/mergework/.venv/bin/python -m mypy app` -> success, no issues in 30 source files
- `git diff --check upstream/main...HEAD` -> clean
- `gitleaks detect --no-banner --redact --source . --log-opts upstream/main..HEAD --exit-code 1` -> no leaks found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for work proof submissions to require the issue number field when a repository is specified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->