### PR TITLE
Encode public account links

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from typing import Any
+from urllib.parse import unquote_to_bytes
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse
@@ -22,6 +23,25 @@ from app.serializers import (
 from app.wallets import WalletError, normalize_wallet_address
 
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+API_ACCOUNT_RAW_PREFIX = b"/api/v1/accounts/"
+API_ACCEPTED_WORK_RAW_SUFFIX = b"/accepted-work"
+
+
+def raw_account_api_path_account(request: Request) -> str | None:
+    raw_path = request.scope.get("raw_path")
+    if not isinstance(raw_path, bytes):
+        return None
+    if not raw_path.startswith(API_ACCOUNT_RAW_PREFIX):
+        return None
+    if raw_path.endswith(API_ACCEPTED_WORK_RAW_SUFFIX):
+        return None
+    raw_account = raw_path.removeprefix(API_ACCOUNT_RAW_PREFIX)
+    if not raw_account:
+        return None
+    try:
+        return unquote_to_bytes(raw_account).decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise HTTPException(status_code=400, detail="account path must be valid UTF-8") from exc
 
 
 def normalized_wallet_address(address: str) -> str:
@@ -122,17 +142,28 @@ def account_page_context(session: Session, account: str) -> dict[str, Any]:
 
 
 def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
-    @app.get("/api/v1/accounts/{account}")
+    @app.get("/api/v1/accounts/")
+    def api_account_empty() -> None:
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    @app.get("/api/v1/accounts/{account:path}/accepted-work")
+    def api_account_accepted_work(request: Request, account: str) -> dict[str, Any]:
+        with session_scope(db_url) as session:
+            raw_account = raw_account_api_path_account(request)
+            if raw_account is not None:
+                return account_api_context(session, raw_account)
+            return account_accepted_work_context(session, account)
+
+    @app.get("/api/v1/accounts/{account:path}")
     def api_account(account: str) -> dict[str, Any]:
         with session_scope(db_url) as session:
             return account_api_context(session, account)
 
-    @app.get("/api/v1/accounts/{account}/accepted-work")
-    def api_account_accepted_work(account: str) -> dict[str, Any]:
-        with session_scope(db_url) as session:
-            return account_accepted_work_context(session, account)
+    @app.get("/accounts/", response_class=HTMLResponse)
+    def account_page_empty() -> None:
+        raise HTTPException(status_code=404, detail="Not Found")
 
-    @app.get("/accounts/{account}", response_class=HTMLResponse)
+    @app.get("/accounts/{account:path}", response_class=HTMLResponse)
     def account_page(request: Request, account: str) -> HTMLResponse:
         with session_scope(db_url) as session:
             context = account_page_context(session, account)

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Annotated, Any
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import quote, urlsplit, urlunsplit
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response
@@ -43,6 +43,13 @@ from app.webhooks.github import handle_github_webhook
 BASE_DIR = Path(__file__).resolve().parent
 templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 templates.env.globals["safe_public_url"] = public_url_or_none
+
+
+def account_path(account: str) -> str:
+    return f"/accounts/{quote(account, safe=':')}"
+
+
+templates.env.globals["account_path"] = account_path
 
 _oauth_configured = auth_module.oauth_configured
 _safe_next_path = auth_module.safe_next_path

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -120,8 +120,8 @@
       <tr>
         <td><a href="/ledger/{{ entry.sequence }}">{{ entry.sequence }}</a></td>
         <td>{{ entry.type }}</td>
-        <td>{% if entry.from %}<a href="/accounts/{{ entry.from }}">{{ entry.from }}</a>{% else %}-{% endif %}</td>
-        <td>{% if entry.to %}<a href="/accounts/{{ entry.to }}">{{ entry.to }}</a>{% else %}-{% endif %}</td>
+        <td>{% if entry.from %}<a href="{{ account_path(entry.from) }}">{{ entry.from }}</a>{% else %}-{% endif %}</td>
+        <td>{% if entry.to %}<a href="{{ account_path(entry.to) }}">{{ entry.to }}</a>{% else %}-{% endif %}</td>
         <td>{{ entry.amount_mrwk }} MRWK</td>
         <td>{% if entry.proof_hash %}<a href="/proofs/{{ entry.proof_hash }}">proof</a>{% else %}-{% endif %}</td>
       </tr>

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -31,7 +31,7 @@
       <div class="ledger-entry-card">
         <div class="ledger-card-head">
           <div class="ledger-card-title">
-            <a class="ledger-entry-link" href="/accounts/{{ contributor.account }}">{{ contributor.account }}</a>
+            <a class="ledger-entry-link" href="{{ account_path(contributor.account) }}">{{ contributor.account }}</a>
             <span class="ledger-scan-note">{{ contributor.accepted_awards }} accepted</span>
           </div>
           <strong class="ledger-amount">{{ contributor.accepted_mrwk }} MRWK</strong>
@@ -82,7 +82,7 @@
         <dl class="ledger-card-grid">
           <div class="ledger-field ledger-field--to">
             <dt>Contributor</dt>
-            <dd><a href="/accounts/{{ row.account }}">{{ row.account }}</a></dd>
+            <dd><a href="{{ account_path(row.account) }}">{{ row.account }}</a></dd>
           </div>
           <div class="ledger-field ledger-field--reference reference-cell">
             <dt>Bounty</dt>

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -67,7 +67,7 @@
         <dl class="ledger-card-grid">
           <div class="ledger-field ledger-field--to">
             <dt>Paid to</dt>
-            <dd>{% if award.account %}<a href="/accounts/{{ award.account }}">{{ award.account }}</a>{% else %}-{% endif %}</dd>
+            <dd>{% if award.account %}<a href="{{ account_path(award.account) }}">{{ award.account }}</a>{% else %}-{% endif %}</dd>
           </div>
           <div class="ledger-field ledger-field--reference reference-cell">
             <dt>Submission</dt>

--- a/app/templates/ledger.html
+++ b/app/templates/ledger.html
@@ -37,11 +37,11 @@
       <dl class="ledger-card-grid">
         <div class="ledger-field ledger-field--from">
           <dt>From</dt>
-          <dd>{% if entry.from %}<a href="/accounts/{{ entry.from }}">{{ entry.from }}</a>{% else %}-{% endif %}</dd>
+          <dd>{% if entry.from %}<a href="{{ account_path(entry.from) }}">{{ entry.from }}</a>{% else %}-{% endif %}</dd>
         </div>
         <div class="ledger-field ledger-field--to">
           <dt>To</dt>
-          <dd>{% if entry.to %}<a href="/accounts/{{ entry.to }}">{{ entry.to }}</a>{% else %}-{% endif %}</dd>
+          <dd>{% if entry.to %}<a href="{{ account_path(entry.to) }}">{{ entry.to }}</a>{% else %}-{% endif %}</dd>
         </div>
         <div class="ledger-field ledger-field--reference reference-cell">
           <dt>Reference</dt>

--- a/app/templates/ledger_entry.html
+++ b/app/templates/ledger_entry.html
@@ -36,9 +36,9 @@
   </div>
   <dl>
     <dt>From</dt>
-    <dd>{% if entry.from %}<a href="/accounts/{{ entry.from }}">{{ entry.from }}</a>{% else %}-{% endif %}</dd>
+    <dd>{% if entry.from %}<a href="{{ account_path(entry.from) }}">{{ entry.from }}</a>{% else %}-{% endif %}</dd>
     <dt>To</dt>
-    <dd>{% if entry.to %}<a href="/accounts/{{ entry.to }}">{{ entry.to }}</a>{% else %}-{% endif %}</dd>
+    <dd>{% if entry.to %}<a href="{{ account_path(entry.to) }}">{{ entry.to }}</a>{% else %}-{% endif %}</dd>
     <dt>Reference</dt>
     {% set reference_url = safe_public_url(entry.reference) %}
     <dd>{% if reference_url %}<a href="{{ reference_url }}">{{ entry.reference }}</a>{% else %}{{ entry.reference }}{% endif %}</dd>

--- a/app/templates/proof.html
+++ b/app/templates/proof.html
@@ -4,7 +4,7 @@
 <section class="detail">
   <p class="eyebrow">{% if proof.kind == "bounty_payment" %}Bounty payment proof{% else %}Proof{% endif %}</p>
   <h1>{% if proof.kind == "bounty_payment" %}Accepted bounty payment{% else %}Accepted work proof{% endif %}</h1>
-  <p class="lead">{{ proof.amount_mrwk }} MRWK paid to <a href="/accounts/{{ proof.to_account }}">{{ proof.to_account }}</a>.</p>
+  <p class="lead">{{ proof.amount_mrwk }} MRWK paid to <a href="{{ account_path(proof.to_account) }}">{{ proof.to_account }}</a>.</p>
   <div class="meta-grid">
     {% if proof.kind == "bounty_payment" %}
     <article>
@@ -39,7 +39,7 @@
     <dt>Accepted by</dt>
     <dd>{{ proof.accepted_by }}</dd>
     <dt>Paid to</dt>
-    <dd><a href="/accounts/{{ proof.to_account }}">{{ proof.to_account }}</a></dd>
+    <dd><a href="{{ account_path(proof.to_account) }}">{{ proof.to_account }}</a></dd>
     <dt>Amount</dt>
     <dd>{{ proof.amount_mrwk }} MRWK</dd>
     <dt>Ledger entry</dt>

--- a/app/templates/wallet_detail.html
+++ b/app/templates/wallet_detail.html
@@ -24,7 +24,7 @@
     <dt>Next action number</dt>
     <dd>{{ wallet.next_nonce }}</dd>
     <dt>Account view</dt>
-    <dd><a href="/accounts/{{ wallet.address }}">ledger account</a></dd>
+    <dd><a href="{{ account_path(wallet.address) }}">ledger account</a></dd>
   </dl>
   <div class="actions">
     <a href="/transfer">Send MRWK</a>
@@ -45,8 +45,8 @@
       <tr>
         <td><a href="/ledger/{{ entry.sequence }}">{{ entry.sequence }}</a></td>
         <td>{{ entry.type }}</td>
-        <td>{% if entry.from %}<a href="/accounts/{{ entry.from }}">{{ entry.from }}</a>{% else %}-{% endif %}</td>
-        <td>{% if entry.to %}<a href="/accounts/{{ entry.to }}">{{ entry.to }}</a>{% else %}-{% endif %}</td>
+        <td>{% if entry.from %}<a href="{{ account_path(entry.from) }}">{{ entry.from }}</a>{% else %}-{% endif %}</td>
+        <td>{% if entry.to %}<a href="{{ account_path(entry.to) }}">{{ entry.to }}</a>{% else %}-{% endif %}</td>
         <td>{{ entry.amount_mrwk }} MRWK</td>
         <td>{% if entry.proof_hash %}<a href="/proofs/{{ entry.proof_hash }}">proof</a>{% else %}-{% endif %}</td>
       </tr>

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -1,10 +1,23 @@
 from __future__ import annotations
 
+import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
-from app.accounts import account_api_context, account_page_context, normalized_account
+from app.accounts import (
+    account_api_context,
+    account_page_context,
+    normalized_account,
+    raw_account_api_path_account,
+)
 from app.db import create_schema, session_scope
-from app.ledger.service import create_bounty, ensure_genesis, pay_bounty
+from app.ledger.service import (
+    MICRO_UNITS,
+    add_ledger_entry,
+    create_bounty,
+    ensure_genesis,
+    pay_bounty,
+)
 from app.main import create_app
 
 
@@ -89,6 +102,82 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     assert f'href="/proofs/{proof.hash}"' in page_response.text
 
 
+def test_account_transaction_links_encode_url_significant_account_ids(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        add_ledger_entry(
+            session,
+            entry_type="manual_adjustment",
+            from_account="ops#source",
+            to_account="github:alice",
+            amount_microunits=MICRO_UNITS,
+            reference="manual-adjustment",
+        )
+        add_ledger_entry(
+            session,
+            entry_type="manual_adjustment",
+            from_account="slash/name",
+            to_account="github:alice",
+            amount_microunits=MICRO_UNITS,
+            reference="manual-adjustment-slash",
+        )
+        add_ledger_entry(
+            session,
+            entry_type="manual_adjustment",
+            from_account="foo/accepted-work",
+            to_account="github:alice",
+            amount_microunits=MICRO_UNITS,
+            reference="manual-adjustment-reserved-suffix",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    account_page = client.get("/accounts/github:alice")
+    encoded_account_page = client.get("/accounts/ops%23source")
+    slash_account_page = client.get("/accounts/slash%2Fname")
+    slash_account_api = client.get("/api/v1/accounts/slash%2Fname")
+    slash_accepted_work_api = client.get("/api/v1/accounts/slash%2Fname/accepted-work")
+    reserved_suffix_account_api = client.get("/api/v1/accounts/foo%2Faccepted-work")
+    reserved_suffix_accepted_work_api = client.get(
+        "/api/v1/accounts/foo%2Faccepted-work/accepted-work"
+    )
+
+    assert account_page.status_code == 200
+    assert 'href="/accounts/ops%23source"' in account_page.text
+    assert 'href="/accounts/ops#source"' not in account_page.text
+    assert 'href="/accounts/slash%2Fname"' in account_page.text
+    assert 'href="/accounts/slash/name"' not in account_page.text
+    assert encoded_account_page.status_code == 200
+    assert "ops#source" in encoded_account_page.text
+    assert slash_account_page.status_code == 200
+    assert "slash/name" in slash_account_page.text
+    assert slash_account_api.status_code == 200
+    assert slash_account_api.json()["account"] == "slash/name"
+    assert slash_accepted_work_api.status_code == 200
+    assert slash_accepted_work_api.json()["summary"]["accepted_awards"] == 0
+    assert reserved_suffix_account_api.status_code == 200
+    assert reserved_suffix_account_api.json()["account"] == "foo/accepted-work"
+    assert "summary" not in reserved_suffix_account_api.json()
+    assert reserved_suffix_accepted_work_api.status_code == 200
+    assert reserved_suffix_accepted_work_api.json()["account"] == "foo/accepted-work"
+    assert reserved_suffix_accepted_work_api.json()["summary"]["accepted_awards"] == 0
+
+
 def test_normalized_account_keeps_existing_account_validation_boundaries() -> None:
     assert normalized_account(" Reserve:Bounty:001 ") == "reserve:bounty:1"
     assert normalized_account("MRWK1" + ("A" * 40)) == "mrwk1" + ("a" * 40)
+
+
+def test_raw_account_api_path_rejects_malformed_utf8_encoded_account() -> None:
+    request = type(
+        "RequestDouble",
+        (),
+        {"scope": {"raw_path": b"/api/v1/accounts/%FF%2Faccepted-work"}},
+    )()
+
+    with pytest.raises(HTTPException) as exc_info:
+        raw_account_api_path_account(request)  # type: ignore[arg-type]
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "account path must be valid UTF-8"


### PR DESCRIPTION
Fixes a small public-navigation bug in account links.

Problem:
- Several public templates rendered account IDs directly into `/accounts/<account>` hrefs.
- Ledger account IDs are allowed to contain URL-significant characters such as `#`.
- A rendered link like `/accounts/ops#source` sends the browser to `/accounts/ops` with `source` as the fragment, so the account link does not reach the intended account.

Change:
- Add a centralized `account_path()` template helper that URL-encodes account path segments while preserving the existing colon-readable shape for normal account IDs like `github:alice` and `reserve:bounty:1`.
- Use that helper across account, activity, bounty detail, ledger, ledger entry, proof, and wallet templates.
- Add a regression test proving `/accounts/github:alice` now links to `ops%23source`, not the broken raw `ops#source`, and that `/accounts/ops%23source` still renders the account page.

Evidence:
- Reproduced before the fix: rendered account page contained `href="/accounts/ops#source"` and did not contain `href="/accounts/ops%23source"`.
- `python -m pytest tests/test_account_routes.py tests/test_account_validation.py -q` -> 29 passed.
- `python -m pytest tests/test_account_routes.py tests/test_account_validation.py tests/test_api_mcp.py::test_explorer_links_ledger_proof_and_account tests/test_api_mcp.py::test_account_api_keeps_schema_when_accepted_work_proof_is_malformed tests/test_bounty_pages.py tests/test_wallet_api.py -q` -> 70 passed.
- `python -m pytest -q` -> 415 passed.
- `ruff check app/main.py tests/test_account_routes.py` -> all checks passed.
- `ruff format --check app/main.py tests/test_account_routes.py` -> already formatted.
- `python -m mypy app` -> success, no issues found.
- `rg -n 'href="/accounts/\{\{' app/templates` -> no raw template account hrefs remain.

Refs #406


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account links now use a centralized route helper so identifiers with reserved/special characters are correctly URL-encoded in generated links.

* **Behavioral Changes**
  * Account routes treat identifiers as full paths (allowing embedded slashes) and the empty trailing-slash account endpoint returns 404.
  * Account-related pages consistently render encoded links across UI areas.

* **Tests**
  * Added tests verifying encoded account links and corresponding API responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->