### PR TITLE
Use API bounty state in submission gate

### DIFF
--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -509,7 +509,7 @@ def _load_live_context(
                 "id": api_bounty.get("id"),
                 "number": issue["number"],
                 "title": issue.get("title"),
-                "state": issue.get("state"),
+                "state": api_bounty.get("state", issue.get("state")),
                 "awards_remaining": awards_remaining,
                 "payability_verified": issue["number"] in api_bounties
                 and awards_remaining is not None,

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -778,3 +778,60 @@ def test_submission_quality_gate_treats_incomplete_api_bounty_as_unverified(
         "status": "warn",
         "message": "referenced bounty #319 payability could not be verified",
     } in result["checks"]
+
+
+def test_submission_quality_gate_live_context_uses_api_state_for_payability(
+    monkeypatch,
+) -> None:
+    def fake_run(args, **kwargs):
+        if args[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="[]", stderr="")
+        if args[:3] == ["gh", "issue", "list"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    [{"number": 319, "title": "MRWK bounty: gate", "state": "CLOSED"}]
+                ),
+                stderr="",
+            )
+        if args[:3] == ["gh", "issue", "view"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps({"createdAt": "2026-05-20T00:00:00Z", "comments": []}),
+                stderr="",
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(submission_quality_gate.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        submission_quality_gate,
+        "_load_api_bounties",
+        lambda repo, api_host: {
+            319: {"id": 11, "number": 319, "state": "open", "awards_remaining": 1}
+        },
+    )
+    monkeypatch.setattr(
+        submission_quality_gate, "_load_api_attempts", lambda api_host, bounty_id: []
+    )
+
+    data = submission_quality_gate._load_live_context(
+        "ramimbo/mergework",
+        "Summary: work\n\nRefs #319\n\nValidation: pytest passed",
+        "https://api.example.test",
+    )
+    result = evaluate_submission(data)
+
+    assert data["bounties"][0]["state"] == "open"
+    assert result["status"] == "warn"
+    assert {
+        "name": "bounty_payable",
+        "status": "pass",
+        "message": "referenced bounty #319 is open",
+    } in result["checks"]
+    assert {
+        "name": "bounty_payable",
+        "status": "fail",
+        "message": "referenced bounty #319 is closed or exhausted",
+    } not in result["checks"]


### PR DESCRIPTION
Summary:
- Use the validated MergeWork API bounty `state` when live submission-gate context has an API row for a bounty.
- Add a regression for the false-fail case where GitHub issue state is closed but the API row is open with awards remaining.

Linked bounty:
Refs #406

Evidence:
Before this fix, `_load_live_context()` could build a bounty with `payability_verified: true` and API `awards_remaining: 1`, but keep the GitHub issue `state: CLOSED`. `evaluate_submission()` then failed the claim as closed/exhausted even though the API row said it was payable.

Changed files:
- `scripts/submission_quality_gate.py`
- `tests/test_submission_quality_gate.py`

Tests:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_submission_quality_gate.py::test_submission_quality_gate_live_context_uses_api_state_for_payability -q` -> 1 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_submission_quality_gate.py -q` -> 24 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 415 passed
- `uv run --extra dev ruff check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` -> passed
- `uv run --extra dev ruff format --check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` -> 2 files already formatted
- `uv run --extra dev mypy app scripts/submission_quality_gate.py` -> success
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

Out of scope:
- No changes to API loading, active-attempt validation, wallet code, tokenomics, public transfer claims, or payout policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bounty state evaluation now prefers the external API's state when present, improving payability accuracy.

* **Tests**
  * Added unit test covering mismatched GitHub vs API bounty states to verify payability logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->