### PR TITLE
Refs #406: Validate bounty issue URL identity

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -195,6 +195,24 @@ def _normalize_repo_name(repo: str) -> str:
     return _clean_required_text(repo, "repo", 200).lower()
 
 
+def _validate_issue_url_identity(issue_url: str, repo: str, issue_number: int) -> None:
+    parsed = urlparse(issue_url)
+    path_parts = [part for part in parsed.path.strip("/").split("/") if part]
+    if parsed.hostname is None or parsed.hostname.lower() != "github.com":
+        raise LedgerError("issue_url must match repo and issue_number")
+    if len(path_parts) != 4 or path_parts[2].lower() != "issues":
+        raise LedgerError("issue_url must match repo and issue_number")
+    url_repo = f"{path_parts[0]}/{path_parts[1]}".lower()
+    if url_repo != repo:
+        raise LedgerError("issue_url must match repo and issue_number")
+    try:
+        url_issue_number = int(path_parts[3])
+    except ValueError as exc:
+        raise LedgerError("issue_url must match repo and issue_number") from exc
+    if url_issue_number != issue_number:
+        raise LedgerError("issue_url must match repo and issue_number")
+
+
 def _clean_optional_account_id(value: str | None, field: str) -> str | None:
     if value is None:
         return None
@@ -462,6 +480,7 @@ def create_bounty(
     if existing_bounty is not None:
         raise LedgerError("bounty already exists for issue")
     clean_issue_url = validate_public_url(issue_url)
+    _validate_issue_url_identity(clean_issue_url, clean_repo, issue_number)
     clean_title = _clean_required_text(title, "title", 300)
     clean_acceptance = _clean_required_text(acceptance, "acceptance", 5_000)
     if get_balance(session, TREASURY_ACCOUNT) < reserved:

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -359,6 +359,43 @@ def test_create_bounty_rejects_oversized_issue_number(sqlite_url: str) -> None:
             )
 
 
+def test_create_bounty_rejects_issue_url_identity_mismatch(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    base_bounty = {
+        "repo": "Ramimbo/MergeWork",
+        "issue_number": 7,
+        "title": "GitHub identity check",
+        "reward_mrwk": "25",
+        "acceptance": "Bounty metadata should point at the same GitHub issue.",
+    }
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            **base_bounty,
+            issue_url="https://github.com/Ramimbo/MergeWork/issues/7#discussion",
+        )
+        assert bounty.repo == "ramimbo/mergework"
+
+        for issue_url, issue_number in (
+            ("https://github.com/other/repo/issues/12", 12),
+            ("https://github.com/ramimbo/mergework/issues/13", 12),
+            ("https://example.com/ramimbo/mergework/issues/12", 12),
+            ("https://github.com/ramimbo/mergework/pull/12", 12),
+        ):
+            with pytest.raises(LedgerError, match="issue_url must match repo and issue_number"):
+                create_bounty(
+                    session,
+                    **{
+                        **base_bounty,
+                        "issue_number": issue_number,
+                        "issue_url": issue_url,
+                    },
+                )
+
+
 def test_create_bounty_rejects_duplicate_repo_issue(sqlite_url: str) -> None:
     create_schema(sqlite_url)
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -307,6 +307,27 @@ def test_admin_bounty_api_rejects_duplicate_repo_issue(
     assert duplicate.json()["detail"] == "bounty already exists for issue"
 
 
+def test_admin_bounty_api_rejects_issue_url_identity_mismatch(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    payload = _admin_bounty_form_data()
+    payload["issue_url"] = "https://github.com/other/repo/issues/77"
+
+    response = client.post(
+        "/api/v1/bounties",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        json=payload,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "issue_url must match repo and issue_number"
+
+
 def test_admin_bounty_api_rejects_fractional_integer_fields(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
/claim #406

Refs #406

Summary:
- require bounty `issue_url` to point at the same GitHub `repo` and `issue_number` stored on the bounty
- reject mismatched hosts, repositories, issue numbers, and non-issue GitHub paths before inconsistent bounty metadata is published
- add service-level and admin API regressions for the new validation

Evidence:
Before this change, `create_bounty(repo="ramimbo/mergework", issue_number=12, issue_url="https://github.com/other/repo/issues/12", ...)` accepted a bounty whose stored repository / issue number disagreed with its source issue link. The admin runbook and public API examples describe bounties as linked to a GitHub issue, and webhook payout lookup resolves bounties by repository plus issue number, so the source URL should commit to the same issue identity.

Validation:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_ledger.py::test_create_bounty_rejects_issue_url_identity_mismatch tests/test_security.py::test_admin_bounty_api_rejects_issue_url_identity_mismatch -q` -> 2 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_ledger.py tests/test_security.py -q` -> 72 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 416 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev ruff check app/ledger/service.py tests/test_ledger.py tests/test_security.py` -> passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev ruff format --check app/ledger/service.py tests/test_ledger.py tests/test_security.py` -> 3 files already formatted
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m mypy app` -> success, no issues found in 30 source files
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean
- `git diff --no-ext-diff origin/main..HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found

Preflight:
- bounty #66 / issue #406 is open with 15 awards remaining
- active attempts endpoint returned no active attempts
- open PR and issue-comment search found no existing `create_bounty` / admin API issue URL identity fix

Out of scope:
- no payout, webhook, ledger proof, wallet, private key, token, price, liquidity, exchange, bridge, or off-ramp behavior changes
- no secrets or private data used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure issue URLs match the provided repository and issue number when creating bounties. Mismatched issue information will now be rejected to prevent inconsistencies.

* **Tests**
  * Added test coverage for issue URL validation in bounty creation workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->