### PR TITLE
Bounty #427: Add ledger entry type filters

### DIFF
--- a/app/ledger_views.py
+++ b/app/ledger_views.py
@@ -9,6 +9,27 @@ from sqlalchemy.orm import Session
 from app.models import LedgerEntry, Proof
 from app.serializers import ledger_to_dict
 
+LEDGER_TYPE_LABELS = {
+    "bounty_reserve": "Bounty Reserve",
+    "bounty_payment": "Bounty Payment",
+    "bounty_release": "Bounty Release",
+    "github_claim": "GitHub claim",
+    "wallet_transfer": "Wallet transfer",
+    "genesis": "Genesis",
+}
+LEDGER_TYPE_FILTER_ERROR = "type must be one of: all, " + ", ".join(LEDGER_TYPE_LABELS.keys())
+
+
+def normalize_ledger_type_filter(entry_type: str | None) -> str | None:
+    if entry_type is None:
+        return None
+    normalized = entry_type.strip().lower()
+    if not normalized or normalized == "all":
+        return None
+    if normalized not in LEDGER_TYPE_LABELS:
+        raise ValueError(LEDGER_TYPE_FILTER_ERROR)
+    return normalized
+
 
 def proof_hashes_by_sequence(session: Session, sequences: Sequence[int]) -> dict[int, str]:
     if not sequences:
@@ -26,10 +47,14 @@ def ledger_entries_to_dicts(
     return [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
 
 
-def recent_ledger_entries(session: Session, limit: int) -> list[dict[str, Any]]:
-    entries = session.scalars(
-        select(LedgerEntry).order_by(LedgerEntry.sequence.desc()).limit(limit)
-    ).all()
+def recent_ledger_entries(
+    session: Session, limit: int, entry_type: str | None = None
+) -> list[dict[str, Any]]:
+    normalized_type = normalize_ledger_type_filter(entry_type)
+    query = select(LedgerEntry)
+    if normalized_type is not None:
+        query = query.where(LedgerEntry.entry_type == normalized_type)
+    entries = session.scalars(query.order_by(LedgerEntry.sequence.desc()).limit(limit)).all()
     return ledger_entries_to_dicts(session, entries)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -22,7 +22,12 @@ from app.config import get_settings
 from app.db import create_schema, session_scope
 from app.hub import is_ltc_lab_host, ltc_lab_context, mergework_hub_context
 from app.ledger.service import ensure_genesis, public_url_or_none
-from app.ledger_views import ledger_entry_to_dict, recent_ledger_entries
+from app.ledger_views import (
+    LEDGER_TYPE_FILTER_ERROR,
+    LEDGER_TYPE_LABELS,
+    ledger_entry_to_dict,
+    recent_ledger_entries,
+)
 from app.mcp import handle_mcp_request
 from app.mcp_tools import call_mcp_tool
 from app.me import me_page_context
@@ -290,9 +295,15 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     )
 
     @app.get("/api/v1/ledger")
-    def api_ledger(limit: Annotated[int, Query(ge=1, le=200)] = 50) -> list[dict[str, Any]]:
+    def api_ledger(
+        limit: Annotated[int, Query(ge=1, le=200)] = 50,
+        entry_type: Annotated[str | None, Query(alias="type")] = None,
+    ) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
-            return recent_ledger_entries(session, limit)
+            try:
+                return recent_ledger_entries(session, limit, entry_type)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=LEDGER_TYPE_FILTER_ERROR) from exc
 
     @app.get("/api/v1/ledger/{sequence}")
     def api_ledger_entry(sequence: int) -> dict[str, Any]:
@@ -360,6 +371,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         api_ledger=api_ledger,
         api_ledger_entry=api_ledger_entry,
         api_proof=api_proof,
