### PR TITLE
Refs #406: Detect duplicate PRs from ref-prefixed titles

### DIFF
--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -12,6 +12,10 @@ from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
 BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+#(\d+)", re.IGNORECASE)
+LEADING_BOUNTY_REF_RE = re.compile(
+    r"^/?(?:bounty|refs?|fixes|closes|claims?)\s+#\d+\s*[:-]?\s*",
+    re.IGNORECASE,
+)
 EVIDENCE_RE = re.compile(
     r"\b(pytest|ruff|mypy|validation|verified|test evidence|checks? passed)\b",
     re.IGNORECASE,
@@ -148,6 +152,9 @@ def _maintainer_activity_check(
 def _title_from_submission(text: str) -> str:
     for line in text.splitlines():
         clean = line.strip(" -:\t")
+        if not clean:
+            continue
+        clean = LEADING_BOUNTY_REF_RE.sub("", clean).strip(" -:\t")
         if not clean:
             continue
         if SUMMARY_RE.search(clean) and len(clean.split()) <= 4:

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -271,6 +271,42 @@ def test_submission_quality_gate_warns_for_similar_open_pr() -> None:
     ]
 
 
+def test_submission_quality_gate_matches_similar_pr_when_title_starts_with_ref() -> None:
+    result = evaluate_submission(
+        {
+            "submission_text": """
+            Refs #319: Add agent submission quality gate.
+
+            Validation: pytest passed.
+            """,
+            "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [
+                {
+                    "number": 12,
+                    "title": "Add agent submission quality gate",
+                    "body": "Refs #319",
+                    "state": "OPEN",
+                    "url": "https://github.com/ramimbo/mergework/pull/12",
+                }
+            ],
+        }
+    )
+
+    assert result["status"] == "warn"
+    assert {
+        "name": "similar_open_pr",
+        "status": "warn",
+        "message": "similar open PRs already reference this bounty",
+    } in result["checks"]
+    assert result["similar_open_prs"] == [
+        {
+            "number": 12,
+            "title": "Add agent submission quality gate",
+            "url": "https://github.com/ramimbo/mergework/pull/12",
+        }
+    ]
+
+
 def test_submission_quality_gate_warns_for_multiple_bounty_references() -> None:
     result = evaluate_submission(
         {


### PR DESCRIPTION
﻿Summary:
Refs #406 / Bounty #406.

This fixes a focused duplicate-detection gap in `scripts/submission_quality_gate.py`.

Before this change, `_title_from_submission()` skipped any candidate title line containing a bounty reference. That made common PR titles like `Refs #406: Add agent submission quality gate` produce no usable submission title, so the `similar_open_pr` check could incorrectly report `pass` even when an open PR with the same scope already referenced the bounty.

The parser now strips a leading `Bounty #...`, `Refs #...`, `Fixes #...`, `Closes #...`, or `/claim #...` prefix and keeps the remaining title text for similarity comparison. Lines that are only a bounty reference are still ignored.

Validation:
- `.\.venv\Scripts\python.exe -m pytest tests/test_submission_quality_gate.py::test_submission_quality_gate_matches_similar_pr_when_title_starts_with_ref -q` -> 1 passed
- `.\.venv\Scripts\python.exe -m pytest tests/test_submission_quality_gate.py::test_submission_quality_gate_warns_for_similar_open_pr -q` -> 1 passed
- `.\.venv\Scripts\python.exe -m pytest tests/test_submission_quality_gate.py -q` -> 24 passed
- `.\.venv\Scripts\python.exe -m pytest -q` -> 415 passed
- `.\.venv\Scripts\python.exe -m ruff check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` -> passed
- `.\.venv\Scripts\python.exe -m ruff format --check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` -> 2 files already formatted
- `.\.venv\Scripts\python.exe -m mypy scripts/submission_quality_gate.py` -> success
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

Safety:
No secrets, wallet material, private keys, tokens, signatures, private data, production mutation, price/exchange/liquidity claim, or off-ramp claim were used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced submission quality checks to properly handle pull request titles that begin with bounty and reference-style prefixes (e.g., `Refs `#319`:`), improving detection of similar open pull requests.

* **Tests**
  * Added test coverage for pull request titles starting with bounty reference prefixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->