### PR TITLE
Bounty #427: Add wallet search filters

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -6,7 +6,7 @@ from typing import Any
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
-from sqlalchemy import select
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from app.accounts import normalized_wallet_address
@@ -37,9 +37,26 @@ def public_bounties_context(
     }
 
 
-def wallets_page_context(session: Session) -> dict[str, Any]:
-    wallets = session.scalars(select(Wallet).order_by(Wallet.created_at.desc()).limit(100)).all()
-    return {"wallets": [wallet_to_dict(session, wallet) for wallet in wallets]}
+def wallets_page_context(session: Session, q: str | None = None) -> dict[str, Any]:
+    query_text = q.strip() if q is not None else ""
+    query = select(Wallet)
+    if query_text:
+        escaped_query = (
+            query_text.lower().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        )
+        like_query = f"%{escaped_query}%"
+        query = query.where(
+            or_(
+                func.lower(Wallet.address).like(like_query, escape="\\"),
+                func.lower(Wallet.label).like(like_query, escape="\\"),
+                func.lower(Wallet.github_login).like(like_query, escape="\\"),
+            )
+        )
+    wallets = session.scalars(query.order_by(Wallet.created_at.desc()).limit(100)).all()
+    return {
+        "wallets": [wallet_to_dict(session, wallet) for wallet in wallets],
+        "query_text": query_text,
+    }
 
 
 def wallet_page_context(session: Session, address: str) -> dict[str, Any]:
@@ -95,9 +112,9 @@ def register_public_routes(
         )
 
     @app.get("/wallets", response_class=HTMLResponse)
-    def wallets_page(request: Request) -> HTMLResponse:
+    def wallets_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:
         with session_scope(db_url) as session:
-            context = wallets_page_context(session)
+            context = wallets_page_context(session, q)
         return templates.TemplateResponse(request, "wallets.html", context)
 
     @app.get("/wallets/{address}", response_class=HTMLResponse)

--- a/app/templates/wallets.html
+++ b/app/templates/wallets.html
@@ -29,6 +29,17 @@
     <h2>Registered wallets</h2>
     <p>Public addresses known to this ledger.</p>
   </div>
+  <form class="search-form" method="get" action="/wallets" role="search">
+    <label for="wallet-search">Search wallets</label>
+    <div class="search-row">
+      <input id="wallet-search" name="q" type="search" value="{{ query_text }}" placeholder="address, label, or GitHub login">
+      <button type="submit">Search</button>
+      {% if query_text %}<a href="/wallets">Clear</a>{% endif %}
+    </div>
+  </form>
+  {% if query_text %}
+  <p class="notice">Showing wallets matching “{{ query_text }}”.</p>
+  {% endif %}
   <table>
     <thead><tr><th>Address</th><th>Label</th><th>Balance</th><th>GitHub</th><th>Signed actions</th></tr></thead>
     <tbody>
@@ -41,7 +52,11 @@
         <td>{{ wallet.nonce }}</td>
       </tr>
       {% else %}
-      <tr><td colspan="5">No registered wallets yet.</td></tr>
+      <tr>
+        <td colspan="5">
+          {% if query_text %}No registered wallets match this search.{% else %}No registered wallets yet.{% endif %}
+        </td>
+      </tr>
       {% endfor %}
     </tbody>
   </table>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -21,6 +21,7 @@ from app.ledger.service import (
     wallet_transfer_payload,
 )
 from app.main import _safe_next_path, _signed_value, _verified_value, create_app
+from app.models import Wallet
 from app.wallets import address_from_public_key_hex, canonical_wallet_json
 
 
@@ -515,9 +516,16 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
     _register_wallet(client, public_hex, "Main smoke wallet")
     _register_wallet(client, funded_public, "Funded smoke wallet")
+    with session_scope(sqlite_url) as session:
+        wallet = session.get(Wallet, address)
+        assert wallet is not None
+        wallet.github_login = "alice-smoke"
     _fund_wallet(sqlite_url, funded_address)
 
     wallets = client.get("/wallets").text
+    main_search = client.get("/wallets?q=Main").text
+    github_search = client.get("/wallets?q=alice-smoke").text
+    no_wallet_match = client.get("/wallets?q=missing-wallet").text
     detail = client.get(f"/wallets/{address}").text
     funded_detail = client.get(f"/wallets/{funded_address}").text
     transfer = client.get("/transfer").text
@@ -534,6 +542,11 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert address in detail
     assert "Main smoke wallet" in wallets
     assert "Main smoke wallet" in detail
+    assert "Search wallets" in wallets
+    assert "Main smoke wallet" in main_search
+    assert "Funded smoke wallet" not in main_search
+    assert "alice-smoke" in github_search
+    assert "No registered wallets match this search." in no_wallet_match
     assert "To claim GitHub bounty balance" in detail
     assert "No activity yet" in detail
     assert "No activity yet" not in funded_detail


### PR DESCRIPTION
## Summary
- add /wallets?q=... filtering by wallet address, label, or linked GitHub login
- keep the latest-wallets default and add clear search and empty-state copy
- cover wallet search in the public wallet page smoke test

## Validation
- ../mergework/.venv/bin/python -m pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows tests/test_public_routes.py -q
- ../mergework/.venv/bin/python -m pytest tests/test_wallet_api.py tests/test_public_routes.py tests/test_wallets.py -q
- ../mergework/.venv/bin/python -m pytest -q
- ../mergework/.venv/bin/python scripts/docs_smoke.py
- ../mergework/.venv/bin/python -m ruff check app/public_routes.py tests/test_wallet_api.py
- ../mergework/.venv/bin/python -m ruff format --check app/public_routes.py tests/test_wallet_api.py
- ../mergework/.venv/bin/python -m mypy app/public_routes.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search functionality to the `/wallets` page. Users can search wallets by address, label, or GitHub login. The search form includes a clear button and displays relevant messaging when no results match the search query.

* **Tests**
  * Added comprehensive test coverage for wallet search behavior, including searches by label, GitHub login, and empty result scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->