### PR TITLE
Bounty #427: Add bounty page row limit controls

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -23,10 +23,14 @@ def public_bounties_context(
     status: str | None,
     q: str | None,
     sort: str | None = None,
+    limit: int | None = None,
 ) -> dict[str, Any]:
     selected_status = status.strip().lower() if status is not None else None
     query_text = q.strip() if q is not None else ""
     selected_sort = normalize_bounty_sort(sort)
+    limit_options: tuple[int, ...] = (10, 25, 50, 100, 200)
+    if limit is not None and limit not in limit_options:
+        limit_options = tuple(sorted((*limit_options, limit)))
     return {
         "bounties": bounties,
         "summary": bounty_list_summary(bounties),
@@ -34,6 +38,8 @@ def public_bounties_context(
         "query_text": query_text,
         "selected_sort": selected_sort,
         "sort_options": BOUNTY_SORT_LABELS,
+        "selected_limit": limit,
+        "limit_options": limit_options,
     }
 
 
@@ -58,7 +64,9 @@ def register_public_routes(
     *,
     db_url: str,
     templates: Jinja2Templates,
-    list_bounties_by_status: Callable[[str | None, str | None, str | None], list[dict[str, Any]]],
+    list_bounties_by_status: Callable[
+        [str | None, str | None, str | None, int | None], list[dict[str, Any]]
+    ],
     api_bounty: Callable[[int], dict[str, Any]],
     api_ledger: Callable[[], list[dict[str, Any]]],
     api_ledger_entry: Callable[[int], dict[str, Any]],
@@ -70,12 +78,13 @@ def register_public_routes(
         status: str | None = Query(None),
         q: str | None = Query(None),
         sort: str | None = Query(None),
+        limit: int | None = Query(None, ge=1, le=200),
     ) -> HTMLResponse:
-        bounties = list_bounties_by_status(status, q, sort)
+        bounties = list_bounties_by_status(status, q, sort, limit)
         return templates.TemplateResponse(
             request,
             "bounties.html",
-            public_bounties_context(bounties, status, q, sort),
+            public_bounties_context(bounties, status, q, sort, limit),
         )
 
     @app.get("/bounties/{bounty_id}", response_class=HTMLResponse)

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -12,14 +12,21 @@
     <option value="{{ sort_value }}"{% if selected_sort == sort_value %} selected{% endif %}>{{ sort_label }}</option>
     {% endfor %}
   </select>
+  <label for="bounty-limit">Rows</label>
+  <select id="bounty-limit" name="limit">
+    <option value=""{% if not selected_limit %} selected{% endif %}>All</option>
+    {% for limit_option in limit_options %}
+    <option value="{{ limit_option }}"{% if selected_limit == limit_option %} selected{% endif %}>{{ limit_option }}</option>
+    {% endfor %}
+  </select>
   <button type="submit">Search</button>
-  {% if query_text %}<a href="/bounties{% if selected_status or selected_sort != "newest" %}?{% if selected_status %}status={{ selected_status }}{% endif %}{% if selected_status and selected_sort != "newest" %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% endif %}">Clear search</a>{% endif %}
+  {% if query_text %}<a href="/bounties{% if selected_status or selected_sort != "newest" or selected_limit %}?{% if selected_status %}status={{ selected_status }}{% endif %}{% if selected_status and (selected_sort != "newest" or selected_limit) %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% if selected_sort != "newest" and selected_limit %}&{% endif %}{% if selected_limit %}limit={{ selected_limit }}{% endif %}{% endif %}">Clear search</a>{% endif %}
 </form>
 <nav aria-label="Bounty status filters">
-  <a href="/bounties{% if query_text or selected_sort != "newest" %}?{% if query_text %}q={{ query_text | urlencode }}{% endif %}{% if query_text and selected_sort != "newest" %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% endif %}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
-  <a href="/bounties?status=open{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
-  <a href="/bounties?status=paid{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
-  <a href="/bounties?status=closed{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
+  <a href="/bounties{% if query_text or selected_sort != "newest" or selected_limit %}?{% if query_text %}q={{ query_text | urlencode }}{% endif %}{% if query_text and (selected_sort != "newest" or selected_limit) %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% if selected_sort != "newest" and selected_limit %}&{% endif %}{% if selected_limit %}limit={{ selected_limit }}{% endif %}{% endif %}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
+  <a href="/bounties?status=open{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
+  <a href="/bounties?status=paid{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
+  <a href="/bounties?status=closed{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
 </nav>
 {% if query_text %}<p>Showing matches for “{{ query_text }}”.</p>{% endif %}
 <section class="bounty-list-summary" aria-label="Bounty list summary">

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -180,6 +180,12 @@ def test_bounties_page_honors_limit_filter(sqlite_url: str) -> None:
     invalid_limit = client.get("/bounties?limit=0")
     assert invalid_limit.status_code == 422
 
+    max_limit = client.get("/bounties?limit=200")
+    assert max_limit.status_code == 200
+
+    too_large_limit = client.get("/bounties?limit=201")
+    assert too_large_limit.status_code == 422
+
 
 def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) -> None:
     create_schema(sqlite_url)

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -126,6 +126,61 @@ def test_bounties_summary_api_matches_public_list_filters(sqlite_url: str) -> No
     assert invalid.json()["detail"] == "status must be one of: open, paid, closed"
 
 
+def test_bounties_page_honors_limit_filter(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=72,
+            issue_url="https://github.com/ramimbo/mergework/issues/72",
+            title="Old public bounty",
+            reward_mrwk="20",
+            acceptance="Old row should be hidden when the page limit is two.",
+        )
+        middle = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=73,
+            issue_url="https://github.com/ramimbo/mergework/issues/73",
+            title="Middle public bounty",
+            reward_mrwk="30",
+            acceptance="Middle row should stay visible with the newest row.",
+        )
+        newest = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=74,
+            issue_url="https://github.com/ramimbo/mergework/issues/74",
+            title="Newest public bounty",
+            reward_mrwk="40",
+            acceptance="Newest row should stay visible.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    limited_page = client.get("/bounties?limit=2")
+    assert limited_page.status_code == 200
+    assert limited_page.text.index(newest.title) < limited_page.text.index(middle.title)
+    assert "Old public bounty" not in limited_page.text
+    assert "<strong>2</strong>" in limited_page.text
+    assert '<option value="2" selected>2</option>' in limited_page.text
+    assert '<option value=""' in limited_page.text
+    assert 'href="/bounties?status=open&limit=2"' in limited_page.text
+
+    filtered_limited_page = client.get("/bounties?q=public&sort=reward&limit=2")
+    assert filtered_limited_page.status_code == 200
+    assert (
+        '<option value="reward" selected>Highest per-award reward</option>'
+        in filtered_limited_page.text
+    )
+    assert 'href="/bounties?sort=reward&limit=2">Clear search</a>' in filtered_limited_page.text
+
+    invalid_limit = client.get("/bounties?limit=0")
+    assert invalid_limit.status_code == 422
+
+
 def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -31,4 +31,6 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
             "available": "Most MRWK available",
             "awards": "Most award slots",
         },
