### PR TITLE
Refs #406: Accept hash-prefixed issue searches

### DIFF
--- a/app/path_params.py
+++ b/app/path_params.py
@@ -10,10 +10,11 @@ HEX_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 
 def issue_number_search_value(query: str) -> int | None:
     """Return a bounded GitHub issue number from a plain numeric search query."""
-    if not query.isdigit():
+    clean = query.removeprefix("#")
+    if not clean.isdigit():
         return None
     try:
-        issue_number = int(query)
+        issue_number = int(clean)
     except ValueError:
         return None
     return issue_number if issue_number <= SQLITE_INTEGER_MAX else None

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -172,6 +172,16 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     assert issue_search.status_code == 200
     assert [row["issue_number"] for row in issue_search.json()] == [65]
 
+    hash_issue_search = client.get("/api/v1/bounties?q=%2365")
+    assert hash_issue_search.status_code == 200
+    assert [row["issue_number"] for row in hash_issue_search.json()] == [65]
+
+    hash_issue_page = client.get("/bounties?q=%2365")
+    assert hash_issue_page.status_code == 200
+    assert "Showing matches for “#65”." in hash_issue_page.text
+    assert "Internal admin cleanup" in hash_issue_page.text
+    assert "Improve public bounty discovery" not in hash_issue_page.text
+
     oversized_issue_search = client.get("/api/v1/bounties", params={"q": "9" * 40})
     assert oversized_issue_search.status_code == 200
     assert oversized_issue_search.json() == []

--- a/tests/test_path_params.py
+++ b/tests/test_path_params.py
@@ -20,12 +20,15 @@ def assert_bad_request(func, *args):
 
 def test_issue_number_search_value_accepts_bounded_numeric_query():
     assert issue_number_search_value("340") == 340
+    assert issue_number_search_value("#340") == 340
     assert issue_number_search_value(str(SQLITE_INTEGER_MAX)) == SQLITE_INTEGER_MAX
 
 
 def test_issue_number_search_value_rejects_non_numeric_or_overflow_query():
     assert issue_number_search_value("") is None
+    assert issue_number_search_value("#") is None
     assert issue_number_search_value(" 340") is None
+    assert issue_number_search_value(" #340") is None
     assert issue_number_search_value("340a") is None
     assert issue_number_search_value(str(SQLITE_INTEGER_MAX + 1)) is None
 


### PR DESCRIPTION
## Summary
- Treat `#123` bounty search queries as issue-number searches, matching the common GitHub issue-reference form.
- Keep non-numeric and whitespace-prefixed values rejected by the shared parser.
- Add REST/page coverage for `/api/v1/bounties?q=%2365` and `/bounties?q=%2365`.

## Evidence
- User-facing confusion addressed: GitHub issue references are commonly copied as `#65`, but the bounty search only accepted plain numeric issue queries before this change.
- Intended surfaces: shared issue-number parsing, `/api/v1/bounties`, and the public `/bounties` page search form/results.
- Scope control: this does not change route path parameters, bounty storage, or broad text search semantics; it only normalizes a leading `#` for issue-number search values.
- Live bounty capacity at submission: issue #406 was open with 15 awards remaining via the public bounty API.
- Regression coverage: accepts `#340`, rejects bare `#`, rejects non-numeric/whitespace-prefixed values through the existing parser boundaries, and verifies API/page search results for `#65`.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_bounty_api.py tests/test_path_params.py tests/test_bounty_pages.py::test_bounties_page_and_api_search_by_text_and_issue_number -q` -> 19 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_path_params.py tests/test_bounty_pages.py::test_bounties_page_and_api_search_by_text_and_issue_number -q` -> 6 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev ruff check app/path_params.py tests/test_path_params.py tests/test_bounty_pages.py` -> passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev ruff format --check app/path_params.py tests/test_path_params.py tests/test_bounty_pages.py` -> 3 files already formatted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issue number search now accepts queries with `#` prefix notation (e.g., `#65`), making searches more user-friendly and consistent with common issue tracking conventions

* **Tests**
  * Expanded test coverage for issue number search with `#` prefix notation
  * Updated validation tests to ensure `#`-prefixed issue numbers are correctly normalized and invalid formats are properly rejected

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->