### PR TITLE
Bounty #427: Clear transfer private key after submit

### DIFF
--- a/app/static/wallet.js
+++ b/app/static/wallet.js
@@ -211,6 +211,8 @@ function setupTransfer() {
       await getNextNonce(fromAddress, "[data-transfer-nonce-status]");
     } catch (error) {
       setText("[data-transfer-result]", error.message);
+    } finally {
+      clearPrivateKeyField(form);
     }
   });
 }

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -618,6 +618,19 @@ def test_github_wallet_actions_clear_private_key_after_submit_attempt() -> None:
     assert idx_set_result < idx_refresh_nonce < idx_set_error < idx_finally < idx_clear_private_key
 
 
+def test_transfer_action_clears_private_key_after_submit_attempt() -> None:
+    wallet_js = Path("app/static/wallet.js").read_text(encoding="utf-8")
+    transfer_start = wallet_js.find("function setupTransfer()")
+    github_actions_start = wallet_js.find("function setupGithubActions()")
+    transfer_block = wallet_js[transfer_start:github_actions_start]
+
+    assert 'form[data-action="submit-transfer"]' in transfer_block
+    assert 'setText("[data-transfer-result]", transfer);' in transfer_block
+    assert 'setText("[data-transfer-result]", error.message);' in transfer_block
+    assert "} finally {" in transfer_block
+    assert "clearPrivateKeyField(form);" in transfer_block
+
+
 def test_reject_self_transfer(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Summary:
- clear the transfer form private key field after every submit attempt
- match the existing cleanup behavior already used by the GitHub link and claim wallet forms
- add a focused wallet.js regression so the transfer flow keeps this behavior

Evidence:
- /transfer asks users to paste a private key for signed transfers, but setupTransfer left the key in the field after success or failure
- setupGithubActions already clears private keys in a finally block after link/claim submit attempts
- open PR search for transfer private key clear wallet UX #427 found only unrelated docs PR #440, not this behavior change
- bounty #73 is open with 2 awards remaining and no active attempts
- no visual layout change, so screenshot is not applicable; this is submit-state behavior covered by tests

Validation:
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_wallet_api.py::test_transfer_action_clears_private_key_after_submit_attempt tests/test_wallet_api.py::test_github_wallet_actions_clear_private_key_after_submit_attempt -q: 2 passed
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_wallet_api.py tests/test_wallets.py -q: 44 passed
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q: 415 passed
- uv run --extra dev ruff check .: passed
- uv run --extra dev ruff format --check .: 79 files already formatted
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m mypy app: success
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py: docs smoke ok
- git diff --check: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Private key field is now automatically cleared after transfer submission completes, ensuring sensitive data is removed from the form following both successful and failed attempts.

* **Tests**
  * Added test case to verify private key field clearing behavior in the transfer submission flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->