+        ledger_type_options=LEDGER_TYPE_LABELS,
     )
 
     @app.get("/me", response_class=HTMLResponse)

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -60,9 +60,10 @@ def register_public_routes(
     templates: Jinja2Templates,
     list_bounties_by_status: Callable[[str | None, str | None, str | None], list[dict[str, Any]]],
     api_bounty: Callable[[int], dict[str, Any]],
-    api_ledger: Callable[[], list[dict[str, Any]]],
+    api_ledger: Callable[[int, str | None], list[dict[str, Any]]],
     api_ledger_entry: Callable[[int], dict[str, Any]],
     api_proof: Callable[[str], dict[str, Any]],
+    ledger_type_options: dict[str, str],
 ) -> None:
     @app.get("/bounties", response_class=HTMLResponse)
     def bounties_page(
@@ -85,8 +86,19 @@ def register_public_routes(
         )
 
     @app.get("/ledger", response_class=HTMLResponse)
-    def ledger_page(request: Request) -> HTMLResponse:
-        return templates.TemplateResponse(request, "ledger.html", {"entries": api_ledger()})
+    def ledger_page(
+        request: Request,
+        entry_type: str | None = Query(None, alias="type"),
+    ) -> HTMLResponse:
+        return templates.TemplateResponse(
+            request,
+            "ledger.html",
+            {
+                "entries": api_ledger(50, entry_type),
+                "selected_type": entry_type.strip().lower() if entry_type else None,
+                "type_options": ledger_type_options,
+            },
+        )
 
     @app.get("/ledger/{sequence}", response_class=HTMLResponse)
     def ledger_entry_page(request: Request, sequence: int) -> HTMLResponse:

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -35,6 +35,21 @@ header {
 }
 a { color: var(--accent); text-decoration: none; }
 nav { display: flex; gap: 16px; flex-wrap: wrap; }
+.filter-nav {
+  gap: 8px;
+  margin: 22px 0;
+}
+.filter-nav a {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--panel);
+  padding: 7px 11px;
+}
+.filter-nav a[aria-current="page"] {
+  border-color: color-mix(in srgb, var(--accent) 60%, var(--line));
+  color: var(--text);
+  font-weight: 700;
+}
 main { max-width: 980px; margin: 0 auto; padding: 48px 20px; }
 .brand { color: var(--text); font-weight: 800; }
 .brand span { color: var(--accent); }

--- a/app/templates/ledger.html
+++ b/app/templates/ledger.html
@@ -3,14 +3,16 @@
 {% block content %}
 <h1>Ledger</h1>
 <p class="lead">Every MRWK reserve and payout is recorded as a hash-linked ledger entry.</p>
-{% set type_labels = {
-  "bounty_reserve": "Bounty Reserve",
-  "bounty_payment": "Bounty Payment",
-  "bounty_release": "Bounty Release",
-  "github_claim": "GitHub claim",
-  "wallet_transfer": "Wallet transfer",
-  "genesis": "Genesis"
-} %}
+{% set type_labels = type_options %}
+<nav class="filter-nav" aria-label="Ledger type filters">
+  <a href="/ledger"{% if not selected_type or selected_type == "all" %} aria-current="page"{% endif %}>All</a>
+  {% for type_value, type_label in type_options.items() %}
+  <a href="/ledger?type={{ type_value }}"{% if selected_type == type_value %} aria-current="page"{% endif %}>{{ type_label }}</a>
+  {% endfor %}
+</nav>
+{% if selected_type and selected_type != "all" %}
+<p>Showing ledger entries for {{ type_options[selected_type] }}.</p>
+{% endif %}
 <div class="ledger-list">
   {% for entry in entries %}
   {% set type_class = entry.type | replace("_", "-") %}

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -443,3 +443,59 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert missing_proof.status_code == 404
     assert client.get("/api/v1/proofs/not-a-proof-hash").status_code == 400
     assert client.get("/proofs/not-a-proof-hash").status_code == 400
