### PR TITLE
Refs #406: Canonicalize wallet unicode memos

### DIFF
--- a/app/static/wallet.js
+++ b/app/static/wallet.js
@@ -16,6 +16,12 @@ function hexToBytes(hex) {
   return bytes;
 }
 
+function asciiJson(value) {
+  return JSON.stringify(value).replace(/[\u0080-\uFFFF]/g, (char) => {
+    return `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`;
+  });
+}
+
 function stableJson(value) {
   if (Array.isArray(value)) {
     return `[${value.map(stableJson).join(",")}]`;
@@ -23,10 +29,10 @@ function stableJson(value) {
   if (value && typeof value === "object") {
     return `{${Object.keys(value)
       .sort()
-      .map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+      .map((key) => `${asciiJson(key)}:${stableJson(value[key])}`)
       .join(",")}}`;
   }
-  return JSON.stringify(value);
+  return asciiJson(value);
 }
 
 async function sha256Hex(bytes) {

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import shutil
+import subprocess
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
@@ -616,6 +619,42 @@ def test_github_wallet_actions_clear_private_key_after_submit_attempt() -> None:
         idx_clear_private_key,
     }
     assert idx_set_result < idx_refresh_nonce < idx_set_error < idx_finally < idx_clear_private_key
+
+
+def test_wallet_js_canonicalizes_unicode_like_server() -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required to execute wallet.js canonicalization")
+    wallet_js = Path("app/static/wallet.js").read_text(encoding="utf-8")
+    payload = {
+        "type": "mrwk_transfer_v1",
+        "from_address": "mrwk1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "to_address": "mrwk1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "amount_microunits": 1_500_000,
+        "nonce": 7,
+        "memo": "café 😀",
+    }
+    node_script = f"""
+const vm = require("vm");
+const context = {{
+  console,
+  TextEncoder,
+  Uint8Array,
+  crypto: {{subtle: {{}}}},
+  document: {{querySelector: () => null, getElementById: () => null}},
+}};
+vm.createContext(context);
+vm.runInContext({json.dumps(wallet_js)}, context);
+console.log(vm.runInContext(`stableJson({json.dumps(payload)})`, context));
+"""
+    result = subprocess.run(
+        [node, "-e", node_script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == canonical_wallet_json(payload)
 
 
 def test_reject_self_transfer(sqlite_url: str) -> None:


### PR DESCRIPTION
Summary:
- make browser wallet JSON canonicalization ASCII-escape non-ASCII strings like the server
- keep wallet signing stable for Unicode transfer memos and object keys
- add a regression that executes wallet.js in Node and compares it to canonical_wallet_json

Evidence:
- before this fix, wallet.js stableJson({memo: "café", type: "mrwk_transfer_v1"}) emitted {"memo":"café","type":"mrwk_transfer_v1"}
- the server verifies the same payload as {"memo":"caf\u00e9","type":"mrwk_transfer_v1"}
- that mismatch can make a valid browser-signed transfer with a non-ASCII memo fail as invalid signature
- open PR search for wallet.js stableJson unicode memo ensure_ascii transfer #406 returned no matching implementation PR
- bounty #66 is open with 15 awards remaining and no active attempts

Validation:
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_wallet_api.py::test_wallet_js_canonicalizes_unicode_like_server -q: 1 passed
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_wallet_api.py tests/test_wallets.py -q: 44 passed
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q: 415 passed
- uv run --extra dev ruff check .: passed
- uv run --extra dev ruff format --check .: 79 files already formatted
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m mypy app: success
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py: docs smoke ok
- git diff --check: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Unicode character handling in wallet JSON serialization for deterministic payload signing and consistent operation results.

* **Tests**
  * Added comprehensive test to validate Unicode canonicalization consistency between client-side and server-side wallet implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->