### PR TITLE
Refs #406: Handle malformed duplicate payout proof payloads

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -35,7 +35,10 @@ from app.serializers import (
 
 
 def _payout_response_from_proof(proof: Proof, *, status: str) -> dict[str, Any]:
-    data = json.loads(proof.public_json)
+    try:
+        data = json.loads(proof.public_json)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise HTTPException(status_code=500, detail="invalid proof payload") from exc
     if not isinstance(data, dict) or data.get("kind") != "bounty_payment":
         raise HTTPException(status_code=500, detail="invalid proof payload")
     return {

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -567,6 +567,53 @@ def test_admin_payout_api_returns_existing_proof_for_duplicate_submission(
     assert final.json()["awards_remaining"] == 0
 
 
+def test_admin_payout_duplicate_reports_malformed_existing_proof(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    create_schema(sqlite_url)
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=284,
+            issue_url="https://github.com/ramimbo/mergework/issues/284",
+            title="Duplicate payout proof payload observability",
+            reward_mrwk="15",
+            max_awards=2,
+            acceptance="Maintainer needs bounded duplicate payout responses.",
+        )
+        bounty_id = bounty.id
+
+    headers = {"x-mergework-admin-token": "admin-token-for-tests"}
+    payout_payload = {
+        "to_account": "github:alice",
+        "submission_url": "https://github.com/ramimbo/mergework/pull/284",
+        "accepted_by": "maintainer",
+    }
+    first = client.post(f"/api/v1/bounties/{bounty_id}/pay", headers=headers, json=payout_payload)
+
+    assert first.status_code == 200
+    with session_scope(sqlite_url) as session:
+        proof = session.get(Proof, first.json()["proof_hash"])
+        assert proof is not None
+        proof.public_json = "{"
+
+    duplicate = client.post(
+        f"/api/v1/bounties/{bounty_id}/pay",
+        headers=headers,
+        json={**payout_payload, "to_account": "github:carol"},
+    )
+
+    assert duplicate.status_code == 500
+    assert duplicate.json()["detail"] == "invalid proof payload"
+
+
 def test_admin_payout_reconciliation_api_reports_missing_and_duplicate_evidence(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Catch malformed stored proof JSON when building the duplicate payout already_paid response.
- Return the same bounded invalid proof payload error used for non-object proof payloads.
- Add a regression that corrupts an existing payout proof and retries the same submission URL.

## Evidence
The admin payout API duplicate path uses _payout_response_from_proof() after finding an existing bounty payment proof for the submission. It already rejects non-object proof JSON as invalid proof payload, but malformed stored JSON escaped through json.loads() as an unbounded server exception.

This is distinct from PR #525 and PR #526: those cover public REST and MCP proof lookups. This covers the admin payout duplicate/idempotency response path.

Bounty #406.

## Validation
- ../mergework/.venv/bin/python -m pytest tests/test_security.py::test_admin_payout_duplicate_reports_malformed_existing_proof tests/test_security.py::test_admin_payout_api_returns_existing_proof_for_duplicate_submission -q -> 2 passed
- ../mergework/.venv/bin/python -m pytest tests/test_security.py -q -> 49 passed
- ../mergework/.venv/bin/python -m pytest -q -> 415 passed
- ../mergework/.venv/bin/python scripts/docs_smoke.py -> docs smoke ok
- ../mergework/.venv/bin/python -m ruff check app/bounty_api.py tests/test_security.py -> passed
- ../mergework/.venv/bin/python -m ruff format --check app/bounty_api.py tests/test_security.py -> 2 files already formatted
- ../mergework/.venv/bin/python -m mypy app/bounty_api.py -> success
- git diff --check -> clean

No secrets, wallet material, private keys, tokens, signatures, private data, price claims, exchange claims, liquidity claims, or off-ramp claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for proof payload validation. The payout system now gracefully handles malformed or invalid proof data by returning a descriptive error message, preventing unexpected failures.

* **Tests**
  * Added security regression test to verify proper handling of corrupted proof data in payout operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->