### PR TITLE
Honor MCP bounty sort filter

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -14,7 +14,7 @@ MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
-        "description": "List MRWK bounties with optional status, q, and limit filters",
+        "description": "List MRWK bounties with optional status, q, sort, and limit filters",
     },
     {
         "name": "get_bounty",

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -7,6 +7,7 @@ from sqlalchemy import func, or_, select
 
 from app.accounts import normalized_account, normalized_wallet_address
 from app.bounty_attempts import list_bounty_attempts
+from app.bounty_sorting import sort_bounties
 from app.db import session_scope
 from app.ledger.service import format_mrwk, get_balance, register_wallet, submit_wallet_transfer
 from app.ledger_views import ledger_entry_to_dict
@@ -135,10 +136,9 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 if issue_number is not None:
                     text_filter = or_(text_filter, Bounty.issue_number == issue_number)
                 query = query.where(text_filter)
-            bounties = session.scalars(
-                query.order_by(Bounty.id.desc()).limit(list_limit_arg())
-            ).all()
-            return json.dumps([bounty_to_dict(bounty) for bounty in bounties])
+            bounty_payloads = [bounty_to_dict(bounty) for bounty in session.scalars(query).all()]
+            sorted_bounties = sort_bounties(bounty_payloads, optional_clean_str_arg("sort"))
+            return json.dumps(sorted_bounties[: list_limit_arg()])
         if name == "get_bounty":
             bounty = session.get(Bounty, positive_int_arg("id"))
             if bounty is None:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -173,7 +173,7 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
 
     tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()
     assert tools["result"]["tools"][0]["name"] == "list_bounties"
-    assert "status, q, and limit filters" in tools["result"]["tools"][0]["description"]
+    assert "status, q, sort, and limit filters" in tools["result"]["tools"][0]["description"]
     submit_tool = next(
         tool for tool in tools["result"]["tools"] if tool["name"] == "submit_work_proof"
     )
@@ -349,6 +349,16 @@ def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> No
             reward_mrwk="100",
             acceptance="Agents should find open MCP bounty workflow work.",
         )
+        high_pool_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=287,
+            issue_url="https://github.com/ramimbo/mergework/issues/287",
+            title="Available pool workflow filters",
+            reward_mrwk="25",
+            max_awards=8,
+            acceptance="Agents should find the largest available open bounty pool.",
+        )
         paid_bounty = create_bounty(
             session,
             repo="ramimbo/mergework",
@@ -394,7 +404,22 @@ def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> No
         },
     ).json()
     default_payload = json.loads(default_result["result"]["content"][0]["text"])
-    assert [item["id"] for item in default_payload] == [open_bounty.id]
+    assert [item["id"] for item in default_payload] == [high_pool_bounty.id, open_bounty.id]
+
+    available_sort_result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounties",
+                "arguments": {"status": "open", "sort": " Available ", "limit": 1},
+            },
+        },
+    ).json()
+    available_sort_payload = json.loads(available_sort_result["result"]["content"][0]["text"])
+    assert [item["id"] for item in available_sort_payload] == [high_pool_bounty.id]
 
     paid_result = client.post(
         "/mcp",
@@ -466,6 +491,7 @@ def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> No
         ({"q": 284}, 33),
         ({"limit": 0}, 34),
         ({"limit": 101}, 35),
+        ({"sort": "oldest"}, 36),
     ],
 )
 def test_mcp_list_bounties_rejects_invalid_filters(


### PR DESCRIPTION
Bounty #406

Summary:
- pass the MCP `list_bounties` `sort` argument through the shared bounty sorting contract
- sort before applying the MCP result limit so `available`, `reward`, and `awards` match the public API behavior
- update the MCP tool description and add regression coverage for valid and invalid sort values

Evidence:
- live API `GET /api/v1/bounties?status=open&sort=available&limit=3` returned open bounties ordered by available pool: #459, #406, #447
- live MCP `list_bounties` with `status=open`, `sort=available`, `limit=3` ignored `sort` and returned newest order: #459, #456, #447
- this is distinct from the existing whitespace-only bounty sort fix because it targets the MCP tool path and its advertised filters
- no private keys, cookies, tokens, wallet JSON, browser storage, OAuth state, signatures, private data, price claims, liquidity claims, exchange claims, or off-ramp claims are added

Verification:
- .venv/bin/python -m pytest tests/test_api_mcp.py::test_mcp_list_bounties_filters_status_query_and_limit tests/test_api_mcp.py::test_mcp_list_bounties_rejects_invalid_filters -q
- .venv/bin/python -m pytest tests/test_api_mcp.py tests/test_mcp_tools.py -q
- .venv/bin/python -m pytest -q
- .venv/bin/python -m ruff check app/mcp.py app/mcp_tools.py tests/test_api_mcp.py tests/test_mcp_tools.py
- .venv/bin/python -m ruff format --check app/mcp.py app/mcp_tools.py tests/test_api_mcp.py tests/test_mcp_tools.py
- .venv/bin/python -m mypy app
- .venv/bin/python scripts/docs_smoke.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `sort` filter to bounty listing functionality, complementing existing status, search, and limit filters.

* **Tests**
  * Enhanced test coverage to validate sorting options and filter combinations for bounty listings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->