### PR TITLE
Refs #406: Honor activity feed limit

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import FastAPI, Query, Request
 from fastapi.responses import HTMLResponse
@@ -11,18 +11,27 @@ from app.db import session_scope
 from app.serializers import activity_to_dict
 
 
-def activity_context(session: Session, query: str | None = None) -> dict[str, Any]:
-    return activity_to_dict(session, query)
+def activity_context(
+    session: Session, query: str | None = None, recent_limit: int = 100
+) -> dict[str, Any]:
+    return activity_to_dict(session, query, recent_limit=recent_limit)
 
 
 def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
     @app.get("/api/v1/activity")
-    def api_activity(q: str | None = Query(None)) -> dict[str, Any]:
+    def api_activity(
+        q: str | None = Query(None),
+        limit: Annotated[int, Query(ge=1, le=100)] = 100,
+    ) -> dict[str, Any]:
         with session_scope(db_url) as session:
-            return activity_context(session, q)
+            return activity_context(session, q, recent_limit=limit)
 
     @app.get("/activity", response_class=HTMLResponse)
-    def activity_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:
+    def activity_page(
+        request: Request,
+        q: str | None = Query(None),
+        limit: Annotated[int, Query(ge=1, le=100)] = 100,
+    ) -> HTMLResponse:
         with session_scope(db_url) as session:
-            context = activity_context(session, q)
+            context = activity_context(session, q, recent_limit=limit)
         return templates.TemplateResponse(request, "activity.html", context)

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -184,7 +184,9 @@ def _activity_row_matches(row: dict[str, Any], query: str) -> bool:
     return any(query in str(value or "").lower() for value in searchable_values)
 
 
-def activity_to_dict(session: Session, query: str | None = None) -> dict[str, Any]:
+def activity_to_dict(
+    session: Session, query: str | None = None, recent_limit: int = 100
+) -> dict[str, Any]:
     """Build the public activity feed and contributor totals."""
     search_query = _activity_search_query(query)
     rows = session.execute(
@@ -247,7 +249,7 @@ def activity_to_dict(session: Session, query: str | None = None) -> dict[str, An
         },
         "query": search_query,
         "contributors": contributors,
-        "recent": recent[:100],
+        "recent": recent[:recent_limit],
     }
 
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -208,12 +208,16 @@ Read accepted-work activity summarized from proof-backed bounty payments:
 ```bash
 curl -s "$API_HOST/api/v1/activity"
 curl -s "$API_HOST/api/v1/activity?q=p3xill"
+curl -s "$API_HOST/api/v1/activity?limit=25"
 ```
 
-The optional `q` parameter filters activity rows by account, amount, submission
-URL, proof hash, bounty repo, bounty issue URL, internal bounty id, or GitHub
-issue number. The response groups matching proof-backed bounty payments into
-`totals`, contributor rollups, and the most recent payment rows:
+The optional `q` parameter filters activity rows by account, amount,
+submission URL, proof hash, bounty repo, bounty issue URL, internal bounty id,
+or GitHub issue number. The optional `limit` parameter defaults to `100`,
+accepts values from `1` to `100`, and limits only the returned `recent` payment
+rows; `totals` and contributor rollups still summarize all matching
+proof-backed payments. The response groups matching proof-backed bounty
+payments into `totals`, contributor rollups, and the most recent payment rows:
 
 ```json
 {
@@ -256,7 +260,7 @@ issue number. The response groups matching proof-backed bounty payments into
 ```
 
 `contributors` is sorted by accepted MRWK amount, while `recent` is sorted by
-newest ledger sequence and capped to the latest 100 matching rows. Use
+newest ledger sequence and capped to the requested `limit`. Use
 `proof_hash` with `/api/v1/proofs/<proof_hash>` to inspect the public proof
 payload for a payment.
 

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -110,6 +110,15 @@ def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -
     assert payload["recent"][0]["bounty_url"] == f"/bounties/{second_bounty.id}"
     assert all("unproved" not in row["submission_url"] for row in payload["recent"])
 
+    limited = client.get("/api/v1/activity?limit=1")
+    assert limited.status_code == 200
+    limited_payload = limited.json()
+    assert limited_payload["totals"] == payload["totals"]
+    assert [row["proof_hash"] for row in limited_payload["recent"]] == [wallet_proof.hash]
+
+    invalid_limit = client.get("/api/v1/activity?limit=0")
+    assert invalid_limit.status_code == 422
+
 
 def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
     create_schema(sqlite_url)

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -119,6 +119,9 @@ def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -
     invalid_limit = client.get("/api/v1/activity?limit=0")
     assert invalid_limit.status_code == 422
 
+    invalid_high_limit = client.get("/api/v1/activity?limit=101")
+    assert invalid_high_limit.status_code == 422
+
 
 def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
     create_schema(sqlite_url)

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -306,6 +306,7 @@ def test_api_examples_document_activity_response_shape() -> None:
     assert "/api/v1/activity?q=p3xill" in examples
     assert "/api/v1/activity?limit=25" in examples
     assert "optional `limit` parameter defaults to `100`" in examples
+    assert "accepts values from `1` to `100`" in examples
     assert "limits only the returned `recent` payment" in examples
     assert '"totals": {' in examples
     assert '"accepted_awards": 2' in examples

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -304,6 +304,9 @@ def test_api_examples_document_activity_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 
     assert "/api/v1/activity?q=p3xill" in examples
+    assert "/api/v1/activity?limit=25" in examples
+    assert "optional `limit` parameter defaults to `100`" in examples
+    assert "limits only the returned `recent` payment" in examples
     assert '"totals": {' in examples
     assert '"accepted_awards": 2' in examples
     assert '"accepted_mrwk": "115"' in examples


### PR DESCRIPTION
Refs #406

Summary:
- Adds a bounded `limit` query parameter to `/api/v1/activity` and `/activity`.
- Uses it to cap the returned/rendered `recent` accepted-work rows.
- Keeps aggregate totals and contributor summaries based on the full matching accepted-work set.

Evidence:
- Live public read before the fix: `GET https://api.mrwk.ltclab.site/api/v1/activity?limit=1` returned `recent: 100`, the same as `limit=3` and `limit=200`.
- Live public read before the fix: `GET https://api.mrwk.ltclab.site/api/v1/activity?limit=1&q=github%3AGHX5T-SOL` returned all 9 matching recent rows.
- Open PR search for activity-limit work returned no matching PR, and bounty #66 had no active attempts at preflight.

Validation:
- `uv run --extra dev python -m pytest tests/test_activity.py tests/test_activity_routes.py -q` -> 4 passed
- `uv run --extra dev python -m pytest -q` -> 414 passed
- `uv run --extra dev ruff check app/activity.py app/serializers.py tests/test_activity.py` -> passed
- `uv run --extra dev ruff format --check app/activity.py app/serializers.py tests/test_activity.py` -> 3 files already formatted
- `uv run --extra dev python -m mypy app` -> success, no issues found in 30 source files
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean
- `git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found

No secrets, private data, wallet material, signatures, production mutation, price claims, exchange claims, liquidity claims, or off-ramp claims were used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `limit` query parameter to activity endpoints to control how many recent activities are returned (range: 1–100, default: 100).

* **Bug Fixes**
  * Endpoints now validate `limit` and reject out-of-range values; `recent` results are capped to the requested size while aggregate totals remain complete.

* **Tests**
  * Updated tests to cover pagination behavior and `limit` validation.

* **Documentation**
  * API docs clarified `q` filtering and `limit` behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->