### PR TITLE
Refs #406: Reject malformed IPv4 public URLs

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -41,6 +41,7 @@ GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 MRWK_AMOUNT_RE = re.compile(r"^-?\d+(?:\.\d+)?$")
 PUBLIC_DNS_LABEL_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$", re.I)
+IPV4_DOTTED_QUAD_RE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
 
 
 class LedgerError(RuntimeError):
@@ -109,6 +110,8 @@ def validate_public_url(url: str) -> str:
     try:
         ip = ipaddress.ip_address(hostname)
     except ValueError:
+        if IPV4_DOTTED_QUAD_RE.fullmatch(hostname):
+            raise LedgerError("URL must include a valid host") from None
         try:
             ascii_hostname = hostname.encode("idna").decode("ascii").rstrip(".")
         except UnicodeError as exc:

--- a/tests/test_security_url_validation.py
+++ b/tests/test_security_url_validation.py
@@ -53,6 +53,8 @@ def test_public_urls_reject_malformed_hosts_and_ports() -> None:
         "https://example.com:bad/path",
         "https://example.com:/path",
         "https://:443/path",
+        "https://999.999.999.999/path",
+        "https://01.02.03.04/path",
         "https://api..example/path",
         "https://bad_host.example/path",
         "https://-bad.example/path",
@@ -63,6 +65,7 @@ def test_public_urls_reject_malformed_hosts_and_ports() -> None:
 
     assert public_url_or_none("https://[bad") is None
     assert public_url_or_none("https://:443/path") is None
+    assert public_url_or_none("https://999.999.999.999/path") is None
     assert public_url_or_none("https://bad_host.example/path") is None
 
 


### PR DESCRIPTION
Summary:
- reject malformed dotted-quad public URLs such as `https://999.999.999.999/path`
- keep valid public IP literals and normal DNS names accepted
- add regression coverage for `validate_public_url()` and `public_url_or_none()`

Evidence:
- before this change, `validate_public_url("https://999.999.999.999/path")` returned the URL because the invalid IPv4-looking hostname fell through to DNS-label validation
- deploy readiness already treats the same malformed dotted-quad pattern as an invalid public host, so bounty issue/submission URL validation was inconsistent
- live bounty #66 / issue #406 is open with remaining award capacity

Validation:
- `../mergework/.venv/bin/python -m pytest tests/test_security_url_validation.py::test_public_urls_reject_malformed_hosts_and_ports -q` -> 1 passed
- `../mergework/.venv/bin/python -m pytest tests/test_security_url_validation.py -q` -> 5 passed
- `../mergework/.venv/bin/python -m pytest tests/test_security.py::test_public_url_or_none_omits_control_character_urls tests/test_security_url_validation.py::test_bounty_urls_reject_non_public_hosts -q` -> 2 passed
- `../mergework/.venv/bin/python -m pytest -q` -> 414 passed
- `../mergework/.venv/bin/python -m ruff check app/ledger/service.py tests/test_security_url_validation.py` -> passed
- `../mergework/.venv/bin/python -m ruff format --check app/ledger/service.py tests/test_security_url_validation.py` -> 2 files already formatted
- `../mergework/.venv/bin/python -m mypy app/ledger/service.py` -> success
- `../mergework/.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

Safety:
No secrets, wallet material, private keys, tokens, signatures, private data, production mutation, price/exchange/liquidity claim, bridge claim, off-ramp claim, or fabricated payout claim are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL validation to properly detect and reject invalid IPv4-like hostnames with malformed octets. The system now correctly identifies and rejects addresses with out-of-range values (such as 999.999.999.999) and leading-zero formats (such as 01.02.03.04), providing users with appropriate error messages for better clarity during URL submission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->