### PR TITLE
Refs #406: Add MCP input schemas for public tools

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -15,27 +15,207 @@ MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
         "description": "List MRWK bounties with optional status, q, sort, and limit filters",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": ["open", "paid", "closed"],
+                    "default": "open",
+                    "description": "Filter bounties by status.",
+                },
+                "q": {
+                    "type": "string",
+                    "description": (
+                        "Case-insensitive search across repo, title, acceptance, or issue number."
+                    ),
+                },
+                "sort": {
+                    "type": "string",
+                    "enum": ["newest", "reward", "available", "awards"],
+                    "default": "newest",
+                    "description": "Sort order for the returned bounty rows.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "Maximum bounty rows to return.",
+                },
+            },
+            "additionalProperties": False,
+        },
     },
     {
         "name": "get_bounty",
         "description": "Get a bounty by id, optionally with accepted awards",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Internal MRWK bounty id.",
+                },
+                "include_awards": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Include accepted award rows in the response.",
+                },
+            },
+            "required": ["id"],
+            "additionalProperties": False,
+        },
     },
     {
         "name": "list_bounty_attempts",
         "description": "List advisory active-attempt reservations for a bounty",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "bounty_id": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Internal MRWK bounty id.",
+                },
+                "include_expired": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Include expired attempt reservations.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "Maximum attempt rows to return.",
+                },
+            },
+            "required": ["bounty_id"],
+            "additionalProperties": False,
+        },
     },
-    {"name": "get_balance", "description": "Get an account balance"},
+    {
+        "name": "get_balance",
+        "description": "Get an account balance",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "account": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Ledger account id such as github:alice or mrwk1...",
+                },
+            },
+            "required": ["account"],
+            "additionalProperties": False,
+        },
+    },
     {
         "name": "register_wallet",
         "description": "Register an MRWK wallet public key",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "public_key_hex": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Wallet public key in hex form.",
+                },
+                "label": {
+                    "type": "string",
+                    "description": "Optional public wallet label.",
+                },
+            },
+            "required": ["public_key_hex"],
+            "additionalProperties": False,
+        },
     },
-    {"name": "get_wallet", "description": "Get an MRWK wallet by address"},
+    {
+        "name": "get_wallet",
+        "description": "Get an MRWK wallet by address",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Registered mrwk1 wallet address.",
+                },
+            },
+            "required": ["address"],
+            "additionalProperties": False,
+        },
+    },
     {
         "name": "submit_wallet_transfer",
         "description": "Submit a signed MRWK wallet transfer",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "from_address": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Sender mrwk1 wallet address.",
+                },
+                "to_address": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Recipient mrwk1 wallet address.",
+                },
+                "amount_mrwk": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Amount to transfer in MRWK.",
+                },
+                "nonce": {
+                    "type": "integer",
+                    "description": "Sender wallet nonce for this transfer.",
+                },
+                "memo": {"type": "string", "description": "Optional public transfer memo."},
+                "signature_hex": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Hex signature authorizing the transfer.",
+                },
+            },
+            "required": ["from_address", "to_address", "amount_mrwk", "nonce", "signature_hex"],
+            "additionalProperties": False,
+        },
     },
