### PR TITLE
Refs #406: Accept claim-command bounty references in webhook payouts

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -19,7 +19,7 @@ ACCEPTED_LABEL = "mrwk:accepted"
 ISSUE_NUMBER_BOUNDARY = r"(?![A-Za-z0-9_-])"
 MAX_SQLITE_INTEGER = 2**63 - 1
 LINKED_ISSUE_RE = re.compile(
-    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?|bounty)\s+"
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?|bounty|claims?)\s+"
     rf"(?:(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(?P<repo_number>\d+){ISSUE_NUMBER_BOUNDARY}"
     rf"|#(?P<number>\d+){ISSUE_NUMBER_BOUNDARY})",
     re.IGNORECASE,

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -155,6 +155,55 @@ def test_accepted_pr_label_pays_pr_author_for_linked_bounty_issue(sqlite_url: st
         assert get_balance(session, "github:maintainer") == 0
 
 
+def test_accepted_pr_label_accepts_claim_bounty_reference(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "labeled",
+            "label": {"name": "mrwk:accepted"},
+            "pull_request": {
+                "number": 9,
+                "html_url": "https://github.com/ramimbo/mergework/pull/9",
+                "body": "Summary: focused fix\n\n/claim #3\n\nTests: pytest passed",
+                "user": {"login": "contributor"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "maintainer"},
+        },
+        separators=(",", ":"),
+    ).encode()
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=3,
+            issue_url="https://github.com/ramimbo/mergework/issues/3",
+            title="Claim reference payout",
+            reward_mrwk="50",
+            acceptance="Accepted PRs can cite the bounty with /claim.",
+        )
+
+    result = handle_github_webhook(
+        sqlite_url,
+        {
+            "X-GitHub-Delivery": "delivery-pr-claim-reference",
+            "X-GitHub-Event": "pull_request",
+            "X-Hub-Signature-256": _signature("secret", body),
+        },
+        body,
+        "secret",
+    )
+
+    assert result["status"] == "paid"
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:contributor") == 50_000_000
+        event = session.get(WebhookEvent, "delivery-pr-claim-reference")
+        assert event is not None
+        assert event.processed_status == "paid"
+
+
 def test_accepted_issue_event_for_pull_request_does_not_pay_matching_bounty(
     sqlite_url: str,
 ) -> None:


### PR DESCRIPTION
Summary: Align GitHub accepted-label webhook bounty reference parsing with the existing submission quality gate and queue-health reference formats. Accepted PR bodies that use the claim-command bounty syntax now resolve the bounty instead of recording missing_issue.

Refs #406

Changed files:
- app/webhooks/github.py
- tests/test_webhooks.py

Evidence: The regression test showed a pull_request labeled mrwk:accepted with a claim-command bounty reference returned missing_issue before the fix; after the parser update it returns paid and records the paid webhook event.

Tests:
- pytest tests/test_webhooks.py tests/test_submission_quality_gate.py tests/test_pr_queue_health.py -q -> 51 passed
- pytest -q -> 415 passed
- ruff format --check . -> 79 files already formatted
- ruff check . -> All checks passed
- mypy app -> success
- scripts/docs_smoke.py -> docs smoke ok
- git diff --check -> clean

Out of scope: payout authorization, labeler checks, delivery replay handling, wallet logic, or MRWK pricing/liquidity/off-ramp claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended bounty reference recognition patterns to support "/claim" style references in pull request bodies. Contributors can now use claim syntax to reference bounties in their PR descriptions (e.g., "/claim `#1234`"). The system properly processes these references during GitHub webhook handling, enabling accurate bounty tracking, attribution, and timely payment distribution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->