### PR TITLE
Bound parsed bounty references

### DIFF
--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -14,6 +14,7 @@ UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable
 GH_TIMEOUT_SECONDS = 30
 GH_PR_SAFETY_CAP = 201
 GH_ISSUE_SAFETY_CAP = 201
+MAX_BOUNTY_REF = 2**63 - 1
 
 
 def _labels(raw: dict[str, Any]) -> list[str]:
@@ -55,7 +56,15 @@ def _bounty_refs(raw: dict[str, Any]) -> list[int]:
         for key in ("title", "body", "description")
         if raw.get(key) is not None
     )
-    return sorted({int(match) for match in BOUNTY_REF_RE.findall(text)})
+    found_refs: set[int] = set()
+    for match in BOUNTY_REF_RE.findall(text):
+        try:
+            ref = int(match)
+        except ValueError:
+            continue
+        if ref <= MAX_BOUNTY_REF:
+            found_refs.add(ref)
+    return sorted(found_refs)
 
 
 def _is_open_bounty(raw: dict[str, Any]) -> bool:

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -21,6 +21,7 @@ GH_TIMEOUT_SECONDS = 30
 DEFAULT_API_HOST = "https://api.mrwk.ltclab.site"
 DEFAULT_MAX_MAINTAINER_AGE_DAYS = 14
 MAINTAINER_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+MAX_BOUNTY_REF = 2**63 - 1
 
 
 def _check(name: str, status: str, message: str) -> dict[str, str]:
@@ -31,7 +32,12 @@ def _bounty_refs(text: str) -> list[int]:
     refs: list[int] = []
     seen: set[int] = set()
     for match in BOUNTY_REF_RE.findall(text):
-        ref = int(match)
+        try:
+            ref = int(match)
+        except ValueError:
+            continue
+        if ref > MAX_BOUNTY_REF:
+            continue
         if ref in seen:
             continue
         seen.add(ref)

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -127,6 +127,27 @@ def test_pr_queue_health_accepts_claim_command_reference() -> None:
     assert report["missing_bounty_references"] == []
 
 
+def test_pr_queue_health_ignores_oversized_numeric_bounty_refs() -> None:
+    oversized_ref = "9" * 5000
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 406, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [
+                {
+                    "number": 41,
+                    "title": "Bound bounty references",
+                    "body": f"Refs #{oversized_ref}\nRefs #406",
+                    "merge_state": "clean",
+                    "labels": [],
+                }
+            ],
+        }
+    )
+
+    assert report["summary"]["missing_bounty_references"] == 0
+    assert report["summary"]["closed_bounty_references"] == 0
+
+
 def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     report = analyze_queue(
         {

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -66,6 +66,29 @@ def test_submission_quality_gate_accepts_claim_command_reference() -> None:
     } in result["checks"]
 
 
+def test_submission_quality_gate_ignores_oversized_numeric_bounty_refs() -> None:
+    oversized_ref = "9" * 5000
+
+    result = evaluate_submission(
+        {
+            "submission_text": (
+                f"Summary: add validation\n\nRefs #{oversized_ref}\nRefs #319\n\n"
+                "Validation: pytest passed"
+            ),
+            "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [],
+        }
+    )
+
+    assert result["status"] == "pass"
+    assert result["bounty_reference"] == 319
+    assert {
+        "name": "bounty_reference",
+        "status": "pass",
+        "message": "found bounty reference #319",
+    } in result["checks"]
+
+
 def test_submission_quality_gate_fails_missing_reference() -> None:
     result = evaluate_submission(
         {


### PR DESCRIPTION
## Summary
- skip oversized numeric bounty references in submission and PR queue parsing instead of crashing on Python's integer conversion guard
- preserve valid bounty refs that appear alongside an oversized ref
- add regressions for both `submission_quality_gate.py` and `pr_queue_health.py`

Refs #406.

## Root cause
Both scripts converted every `Refs #<digits>` match with `int(...)`. A very long digit run raises `ValueError` before the tools can return a controlled missing/valid bounty-reference result.

## Validation
- `uv run --extra dev python -m pytest tests/test_submission_quality_gate.py tests/test_pr_queue_health.py -q`
- `uv run --extra dev ruff check scripts/submission_quality_gate.py scripts/pr_queue_health.py tests/test_submission_quality_gate.py tests/test_pr_queue_health.py`
- `uv run --extra dev ruff format --check scripts/submission_quality_gate.py scripts/pr_queue_health.py tests/test_submission_quality_gate.py tests/test_pr_queue_health.py`
- `uv run --extra dev python -m mypy scripts/submission_quality_gate.py scripts/pr_queue_health.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bounty reference parsing to safely ignore oversized or invalid reference values.
  * Added defensive error handling to prevent processing of malformed inputs.

* **Tests**
  * Added test coverage for edge cases with oversized numeric bounty references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->