### PR TITLE
Refs #406: Reject dotless public base URLs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -229,6 +229,8 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
         except ValueError:
             if has_bracketed_host or not _is_valid_dns_hostname(parsed_base_url.hostname):
                 errors.append("MERGEWORK_PUBLIC_BASE_URL must include a valid host")
+            elif "." not in parsed_base_url.hostname.rstrip("."):
+                errors.append("MERGEWORK_PUBLIC_BASE_URL must use a public host")
             is_loopback = parsed_base_url.hostname.lower() == "localhost"
             is_private_or_link_local = False
             is_non_global = False

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -407,6 +407,12 @@ def test_deploy_readiness_rejects_malformed_public_base_url_hosts() -> None:
     assert expected in underscore_errors
 
 
+def test_deploy_readiness_rejects_dotless_public_base_url_host() -> None:
+    errors = validate_deploy_settings(_settings(public_base_url="https://internal"))
+
+    assert "MERGEWORK_PUBLIC_BASE_URL must use a public host" in errors
+
+
 def test_deploy_readiness_script_runs_directly_from_source() -> None:
     env = {
         **os.environ,


### PR DESCRIPTION
## Summary
- reject dotless MERGEWORK_PUBLIC_BASE_URL DNS hosts as non-public origins
- keep internal dotless database hostnames allowed for deployment DB URLs
- cover the deploy-readiness gap with a focused regression test

## Validation
- ../mergework/.venv/bin/python -m pytest tests/test_deploy_readiness.py -q
- ../mergework/.venv/bin/python -m pytest -q
- ../mergework/.venv/bin/python scripts/docs_smoke.py
- ../mergework/.venv/bin/python -m ruff check app/config.py tests/test_deploy_readiness.py
- ../mergework/.venv/bin/python -m ruff format --check app/config.py tests/test_deploy_readiness.py
- ../mergework/.venv/bin/python -m mypy app/config.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Public URL configuration validation now enforces that hostnames contain a domain extension, rejecting single-word hostnames without dots.

* **Tests**
  * Added test coverage for public URL hostname validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->