### PR TITLE
Refs #406: Accept hash-prefixed activity searches

### DIFF
--- a/app/serializers.py
+++ b/app/serializers.py
@@ -168,6 +168,13 @@ def _activity_search_query(query: str | None) -> str:
     return (query or "").strip().lower()
 
 
+def _activity_hash_issue_query(query: str) -> str | None:
+    if not query.startswith("#"):
+        return None
+    issue_number = query[1:]
+    return issue_number if issue_number.isdigit() else None
+
+
 def _activity_row_matches(row: dict[str, Any], query: str) -> bool:
     if not query:
         return True
@@ -181,7 +188,15 @@ def _activity_row_matches(row: dict[str, Any], query: str) -> bool:
         row["bounty_issue_url"],
         row["bounty_issue_number"],
     )
-    return any(query in str(value or "").lower() for value in searchable_values)
+    if any(query in str(value or "").lower() for value in searchable_values):
+        return True
+    issue_number = _activity_hash_issue_query(query)
+    if issue_number is None:
+        return False
+    return issue_number in {
+        str(row["bounty_id"] or ""),
+        str(row["bounty_issue_number"] or ""),
+    }
 
 
 def activity_to_dict(session: Session, query: str | None = None) -> dict[str, Any]:

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -147,6 +147,7 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
     by_account = client.get("/api/v1/activity?q=ALICE").json()
     by_repo = client.get("/api/v1/activity?q=ramimbo%2Fmergework").json()
     by_proof = client.get(f"/api/v1/activity?q={alice_proof.hash[:12]}").json()
+    by_issue_ref = client.get("/api/v1/activity?q=%23164").json()
     no_match = client.get("/api/v1/activity?q=carol").json()
 
     assert by_account["query"] == "alice"
@@ -157,6 +158,13 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
     }
     assert by_account["contributors"][0]["account"] == "github:alice"
     assert by_account["recent"][0]["submission_url"].endswith("/pull/164")
+    assert by_issue_ref["query"] == "#164"
+    assert by_issue_ref["totals"] == {
+        "accepted_awards": 2,
+        "accepted_mrwk": "200",
+        "contributors": 2,
+    }
+    assert {row["bounty_issue_number"] for row in by_issue_ref["recent"]} == {164}
     assert by_repo["totals"] == {
         "accepted_awards": 2,
         "accepted_mrwk": "200",
@@ -216,6 +224,7 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert "/accounts/github:bob" in paid.text
 
     filtered = client.get("/activity?q=bob")
+    issue_ref = client.get("/activity?q=%2312")
 
     assert filtered.status_code == 200
     assert 'value="bob"' in filtered.text
@@ -223,6 +232,10 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert 'href="/activity">Clear</a>' in filtered.text
     assert "No contributors match this search." not in filtered.text
     assert "No accepted work matches this search." not in filtered.text
+    assert issue_ref.status_code == 200
+    assert 'value="#12"' in issue_ref.text
+    assert "Showing accepted work matching “#12”." in issue_ref.text
+    assert "github:bob" in issue_ref.text
 
     no_match = client.get("/activity?q=alice")
 

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -149,6 +149,10 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
     by_proof = client.get(f"/api/v1/activity?q={alice_proof.hash[:12]}").json()
     by_issue_ref = client.get("/api/v1/activity?q=%23164").json()
     no_match = client.get("/api/v1/activity?q=carol").json()
+    invalid_hash_queries = [
+        client.get("/api/v1/activity", params={"q": query}).json()
+        for query in ("#", "#abc", "#123abc")
+    ]
 
     assert by_account["query"] == "alice"
     assert by_account["totals"] == {
@@ -178,6 +182,14 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
     }
     assert no_match["contributors"] == []
     assert no_match["recent"] == []
+    for invalid_hash_query in invalid_hash_queries:
+        assert invalid_hash_query["totals"] == {
+            "accepted_awards": 0,
+            "accepted_mrwk": "0",
+            "contributors": 0,
+        }
+        assert invalid_hash_query["contributors"] == []
+        assert invalid_hash_query["recent"] == []
 
 
 def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- Let accepted-work activity search treat `#<number>` as a GitHub-style issue/bounty reference.
- Preserve the displayed query text (`#164`) while matching the numeric bounty issue or bounty id fields.
- Add API and rendered activity-page coverage for hash-prefixed issue searches.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_activity.py -q` -> 3 passed, including invalid hash queries `#`, `#abc`, and `#123abc`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev ruff check tests/test_activity.py` -> passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev ruff format --check tests/test_activity.py` -> 1 file already formatted
- `git diff --check` -> passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity search now supports filtering by GitHub issue number with a `#` prefix (e.g., `#164`) to find work tied to a specific issue.

* **Tests**
  * Added test coverage for filtering by issue reference and for invalid `#` queries returning no results.

* **Bug Fixes / UI**
  * Activity page correctly shows the `#` query in the search input, a “Showing accepted work matching” message, and a “Clear” link when filtered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->