+
+
+def test_ledger_page_and_api_filter_by_entry_type(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=427,
+            issue_url="https://github.com/ramimbo/mergework/issues/427",
+            title="Filter ledger by entry type",
+            reward_mrwk="125",
+            max_awards=2,
+            acceptance="Ledger pages should let contributors scan one entry type.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:contributor",
+            submission_url="https://github.com/ramimbo/mergework/pull/511",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        close_bounty(
+            session,
+            bounty_id=bounty.id,
+            closed_by="maintainer",
+            reference="https://github.com/ramimbo/mergework/issues/427",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    payment_rows = client.get("/api/v1/ledger?type=bounty_payment")
+    assert payment_rows.status_code == 200
+    assert [row["type"] for row in payment_rows.json()] == ["bounty_payment"]
+    assert payment_rows.json()[0]["proof_hash"] == proof.hash
+
+    invalid_type = client.get("/api/v1/ledger?type=bogus")
+    assert invalid_type.status_code == 400
+    assert invalid_type.json()["detail"] == (
+        "type must be one of: all, bounty_reserve, bounty_payment, bounty_release, "
+        "github_claim, wallet_transfer, genesis"
+    )
+
+    page = client.get("/ledger?type=bounty_payment")
+    assert page.status_code == 200
+    assert "Ledger type filters" in page.text
+    assert 'href="/ledger?type=bounty_payment" aria-current="page"' in page.text
+    assert "Showing ledger entries for Bounty Payment." in page.text
+    assert "Award paid" in page.text
+    assert "Unused reserve released" not in page.text
+
+    all_page = client.get("/ledger?type=all")
+    assert all_page.status_code == 200
+    assert 'href="/ledger" aria-current="page"' in all_page.text

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -481,6 +481,19 @@ def test_ledger_page_and_api_filter_by_entry_type(sqlite_url: str) -> None:
     assert [row["type"] for row in payment_rows.json()] == ["bounty_payment"]
     assert payment_rows.json()[0]["proof_hash"] == proof.hash
 
+    uppercase_payment_rows = client.get("/api/v1/ledger?type=BOUNTY_PAYMENT")
+    assert uppercase_payment_rows.status_code == 200
+    assert [row["type"] for row in uppercase_payment_rows.json()] == ["bounty_payment"]
+
+    blank_filter_rows = client.get("/api/v1/ledger?type=%20%20")
+    assert blank_filter_rows.status_code == 200
+    assert [row["type"] for row in blank_filter_rows.json()] == [
+        "bounty_release",
+        "bounty_payment",
+        "bounty_reserve",
+        "genesis",
+    ]
+
     invalid_type = client.get("/api/v1/ledger?type=bogus")
     assert invalid_type.status_code == 400
     assert invalid_type.json()["detail"] == (
@@ -495,6 +508,10 @@ def test_ledger_page_and_api_filter_by_entry_type(sqlite_url: str) -> None:
     assert "Showing ledger entries for Bounty Payment." in page.text
     assert "Award paid" in page.text
     assert "Unused reserve released" not in page.text
+
+    uppercase_page = client.get("/ledger?type=BOUNTY_PAYMENT")
+    assert uppercase_page.status_code == 200
+    assert 'href="/ledger?type=bounty_payment" aria-current="page"' in uppercase_page.text
 
     all_page = client.get("/ledger?type=all")
     assert all_page.status_code == 200


### PR DESCRIPTION
Refs #427

This adds type filters to the public ledger so contributors can scan one workflow at a time instead of reading every reserve, payment, release, transfer, claim, and genesis row together.

Before:
- `/ledger` always showed the latest ledger rows as one mixed stream.
- `/api/v1/ledger` could limit rows but could not filter by entry type.

After:
- `/ledger` shows filter links for All, Bounty Reserve, Bounty Payment, Bounty Release, GitHub claim, Wallet transfer, and Genesis.
- `/api/v1/ledger?type=bounty_payment` returns only payment rows while keeping proof hashes attached.
- Blank or `type=all` stays unfiltered; unsupported types return a bounded 400.

Checked against the ledger entry types produced by `app/ledger/service.py`.

Validation:
- `./.venv/bin/python -m pytest tests/test_bounty_pages.py::test_ledger_page_and_api_filter_by_entry_type tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable tests/test_ledger_views.py -q` -> 4 passed
- `./.venv/bin/python -m ruff check app/ledger_views.py app/main.py app/public_routes.py tests/test_bounty_pages.py` -> passed
- `./.venv/bin/python -m ruff format --check app/ledger_views.py app/main.py app/public_routes.py tests/test_bounty_pages.py` -> passed
- `./.venv/bin/python -m mypy app/ledger_views.py app/public_routes.py app/main.py` -> passed
- `git diff --check` -> clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter ledger entries by type via a new query parameter on the ledger page and API.
  * UI filter navigation shows available entry types and highlights the selected filter.
  * "All" option and case-insensitive type matching supported.

* **Bug Fixes**
  * Invalid type selections return a clear, user-friendly error (400).

* **Tests**
  * End-to-end tests added to verify API and page filtering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->