### PR TITLE
Refs #406: Skip malformed bounty award proofs

### DIFF
--- a/app/serializers.py
+++ b/app/serializers.py
@@ -46,8 +46,8 @@ def bounty_awards_to_dict(session: Session, bounty_id: int) -> list[dict[str, An
     ).all()
     awards: list[dict[str, Any]] = []
     for proof in proofs:
-        data = json.loads(proof.public_json)
-        if not isinstance(data, dict) or data.get("kind") != "bounty_payment":
+        data = _proof_payload(proof)
+        if data is None:
             continue
         proof_hash = str(proof.hash)
         awards.append(

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -652,6 +652,53 @@ def test_mcp_get_bounty_can_include_accepted_awards(sqlite_url: str) -> None:
     ]
 
 
+def test_mcp_get_bounty_skips_malformed_award_proof_payloads(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=285,
+            issue_url="https://github.com/ramimbo/mergework/issues/285",
+            title="MCP malformed award proof",
+            reward_mrwk="75",
+            acceptance="Malformed stored proof JSON should not break MCP bounty inspection.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/285",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        proof_row = session.get(Proof, proof.hash)
+        assert proof_row is not None
+        proof_row.public_json = "{"
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "get_bounty",
+                "arguments": {"id": bounty_id, "include_awards": True},
+            },
+        },
+    ).json()
+
+    payload = json.loads(result["result"]["content"][0]["text"])
+    assert payload["id"] == bounty_id
+    assert payload["awards_paid"] == 1
+    assert payload["awards"] == []
+
+
 def test_mcp_get_bounty_rejects_fractional_id(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
+from app.models import Proof
 
 
 def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
@@ -363,6 +364,44 @@ def test_bounty_detail_shows_accepted_award_history(sqlite_url: str) -> None:
     assert f'href="/proofs/{second_proof.hash}"' in page.text
     assert f'href="/ledger/{second_proof.ledger_sequence}"' in page.text
     assert "/accounts/github:bob" in page.text
+
+
+def test_bounty_detail_skips_malformed_award_proof_payloads(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=165,
+            issue_url="https://github.com/ramimbo/mergework/issues/165",
+            title="Malformed award proof payload",
+            reward_mrwk="100",
+            acceptance="Bounty details should survive malformed stored proof JSON.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/203",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        proof_row = session.get(Proof, proof.hash)
+        assert proof_row is not None
+        proof_row.public_json = "{"
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    api_response = client.get(f"/api/v1/bounties/{bounty_id}")
+    page = client.get(f"/bounties/{bounty_id}")
+
+    assert api_response.status_code == 200
+    assert api_response.json()["accepted_awards"] == []
+    assert page.status_code == 200
+    assert "Malformed award proof payload" in page.text
+    assert "No accepted work has been paid for this bounty yet." in page.text
 
 
 def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) -> None:

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -9,6 +9,7 @@ from app.serializers import (
     accepted_work_for_account,
     account_accepted_summary,
     activity_to_dict,
+    bounty_awards_to_dict,
     bounty_list_summary,
     bounty_to_dict,
     empty_accepted_summary,
@@ -136,6 +137,36 @@ def test_activity_serializers_skip_malformed_public_proofs(sqlite_url: str) -> N
     }
     assert summary == empty_accepted_summary()
     assert accepted_work == []
+
+
+def test_bounty_award_serializer_skips_malformed_public_proofs(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=321,
+            issue_url="https://github.com/ramimbo/mergework/issues/321",
+            title="Public bounty award history",
+            reward_mrwk="40",
+            acceptance="Malformed proof payloads should not break bounty award history.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:tatelyman",
+            submission_url="https://github.com/ramimbo/mergework/pull/321",
+            accepted_by="ramimbo",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        proof_row = session.get(Proof, proof.hash)
+        assert proof_row is not None
+        proof_row.public_json = "{"
+
+        awards = bounty_awards_to_dict(session, bounty.id)
+
+    assert awards == []
 
 
 def test_wallet_transfer_serializer_normalizes_aware_timestamp() -> None:


### PR DESCRIPTION
Refs #406

Summary
- make bounty award history reuse the safe proof payload parser already used by activity/account serializers
- skip malformed stored bounty-payment proof JSON instead of crashing bounty detail readers
- cover the serializer, public API/page, and MCP get_bounty include_awards paths

Validation
- ../mergework/.venv/bin/python -m pytest -q
- ../mergework/.venv/bin/python -m pytest tests/test_serializers.py tests/test_bounty_pages.py tests/test_api_mcp.py -q
- ../mergework/.venv/bin/python -m ruff format --check .
- ../mergework/.venv/bin/python -m ruff check .
- ../mergework/.venv/bin/python -m mypy app
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced resilience when retrieving bounty awards; malformed proof data is now gracefully skipped without affecting the overall bounty display or award counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->