### PR TITLE
Refs #406: Return existing proof for paid duplicate payouts

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -647,6 +647,14 @@ def pay_bounty(
     bounty = session.get(Bounty, bounty_id)
     if bounty is None:
         raise LedgerError("bounty not found")
+    clean_submission_url = validate_public_url(submission_url)
+    existing_submission = session.scalar(
+        select(Submission)
+        .where(Submission.bounty_id == bounty.id, Submission.url == clean_submission_url)
+        .limit(1)
+    )
+    if existing_submission is not None:
+        raise LedgerError("submission already paid")
     if bounty.awards_paid >= bounty.max_awards:
         raise LedgerError("bounty already paid")
     if bounty.status != "open":
@@ -656,14 +664,6 @@ def pay_bounty(
     if "accepted_by" in clean_verifier_result:
         clean_verifier_result["accepted_by"] = clean_accepted_by
     clean_to_account = _clean_required_text(to_account, "to_account", 128)
-    clean_submission_url = validate_public_url(submission_url)
-    existing_submission = session.scalar(
-        select(Submission)
-        .where(Submission.bounty_id == bounty.id, Submission.url == clean_submission_url)
-        .limit(1)
-    )
-    if existing_submission is not None:
-        raise LedgerError("submission already paid")
     reserve_account = reserve_account_for_bounty(bounty.id)
     if get_balance(session, reserve_account) < bounty.reward_microunits:
         raise LedgerError("bounty reserve balance too low")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -562,9 +562,33 @@ def test_admin_payout_api_returns_existing_proof_for_duplicate_submission(
     )
 
     assert final.status_code == 200
-    assert final.json()["bounty_status"] == "paid"
-    assert final.json()["awards_paid"] == 2
-    assert final.json()["awards_remaining"] == 0
+    final_body = final.json()
+    assert final_body["bounty_status"] == "paid"
+    assert final_body["awards_paid"] == 2
+    assert final_body["awards_remaining"] == 0
+
+    paid_duplicate = client.post(
+        f"/api/v1/bounties/{bounty_id}/pay",
+        headers=headers,
+        json={
+            "to_account": "github:carol",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/284",
+            "accepted_by": "maintainer",
+        },
+    )
+
+    assert paid_duplicate.status_code == 409
+    assert paid_duplicate.json()["status"] == "already_paid"
+    assert paid_duplicate.json()["proof_hash"] == final_body["proof_hash"]
+    assert paid_duplicate.json()["ledger_sequence"] == final_body["ledger_sequence"]
+    assert paid_duplicate.json()["submission_id"] == final_body["submission_id"]
+    with session_scope(sqlite_url) as session:
+        payments = session.scalars(
+            select(LedgerEntry).where(LedgerEntry.entry_type == "bounty_payment")
+        ).all()
+        assert len(payments) == 2
+        assert get_balance(session, "github:bob") == 15_000_000
+        assert get_balance(session, "github:carol") == 0
 
 
 def test_admin_payout_reconciliation_api_reports_missing_and_duplicate_evidence(


### PR DESCRIPTION
## Summary
- Return the existing `already_paid` proof response for duplicate admin payout submissions even after a single-award bounty has reached `paid`.
- Move duplicate submission lookup ahead of award-capacity checks so idempotent retries keep returning the original proof instead of a generic `bounty already paid` error.
- Extend the admin payout regression to retry the final award URL after the bounty is paid and verify no extra ledger entry or recipient balance is created.

## Evidence
Before this change, the existing duplicate-payout path only worked while a multi-award bounty still had award capacity. Once the final award set `awards_paid == max_awards`, a retry with the same `submission_url` hit `bounty already paid` before the duplicate submission check, so the API returned `400` instead of the existing `409 {"status":"already_paid", ...}` proof response.

Bounty #406.

## Validation
- `uv run --extra dev python -m pytest tests/test_security.py::test_admin_payout_api_returns_existing_proof_for_duplicate_submission -q` -> 1 passed
- `uv run --extra dev python -m pytest tests/test_security.py::test_admin_payout_api_returns_existing_proof_for_duplicate_submission tests/test_ledger.py::test_multi_award_bounty_rejects_duplicate_submission_url -q` -> 2 passed
- `uv run --extra dev python -m pytest -q` -> 414 passed
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --extra dev ruff format --check app/ledger/service.py tests/test_security.py` -> 2 files already formatted
- `uv run --extra dev ruff check app/ledger/service.py tests/test_security.py` -> all checks passed
- `uv run --extra dev mypy app` -> success
- `git diff --check` -> clean

No secrets, wallet material, private keys, tokens, private data, deployment credentials, price claims, liquidity claims, exchange claims, bridge/off-ramp promises, or private security details are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bounty payment validation to detect and reject duplicate submissions earlier in the processing flow, preventing accidental duplicate payments.

* **Tests**
  * Enhanced security tests to verify duplicate payment protection correctly rejects repeated payout attempts and maintains accurate transaction records.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/527?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->