### PR TITLE
Document agent-friendly bounty post template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -13,7 +13,7 @@ body:
     id: reward
     attributes:
       label: Reward
-      description: MRWK per accepted award. Repeat this in the issue body as `Reward: <amount> MRWK per accepted award`.
+      description: "MRWK per accepted award. Repeat this in the issue body as `Reward: <amount> MRWK per accepted award`."
       placeholder: "250 MRWK per accepted award"
     validations:
       required: true
@@ -21,7 +21,7 @@ body:
     id: max_awards
     attributes:
       label: Max awards
-      description: Number of separate payouts allowed. Repeat this in the issue body as `Max awards: <number>`.
+      description: "Number of separate payouts allowed. Repeat this in the issue body as `Max awards: <number>`."
       placeholder: "1"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -1,33 +1,79 @@
 name: MRWK bounty
 description: Propose work that may receive an MRWK bounty.
-title: "[bounty] "
+title: "MRWK bounty: <amount> MRWK - <short scope>"
 labels: ["mrwk:bounty"]
 body:
-  - type: textarea
-    id: work
+  - type: markdown
     attributes:
-      label: Work needed
-      description: Describe the useful accepted work.
-    validations:
-      required: true
+      value: |
+        Use the agent-friendly bounty post template from docs/bounty-rules.md.
+        Keep the public text factual; do not claim fiat value, exchange support,
+        bridge availability, acceptance, or payment until public proof exists.
   - type: input
     id: reward
     attributes:
-      label: Proposed MRWK per award
-      placeholder: "250"
+      label: Reward
+      description: MRWK per accepted award. Repeat this in the issue body as `Reward: <amount> MRWK per accepted award`.
+      placeholder: "250 MRWK per accepted award"
     validations:
       required: true
   - type: input
     id: max_awards
     attributes:
       label: Max awards
+      description: Number of separate payouts allowed. Repeat this in the issue body as `Max awards: <number>`.
       placeholder: "1"
+    validations:
+      required: true
+  - type: textarea
+    id: work
+    attributes:
+      label: Work Needed
+      description: Name the files, pages, commands, APIs, or behavior to change or verify.
+      placeholder: "Concrete, reviewable scope only."
     validations:
       required: true
   - type: textarea
     id: acceptance
     attributes:
-      label: Acceptance criteria
-      description: Explain what must be true before mrwk:accepted is applied.
+      label: Acceptance Criteria
+      description: Objective conditions maintainers can verify before applying mrwk:accepted.
+      placeholder: |
+        - Focused PR or comment references this bounty.
+        - Evidence/test output is included.
+        - Public wording stays factual.
+    validations:
+      required: true
+  - type: textarea
+    id: how_to_submit
+    attributes:
+      label: How To Submit
+      description: Tell contributors exactly how to submit the work.
+      placeholder: |
+        Open a focused PR or comment with Summary, Linked bounty, Changed files or checked surface, Evidence and test output, and Out-of-scope notes.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence_required
+    attributes:
+      label: Evidence Required
+      description: Exact commands, screenshots, links, fixtures, or review notes required for reproduction.
+      placeholder: "Command output, screenshots, links, fixtures, or review notes."
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of Scope
+      description: List speculative, unrelated, private, security-sensitive, tokenomics, price, liquidity, exchange, bridge, or broad rewrite work that will not qualify.
+      placeholder: "No tokenomics/price claims, exchange/bridge claims, private data, unrelated rewrites, or unfocused submissions."
+    validations:
+      required: true
+  - type: textarea
+    id: duplicate_stale_rules
+    attributes:
+      label: Duplicate and Stale Work Rules
+      description: Explain duplicate and stale submission handling.
+      placeholder: "Duplicate submissions do not qualify unless they add distinct accepted evidence or a maintainer asks for another award slot."
     validations:
       required: true

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -4,12 +4,19 @@
 
 1. Create or choose a GitHub issue.
 2. Decide the MRWK amount using the reference tiers.
