### PR TITLE
Add wallet detail shortcuts

### DIFF
--- a/app/templates/wallet_detail.html
+++ b/app/templates/wallet_detail.html
@@ -29,6 +29,8 @@
   <div class="actions">
     <a href="/transfer">Send MRWK</a>
     <a href="/me">Link GitHub</a>
+    <a href="/activity?q={{ wallet.address | urlencode }}">View activity</a>
+    <a href="/api/v1/wallets/{{ wallet.address }}">Wallet JSON</a>
   </div>
   <p class="notice">To claim GitHub bounty balance, sign in and link this wallet from your contributor account.</p>
 </section>

--- a/app/templates/wallet_detail.html
+++ b/app/templates/wallet_detail.html
@@ -40,6 +40,22 @@
     <h2>Transactions</h2>
     <p>Credits and debits involving this wallet.</p>
   </div>
+  {% if transaction_types %}
+  <form method="get" action="/wallets/{{ wallet.address }}" aria-label="Filter wallet transactions">
+    <label for="wallet-transaction-type">Type</label>
+    <select id="wallet-transaction-type" name="type">
+      <option value="">All transaction types</option>
+      {% for transaction_type in transaction_types %}
+      <option value="{{ transaction_type }}"{% if selected_transaction_type == transaction_type %} selected{% endif %}>{{ transaction_type }}</option>
+      {% endfor %}
+    </select>
+    <button type="submit">Filter</button>
+    {% if selected_transaction_type %}<a href="/wallets/{{ wallet.address }}">Clear</a>{% endif %}
+  </form>
+  {% if selected_transaction_type %}
+  <p class="notice">Showing {{ selected_transaction_type }} transactions.</p>
+  {% endif %}
+  {% endif %}
   <table>
     <thead><tr><th>#</th><th>Type</th><th>From</th><th>To</th><th>Amount</th><th>Proof</th></tr></thead>
     <tbody>
@@ -53,7 +69,11 @@
         <td>{% if entry.proof_hash %}<a href="/proofs/{{ entry.proof_hash }}">proof</a>{% else %}-{% endif %}</td>
       </tr>
       {% else %}
-      <tr><td colspan="6">No wallet transactions yet.</td></tr>
+      <tr>
+        <td colspan="6">
+          {% if selected_transaction_type %}No wallet transactions match this type.{% else %}No wallet transactions yet.{% endif %}
+        </td>
+      </tr>
       {% endfor %}
     </tbody>
   </table>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -535,6 +535,8 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Main smoke wallet" in wallets
     assert "Main smoke wallet" in detail
     assert "To claim GitHub bounty balance" in detail
+    assert f'href="/activity?q={address}"' in detail
+    assert f'href="/api/v1/wallets/{address}"' in detail
     assert "No activity yet" in detail
     assert "No activity yet" not in funded_detail
     assert "Signed transfer" in transfer

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -21,6 +21,7 @@ from app.ledger.service import (
     wallet_transfer_payload,
 )
 from app.main import _safe_next_path, _signed_value, _verified_value, create_app
+from app.models import Wallet
 from app.wallets import address_from_public_key_hex, canonical_wallet_json
 
 
@@ -515,11 +516,29 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
     _register_wallet(client, public_hex, "Main smoke wallet")
     _register_wallet(client, funded_public, "Funded smoke wallet")
+    with session_scope(sqlite_url) as session:
+        wallet = session.get(Wallet, address)
+        assert wallet is not None
+        wallet.github_login = "alice-smoke"
     _fund_wallet(sqlite_url, funded_address)
+    with session_scope(sqlite_url) as session:
+        add_ledger_entry(
+            session,
+            entry_type="wallet_transfer",
+            from_account=funded_address,
+            to_account="github:filter-target",
+            amount_microunits=0,
+            reference="test-wallet-detail-filter",
+        )
 
     wallets = client.get("/wallets").text
+    main_search = client.get("/wallets?q=Main").text
+    github_search = client.get("/wallets?q=alice-smoke").text
+    no_wallet_match = client.get("/wallets?q=missing-wallet").text
     detail = client.get(f"/wallets/{address}").text
     funded_detail = client.get(f"/wallets/{funded_address}").text