-    {"name": "get_ledger_entry", "description": "Get a ledger entry"},
-    {"name": "get_proof", "description": "Get a public proof by hash"},
+    {
+        "name": "get_ledger_entry",
+        "description": "Get a ledger entry",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "sequence": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Ledger sequence number.",
+                },
+            },
+            "required": ["sequence"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "get_proof",
+        "description": "Get a public proof by hash",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "hash": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Public proof hash.",
+                },
+            },
+            "required": ["hash"],
+            "additionalProperties": False,
+        },
+    },
     {
         "name": "submit_work_proof",
         "description": (

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -174,6 +174,20 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()
     assert tools["result"]["tools"][0]["name"] == "list_bounties"
     assert "status, q, sort, and limit filters" in tools["result"]["tools"][0]["description"]
+    tools_list = tools["result"]["tools"]
+    tool_by_name = {tool["name"]: tool for tool in tools_list}
+    assert len(tool_by_name) == len(tools_list)
+    assert all("inputSchema" in tool for tool in tool_by_name.values())
+    list_schema = tool_by_name["list_bounties"]["inputSchema"]
+    assert list_schema["type"] == "object"
+    assert list_schema["properties"]["status"]["enum"] == ["open", "paid", "closed"]
+    assert list_schema["properties"]["status"]["default"] == "open"
+    assert list_schema["properties"]["sort"]["enum"] == ["newest", "reward", "available", "awards"]
+    assert list_schema["properties"]["sort"]["default"] == "newest"
+    assert list_schema["properties"]["limit"]["minimum"] == 1
+    assert list_schema["properties"]["limit"]["maximum"] == 100
+    assert list_schema["properties"]["limit"]["default"] == 25
+    assert list_schema["additionalProperties"] is False
     submit_tool = next(
         tool for tool in tools["result"]["tools"] if tool["name"] == "submit_work_proof"
     )
@@ -186,12 +200,55 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert submit_schema["properties"]["issue_number"]["minimum"] == 1
     assert submit_schema["properties"]["repo"]["maxLength"] == 200
     assert submit_schema["not"] == {"required": ["bounty_id", "issue_number"]}
-    bounty_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_bounty")
+    bounty_tool = tool_by_name["get_bounty"]
     assert "accepted awards" in bounty_tool["description"]
-    attempt_tool = next(
-        tool for tool in tools["result"]["tools"] if tool["name"] == "list_bounty_attempts"
-    )
+    bounty_schema = bounty_tool["inputSchema"]
+    assert bounty_schema["required"] == ["id"]
+    assert bounty_schema["properties"]["id"]["minimum"] == 1
+    assert bounty_schema["properties"]["include_awards"]["type"] == "boolean"
+    assert bounty_schema["properties"]["include_awards"]["default"] is False
+    assert bounty_schema["additionalProperties"] is False
+    attempt_tool = tool_by_name["list_bounty_attempts"]
     assert "active-attempt reservations" in attempt_tool["description"]
+    attempt_schema = attempt_tool["inputSchema"]
+    assert attempt_schema["required"] == ["bounty_id"]
+    assert attempt_schema["properties"]["bounty_id"]["minimum"] == 1
+    assert attempt_schema["properties"]["include_expired"]["type"] == "boolean"
+    assert attempt_schema["properties"]["include_expired"]["default"] is False
+    assert attempt_schema["properties"]["limit"]["maximum"] == 100
+    assert attempt_schema["additionalProperties"] is False
+    balance_schema = tool_by_name["get_balance"]["inputSchema"]
+    assert balance_schema["required"] == ["account"]
+    assert balance_schema["properties"]["account"]["minLength"] == 1
+    assert balance_schema["additionalProperties"] is False
+    register_schema = tool_by_name["register_wallet"]["inputSchema"]
+    assert register_schema["required"] == ["public_key_hex"]
+    assert register_schema["properties"]["public_key_hex"]["minLength"] == 1
+    assert register_schema["additionalProperties"] is False
+    wallet_schema = tool_by_name["get_wallet"]["inputSchema"]
+    assert wallet_schema["required"] == ["address"]
+    assert wallet_schema["properties"]["address"]["minLength"] == 1
+    assert wallet_schema["additionalProperties"] is False
+    transfer_schema = tool_by_name["submit_wallet_transfer"]["inputSchema"]
+    assert transfer_schema["required"] == [
+        "from_address",
+        "to_address",
+        "amount_mrwk",
+        "nonce",
+        "signature_hex",
+    ]
+    for field in ("from_address", "to_address", "amount_mrwk", "signature_hex"):
+        assert transfer_schema["properties"][field]["minLength"] == 1
+    assert transfer_schema["properties"]["nonce"]["type"] == "integer"
+    assert transfer_schema["additionalProperties"] is False
+    ledger_schema = tool_by_name["get_ledger_entry"]["inputSchema"]
+    assert ledger_schema["required"] == ["sequence"]
+    assert ledger_schema["properties"]["sequence"]["minimum"] == 1
+    assert ledger_schema["additionalProperties"] is False
+    proof_schema = tool_by_name["get_proof"]["inputSchema"]
+    assert proof_schema["required"] == ["hash"]
+    assert proof_schema["properties"]["hash"]["minLength"] == 1
+    assert proof_schema["additionalProperties"] is False
 
     balance = client.post(
         "/mcp",


### PR DESCRIPTION
## Summary
- add `inputSchema` metadata for the public MCP tools that previously only exposed name/description
- document required arguments, defaults, enum values, and bounds for list/detail/account/wallet/ledger/proof tools
- extend the MCP tools/list regression so every advertised tool includes a schema

Refs #406.

## Evidence
The public MCP `tools/list` response currently lists 10 tools, but only `submit_work_proof` advertises an `inputSchema`. Public tools such as `list_bounty_attempts`, `get_bounty`, `get_balance`, `get_wallet`, `get_ledger_entry`, and `get_proof` accept arguments, but agents cannot discover the accepted shape from the tool list. A live public smoke check reproduced this with unauthenticated JSON-RPC calls and showed `list_bounty_attempts` works with `bounty_id` while repo/issue arguments return `invalid tool arguments` without schema guidance.

This PR keeps handler behavior unchanged and only exposes the existing argument contracts through MCP metadata.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_api_mcp.py::test_mcp_tools_list_and_call tests/test_api_mcp.py::test_mcp_list_bounty_attempts_reports_active_and_expired tests/test_api_mcp.py::test_mcp_get_proof_returns_public_proof_details -q` -> 3 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_api_mcp.py -q` -> 76 passed
- `uv run --extra dev ruff check app/mcp.py tests/test_api_mcp.py` -> passed
- `uv run --extra dev ruff format --check app/mcp.py tests/test_api_mcp.py` -> 2 files already formatted
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --extra dev python -m mypy app` -> success
- `git diff --check` -> clean
- changed-file sensitive string scan -> no matches

## Out of scope
- No MCP handler behavior changes.
- No wallet private keys, signatures, tokens, price claims, exchange claims, bridge claims, or off-ramp claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved input validation for ledger, bounty, and wallet tools: structured schemas with typed parameters, required fields, defaults, value constraints, and stricter rejection of unknown inputs.

* **Tests**
  * Expanded test coverage to validate tool input schemas, required parameters, defaults, enums/ranges, and enforcement of additional-properties restrictions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->