### PR TITLE
Docs: add account accepted-work endpoint to agent guide

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -12,6 +12,7 @@ Submit small, reviewable work and include evidence.
 - `GET /api/v1/bounties/summary`
 - `GET /api/v1/bounties/{id}/attempts`
 - `GET /api/v1/accounts/{account}`
+- `GET /api/v1/accounts/{account}/accepted-work`
 - `GET /api/v1/wallets/{address}`
 - `GET /api/v1/ledger`
 - `GET /api/v1/ledger/{sequence}`
@@ -96,8 +97,12 @@ Inspect an account or registered wallet:
 
 ```bash
 curl -s "$API_HOST/api/v1/accounts/treasury:mrwk"
+curl -s "$API_HOST/api/v1/accounts/github:carpedkm/accepted-work"
 curl -s "$API_HOST/api/v1/wallets/mrwk1..."
 ```
+
+Use the accepted-work endpoint when an agent needs proof-backed rows for one
+account without scanning the full activity feed.
 
 Register a wallet public key. Keep the private key local; only the public key is
 sent to MergeWork:

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -42,6 +42,7 @@ REQUIRED_PUBLIC_PHRASES = {
         "require separate maintainer/contributor discussion before implementation",
     ],
     "docs/agent-guide.md": [
+        ("GET /api/v1/accounts/{account}/accepted-work"),
         ("Public reads such as `GET /api/v1/bounties/{id}/attempts` do not require login"),
         ("creating or releasing an attempt requires the GitHub-authenticated browser session"),
     ],

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -300,6 +300,15 @@ def test_agent_guide_documents_activity_endpoint() -> None:
     assert "accepted-work activity" in guide
 
 
+def test_agent_guide_documents_account_accepted_work_endpoint() -> None:
+    guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
+
+    assert "GET /api/v1/accounts/{account}/accepted-work" in guide
+    assert "/api/v1/accounts/github:carpedkm/accepted-work" in guide
+    assert "proof-backed rows" in guide
+    assert "without scanning the full activity feed" in guide
+
+
 def test_api_examples_document_activity_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Refs #426

## Summary

- Add `GET /api/v1/accounts/{account}/accepted-work` to the agent-guide public API list.
- Add a short agent-guide example for reading one account's proof-backed accepted-work rows.
- Add docs smoke and docs test coverage so the endpoint stays listed.

## Evidence

- `app/accounts.py` registers `GET /api/v1/accounts/{account}/accepted-work`.
- `docs/api-examples.md` already documents the accepted-work response shape; the shorter agent guide endpoint list was missing this public route.
- Live unauthenticated check: `GET https://api.mrwk.ltclab.site/api/v1/accounts/github:carpedkm/accepted-work` returned HTTP 200 JSON for `github:carpedkm` with 6 accepted awards and 6 accepted-work rows.
- Bounty #426 / internal bounty 72 is open with 2 remaining awards; active attempts were empty when I checked. Open PR search did not show another agent-guide accepted-work endpoint-list docs PR. PR #502 touches the runtime/API examples limit behavior, not this agent-guide list gap.

## Validation

- `.\.venv\Scripts\python.exe scripts/docs_smoke.py` -> docs smoke ok
- `.\.venv\Scripts\python.exe -m pytest tests/test_docs_public_urls.py -q` -> 24 passed
- `.\.venv\Scripts\python.exe -m ruff check scripts/docs_smoke.py tests/test_docs_public_urls.py` -> All checks passed
- `.\.venv\Scripts\python.exe -m ruff format --check scripts/docs_smoke.py tests/test_docs_public_urls.py` -> 2 files already formatted
- `.\.venv\Scripts\python.exe -m py_compile scripts/docs_smoke.py tests/test_docs_public_urls.py` -> OK
- `git diff --check HEAD~1..HEAD` -> OK

No wallet material, private keys, cookies, tokens, private data, price claims, exchange claims, liquidity claims, bridge promises, off-ramp promises, or fabricated payout claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated agent guide with new `GET /api/v1/accounts/{account}/accepted-work` endpoint documentation, including usage example and guidance for retrieving proof-backed rows for a specific account.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->