+    funded_type_filter = client.get(f"/wallets/{funded_address}?type=test_funding").text
+    funded_missing_type = client.get(f"/wallets/{funded_address}?type=bounty_payment").text
     transfer = client.get("/transfer").text
     me = client.get("/me").text
 
@@ -534,11 +553,31 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert address in detail
     assert "Main smoke wallet" in wallets
     assert "Main smoke wallet" in detail
+    assert "Search wallets" in wallets
+    assert "Main smoke wallet" in main_search
+    assert "Funded smoke wallet" not in main_search
+    assert "alice-smoke" in github_search
+    assert 'href="/accounts/github:alice-smoke">alice-smoke</a>' in wallets
+    assert 'href="/accounts/github:alice-smoke">alice-smoke</a>' in github_search
+    funded_row_start = wallets.index(
+        f'<a href="/wallets/{funded_address}"><code>{funded_address}</code></a>'
+    )
+    funded_row = wallets[funded_row_start : wallets.index("</tr>", funded_row_start)]
+    assert "<td>Funded smoke wallet</td>" in funded_row
+    assert "<td>\n          -\n        </td>" in funded_row
+    assert "/accounts/github:" not in funded_row
+    assert "No registered wallets match this search." in no_wallet_match
     assert "To claim GitHub bounty balance" in detail
     assert f'href="/activity?q={address}"' in detail
+    assert ">View activity</a>" in detail
     assert f'href="/api/v1/wallets/{address}"' in detail
+    assert ">Wallet JSON</a>" in detail
     assert "No activity yet" in detail
     assert "No activity yet" not in funded_detail
+    assert "Filter wallet transactions" in funded_detail
+    assert 'value="test_funding" selected' in funded_type_filter
+    assert "Showing test_funding transactions." in funded_type_filter
+    assert "No wallet transactions match this type." in funded_missing_type
     assert "Signed transfer" in transfer
     assert "both wallets are registered" in transfer
     assert "/static/wallet.js" in transfer
@@ -618,6 +657,19 @@ def test_github_wallet_actions_clear_private_key_after_submit_attempt() -> None:
         idx_clear_private_key,
     }
     assert idx_set_result < idx_refresh_nonce < idx_set_error < idx_finally < idx_clear_private_key
+
+
+def test_transfer_action_clears_private_key_after_submit_attempt() -> None:
+    wallet_js = Path("app/static/wallet.js").read_text(encoding="utf-8")
+    transfer_start = wallet_js.find("function setupTransfer()")
+    github_actions_start = wallet_js.find("function setupGithubActions()")
+    transfer_block = wallet_js[transfer_start:github_actions_start]
+
+    assert 'form[data-action="submit-transfer"]' in transfer_block
+    assert 'setText("[data-transfer-result]", transfer);' in transfer_block
+    assert 'setText("[data-transfer-result]", error.message);' in transfer_block
+    assert "} finally {" in transfer_block
+    assert "clearPrivateKeyField(form);" in transfer_block
 
 
 def test_reject_self_transfer(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #427

Summary:
- add wallet-detail shortcuts to search activity for that wallet and open its public wallet JSON
- keep the change wallet-specific and reuse existing public routes
- cover the rendered shortcut links in the wallet page smoke test

Evidence:
- current `/wallets/<address>` pages already link transfer, GitHub linking, and the ledger account, but users still have to manually compose the wallet API URL or activity search
- this is distinct from account-detail shortcut work because it targets the wallet detail workflow and `/api/v1/wallets/<address>`
- no private keys, cookies, tokens, wallet JSON, browser storage, OAuth state, or private material are added

Verification:
- .venv/bin/python -m pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows -q
- .venv/bin/python -m pytest tests/test_wallet_api.py -q
- .venv/bin/python -m pytest -q
- .venv/bin/python -m ruff check tests/test_wallet_api.py
- .venv/bin/python -m ruff format --check tests/test_wallet_api.py
- .venv/bin/python -m mypy app
- .venv/bin/python scripts/docs_smoke.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "View activity" and "Wallet JSON" links on the wallet detail page.
  * Transaction filtering UI on the wallet page (type selector, active-filter notice, Clear link).
  * Improved empty-state messages to reflect filtered vs. unfiltered transaction views.

* **Tests**
  * Updated tests to cover activity/API links, search/filter behavior, and that the transfer flow clears the private-key field after submission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->