### PR TITLE
Flag draft PRs in queue health report

### DIFF
--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from typing import Any
 
 BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+#(\d+)", re.IGNORECASE)
+DRAFT_TITLE_RE = re.compile(r"^\s*(?:\[draft\]|draft:)", re.IGNORECASE)
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
 UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
 GH_TIMEOUT_SECONDS = 30
@@ -101,6 +102,7 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
                 "labels": _labels(pr),
                 "merge_state": _merge_state(pr),
                 "scope": _scope_key(pr),
+                "is_draft": bool(pr.get("isDraft") or pr.get("is_draft")),
             }
         )
 
@@ -108,6 +110,7 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
     missing_bounty_references: list[dict[str, Any]] = []
     dirty_or_unstable_merge_state: list[dict[str, Any]] = []
     needs_info: list[dict[str, Any]] = []
+    drafts: list[dict[str, Any]] = []
     duplicate_groups: dict[tuple[int, str], list[int]] = defaultdict(list)
 
     for pr in normalized_prs:
@@ -144,6 +147,8 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
             )
         if any(label.lower() == "mrwk:needs-info" for label in pr["labels"]):
             needs_info.append(_issue(pr, "mrwk_needs_info", "PR has mrwk:needs-info label"))
+        if pr["is_draft"] or DRAFT_TITLE_RE.search(pr["title"]):
+            drafts.append(_issue(pr, "draft_pull_request", "PR is still marked as draft"))
 
     duplicate_scope_groups = [
         {"bounty": bounty, "scope": scope, "pull_requests": sorted(numbers)}
@@ -162,12 +167,14 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
             "missing_bounty_references": len(missing_bounty_references),
             "dirty_or_unstable_merge_state": len(dirty_or_unstable_merge_state),
             "needs_info": len(needs_info),
+            "drafts": len(drafts),
             "duplicate_scope_groups": len(duplicate_scope_groups),
         },
         "closed_bounty_references": closed_bounty_references,
         "missing_bounty_references": missing_bounty_references,
         "dirty_or_unstable_merge_state": dirty_or_unstable_merge_state,
         "needs_info": needs_info,
+        "drafts": drafts,
         "duplicate_scope_groups": duplicate_scope_groups,
     }
     return report
@@ -181,6 +188,7 @@ def has_queue_issues(report: dict[str, Any]) -> bool:
             "missing_bounty_references",
             "dirty_or_unstable_merge_state",
             "needs_info",
+            "drafts",
             "duplicate_scope_groups",
         )
     )
@@ -199,6 +207,8 @@ def format_text_report(report: dict[str, Any]) -> str:
         ("Missing bounty references", "missing_bounty_references"),
         ("Dirty or unstable merge state", "dirty_or_unstable_merge_state"),
         ("Needs info", "needs_info"),
+        ("Draft pull requests", "drafts"),
+        ("Draft pull requests", "drafts"),
     ]
     for title, key in sections:
         if report[key]:
@@ -241,6 +251,7 @@ def format_markdown_report(report: dict[str, Any]) -> str:
         ("Missing bounty references", "missing_bounty_references"),
         ("Dirty or unstable merge state", "dirty_or_unstable_merge_state"),
         ("Needs info", "needs_info"),
+        ("Draft pull requests", "drafts"),
     ]
     for title, key in sections:
         if report[key]:
@@ -294,7 +305,7 @@ def load_live_queue(repo: str) -> dict[str, Any]:
             "--limit",
             str(GH_PR_SAFETY_CAP),
             "--json",
-            "number,title,url,body,labels,mergeStateStatus",
+            "number,title,url,body,labels,mergeStateStatus,isDraft",
         ]
     )
     if len(prs) >= GH_PR_SAFETY_CAP:

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -43,7 +43,7 @@ def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
             },
             {
                 "number": 4,
-                "title": "Guard MCP bounty search oversized numeric query",
+                "title": "[Draft] Guard MCP bounty search oversized numeric query",
                 "url": "https://github.com/ramimbo/mergework/pull/4",
                 "body": "Refs #292",
                 "merge_state": "unknown",
@@ -62,12 +62,14 @@ def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
         "missing_bounty_references": 1,
         "dirty_or_unstable_merge_state": 2,
         "needs_info": 1,
+        "drafts": 1,
         "duplicate_scope_groups": 1,
     }
     assert report["closed_bounty_references"][0]["pull_request"] == 1
     assert report["missing_bounty_references"][0]["pull_request"] == 2
     assert {item["pull_request"] for item in report["dirty_or_unstable_merge_state"]} == {3, 4}
     assert report["needs_info"][0]["pull_request"] == 3
+    assert report["drafts"][0]["pull_request"] == 4
     assert report["duplicate_scope_groups"] == [
         {
             "bounty": 292,
@@ -161,7 +163,7 @@ def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
                 },
                 {
                     "number": 4,
-                    "title": "Guard MCP bounty search oversized numeric query",
+                    "title": "[Draft] Guard MCP bounty search oversized numeric query",
                     "url": "https://github.com/ramimbo/mergework/pull/4",
                     "body": "Refs #292",
                     "merge_state": "unknown",
@@ -189,6 +191,8 @@ def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     assert "Merge state is dirty" in markdown
     assert "### Needs info" in markdown
     assert "PR has mrwk:needs-info label" in markdown
+    assert "### Draft pull requests" in markdown
+    assert "PR is still marked as draft" in markdown
     assert "### Likely duplicate bounty scope" in markdown
     assert "- Bounty #292: guard mcp bounty search oversized numeric query (#3, #4)" in markdown
 
@@ -289,3 +293,12 @@ def test_pr_queue_health_fails_fast_when_pr_fetch_hits_cap(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="pr list reached the 201 item safety cap"):
         pr_queue_health.load_live_queue("ramimbo/mergework")
+
+
+def test_pr_queue_health_flags_gh_draft_field() -> None:
+    report = analyze_queue(
+        {"bounties": [], "pull_requests": [{"number": 9, "title": "Ship preview", "isDraft": True}]}
+    )
+
+    assert report["summary"]["drafts"] == 1
+    assert report["drafts"][0]["pull_request"] == 9


### PR DESCRIPTION
Refs #447

## Summary
- flag draft pull requests in `scripts/pr_queue_health.py`
- include draft counts/section in text + markdown + JSON reports
- collect `isDraft` from live `gh pr list` input

## Tests
- `ruff check .`
- `python3 -m pytest tests/test_pr_queue_health.py -q`

This helps bounty reviewers avoid paying/processing PRs that are still draft/WIP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queue health reporting now detects and includes draft pull requests in analysis.
  * Draft PR count is displayed in queue health summaries and reports.
  * Draft pull requests appear in both text and markdown formatted reports.
  * Draft PRs can be flagged as queue issues when using the `--fail-on-issues` option.

* **Tests**
  * Added test coverage for draft pull request detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->