### PR TITLE
Refs #406: Handle malformed MCP proof payloads

### DIFF
--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -200,9 +200,12 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             proof = session.get(Proof, proof_hash_from_path(str_arg("hash")))
             if proof is None:
                 return "proof not found"
-            public_payload = json.loads(proof.public_json)
+            try:
+                public_payload = json.loads(proof.public_json)
+            except (TypeError, json.JSONDecodeError):
+                return "invalid proof payload"
             if not isinstance(public_payload, dict):
-                raise ValueError("invalid proof payload")
+                return "invalid proof payload"
             return json.dumps(
                 {
                     "hash": proof.hash,

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -995,6 +995,46 @@ def test_mcp_get_proof_reports_unknown_hash(sqlite_url: str) -> None:
     assert result["result"]["content"][0]["text"] == "proof not found"
 
 
+def test_mcp_get_proof_reports_malformed_payload(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=37,
+            issue_url="https://github.com/ramimbo/mergework/issues/37",
+            title="MCP malformed proof lookup",
+            reward_mrwk="150",
+            acceptance="Accepted label",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/37",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        proof_row = session.get(Proof, proof.hash)
+        assert proof_row is not None
+        proof_row.public_json = "{"
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {"name": "get_proof", "arguments": {"hash": proof.hash}},
+        },
+    ).json()
+
+    assert result["result"]["content"][0]["text"] == "invalid proof payload"
+
+
 def test_mcp_get_proof_rejects_malformed_hash(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Refs #406

## Summary
- Make MCP `get_proof` return a bounded `invalid proof payload` result when stored public proof JSON is malformed or non-object.
- Add a regression that corrupts `Proof.public_json` and verifies the public MCP `tools/call get_proof` response.

## Evidence
- Before this change, malformed stored proof JSON raised from `json.loads(proof.public_json)` inside the MCP tool path and surfaced as a generic JSON-RPC `invalid tool arguments` response, even though the caller supplied a valid proof hash.
- This is distinct from the REST proof API hardening in PR #525; this PR covers the public MCP `get_proof` tool surface.
- The normal proof lookup, unknown hash, and malformed hash behavior are preserved.

## Validation
- `../mergework/.venv/bin/python -m pytest tests/test_api_mcp.py::test_mcp_get_proof_reports_malformed_payload tests/test_api_mcp.py::test_mcp_get_proof_returns_public_proof_details tests/test_api_mcp.py::test_mcp_get_proof_reports_unknown_hash tests/test_api_mcp.py::test_mcp_get_proof_rejects_malformed_hash -q` -> 4 passed
- `../mergework/.venv/bin/python -m pytest tests/test_api_mcp.py -q` -> 77 passed
- `../mergework/.venv/bin/python -m pytest -q` -> 415 passed
- `../mergework/.venv/bin/python -m ruff check app/mcp_tools.py tests/test_api_mcp.py` -> passed
- `../mergework/.venv/bin/python -m ruff format --check app/mcp_tools.py tests/test_api_mcp.py` -> 2 files already formatted
- `../mergework/.venv/bin/python -m mypy app/mcp_tools.py app/mcp.py` -> success
- `../mergework/.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No secrets, wallet material, private keys, tokens, signatures, private data, price/off-ramp claims, or private security details are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resilience when handling corrupted proof records—the system now gracefully manages malformed JSON payloads and provides clear error messaging to users instead of crashing.

* **Tests**
  * Added test coverage to verify proper error handling for malformed proof payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->