### PR TITLE
Refs #406: Reject overprecise MRWK amounts

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -51,6 +51,8 @@ def parse_mrwk_amount(amount: str | int | Decimal) -> int:
     amount_text = str(amount).strip()
     if not MRWK_AMOUNT_RE.fullmatch(amount_text):
         raise LedgerError("invalid MRWK amount")
+    if "." in amount_text and len(amount_text.rsplit(".", 1)[1]) > 6:
+        raise LedgerError("MRWK supports at most 6 decimal places")
     try:
         value = Decimal(amount_text)
     except (InvalidOperation, ValueError) as exc:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -885,6 +885,12 @@ def test_amount_parser_rejects_non_decimal_notation() -> None:
         parse_mrwk_amount("-1")
 
 
+@pytest.mark.parametrize("amount", ("1.0000000", "0.0000010", "0.1000000"))
+def test_amount_parser_rejects_more_than_six_decimal_places(amount: str) -> None:
+    with pytest.raises(LedgerError, match="MRWK supports at most 6 decimal places"):
+        parse_mrwk_amount(amount)
+
+
 def test_amount_parser_rejects_values_above_fixed_supply() -> None:
     with pytest.raises(LedgerError, match="amount exceeds fixed supply"):
         parse_mrwk_amount("100000001")


### PR DESCRIPTION
Refs #406

Summary
- reject MRWK amount strings with more than six fractional digits before Decimal scaling
- align backend parsing with the browser wallet parser for trailing-zero overprecision
- add regression coverage for 7-decimal values that previously scaled to whole microunits

Validation
- ../mergework/.venv/bin/python -m pytest -q
- ../mergework/.venv/bin/python -m pytest tests/test_security.py tests/test_wallet_api.py tests/test_wallets.py tests/test_ledger.py -q
- ../mergework/.venv/bin/python -m ruff format --check .
- ../mergework/.venv/bin/python -m ruff check .
- ../mergework/.venv/bin/python -m mypy app
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Monetary amount validation now includes early precision checking to reject amounts with more than 6 decimal places before further processing, ensuring users receive immediate feedback.

* **Tests**
  * Added parameterized test coverage verifying the system correctly rejects monetary amounts exceeding the supported 6 decimal place precision constraint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->