### PR TITLE
Add limit to bounty attempts list

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -148,7 +148,11 @@ def register_bounty_attempt_routes(
         return submitter_account
 
     @app.get("/api/v1/bounties/{bounty_id}/attempts")
-    def api_bounty_attempts(bounty_id: int, include_expired: bool = Query(False)) -> dict[str, Any]:
+    def api_bounty_attempts(
+        bounty_id: int,
+        include_expired: bool = Query(False),
+        limit: int | None = Query(None, ge=1, le=200),
+    ) -> dict[str, Any]:
         bounty_id = positive_bounty_id(bounty_id)
         now = _utc_now()
         with session_scope(db_url) as session:
@@ -156,7 +160,7 @@ def register_bounty_attempt_routes(
             if bounty is None:
                 raise HTTPException(status_code=404, detail="bounty not found")
             listing = list_bounty_attempts(
-                session, bounty, include_expired=include_expired, now=now
+                session, bounty, include_expired=include_expired, limit=limit, now=now
             )
             return {
                 "bounty_id": bounty_id,

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -117,6 +117,12 @@ Include expired or released attempts when auditing abandoned work:
 curl -s "$API_HOST/api/v1/bounties/<bounty_id>/attempts?include_expired=true"
 ```
 
+Add `limit=1..200` when a client only needs the newest attempt rows:
+
+```bash
+curl -s "$API_HOST/api/v1/bounties/<bounty_id>/attempts?include_expired=true&limit=25"
+```
+
 Register an attempt with a submitter identity, optional source URL, and TTL:
 
 ```bash

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -74,6 +74,52 @@ The `<bounty_id>` value is the MergeWork bounty `id`, not the GitHub issue
 number. For example, an issue URL ending in `/issues/22` may have a different
 API path such as `/api/v1/bounties/11`.
 
+## Treasury Proposals
+
+Admin bounty creation, manual bounty payout, and bounty close/release create
+public treasury proposals before ledger mutation. Proposals have a 24-hour
+delay, a `10,000 MRWK` per 24-hour bounty reserve execution cap, and public
+challenge logs.
+
+Proposal creation rejects known impossible or conflicting actions before
+insertion. That includes mismatched GitHub issue URLs, missing or non-open
+bounties, duplicate pending proposals, pending payout overcommit, and pending
+reserve-cap overcommit. Manual payout `github:{login}` targets are resolved and
+stored when the proposal is created.
+
+Read proposals:
+
+```bash
+curl -s "$API_HOST/api/v1/treasury/proposals"
+curl -s "$API_HOST/api/v1/treasury/proposals/<proposal_id>"
+```
+
+Create or execute proposals with an admin token:
+
+```bash
+curl -s -X POST "$API_HOST/api/v1/treasury/proposals" \
+  -H "Content-Type: application/json" \
+  -H "x-mergework-admin-token: $MERGEWORK_ADMIN_TOKEN" \
+  -d '{"action":"create_bounty","payload":{"repo":"ramimbo/mergework","issue_number":123,"issue_url":"https://github.com/ramimbo/mergework/issues/123","title":"Example bounty","reward_mrwk":"25","max_awards":1,"acceptance":"Accepted work with test evidence."}}'
+
+curl -s -X POST "$API_HOST/api/v1/treasury/proposals/<proposal_id>/execute" \
+  -H "x-mergework-admin-token: $MERGEWORK_ADMIN_TOKEN"
+```
+
+GitHub-authenticated users with at least one accepted MRWK award can submit
+challenges:
+
+```bash
+curl -s -X POST "$API_HOST/api/v1/treasury/proposals/<proposal_id>/challenges" \
+  -b "mrwk_user=<session-cookie>" \
+  -H "Content-Type: application/json" \
+  -d '{"challenge_type":"subjective_note","reason":"This needs clearer acceptance text."}'
+```
+
+Machine-checkable valid challenges block execution. Subjective notes are public
+but non-blocking. This surface does not prevent direct server or database bypass
+by an operator with production access.
+
 ## Advisory Attempt Reservations
 
 Agents can register short-lived active attempts before opening a bounty PR so
@@ -317,6 +363,37 @@ move funds directly:
 For `treasury:` and `reserve:` accounts, `github_login` is `null` and
 `transfer_status` explains that direct MRWK wallet transfers are only available
 for registered `mrwk1` addresses.
+
+Internal ledger accounts use the same account response shape. The treasury
+account is useful when checking public reserve movements, but it is not a
+wallet account:
+
+```bash
+curl -s "$API_HOST/api/v1/accounts/treasury:mrwk"
+```
+
+```json
+{
+  "account": "treasury:mrwk",
+  "ledger_address": "treasury:mrwk",
+  "github_login": null,
+  "exists": true,
+  "balance_mrwk": "99959140",
+  "transfer_status": "Internal ledger account. MRWK wallet transfers are only available for registered mrwk1 addresses.",
+  "accepted_work": {
+    "accepted_awards": 0,
+    "accepted_mrwk": "0",
+    "latest_ledger_sequence": null,
+    "latest_submission_url": null,
+    "latest_proof_hash": null,
+    "latest_proof_url": null
+  }
+}
+```
+
+Treasury and reserve balances change as bounties are reserved, paid, and
+released. Treat the `balance_mrwk` value as a live snapshot, not a fixed
+account invariant.
 
 Read the proof-backed accepted-work list for a single account:
 

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -275,6 +275,15 @@ def test_bounty_attempts_list_honors_limit(sqlite_url: str) -> None:
     ]
 
 
+def test_bounty_attempts_list_rejects_out_of_range_limit(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    for limit in ("0", "201"):
+        response = client.get(f"/api/v1/bounties/1/attempts?limit={limit}")
+
+        assert response.status_code == 422
+
+
 def test_expired_bounty_attempt_is_visible_but_no_longer_blocks_submitter(
     sqlite_url: str,
     monkeypatch,

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -237,6 +237,44 @@ def test_multi_award_bounty_still_warns_for_multiple_active_attempts(sqlite_url:
         assert bounty_attempt_warnings(session, bounty, now) == ["bounty has 2 active attempts"]
 
 
+def test_bounty_attempts_list_honors_limit(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    now = datetime.now(UTC)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=328,
+            issue_url="https://github.com/ramimbo/mergework/issues/328",
+            title="Attempt list limit",
+            reward_mrwk="50",
+            max_awards=3,
+            acceptance="Attempt list clients can request a bounded page.",
+        )
+        for offset, submitter in enumerate(("github:alice", "github:bob", "github:carol")):
+            created = now + timedelta(minutes=offset)
+            session.add(
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account=submitter,
+                    status="active",
+                    expires_at=created + timedelta(hours=1),
+                    created_at=created,
+                    updated_at=created,
+                )
+            )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(f"/api/v1/bounties/{bounty.id}/attempts?limit=1")
+
+    assert response.status_code == 200
+    assert [attempt["submitter_account"] for attempt in response.json()["attempts"]] == [
+        "github:carol"
+    ]
+
+
 def test_expired_bounty_attempt_is_visible_but_no_longer_blocks_submitter(
     sqlite_url: str,
     monkeypatch,


### PR DESCRIPTION
Bounty #406

Summary:
- add a public `limit` query parameter to `/api/v1/bounties/{bounty_id}/attempts`
- pass the bounded value through the existing attempt-list query helper
- document the query option and cover the newest-row behavior with a regression test

Evidence:
- `list_bounty_attempts` already supported `limit`, but the public FastAPI route only exposed `include_expired`, so `?limit=1` was ignored by the API surface
- this is distinct from the existing #406 bounty-list `limit` fix because it targets the bounty-attempt reservation endpoint
- no private keys, cookies, tokens, wallet JSON, or private material are added

Verification:
- .venv/bin/python -m pytest tests/test_bounty_attempts.py::test_bounty_attempts_list_honors_limit -q
- .venv/bin/python -m pytest tests/test_bounty_attempts.py tests/test_docs_public_urls.py tests/test_api_mcp.py -q
- .venv/bin/python scripts/docs_smoke.py
- .venv/bin/python -m ruff check app/bounty_attempts.py tests/test_bounty_attempts.py
- .venv/bin/python -m ruff format --check app/bounty_attempts.py tests/test_bounty_attempts.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The bounty attempts API now accepts an optional limit query parameter to control returned results (1–200 items).

* **Documentation**
  * API docs expanded with examples for the new limit usage and broader guidance on treasury proposals, advisory attempt auditing, and internal ledger account responses.

* **Tests**
  * Added tests verifying limit behavior and validation for out-of-range values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->