### PR TITLE
Refs #406: Handle malformed public proof payloads

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -310,7 +310,10 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             proof = session.get(Proof, proof_hash)
             if proof is None:
                 raise HTTPException(status_code=404, detail="proof not found")
-            data = json.loads(proof.public_json)
+            try:
+                data = json.loads(proof.public_json)
+            except (TypeError, json.JSONDecodeError) as exc:
+                raise HTTPException(status_code=500, detail="invalid proof payload") from exc
             if not isinstance(data, dict):
                 raise HTTPException(status_code=500, detail="invalid proof payload")
             return data

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -995,6 +995,39 @@ def test_mcp_get_proof_reports_unknown_hash(sqlite_url: str) -> None:
     assert result["result"]["content"][0]["text"] == "proof not found"
 
 
+def test_public_proof_api_reports_malformed_payload(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=38,
+            issue_url="https://github.com/ramimbo/mergework/issues/38",
+            title="Proof payload lookup",
+            reward_mrwk="25",
+            acceptance="Public proof lookups should return bounded errors.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/38",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        proof_row = session.get(Proof, proof.hash)
+        assert proof_row is not None
+        proof_row.public_json = "{"
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(f"/api/v1/proofs/{proof.hash}")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "invalid proof payload"
+
+
 def test_mcp_get_proof_rejects_malformed_hash(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Refs #406.

Summary:
- return the existing `invalid proof payload` response when `/api/v1/proofs/{hash}` finds malformed stored JSON
- add a regression test that corrupts a proof payload and verifies the public proof API stays bounded

Validation:
- `../mergework/.venv/bin/python -m pytest tests/test_api_mcp.py::test_public_proof_api_reports_malformed_payload -q`
- `../mergework/.venv/bin/python -m pytest tests/test_api_mcp.py::test_mcp_get_proof_returns_public_proof_details tests/test_api_mcp.py::test_mcp_get_proof_reports_unknown_hash tests/test_api_mcp.py::test_public_proof_api_reports_malformed_payload tests/test_api_mcp.py::test_mcp_get_proof_rejects_malformed_hash -q`
- `../mergework/.venv/bin/python -m pytest -q`
- `../mergework/.venv/bin/python -m ruff check app/main.py tests/test_api_mcp.py`
- `../mergework/.venv/bin/python -m ruff format --check app/main.py tests/test_api_mcp.py`
- `../mergework/.venv/bin/python -m mypy app/main.py app/mcp_tools.py`
- `../mergework/.venv/bin/python scripts/docs_smoke.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for the proof API endpoint. The API now returns a clear error message when proof data contains invalid or malformed payload that cannot be parsed, instead of failing silently.

* **Tests**
  * Added test coverage for malformed proof payload scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->