### PR TITLE
Refs #406: Canonicalize GitHub source schemes

### DIFF
--- a/app/ledger/reconciliation.py
+++ b/app/ledger/reconciliation.py
@@ -159,6 +159,7 @@ def _canonical_source_url(url: str) -> str:
             )
             query = ""
             fragment = ""
+            return urlunsplit(("https", netloc, path, query, fragment))
     return urlunsplit((parsed.scheme.lower(), netloc, path, query, fragment))
 
 

--- a/tests/test_ledger_reconciliation.py
+++ b/tests/test_ledger_reconciliation.py
@@ -411,6 +411,15 @@ def test_duplicate_accepted_source_urls_groups_distinct_accepted_submissions(
             reward_mrwk="5",
             acceptance="Maintainer applies mrwk:accepted.",
         )
+        third_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=41,
+            issue_url="https://github.com/ramimbo/mergework/issues/41",
+            title="Third source URL bounty",
+            reward_mrwk="5",
+            acceptance="Maintainer applies mrwk:accepted.",
+        )
         source_url = "https://github.com/ramimbo/mergework/pull/281"
         session.add_all(
             [
@@ -431,6 +440,13 @@ def test_duplicate_accepted_source_urls_groups_distinct_accepted_submissions(
                     status="accepted",
                     verifier_result=canonical_json({"label": "mrwk:accepted"}),
                 ),
+                Submission(
+                    bounty_id=third_bounty.id,
+                    submitter_account="github:carol",
+                    url="http://github.com/Ramimbo/MergeWork/pull/281/commits?plain=1",
+                    status="accepted",
+                    verifier_result=canonical_json({"label": "mrwk:accepted"}),
+                ),
             ]
         )
         session.flush()
@@ -444,10 +460,11 @@ def test_duplicate_accepted_source_urls_groups_distinct_accepted_submissions(
         assert {ref.bounty_issue for ref in groups[0].submissions} == {
             "ramimbo/mergework#39",
             "ramimbo/mergework#40",
+            "ramimbo/mergework#41",
         }
         assert duplicate_source_summary(groups) == {
             "duplicate_source_urls": 1,
-            "duplicate_source_submissions": 2,
+            "duplicate_source_submissions": 3,
         }
         assert len(session.scalars(select(LedgerEntry)).all()) == ledger_entries_before
         assert len(session.scalars(select(Proof)).all()) == proofs_before


### PR DESCRIPTION
Refs #406

Summary
- normalize matched GitHub pull/issue source URLs to https during duplicate accepted-source reconciliation
- keep the existing GitHub owner/repo/path/view/query/fragment canonicalization
- add regression coverage for http and https variants of the same GitHub PR source

Validation
- ../mergework/.venv/bin/python -m pytest -q
- ../mergework/.venv/bin/python -m pytest tests/test_ledger_reconciliation.py -q
- ../mergework/.venv/bin/python -m ruff format --check .
- ../mergework/.venv/bin/python -m ruff check .
- ../mergework/.venv/bin/python -m mypy app
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL canonicalization for GitHub issues and pull requests to ensure proper HTTPS normalization and accurate duplicate source tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->