### PR TITLE
Bounty #406: Validate nested proof metadata strings

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -201,15 +201,28 @@ def _clean_optional_account_id(value: str | None, field: str) -> str | None:
     return _clean_required_text(value, field, 128)
 
 
+def _reject_metadata_control_chars(value: Any, path: str) -> None:
+    if isinstance(value, str):
+        if CONTROL_CHAR_RE.search(value):
+            raise LedgerError(f"{path} must not contain control characters")
+        return
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            nested_path = f"{path}.{key}" if isinstance(key, str) else f"{path}.{key!r}"
+            _reject_metadata_control_chars(nested_value, nested_path)
+        return
+    if isinstance(value, (list, tuple)):
+        for index, nested_value in enumerate(value):
+            _reject_metadata_control_chars(nested_value, f"{path}[{index}]")
+
+
 def _clean_proof_metadata(verifier_result: dict[str, Any]) -> dict[str, Any]:
     clean = dict(verifier_result)
-    for key, value in clean.items():
-        if isinstance(value, str) and CONTROL_CHAR_RE.search(value):
-            raise LedgerError(f"verifier_result.{key} must not contain control characters")
     try:
         canonical_json(clean)
     except (TypeError, ValueError) as exc:
         raise LedgerError("verifier_result must be JSON serializable") from exc
+    _reject_metadata_control_chars(clean, "verifier_result")
     return clean
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -940,6 +940,84 @@ def test_bounty_payment_proof_rejects_control_character_metadata(sqlite_url: str
         assert get_balance(session, "github:bob") == 0
 
 
+@pytest.mark.parametrize(
+    ("verifier_result", "message"),
+    (
+        (
+            {"label": "mrwk:accepted", "details": {"note": "line1\nline2"}},
+            "verifier_result.details.note must not contain control characters",
+        ),
+        (
+            {"label": "mrwk:accepted", "checks": ["ci:passed", "line1\rline2"]},
+            r"verifier_result.checks\[1\] must not contain control characters",
+        ),
+    ),
+)
+def test_bounty_payment_proof_rejects_nested_control_character_metadata(
+    sqlite_url: str, verifier_result: dict[str, object], message: str
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=17,
+            issue_url="https://github.com/ramimbo/mergework/issues/17",
+            title="Nested proof metadata",
+            reward_mrwk="1",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+
+        with pytest.raises(LedgerError, match=message):
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:alice",
+                submission_url="https://github.com/ramimbo/mergework/pull/17",
+                accepted_by="maintainer",
+                verifier_result=verifier_result,
+            )
+
+        assert bounty.awards_paid == 0
+        assert get_balance(session, "github:alice") == 0
+        assert session.scalars(select(Submission)).all() == []
+        assert session.scalars(select(Proof)).all() == []
+
+
+def test_bounty_payment_proof_preserves_safe_nested_metadata(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=17,
+            issue_url="https://github.com/ramimbo/mergework/issues/17",
+            title="Safe nested proof metadata",
+            reward_mrwk="1",
+            acceptance="Maintainer applies mrwk:accepted",
+        )
+        verifier_result = {
+            "label": "mrwk:accepted",
+            "details": {"note": "manual review", "checks": ["ci:passed", "tests:passed"]},
+        }
+
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/17",
+            accepted_by="maintainer",
+            verifier_result=verifier_result,
+        )
+
+        proof_payload = json.loads(proof.public_json)
+        submission = session.scalars(select(Submission)).one()
+        assert proof_payload["verifier_result"] == verifier_result
+        assert json.loads(submission.verifier_result) == verifier_result
+
+
 def test_admin_payout_api_rejects_control_character_note(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Refs #406

Summary
- reject control characters in nested verifier_result proof metadata before public proof JSON is stored
- keep safe nested metadata JSON-serializable and unchanged
- add regression coverage for nested object and list strings

Validation
- ../mergework/.venv/bin/python -m pytest -q
- ../mergework/.venv/bin/python -m pytest tests/test_ledger.py tests/test_security.py -q
- ../mergework/.venv/bin/python -m ruff format --check .
- ../mergework/.venv/bin/python -m ruff check .
- ../mergework/.venv/bin/python -m mypy app
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of proof metadata to detect control characters throughout nested structures, not just at the top level. Error messages now indicate the exact location of problematic characters.

* **Tests**
  * Added comprehensive security tests verifying that invalid control characters in nested metadata are properly rejected and safe nested metadata structures are preserved during bounty payouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->