### PR TITLE
Use API award capacity in queue health

### DIFF
--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from collections import defaultdict
 from typing import Any
+from urllib.error import URLError
+from urllib.request import urlopen
 
 BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+#(\d+)", re.IGNORECASE)
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
@@ -14,6 +16,7 @@ UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable
 GH_TIMEOUT_SECONDS = 30
 GH_PR_SAFETY_CAP = 201
 GH_ISSUE_SAFETY_CAP = 201
+DEFAULT_API_HOST = "https://api.mrwk.ltclab.site"
 
 
 def _labels(raw: dict[str, Any]) -> list[str]:
@@ -281,6 +284,33 @@ def _run_gh_json(args: list[str]) -> Any:
     return json.loads(completed.stdout)
 
 
+def _load_api_bounties(repo: str, api_host: str = DEFAULT_API_HOST) -> dict[int, dict[str, Any]]:
+    url = f"{api_host.rstrip('/')}/api/v1/bounties?limit=200"
+    try:
+        with urlopen(url, timeout=GH_TIMEOUT_SECONDS) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (OSError, URLError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"MergeWork API bounty data unavailable: {exc}") from exc
+    if not isinstance(payload, list):
+        raise RuntimeError("MergeWork API bounty data must be a list")
+    bounties: dict[int, dict[str, Any]] = {}
+    for item in payload:
+        if not isinstance(item, dict) or item.get("repo") != repo:
+            continue
+        issue_number = item.get("issue_number")
+        if not isinstance(issue_number, int):
+            continue
+        if issue_number in bounties:
+            continue
+        bounties[issue_number] = {
+            "number": issue_number,
+            "title": item.get("title"),
+            "state": item.get("status", "open"),
+            "awards_remaining": item.get("awards_remaining"),
+        }
+    return bounties
+
+
 def load_live_queue(repo: str) -> dict[str, Any]:
     prs = _run_gh_json(
         [
@@ -322,12 +352,18 @@ def load_live_queue(repo: str) -> dict[str, Any]:
             f"gh issue list reached the {GH_ISSUE_SAFETY_CAP} item safety cap; "
             "use an API-paginated collector before trusting this live report"
         )
+    try:
+        api_bounties = _load_api_bounties(repo)
+    except RuntimeError:
+        api_bounties = {}
     bounty_issues = [
         {
             "number": issue["number"],
             "title": issue.get("title"),
-            "state": issue.get("state"),
-            "awards_remaining": 1 if issue.get("state") == "OPEN" else 0,
+            "state": api_bounties.get(issue["number"], {}).get("state", issue.get("state")),
+            "awards_remaining": api_bounties.get(issue["number"], {}).get(
+                "awards_remaining", 1 if issue.get("state") == "OPEN" else 0
+            ),
         }
         for issue in issues
         if "bounty" in str(issue.get("title", "")).lower()

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -289,3 +289,167 @@ def test_pr_queue_health_fails_fast_when_pr_fetch_hits_cap(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="pr list reached the 201 item safety cap"):
         pr_queue_health.load_live_queue("ramimbo/mergework")
+
+
+def test_pr_queue_health_live_mode_uses_api_award_capacity(monkeypatch) -> None:
+    def fake_run(args, **kwargs):
+        if args[:3] == ["gh", "pr", "list"]:
+            stdout = json.dumps(
+                [
+                    {
+                        "number": 71,
+                        "title": "Late fix for exhausted bounty",
+                        "body": "Refs #406",
+                        "labels": [],
+                        "mergeStateStatus": "clean",
+                        "url": "https://github.com/ramimbo/mergework/pull/71",
+                    }
+                ]
+            )
+        elif args[:3] == ["gh", "issue", "list"]:
+            stdout = json.dumps(
+                [
+                    {
+                        "number": 406,
+                        "title": "MRWK bounty: useful bug reports",
+                        "state": "OPEN",
+                    }
+                ]
+            )
+        else:
+            raise AssertionError(args)
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def read(self):
+            return json.dumps(
+                [
+                    {
+                        "repo": "ramimbo/mergework",
+                        "issue_number": 406,
+                        "title": "MRWK bounty: useful bug reports",
+                        "status": "open",
+                        "awards_remaining": 0,
+                    }
+                ]
+            ).encode()
+
+    def fake_urlopen(url, timeout):
+        assert url == "https://api.mrwk.ltclab.site/api/v1/bounties?limit=200"
+        assert timeout == pr_queue_health.GH_TIMEOUT_SECONDS
+        return FakeResponse()
+
+    monkeypatch.setattr(pr_queue_health.subprocess, "run", fake_run)
+    monkeypatch.setattr(pr_queue_health, "urlopen", fake_urlopen, raising=False)
+
+    report = analyze_queue(pr_queue_health.load_live_queue("ramimbo/mergework"))
+
+    assert report["summary"]["closed_bounty_references"] == 1
+    assert report["closed_bounty_references"][0]["pull_request"] == 71
+    assert report["closed_bounty_references"][0]["detail"] == (
+        "Referenced bounty #406 is not payable"
+    )
+
+
+def test_pr_queue_health_falls_back_when_api_response_is_not_utf8(monkeypatch) -> None:
+    def fake_run(args, **kwargs):
+        if args[:3] == ["gh", "pr", "list"]:
+            stdout = json.dumps(
+                [
+                    {
+                        "number": 71,
+                        "title": "Late fix for open bounty",
+                        "body": "Refs #406",
+                        "labels": [],
+                        "mergeStateStatus": "clean",
+                        "url": "https://github.com/ramimbo/mergework/pull/71",
+                    }
+                ]
+            )
+        elif args[:3] == ["gh", "issue", "list"]:
+            stdout = json.dumps(
+                [
+                    {
+                        "number": 406,
+                        "title": "MRWK bounty: useful bug reports",
+                        "state": "OPEN",
+                    }
+                ]
+            )
+        else:
+            raise AssertionError(args)
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+
+    class BadUtf8Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def read(self):
+            return b"\xff\xfe"
+
+    monkeypatch.setattr(pr_queue_health.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        pr_queue_health,
+        "urlopen",
+        lambda url, timeout: BadUtf8Response(),
+        raising=False,
+    )
+
+    report = analyze_queue(pr_queue_health.load_live_queue("ramimbo/mergework"))
+
+    assert report["summary"]["closed_bounty_references"] == 0
+    assert report["summary"]["open_bounties"] == 1
+
+
+def test_pr_queue_health_keeps_first_api_bounty_for_duplicate_issue(monkeypatch) -> None:
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def read(self):
+            return json.dumps(
+                [
+                    {
+                        "repo": "ramimbo/mergework",
+                        "issue_number": 406,
+                        "title": "current row",
+                        "status": "open",
+                        "awards_remaining": 5,
+                    },
+                    {
+                        "repo": "ramimbo/mergework",
+                        "issue_number": 406,
+                        "title": "stale row",
+                        "status": "paid",
+                        "awards_remaining": 0,
+                    },
+                ]
+            ).encode()
+
+    monkeypatch.setattr(
+        pr_queue_health,
+        "urlopen",
+        lambda url, timeout: FakeResponse(),
+        raising=False,
+    )
+
+    bounties = pr_queue_health._load_api_bounties("ramimbo/mergework")
+
+    assert bounties[406] == {
+        "number": 406,
+        "title": "current row",
+        "state": "open",
+        "awards_remaining": 5,
+    }


### PR DESCRIPTION
Refs #406

## Summary

- Make live `scripts/pr_queue_health.py --repo ...` read MergeWork bounty capacity from the public bounty API.
- Preserve the existing GitHub-only fallback when the API is unavailable.
- Add regression coverage for an open GitHub bounty issue whose API-backed `awards_remaining` is `0`.

## Why

The runbook says queue health reports closed or exhausted bounty references before maintainer batches. Before this change, live mode only looked at GitHub issue state and treated every open bounty issue as having one payable slot, so an open but exhausted bounty could be missed.

## Evidence

- Live bounty preflight: `GET https://api.mrwk.ltclab.site/api/v1/bounties/66` returned issue `#406`, status `open`, `awards_remaining: 15`, `available_mrwk: "750"`.
- Live attempts preflight: `GET /api/v1/bounties/66/attempts?include_expired=false` returned no warnings and no active attempts.
- Open PR search found no existing queue-health award-capacity PR; existing #406 queue-health work only covered `/claim #N` reference parsing.

## Validation

- `uv run --extra dev python -m pytest tests/test_pr_queue_health.py -q` -> 10 passed
- `uv run --extra dev ruff check scripts/pr_queue_health.py tests/test_pr_queue_health.py` -> passed
- `uv run --extra dev ruff format --check scripts/pr_queue_health.py tests/test_pr_queue_health.py` -> passed
- `uv run --extra dev python -m mypy app scripts/pr_queue_health.py` -> success
- `git diff --check` -> clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fetches and applies external bounty metadata to live queue health, synchronizing bounty state and remaining awards.

* **Bug Fixes**
  * Falls back gracefully on malformed or non-UTF8 API responses.
  * Deduplicates API entries, preserving the first seen record for a given issue.

* **Tests**
  * Added coverage for API-sourced award capacity, non-UTF8 fallback, and duplicate-entry handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->