### PR TITLE
Refs #406: Search bounties by issue URL

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -114,6 +114,7 @@ def register_bounty_api_routes(
                     issue_number = issue_number_search_value(normalized_query)
                     text_filter = or_(
                         func.lower(Bounty.repo).like(like_query, escape="\\"),
+                        func.lower(Bounty.issue_url).like(like_query, escape="\\"),
                         func.lower(Bounty.title).like(like_query, escape="\\"),
                         func.lower(Bounty.acceptance).like(like_query, escape="\\"),
                     )

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -129,6 +129,7 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 issue_number = issue_number_search_value(query_text)
                 text_filter = or_(
                     func.lower(Bounty.repo).like(like_query, escape="\\"),
+                    func.lower(Bounty.issue_url).like(like_query, escape="\\"),
                     func.lower(Bounty.title).like(like_query, escape="\\"),
                     func.lower(Bounty.acceptance).like(like_query, escape="\\"),
                 )

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -396,6 +396,23 @@ def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> No
     default_payload = json.loads(default_result["result"]["content"][0]["text"])
     assert [item["id"] for item in default_payload] == [open_bounty.id]
 
+    issue_url_result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounties",
+                "arguments": {
+                    "q": "https://github.com/ramimbo/mergework/issues/284",
+                },
+            },
+        },
+    ).json()
+    issue_url_payload = json.loads(issue_url_result["result"]["content"][0]["text"])
+    assert [item["id"] for item in issue_url_payload] == [open_bounty.id]
+
     paid_result = client.post(
         "/mcp",
         json={

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -172,6 +172,21 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     assert issue_search.status_code == 200
     assert [row["issue_number"] for row in issue_search.json()] == [65]
 
+    issue_url_search = client.get(
+        "/api/v1/bounties",
+        params={"q": "https://github.com/ramimbo/mergework/issues/65"},
+    )
+    assert issue_url_search.status_code == 200
+    assert [row["issue_number"] for row in issue_url_search.json()] == [65]
+
+    issue_url_page = client.get(
+        "/bounties",
+        params={"q": "https://github.com/ramimbo/mergework/issues/65"},
+    )
+    assert issue_url_page.status_code == 200
+    assert "Internal admin cleanup" in issue_url_page.text
+    assert "Improve public bounty discovery" not in issue_url_page.text
+
     oversized_issue_search = client.get("/api/v1/bounties", params={"q": "9" * 40})
     assert oversized_issue_search.status_code == 200
     assert oversized_issue_search.json() == []


### PR DESCRIPTION
Summary:
- include stored issue_url values in public bounty q search
- keep matching consistent for API, /bounties, and MCP list_bounties
- add regressions for pasted GitHub issue URLs

Evidence:
- live GET https://api.mrwk.ltclab.site/api/v1/bounties?q=https%3A%2F%2Fgithub.com%2Framimbo%2Fmergework%2Fissues%2F406 returned [] before this fix even though bounty #66 stores that source URL
- bounty #66 is open with 15 awards remaining and no active attempts

Validation:
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_bounty_pages.py::test_bounties_page_and_api_search_by_text_and_issue_number -q: 1 passed
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_api_mcp.py::test_mcp_list_bounties_filters_status_query_and_limit -q: 1 passed
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_bounty_pages.py tests/test_bounty_api_routes.py tests/test_api_mcp.py tests/test_mcp_tools.py -q: 95 passed
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q: 414 passed
- uv run --extra dev ruff check app/bounty_api.py app/mcp_tools.py tests/test_bounty_pages.py tests/test_api_mcp.py: passed
- uv run --extra dev ruff format --check app/bounty_api.py app/mcp_tools.py tests/test_bounty_pages.py tests/test_api_mcp.py: 4 files already formatted
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m mypy app/bounty_api.py app/mcp_tools.py: success
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py: docs smoke ok
- git diff --check: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bounty search functionality has been enhanced to support GitHub issue URLs as a searchable field. Users can now discover bounties by searching with GitHub issue URLs in addition to traditional search criteria such as repository names, issue numbers, titles, and acceptance status. This feature is available across all bounty search interfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/506?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->