### PR TITLE
Refs #406: Accept backticked refs in submission gate

### DIFF
--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -11,7 +11,7 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
-BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+#(\d+)", re.IGNORECASE)
+BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+`?#(\d+)`?", re.IGNORECASE)
 EVIDENCE_RE = re.compile(
     r"\b(pytest|ruff|mypy|validation|verified|test evidence|checks? passed)\b",
     re.IGNORECASE,

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -66,6 +66,33 @@ def test_submission_quality_gate_accepts_claim_command_reference() -> None:
     } in result["checks"]
 
 
+def test_submission_quality_gate_accepts_backticked_bounty_references() -> None:
+    result = evaluate_submission(
+        {
+            "submission_text": """
+            Summary:
+            Harden the bounty submission checks.
+
+            Refs `#319`
+            /claim `#319`
+
+            Validation:
+            - pytest passed.
+            """,
+            "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [],
+        }
+    )
+
+    assert result["status"] == "pass"
+    assert result["bounty_reference"] == 319
+    assert {
+        "name": "bounty_reference",
+        "status": "pass",
+        "message": "found bounty reference #319",
+    } in result["checks"]
+
+
 def test_submission_quality_gate_fails_missing_reference() -> None:
     result = evaluate_submission(
         {


### PR DESCRIPTION
## Summary

- allow `scripts/submission_quality_gate.py` to recognize Markdown inline-code bounty references such as ``Refs `#406` ``
- cover both prose references and `/claim` command bodies with a focused regression test

Refs #406.

## Evidence

The submission quality gate currently recognizes `Refs #406` and `/claim #406`, but common Markdown inline-code variants such as ``Refs `#406` `` or ``/claim `#406` `` are reported as missing bounty references. This can make a valid submission draft look invalid before a contributor opens the PR. This patch mirrors the queue-health parser behavior for the submission preflight path.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ~/.local/bin/uv run --extra dev python -m pytest tests/test_submission_quality_gate.py -q` -> `24 passed`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ~/.local/bin/uv run --extra dev python -m pytest -q` -> `415 passed`
- `~/.local/bin/uv run --extra dev ruff check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` -> passed
- `~/.local/bin/uv run --extra dev ruff format --check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` -> `2 files already formatted`
- `~/.local/bin/uv run --extra dev mypy app scripts/submission_quality_gate.py` -> success
- `git diff --check` -> clean
- changed-file secret scan -> no matches

Note: pytest plugin autoload is disabled because this workstation has an unrelated ROS Humble pytest plugin on the global path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bounty reference recognition now accepts backticked format (e.g., `\`#123\``) in addition to plain `#123` format.

* **Tests**
  * Added validation test for backticked bounty reference handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->