-3. Add acceptance text that explains what counts as useful accepted work.
-4. Set `max_awards` to the number of separate payouts allowed. Use `1` for
+3. Use the agent-friendly bounty post template in
+   [docs/bounty-rules.md](bounty-rules.md#agent-friendly-bounty-post-template).
+   Keep the title shaped like `MRWK bounty: <amount> MRWK - <short scope>` so
+   GitHub search, API clients, MCP clients, humans, and agents can see the
+   award without parsing free-form prose.
+4. Repeat `Reward` and `Max awards` in the body, then add work needed,
+   acceptance criteria, submission instructions, evidence requirements,
+   out-of-scope rules, and duplicate/stale-work rules.
+5. Set `max_awards` to the number of separate payouts allowed. Use `1` for
    a single-award bounty.
-5. Use `/admin` or `POST /api/v1/bounties` with an admin token.
+6. Use `/admin` or `POST /api/v1/bounties` with an admin token.
    Multi-award bounties reserve `reward_mrwk * max_awards`.
-6. Add `mrwk:bounty` to the GitHub issue.
+7. Add `mrwk:bounty` to the GitHub issue.
 
 ## Accept Work
 

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -56,6 +56,73 @@ After accepted work is paid, MergeWork records a public ledger proof. Public
 payment updates should point to those proofs and keep any private security or
 operational details out of public metadata.
 
+
+## Agent-Friendly Bounty Post Template
+
+Use this short, stable shape when posting MRWK bounties so humans, GitHub API
+clients, MCP clients, and AI agents can identify scope, reward, award slots,
+required evidence, duplicate-work rules, and out-of-scope work without guessing.
+
+Title:
+
+```text
+MRWK bounty: <amount> MRWK - <short scope>
+```
+
+Body:
+
+```text
+## MRWK Bounty
+
+Reward: `<amount> MRWK per accepted award>`
+Max awards: `<number>`
+
+## Work Needed
+
+<Concrete scope. Name the files, pages, commands, APIs, or behavior to change or
+verify.>
+
+## Acceptance Criteria
+
+- <Objective condition reviewers can verify.>
+- <Required docs, tests, screenshots, reproduction steps, or command output.>
+- <PR body or comment must include `Bounty #<issue number>` or
+  `Refs #<issue number>`.>
+
+## How To Submit
+
+Open a focused PR or comment with:
+
+- Summary
+- Linked bounty
+- Changed files or checked surface
+- Evidence and test output
+- Out-of-scope notes
+
+## Evidence Required
+
+<Exact commands, screenshots, links, fixtures, or review notes needed for
+maintainers to reproduce the result.>
+
+## Out of Scope
+
+<List speculative, unrelated, private, security-sensitive, tokenomics, price,
+liquidity, exchange, bridge, or broad rewrite work that will not qualify.>
+
+## Duplicate and Stale Work Rules
+
+Duplicate submissions do not qualify unless they add distinct accepted evidence
+or a maintainer asks for another award slot. Stale claims may be skipped when a
+newer submission provides clearer reviewable evidence.
+```
+
+These fields are intentionally redundant: the title exposes the amount in GitHub
+search results, the body repeats `Reward` and `Max awards` for API and MCP
+parsers, and stable headings let agents extract the work packet without reading
+unrelated discussion. Keep public artifact wording factual: do not claim accepted
+status, fiat value, liquidity, exchange support, bridge availability, or payment
+until the public label, maintainer comment, ledger row, or proof exists.
+
 ## Submission Evidence Templates
 
 Use the smallest template that makes the claim reviewable. Delete fields that do

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[1]
 REQUIRED = [
     "README.md",
@@ -101,13 +103,30 @@ def main() -> int:
         ok = False
     else:
         bounty_template = bounty_issue_template.read_text(encoding="utf-8")
+        try:
+            yaml.safe_load(bounty_template)
+        except yaml.YAMLError as exc:
+            print(f"bounty issue template must parse as YAML: {exc}")
+            ok = False
         bounty_required_phrases = [
             "MRWK bounty: <amount> MRWK - <short scope>",
             "agent-friendly bounty post template",
-            "How To Submit",
-            "Evidence Required",
-            "Out of Scope",
-            "Duplicate and Stale Work Rules",
+            "id: reward",
+            "label: Reward",
+            "id: max_awards",
+            "label: Max awards",
+            "id: work",
+            "label: Work Needed",
+            "id: acceptance",
+            "label: Acceptance Criteria",
+            "id: how_to_submit",
+            "label: How To Submit",
+            "id: evidence_required",
+            "label: Evidence Required",
+            "id: out_of_scope",
+            "label: Out of Scope",
+            "id: duplicate_stale_rules",
+            "label: Duplicate and Stale Work Rules",
         ]
         squashed_bounty_template = _squash(bounty_template)
         for phrase in bounty_required_phrases:

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -57,6 +57,7 @@ REQUIRED_PUBLIC_PHRASES = {
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"
 PR_TEMPLATE = ".github/pull_request_template.md"
+BOUNTY_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/bounty.yml"
 
 
 def _local_target_exists(source: Path, target: str) -> bool:
@@ -92,6 +93,26 @@ def main() -> int:
         for link in LINK_RE.findall(text):
             if not _local_target_exists(path, link):
                 print(f"broken local link in {relative}: {link}")
+                ok = False
+
+    bounty_issue_template = ROOT / BOUNTY_ISSUE_TEMPLATE
+    if not bounty_issue_template.exists():
+        print(f"missing bounty issue template: {BOUNTY_ISSUE_TEMPLATE}")
+        ok = False
+    else:
+        bounty_template = bounty_issue_template.read_text(encoding="utf-8")
+        bounty_required_phrases = [
+            "MRWK bounty: <amount> MRWK - <short scope>",
+            "agent-friendly bounty post template",
+            "How To Submit",
+            "Evidence Required",
+            "Out of Scope",
+            "Duplicate and Stale Work Rules",
+        ]
+        squashed_bounty_template = _squash(bounty_template)
+        for phrase in bounty_required_phrases:
+            if _squash(phrase) not in squashed_bounty_template:
+                print(f"bounty issue template missing required phrase: {phrase}")
                 ok = False
     docs_issue_template = ROOT / DOCS_ISSUE_TEMPLATE
     if not docs_issue_template.exists():


### PR DESCRIPTION
## Summary
- Add a canonical agent-friendly bounty post template to `docs/bounty-rules.md`.
- Update the admin runbook posting flow to require the stable title/body fields.

Linked bounty: Refs #456 / Bounty #456

## Evidence
Compared against:
- `.github/ISSUE_TEMPLATE/bounty.yml`: existing required fields are Work needed, Proposed MRWK per award, Max awards, Acceptance criteria.
- `docs/bounty-rules.md`: existing labels, evidence templates, payout flow, PR bounty reference guidance, and public artifact cautions.
- `docs/admin-runbook.md`: existing Post a Bounty steps and PR acceptance flow.
- `docs/agent-guide.md`: agent workflow depends on clear issue scope, evidence, tests, and out-of-scope notes.
- Public bounty behavior in issue #456: title exposes award, body repeats reward/max awards, includes acceptance criteria and submission path.

## Tests
- `python3 scripts/docs_smoke.py` → `docs smoke ok`
- `git diff --check` → no whitespace errors

## Out of scope
- No tokenomics, price, liquidity, exchange, bridge, or payout claims.
- No broad rewrite of bounty flows or issue forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated bounty posting runbook with an agent-friendly bounty post template, structured title format, and explicit required sections (work needed, acceptance criteria, submission/evidence, out-of-scope, duplicate/stale-work)
  * Added a public “Agent-Friendly Bounty Post Template” doc with example formatting and reward/award guidance

* **Chores**
  * Replaced the MRWK bounty issue template with a structured, parameterized form
  * Added a docs validation check to ensure the bounty template exists, parses correctly, and contains required phrasing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->