### PR TITLE
Refs #406: Warn when live submission gate hits GitHub caps

### DIFF
--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -20,6 +20,8 @@ SUMMARY_RE = re.compile(r"\b(summary|what changed|changes?)\b", re.IGNORECASE)
 GH_TIMEOUT_SECONDS = 30
 DEFAULT_API_HOST = "https://api.mrwk.ltclab.site"
 DEFAULT_MAX_MAINTAINER_AGE_DAYS = 14
+GH_PR_SAFETY_CAP = 101
+GH_ISSUE_SAFETY_CAP = 201
 MAINTAINER_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
 
 
@@ -213,6 +215,9 @@ def evaluate_submission(data: dict[str, Any]) -> dict[str, Any]:
     }
     pull_requests = [item for item in data.get("pull_requests", []) if isinstance(item, dict)]
     checks: list[dict[str, str]] = []
+    load_warning = str(data.get("load_warning") or "").strip()
+    if load_warning:
+        checks.append(_check("source_completeness", "warn", load_warning))
     refs = _bounty_refs(text)
     bounty_ref = refs[0] if refs else None
     if bounty_ref is None:
@@ -465,7 +470,7 @@ def _load_live_context(
                 "--state",
                 "open",
                 "--limit",
-                "100",
+                str(GH_PR_SAFETY_CAP),
                 "--json",
                 "number,title,url,body,state",
             ]
@@ -480,7 +485,7 @@ def _load_live_context(
                 "--state",
                 "all",
                 "--limit",
-                "200",
+                str(GH_ISSUE_SAFETY_CAP),
                 "--json",
                 "number,title,state",
             ]
@@ -492,6 +497,16 @@ def _load_live_context(
             "pull_requests": [],
             "load_warning": f"live GitHub data unavailable: {exc}",
         }
+    if len(prs) >= GH_PR_SAFETY_CAP:
+        load_warnings.append(
+            f"gh pr list reached the {GH_PR_SAFETY_CAP} item safety cap; "
+            "similar-open-PR checks may be incomplete"
+        )
+    if len(issues) >= GH_ISSUE_SAFETY_CAP:
+        load_warnings.append(
+            f"gh issue list reached the {GH_ISSUE_SAFETY_CAP} item safety cap; "
+            "bounty discovery may be incomplete"
+        )
     try:
         api_bounties = _load_api_bounties(repo, api_host)
     except RuntimeError as exc:

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -429,6 +429,96 @@ def test_submission_quality_gate_live_mode_warns_when_github_unavailable(
     assert "load_warning" in output
 
 
+def test_submission_quality_gate_warns_when_live_collections_hit_safety_caps(
+    monkeypatch,
+) -> None:
+    def fake_run(args, **kwargs):
+        if args[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "number": number,
+                            "title": "Open PR",
+                            "body": "Refs #319",
+                            "state": "OPEN",
+                            "url": f"https://github.com/ramimbo/mergework/pull/{number}",
+                        }
+                        for number in range(1, submission_quality_gate.GH_PR_SAFETY_CAP + 1)
+                    ]
+                ),
+                stderr="",
+            )
+        if args[:3] == ["gh", "issue", "list"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    [
+                        {
+                            "number": number,
+                            "title": f"MRWK bounty: cap test {number}",
+                            "state": "OPEN",
+                        }
+                        for number in range(
+                            319,
+                            319 + submission_quality_gate.GH_ISSUE_SAFETY_CAP,
+                        )
+                    ]
+                ),
+                stderr="",
+            )
+        if args[:3] == ["gh", "issue", "view"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "author": {"login": "ramimbo"},
+                        "createdAt": "2026-05-25T12:00:00Z",
+                        "comments": [],
+                    }
+                ),
+                stderr="",
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(submission_quality_gate.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        submission_quality_gate,
+        "_load_api_bounties",
+        lambda repo, api_host: {
+            319: {"id": 66, "number": 319, "state": "open", "awards_remaining": 1}
+        },
+    )
+    monkeypatch.setattr(
+        submission_quality_gate, "_load_api_attempts", lambda api_host, bounty_id: []
+    )
+
+    data = submission_quality_gate._load_live_context(
+        "ramimbo/mergework",
+        "Summary: work\n\nRefs #319\n\nValidation: pytest passed",
+        "https://api.example.test",
+    )
+    result = evaluate_submission(data)
+
+    assert result["status"] == "warn"
+    assert (
+        f"gh pr list reached the {submission_quality_gate.GH_PR_SAFETY_CAP}" in data["load_warning"]
+    )
+    assert (
+        f"gh issue list reached the {submission_quality_gate.GH_ISSUE_SAFETY_CAP}"
+        in data["load_warning"]
+    )
+    assert {
+        "name": "source_completeness",
+        "status": "warn",
+        "message": data["load_warning"],
+    } in result["checks"]
+
+
 def test_submission_quality_gate_live_bounties_use_api_award_capacity(monkeypatch) -> None:
     def fake_run(args, **kwargs):
         if args[:3] == ["gh", "pr", "list"]:


### PR DESCRIPTION
## Summary

- Add explicit live-mode safety caps for GitHub PR and issue collection in `scripts/submission_quality_gate.py`.
- Warn when `gh pr list` or `gh issue list` returns exactly the cap, because similar-PR and bounty-discovery checks may be incomplete.
- Surface that warning in the evaluated checks as `source_completeness` so contributors see the uncertainty instead of treating the gate as fully sourced.

Refs #406.

## Evidence

The live submission quality gate depends on bounded `gh pr list` and `gh issue list` calls. Before this change, hitting the limit looked the same as a complete collection, so a crowded repo could silently miss similar open PRs or bounty rows while still producing a normal-looking result.

This is distinct from the current API-focused submission-gate work in PR #478 and queue-health API-capacity work in PR #474. This change covers the GitHub collection boundary used by the live gate.

Live bounty preflight for internal bounty 66 / issue #406:
- API status: `open`
- awards remaining: `15`
- active attempts: none

Open-PR duplicate search found no existing PR for `gh pr list reached`, `gh issue list reached`, `similar-open-PR checks may be incomplete`, or `bounty discovery may be incomplete`.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests\test_submission_quality_gate.py::test_submission_quality_gate_warns_when_live_collections_hit_safety_caps -q` -> 1 passed
- `.\.venv\Scripts\python.exe -m pytest tests\test_submission_quality_gate.py -q` -> 24 passed
- `.\.venv\Scripts\python.exe -m pytest -q` -> 415 passed
- `.\.venv\Scripts\python.exe -m ruff check .` -> All checks passed
- `.\.venv\Scripts\python.exe -m ruff format --check .` -> 79 files already formatted
- `.\.venv\Scripts\python.exe -m mypy app scripts\submission_quality_gate.py` -> success, no issues found
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean
- changed-file secret scan -> no matches


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Submission quality gate now includes source completeness checks that warn when GitHub pull request or issue data collection reaches safety limits.

* **Tests**
  * Added test validating source completeness warnings when GitHub data collection reaches safety caps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->