### PR TITLE
Refs #406: Reject dotless public URL hosts

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -113,12 +113,15 @@ def validate_public_url(url: str) -> str:
             ascii_hostname = hostname.encode("idna").decode("ascii").rstrip(".")
         except UnicodeError as exc:
             raise LedgerError("URL must include a valid host") from exc
+        labels = ascii_hostname.split(".")
         if (
             not ascii_hostname
             or len(ascii_hostname) > 253
-            or not all(PUBLIC_DNS_LABEL_RE.fullmatch(label) for label in ascii_hostname.split("."))
+            or not all(PUBLIC_DNS_LABEL_RE.fullmatch(label) for label in labels)
         ):
             raise LedgerError("URL must include a valid host") from None
+        if len(labels) < 2:
+            raise LedgerError("URL must use a public host") from None
     else:
         if ip.is_multicast or not ip.is_global:
             raise LedgerError("URL must use a public host")

--- a/tests/test_security_url_validation.py
+++ b/tests/test_security_url_validation.py
@@ -124,6 +124,7 @@ def test_bounty_urls_reject_non_public_hosts(sqlite_url: str) -> None:
         for issue_number, issue_url in enumerate(
             (
                 "https://localhost/ramimbo/mergework/issues/21",
+                "https://internal/ramimbo/mergework/issues/21",
                 "https://127.0.0.1/ramimbo/mergework/issues/21",
                 "https://10.0.0.5/ramimbo/mergework/issues/21",
                 "https://100.64.0.1/ramimbo/mergework/issues/21",


### PR DESCRIPTION
## Summary
- reject dotless DNS hostnames in public URL validation
- keep malformed-host errors separate from non-public-host errors
- cover dotless host rejection in the URL validation tests

## Validation
- ../mergework/.venv/bin/python -m pytest tests/test_security_url_validation.py -q
- ../mergework/.venv/bin/python -m pytest -q
- ../mergework/.venv/bin/python scripts/docs_smoke.py
- ../mergework/.venv/bin/python -m ruff check app/ledger/service.py tests/test_security_url_validation.py
- ../mergework/.venv/bin/python -m ruff format --check app/ledger/service.py tests/test_security_url_validation.py
- ../mergework/.venv/bin/python -m mypy app/ledger/service.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL validation to enforce stricter hostname requirements and properly reject non-public hostnames.

* **Tests**
  * Extended hostname validation test coverage for additional rejection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/522?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->