### PR TITLE
fix: remove check_suite/push/label from webhook event routing

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -280,7 +280,7 @@ def handle_github_webhook(
     if not isinstance(payload, dict):
         _record_event(database_url, delivery_id, event_type, hashed, "invalid_payload")
         return {"status": "invalid_payload"}
-    if event_type in {"issues", "pull_request", "label", "check_suite", "push"}:
+    if event_type in {"issues", "pull_request"}:
         return _handle_accepted_issue_label(
             database_url, payload, event_type, delivery_id, hashed, accepted_labelers
         )

--- a/tests/test_webhook_event_routing.py
+++ b/tests/test_webhook_event_routing.py
@@ -5,6 +5,7 @@ routed, which caused unhandled-key errors in the label handler.
 This test ensures those events are recorded as 'ignored' while the two
 supported event types continue to work.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -15,7 +16,6 @@ from app.db import create_schema, session_scope
 from app.ledger.service import create_bounty, ensure_genesis, get_balance
 from app.models import WebhookEvent
 from app.webhooks.github import handle_github_webhook
-
 
 SECRET = "test-secret"
 
@@ -72,6 +72,26 @@ def test_push_event_is_ignored(sqlite_url: str) -> None:
     assert result == {"status": "ignored"}
     with session_scope(sqlite_url) as session:
         event = session.get(WebhookEvent, "delivery-push")
+        assert event is not None
+        assert event.processed_status == "ignored"
+
+
+def test_label_event_is_ignored(sqlite_url: str) -> None:
+    """label events must NOT be routed to the label handler."""
+    create_schema(sqlite_url)
+    payload = {
+        "action": "created",
+        "label": {"name": "bug"},
+        "repository": {"full_name": "ramimbo/mergework"},
+        "sender": {"login": "maintainer"},
+    }
+    headers, body = _wrap("label", payload, "delivery-label")
+
+    result = handle_github_webhook(sqlite_url, headers, body, SECRET)
+
+    assert result == {"status": "ignored"}
+    with session_scope(sqlite_url) as session:
+        event = session.get(WebhookEvent, "delivery-label")
         assert event is not None
         assert event.processed_status == "ignored"
 

--- a/tests/test_webhook_event_routing.py
+++ b/tests/test_webhook_event_routing.py
@@ -1,0 +1,150 @@
+"""Regression test for PR #510: only 'issues' and 'pull_request' events route
+to the label handler.  Previously 'check_suite', 'push', and 'label' were also
+routed, which caused unhandled-key errors in the label handler.
+
+This test ensures those events are recorded as 'ignored' while the two
+supported event types continue to work.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+from app.db import create_schema, session_scope
+from app.ledger.service import create_bounty, ensure_genesis, get_balance
+from app.models import WebhookEvent
+from app.webhooks.github import handle_github_webhook
+
+
+SECRET = "test-secret"
+
+
+def _sig(body: bytes) -> str:
+    return f"sha256={hmac.new(SECRET.encode(), body, hashlib.sha256).hexdigest()}"
+
+
+def _wrap(event_type: str, payload: dict, delivery_id: str) -> tuple[dict, bytes]:
+    body = json.dumps(payload, separators=(",", ":")).encode()
+    headers = {
+        "X-GitHub-Delivery": delivery_id,
+        "X-GitHub-Event": event_type,
+        "X-Hub-Signature-256": _sig(body),
+    }
+    return headers, body
+
+
+# -- events that must be ignored (PR #510 regression) -----------------------
+
+
+def test_check_suite_event_is_ignored(sqlite_url: str) -> None:
+    """check_suite must NOT be routed to the label handler."""
+    create_schema(sqlite_url)
+    payload = {
+        "action": "completed",
+        "check_suite": {"id": 1},
+        "repository": {"full_name": "ramimbo/mergework"},
+        "sender": {"login": "bot"},
+    }
+    headers, body = _wrap("check_suite", payload, "delivery-check-suite")
+
+    result = handle_github_webhook(sqlite_url, headers, body, SECRET)
+
+    assert result == {"status": "ignored"}
+    with session_scope(sqlite_url) as session:
+        event = session.get(WebhookEvent, "delivery-check-suite")
+        assert event is not None
+        assert event.processed_status == "ignored"
+
+
+def test_push_event_is_ignored(sqlite_url: str) -> None:
+    """push must NOT be routed to the label handler."""
+    create_schema(sqlite_url)
+    payload = {
+        "ref": "refs/heads/main",
+        "repository": {"full_name": "ramimbo/mergework"},
+        "sender": {"login": "dev"},
+    }
+    headers, body = _wrap("push", payload, "delivery-push")
+
+    result = handle_github_webhook(sqlite_url, headers, body, SECRET)
+
+    assert result == {"status": "ignored"}
+    with session_scope(sqlite_url) as session:
+        event = session.get(WebhookEvent, "delivery-push")
+        assert event is not None
+        assert event.processed_status == "ignored"
+
+
+# -- events that must still route to the label handler ----------------------
+
+
+def test_issues_event_routes_to_label_handler(sqlite_url: str) -> None:
+    """'issues' events must still be processed by the label handler."""
+    create_schema(sqlite_url)
+    payload = {
+        "action": "labeled",
+        "label": {"name": "mrwk:accepted"},
+        "issue": {
+            "number": 100,
+            "html_url": "https://github.com/ramimbo/mergework/issues/100",
+            "user": {"login": "contributor"},
+        },
+        "repository": {"full_name": "ramimbo/mergework"},
+        "sender": {"login": "maintainer"},
+    }
+    headers, body = _wrap("issues", payload, "delivery-issues-route")
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=100,
+            issue_url="https://github.com/ramimbo/mergework/issues/100",
+            title="Routing test bounty",
+            reward_mrwk="50",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+
+    result = handle_github_webhook(sqlite_url, headers, body, SECRET)
+
+    assert result["status"] == "paid"
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:contributor") == 50_000_000
+
+
+def test_pull_request_event_routes_to_label_handler(sqlite_url: str) -> None:
+    """'pull_request' events must still be processed by the label handler."""
+    create_schema(sqlite_url)
+    payload = {
+        "action": "labeled",
+        "label": {"name": "mrwk:accepted"},
+        "pull_request": {
+            "number": 10,
+            "html_url": "https://github.com/ramimbo/mergework/pull/10",
+            "body": "Closes #101",
+            "user": {"login": "contributor"},
+        },
+        "repository": {"full_name": "ramimbo/mergework"},
+        "sender": {"login": "maintainer"},
+    }
+    headers, body = _wrap("pull_request", payload, "delivery-pr-route")
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=101,
+            issue_url="https://github.com/ramimbo/mergework/issues/101",
+            title="PR routing test bounty",
+            reward_mrwk="75",
+            acceptance="Accepted PR closes the bounty.",
+        )
+
+    result = handle_github_webhook(sqlite_url, headers, body, SECRET)
+
+    assert result["status"] == "paid"
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:contributor") == 75_000_000


### PR DESCRIPTION
## Summary

Fixes webhook event routing for `check_suite`, `push`, and `label` GitHub events.

## Bug Description

Events `check_suite`, `push`, and `label` were being routed to `_handle_accepted_issue_label()`, which expects `issues` or `pull_request` payload structures. These event types have different payload schemas:

- `check_suite` events have: `action`, `check_suite`, `repository`, `sender`
- `push` events have: `ref`, `repository`, `pusher`, `commits`
- `label` events are for label CRUD (create/edit/delete on a repo), NOT for labeling issues/PRs (those fire as `issues` events with `action=labeled`)

Since these payloads lack `issue` and `pull_request` top-level fields, the handler always returned `missing_issue` status, recording a misleading webhook event.

## Fix

Removed `check_suite`, `push`, and `label` from the event type routing. Only `issues` and `pull_request` events are now routed to the label handler. Other event types are properly ignored.

```python
# Before
if event_type in {"issues", "pull_request", "label", "check_suite", "push"}:

# After
if event_type in {"issues", "pull_request"}:
```

## Testing

- Verified that `check_suite` and `push` events are now recorded as `ignored`
- Verified that `issues` and `pull_request` events still route correctly to the label handler
- Existing tests should continue to pass since the removed event types were always returning `missing_issue` anyway

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined GitHub webhook routing: only issues and pull request events are processed; label, check_suite, and push events are now recorded as ignored and return an ignored status.
* **Tests**
  * Added regression tests confirming ignored events return ignored and issues/pull request events continue to route and update balances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->