### PR TITLE
Refs #426: Document payout reconciliation runbook

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -97,6 +97,37 @@ Use `limit` to control the number of delivery rows returned (`1` to `200`,
 default `50`), for example:
 `/api/v1/admin/webhook-events?status=missing_submitter&limit=100`.
 
+### Payout Reconciliation
+
+Before marking a batch done, reconcile accepted submissions against public proof
+and ledger evidence:
+
+```bash
+curl -s "https://api.mrwk.ltclab.site/api/v1/reconciliation/payouts" \
+  -H "x-mergework-admin-token: $MERGEWORK_ADMIN_TOKEN"
+```
+
+The API returns a `summary` plus one check per accepted submission. Check
+statuses are:
+
+- `paid`: exactly one matching bounty-payment proof and ledger entry.
+- `missing_payment`: the accepted submission has no matching payment evidence.
+- `duplicate_payment_evidence`: more than one proof matches the accepted
+  submission.
+- `mismatched_payment_evidence`: a proof exists, but the ledger entry does not
+  match the expected submission URL, account, bounty, type, or amount.
+
+For a local deploy or payout batch note, run the reconciliation script:
+
+```bash
+python scripts/reconcile_payouts.py
+```
+
+The script prints JSON with `summary`, non-paid `issues`, and
+`duplicate_source_urls`. It exits nonzero when unresolved payment issues or
+duplicate accepted source URLs are present, so operators can use it as a hard
+stop before adding `mrwk:paid` labels or paid-bounty documentation rows.
+
 ### PR Queue Health
 
 Use the queue-health script before accepting busy bounty rounds:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -293,6 +293,18 @@ def test_contributing_names_docs_smoke_for_public_docs_changes() -> None:
     assert "docs, templates, examples, or onboarding" in contributing
 
 
+def test_admin_runbook_documents_payout_reconciliation() -> None:
+    runbook = Path("docs/admin-runbook.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/reconciliation/payouts" in runbook
+    assert "python scripts/reconcile_payouts.py" in runbook
+    assert "`missing_payment`" in runbook
+    assert "`duplicate_payment_evidence`" in runbook
+    assert "`mismatched_payment_evidence`" in runbook
+    assert "`duplicate_source_urls`" in runbook
+    assert "exits nonzero" in runbook
+
+
 def test_agent_guide_documents_activity_endpoint() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Documents the admin payout reconciliation endpoint and local reconciliation script in the admin runbook.
- Lists the reconciliation statuses maintainers need to gate payout batches.
- Adds a docs test so the endpoint, script, duplicate-source output, and failure states stay documented.

## Evidence
- Current code exposes `GET /api/v1/reconciliation/payouts` in `app/bounty_api.py`.
- `scripts/reconcile_payouts.py` prints `summary`, non-paid `issues`, and `duplicate_source_urls`, then exits nonzero when unresolved payout evidence or duplicate accepted source URLs remain.
- Live unauthenticated endpoint check returned `401 {"detail":"admin token required"}`, matching the documented admin-token boundary.
- Live bounty #426 preflight returned status `open`, reward `50 MRWK`, and `awards_remaining: 2`.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ../mergework/.venv/bin/python -m pytest tests/test_docs_public_urls.py::test_admin_runbook_documents_payout_reconciliation -q` -> 1 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ../mergework/.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ../mergework/.venv/bin/python -m pytest tests/test_docs_public_urls.py -q` -> 24 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ../mergework/.venv/bin/python -m pytest tests/test_bounty_api.py::TestReconciliationRoute::test_reconciliation_requires_auth tests/test_security.py::test_admin_payout_reconciliation_api_reports_missing_and_duplicate_evidence -q` -> 2 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ../mergework/.venv/bin/python -m pytest -q` -> 415 passed
- `../mergework/.venv/bin/python -m ruff check docs/admin-runbook.md tests/test_docs_public_urls.py` -> passed
- `../mergework/.venv/bin/python -m ruff format --check tests/test_docs_public_urls.py` -> passed
- `git diff --check` -> clean

Bounty #426


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added payout reconciliation section to the admin runbook, documenting the API endpoint, reconciliation script usage, status values, and required validation steps before applying paid designations.

* **Tests**
  * Added test to verify payout reconciliation documentation includes required endpoints and identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->