### PR TITLE
Refs #406: Search MCP bounties by issue URL

### DIFF
--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -129,6 +129,7 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 issue_number = issue_number_search_value(query_text)
                 text_filter = or_(
                     func.lower(Bounty.repo).like(like_query, escape="\\"),
+                    func.lower(Bounty.issue_url).like(like_query, escape="\\"),
                     func.lower(Bounty.title).like(like_query, escape="\\"),
                     func.lower(Bounty.acceptance).like(like_query, escape="\\"),
                 )

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -30,6 +30,38 @@ def test_call_mcp_tool_lists_bounties_from_extracted_dispatcher(sqlite_url: str)
     assert bounties[0]["title"] == "Code health bounty"
 
 
+def test_call_mcp_tool_list_bounties_searches_issue_url(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=406,
+            issue_url="https://github.com/ramimbo/mergework/issues/406",
+            title="Small fix bounty",
+            reward_mrwk="50",
+            acceptance="Useful small fixes should be findable from their source issue URL.",
+        )
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=407,
+            issue_url="https://github.com/ramimbo/mergework/issues/407",
+            title="Different bounty",
+            reward_mrwk="50",
+            acceptance="This row should not match the issue URL query.",
+        )
+
+    result = call_mcp_tool(
+        sqlite_url,
+        "list_bounties",
+        {"status": "open", "q": "https://github.com/ramimbo/mergework/issues/406"},
+    )
+
+    assert [row["issue_number"] for row in json.loads(result)] == [406]
+
+
 def test_submit_work_proof_repo_selector_matches_stored_repo_case(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Refs #406

Small fix: MCP `list_bounties` can now find a bounty when an agent pastes the stored GitHub issue URL. The public API/search flow already supports repo/title/acceptance text and bare issue numbers; this closes the MCP gap for canonical issue URLs.

Before:
- `call_mcp_tool(..., "list_bounties", {"q": "https://github.com/ramimbo/mergework/issues/406"})` returned no rows unless the URL text appeared elsewhere.

After:
- MCP bounty search includes `Bounty.issue_url`, so canonical issue URLs match the intended bounty row while the existing escaping and issue-number handling remain in place.

Validation:
- `./.venv/bin/python -m pytest tests/test_mcp_tools.py::test_call_mcp_tool_list_bounties_searches_issue_url tests/test_mcp_tools.py -q` -> 6 passed
- `./.venv/bin/python -m ruff check app/mcp_tools.py tests/test_mcp_tools.py` -> passed
- `./.venv/bin/python -m ruff format --check app/mcp_tools.py tests/test_mcp_tools.py` -> passed
- `./.venv/bin/python -m mypy app/mcp_tools.py` -> passed
- `git diff --check` -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bounty search now filters by issue URL in addition to existing text search criteria, enabling users to discover bounties for specific issues more efficiently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->