### PR TITLE
Refs #406: Canonicalize hub Host headers

### DIFF
--- a/app/hub.py
+++ b/app/hub.py
@@ -26,7 +26,15 @@ LTC_LAB_PROJECTS = (
 
 
 def host_without_port(host_header: str) -> str:
-    return host_header.split(":", 1)[0].lower()
+    host = host_header.strip().lower()
+    if host.startswith("["):
+        end = host.find("]")
+        if end != -1:
+            return host[1:end]
+        return host
+    if host.count(":") == 1:
+        host = host.split(":", 1)[0]
+    return host.rstrip(".")
 
 
 def is_ltc_lab_host(host_header: str) -> bool:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1517,9 +1517,12 @@ def test_host_specific_homepages(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
     lab = client.get("/", headers={"host": "ltclab.site"}).text
+    lab_trailing_dot = client.get("/", headers={"host": "ltclab.site.:443"}).text
     mrwk = client.get("/", headers={"host": "mrwk.ltclab.site"}).text
 
     assert "LTC Lab" in lab
+    assert "LTC Lab" in lab_trailing_dot
+    assert "Open-source work, recorded as MRWK" not in lab_trailing_dot
     assert "MRWK from LTC Lab" in lab
     assert "https://api.mrwk.ltclab.site" in lab
     assert "https://mcp.mrwk.ltclab.site" in lab

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -10,12 +10,17 @@ from app.hub import (
 
 def test_host_without_port_normalizes_host_headers() -> None:
     assert host_without_port("LtcLab.Site:443") == "ltclab.site"
+    assert host_without_port("LtcLab.Site.:443") == "ltclab.site"
     assert host_without_port("www.ltclab.site") == "www.ltclab.site"
+    assert host_without_port("www.ltclab.site.") == "www.ltclab.site"
+    assert host_without_port("[::1]:8000") == "::1"
+    assert host_without_port("::1") == "::1"
     assert host_without_port("") == ""
 
 
 def test_is_ltc_lab_host_matches_root_domain_only() -> None:
     assert is_ltc_lab_host("ltclab.site")
+    assert is_ltc_lab_host("ltclab.site.:443")
     assert is_ltc_lab_host("www.ltclab.site:8443")
     assert not is_ltc_lab_host("mrwk.ltclab.site")
     assert not is_ltc_lab_host("api.mrwk.ltclab.site")


### PR DESCRIPTION
## Summary
- Treat trailing-dot Host headers as the same canonical hostname before selecting the LTC Lab homepage.
- Preserve bracketed IPv6 hosts in `host_without_port()` instead of splitting at the first colon.
- Add focused hub helper and homepage regressions.

## Evidence
Before this change, `host_without_port("ltclab.site.:443")` returned `ltclab.site.`, so `/` with `Host: ltclab.site.:443` rendered the MergeWork homepage instead of the LTC Lab project hub. `host_without_port("[::1]:8000")` also returned `[` because it split on the first colon.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_hub.py tests/test_api_mcp.py::test_host_specific_homepages -q` -> 5 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_hub.py tests/test_api_mcp.py tests/test_status.py -q` -> 82 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 414 passed
- `uv run --extra dev ruff check app/hub.py tests/test_hub.py tests/test_api_mcp.py` -> passed
- `uv run --extra dev ruff format --check app/hub.py tests/test_hub.py tests/test_api_mcp.py` -> 3 files already formatted
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m mypy app/hub.py app/main.py` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean
- `uv run --extra dev python scripts/submission_quality_gate.py --text-file /dev/stdin --repo ramimbo/mergework --format text` -> PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of host header variations, including domains with trailing dots, explicit port numbers, and IPv6 addresses, for enhanced system reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->