### PR TITLE
Clarify account transfer readiness

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -77,7 +77,7 @@ def github_login_from_account(account: str) -> str | None:
     return login
 
 
-def account_transfer_status(account: str) -> str:
+def account_transfer_status(account: str, *, exists: bool) -> str:
     if account.startswith("github:"):
         return "Claim GitHub balances from /me after linking a registered mrwk1 wallet."
     if account.startswith(("treasury:", "reserve:")):
@@ -85,7 +85,14 @@ def account_transfer_status(account: str) -> str:
             "Internal ledger account. MRWK wallet transfers are only available "
             "for registered mrwk1 addresses."
         )
-    return "MRWK wallet transfers are enabled for registered mrwk1 addresses."
+    if account.startswith("mrwk1"):
+        if exists:
+            return "MRWK wallet transfers are enabled for registered mrwk1 addresses."
+        return "Wallet address is not registered yet. Register this mrwk1 wallet before transfers."
+    return (
+        "This account is not eligible for MRWK wallet transfers. Use a github:<login> "
+        "account or registered mrwk1 wallet."
+    )
 
 
 def account_api_context(session: Session, account: str) -> dict[str, Any]:
@@ -97,7 +104,7 @@ def account_api_context(session: Session, account: str) -> dict[str, Any]:
         "github_login": github_login_from_account(account),
         "exists": account_row is not None,
         "balance_mrwk": format_mrwk(get_balance(session, account)),
-        "transfer_status": account_transfer_status(account),
+        "transfer_status": account_transfer_status(account, exists=account_row is not None),
         "accepted_work": safe_account_accepted_summary(session, account),
     }
 

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -89,6 +89,34 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     assert f'href="/proofs/{proof.hash}"' in page_response.text
 
 
+def test_unknown_account_transfer_status_does_not_report_wallet_ready(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/api/v1/accounts/not-a-wallet")
+
+    assert response.status_code == 200
+    assert response.json()["exists"] is False
+    assert response.json()["transfer_status"] == (
+        "This account is not eligible for MRWK wallet transfers. Use a github:<login> "
+        "account or registered mrwk1 wallet."
+    )
+
+
+def test_unregistered_wallet_transfer_status_requires_registration(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    account = "mrwk1" + ("0" * 40)
+
+    response = client.get(f"/api/v1/accounts/{account}")
+
+    assert response.status_code == 200
+    assert response.json()["exists"] is False
+    assert response.json()["transfer_status"] == (
+        "Wallet address is not registered yet. Register this mrwk1 wallet before transfers."
+    )
+
+
 def test_normalized_account_keeps_existing_account_validation_boundaries() -> None:
     assert normalized_account(" Reserve:Bounty:001 ") == "reserve:bounty:1"
     assert normalized_account("MRWK1" + ("A" * 40)) == "mrwk1" + ("a" * 40)


### PR DESCRIPTION
## Summary
- distinguish registered-wallet transfer readiness from unknown accounts in account API responses
- add regressions for arbitrary unknown accounts and unregistered mrwk1 addresses

## Root cause
The account API passed only the normalized account string into the transfer-status helper, so every non-GitHub/non-internal account received the registered-wallet-ready message even when `exists` was false.

## Validation
- `uv run --extra dev python -m pytest tests/test_account_routes.py -q`
- `uv run --extra dev python -m pytest tests/test_account_validation.py::test_account_views_accept_valid_mrwk_wallet_account tests/test_api_mcp.py::test_account_api_reports_internal_ledger_account_transfer_status -q`
- `uv run --extra dev ruff check app/accounts.py tests/test_account_routes.py`
- `uv run --extra dev ruff format --check app/accounts.py tests/test_account_routes.py`
- `uv run --extra dev python -m mypy app`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Account transfer eligibility status now provides more accurate and contextual messages based on registration state, improving clarity for users attempting transfers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->