### PR TITLE
Bounty #427: Add wallet row limit control

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
@@ -37,9 +37,16 @@ def public_bounties_context(
     }
 
 
-def wallets_page_context(session: Session) -> dict[str, Any]:
-    wallets = session.scalars(select(Wallet).order_by(Wallet.created_at.desc()).limit(100)).all()
-    return {"wallets": [wallet_to_dict(session, wallet) for wallet in wallets]}
+def wallets_page_context(session: Session, limit: int = 100) -> dict[str, Any]:
+    wallets = session.scalars(select(Wallet).order_by(Wallet.created_at.desc()).limit(limit)).all()
+    limit_options = [25, 50, 100, 200]
+    if limit not in limit_options:
+        limit_options = sorted([*limit_options, limit])
+    return {
+        "wallets": [wallet_to_dict(session, wallet) for wallet in wallets],
+        "selected_limit": limit,
+        "limit_options": limit_options,
+    }
 
 
 def wallet_page_context(session: Session, address: str) -> dict[str, Any]:
@@ -95,9 +102,12 @@ def register_public_routes(
         )
 
     @app.get("/wallets", response_class=HTMLResponse)
-    def wallets_page(request: Request) -> HTMLResponse:
+    def wallets_page(
+        request: Request,
+        limit: Annotated[int, Query(ge=1, le=200)] = 100,
+    ) -> HTMLResponse:
         with session_scope(db_url) as session:
-            context = wallets_page_context(session)
+            context = wallets_page_context(session, limit)
         return templates.TemplateResponse(request, "wallets.html", context)
 
     @app.get("/wallets/{address}", response_class=HTMLResponse)

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -17,6 +17,8 @@ from app.models import Wallet
 from app.path_params import proof_hash_from_path
 from app.serializers import bounty_list_summary, wallet_to_dict
 
+WALLET_LIMIT_OPTIONS = [25, 50, 100, 200]
+
 
 def public_bounties_context(
     bounties: list[dict[str, Any]],
@@ -39,7 +41,7 @@ def public_bounties_context(
 
 def wallets_page_context(session: Session, limit: int = 100) -> dict[str, Any]:
     wallets = session.scalars(select(Wallet).order_by(Wallet.created_at.desc()).limit(limit)).all()
-    limit_options = [25, 50, 100, 200]
+    limit_options = WALLET_LIMIT_OPTIONS.copy()
     if limit not in limit_options:
         limit_options = sorted([*limit_options, limit])
     return {

--- a/app/templates/wallets.html
+++ b/app/templates/wallets.html
@@ -29,6 +29,15 @@
     <h2>Registered wallets</h2>
     <p>Public addresses known to this ledger.</p>
   </div>
+  <form method="get" action="/wallets" aria-label="Registered wallet rows">
+    <label for="wallet-limit">Rows</label>
+    <select id="wallet-limit" name="limit">
+      {% for option in limit_options %}
+      <option value="{{ option }}"{% if selected_limit == option %} selected{% endif %}>{{ option }}</option>
+      {% endfor %}
+    </select>
+    <button type="submit">Apply</button>
+  </form>
   <table>
     <thead><tr><th>Address</th><th>Label</th><th>Balance</th><th>GitHub</th><th>Signed actions</th></tr></thead>
     <tbody>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -526,6 +526,8 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Generate wallet" in wallets
     assert "Private key stays in this browser" in wallets
     assert "If you lose the private key" in wallets
+    assert 'id="wallet-limit" name="limit"' in wallets
+    assert '<option value="100" selected>100</option>' in wallets
     assert (
         'id="wallet-private-key" name="private_key_hex" rows="5" readonly autocomplete="off"'
         in wallets
@@ -541,6 +543,24 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "both wallets are registered" in transfer
     assert "/static/wallet.js" in transfer
     assert "Link a wallet" in me
+
+
+def test_wallets_page_honors_limit_filter(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    for index in range(3):
+        _, public_hex, _ = _keypair()
+        _register_wallet(client, public_hex, f"Limit wallet {index}")
+
+    limited = client.get("/wallets?limit=1")
+    assert limited.status_code == 200
+    limited_html = limited.text
+    assert '<option value="1" selected>1</option>' in limited_html
+    assert limited_html.count("<tr>") == 2
+    assert sum(f"Limit wallet {index}" in limited_html for index in range(3)) == 1
+
+    rejected = client.get("/wallets?limit=0")
+    assert rejected.status_code == 422
 
 
 def test_me_page_shows_signed_in_github_claim_balance(sqlite_url: str, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Bounty #427 / Refs #427.

This adds a focused row-count control to the public `/wallets` page so contributors can cap the registered-wallet table without losing the wallet generation and registration workflow above it.

- `/wallets?limit=N` now accepts a bounded `limit=1..200` query parameter.
- The registered-wallet section includes a Rows selector with 25/50/100/200 presets and preserves custom valid values such as `limit=1`.
- Invalid row limits are rejected by FastAPI validation instead of silently falling back.

## Before / After

- Before: `/wallets` always queried and rendered the newest 100 registered wallets, with no page control for a smaller scan set.
- After: `/wallets?limit=1` renders a single registered-wallet row and marks that selected limit in the form; `/wallets?limit=0` returns 422.

## Evidence

Preflight for bounty #73 / issue #427 showed `status=open`, `awards_remaining=2`, and no active attempts.

Open PR search for wallet row-limit work only found the separate wallet summary-card PR #489, which does not add row controls.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest tests/test_wallet_api.py::test_wallets_page_honors_limit_filter -q` -> 1 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest tests/test_wallet_api.py -q` -> 33 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest tests/test_wallet_api.py tests/test_public_routes.py -q` -> 34 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest -q` -> 415 passed
- `./.venv/bin/python -m ruff check app/public_routes.py tests/test_wallet_api.py` -> passed
- `./.venv/bin/python -m ruff format --check app/public_routes.py tests/test_wallet_api.py` -> 2 files already formatted
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m mypy app/public_routes.py` -> success
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

## Safety

No wallet material, private keys, cookies, OAuth state, browser storage, access tokens, signatures, private data, price claims, investment claims, liquidity claims, bridge promises, exchange claims, or fabricated payout claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public wallets page now lets users choose how many wallets to display (default 100). Preset options: 25, 50, 100, 200; non-preset values within 1–200 are accepted and preserved when submitted.

* **Tests**
  * Added tests covering the wallets page limit: valid selections, enforcement of the 1–200 range, and correct row counts when limits are applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->