+        "selected_limit": None,
+        "limit_options": (10, 25, 50, 100, 200),
     }


### PR DESCRIPTION
## Summary

Bounty #427 / Refs #427.

This adds row-count controls to the public `/bounties` page so contributors can cap the visible bounty list without switching to the JSON API.

- `/bounties?limit=N` now reuses the existing bounded bounty list helper and accepts `1..200`, matching the public API contract.
- The search form includes a Rows selector, preserves non-standard current values like `limit=2`, and keeps the selected limit when switching status filters or clearing search text.
- The summary cards now reflect the visible limited result set, matching how `/api/v1/bounties/summary?limit=N` behaves.

## Before / After

- Before: `/api/v1/bounties?limit=2` could cap rows, but `/bounties?limit=2` ignored the query and rendered every matching bounty.
- After: `/bounties?limit=2` renders only the two newest matching rows, preserves the row cap in filter links, and rejects invalid values such as `limit=0` with the route-level 422 validation.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest tests/test_bounty_pages.py::test_bounties_page_honors_limit_filter -q` -> 1 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest tests/test_bounty_pages.py -q` -> 8 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest tests/test_public_routes.py tests/test_bounty_pages.py -q` -> 9 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest -q` -> 415 passed
- `./.venv/bin/python -m ruff check app/public_routes.py tests/test_bounty_pages.py tests/test_public_routes.py` -> passed
- `./.venv/bin/python -m ruff format --check app/public_routes.py tests/test_bounty_pages.py tests/test_public_routes.py` -> 3 files already formatted
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m mypy app/public_routes.py` -> success
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

## Safety

No wallet material, private keys, cookies, OAuth state, browser storage, access tokens, signatures, private data, price claims, investment claims, liquidity claims, bridge promises, exchange claims, or fabricated payout claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Rows" selector to the bounties page to choose how many bounties display at once; the selected value is shown and preserved across filters, sorts, and the "Clear search" action.
* **Bug Fixes**
  * Enforced valid row limits (bounded to 1–200) with appropriate error responses for out-of-range values.
* **Tests**
  * Added/updated end-to-end tests to verify limit behavior, UI selection state, and preservation in links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->