### PR TITLE
Refs #406: Honor offset on public list APIs

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -25,7 +25,7 @@ from app.ledger.service import (
     validate_public_url,
 )
 from app.models import Bounty, Proof, Submission
-from app.path_params import issue_number_search_value, positive_bounty_id
+from app.path_params import SQLITE_INTEGER_MAX, issue_number_search_value, positive_bounty_id
 from app.serializers import (
     bounty_awards_to_dict,
     bounty_list_summary,
@@ -134,7 +134,7 @@ def register_bounty_api_routes(
         status: str | None = Query(None),
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
-        offset: Annotated[int, Query(ge=0)] = 0,
+        offset: Annotated[int, Query(ge=0, le=SQLITE_INTEGER_MAX)] = 0,
         sort: str | None = Query(None),
     ) -> list[dict[str, Any]]:
         return _list_bounties_by_status(status, q, sort=sort, limit=limit, offset=offset)
@@ -144,7 +144,7 @@ def register_bounty_api_routes(
         status: str | None = Query(None),
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
-        offset: Annotated[int, Query(ge=0)] = 0,
+        offset: Annotated[int, Query(ge=0, le=SQLITE_INTEGER_MAX)] = 0,
         sort: str | None = Query(None),
     ) -> dict[str, Any]:
         return bounty_list_summary(

--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -87,6 +87,7 @@ def register_bounty_api_routes(
         query_text: str | None = None,
         sort: str | None = None,
         limit: int | None = None,
+        offset: int = 0,
     ) -> list[dict[str, Any]]:
         try:
             normalized_sort = normalize_bounty_sort(sort)
@@ -125,26 +126,30 @@ def register_bounty_api_routes(
                 [bounty_to_dict(bounty) for bounty in bounties], normalized_sort
             )
             if limit is not None:
-                return sorted_bounties[:limit]
-            return sorted_bounties
+                return sorted_bounties[offset : offset + limit]
+            return sorted_bounties[offset:]
 
     @app.get("/api/v1/bounties")
     def api_bounties(
         status: str | None = Query(None),
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+        offset: Annotated[int, Query(ge=0)] = 0,
         sort: str | None = Query(None),
     ) -> list[dict[str, Any]]:
-        return _list_bounties_by_status(status, q, sort=sort, limit=limit)
+        return _list_bounties_by_status(status, q, sort=sort, limit=limit, offset=offset)
 
     @app.get("/api/v1/bounties/summary")
     def api_bounties_summary(
         status: str | None = Query(None),
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+        offset: Annotated[int, Query(ge=0)] = 0,
         sort: str | None = Query(None),
     ) -> dict[str, Any]:
-        return bounty_list_summary(_list_bounties_by_status(status, q, sort=sort, limit=limit))
+        return bounty_list_summary(
+            _list_bounties_by_status(status, q, sort=sort, limit=limit, offset=offset)
+        )
 
     @app.get("/api/v1/admin/webhook-events")
     def api_admin_webhook_events(

--- a/app/ledger_views.py
+++ b/app/ledger_views.py
@@ -26,9 +26,9 @@ def ledger_entries_to_dicts(
     return [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
 
 
-def recent_ledger_entries(session: Session, limit: int) -> list[dict[str, Any]]:
+def recent_ledger_entries(session: Session, limit: int, offset: int = 0) -> list[dict[str, Any]]:
     entries = session.scalars(
-        select(LedgerEntry).order_by(LedgerEntry.sequence.desc()).limit(limit)
+        select(LedgerEntry).order_by(LedgerEntry.sequence.desc()).offset(offset).limit(limit)
     ).all()
     return ledger_entries_to_dicts(session, entries)
 

--- a/app/main.py
+++ b/app/main.py
@@ -292,7 +292,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     @app.get("/api/v1/ledger")
     def api_ledger(
         limit: Annotated[int, Query(ge=1, le=200)] = 50,
-        offset: Annotated[int, Query(ge=0)] = 0,
+        offset: Annotated[int, Query(ge=0, le=SQLITE_INTEGER_MAX)] = 0,
     ) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
             return recent_ledger_entries(session, limit, offset)

--- a/app/main.py
+++ b/app/main.py
@@ -290,9 +290,12 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     )
 
     @app.get("/api/v1/ledger")
-    def api_ledger(limit: Annotated[int, Query(ge=1, le=200)] = 50) -> list[dict[str, Any]]:
+    def api_ledger(
+        limit: Annotated[int, Query(ge=1, le=200)] = 50,
+        offset: Annotated[int, Query(ge=0)] = 0,
+    ) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
-            return recent_ledger_entries(session, limit)
+            return recent_ledger_entries(session, limit, offset)
 
     @app.get("/api/v1/ledger/{sequence}")
     def api_ledger_entry(sequence: int) -> dict[str, Any]:

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -16,6 +16,7 @@ curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
 curl -s "$API_HOST/api/v1/bounties?status=open"
 curl -s "$API_HOST/api/v1/bounties?status=open&sort=available&limit=5"
+curl -s "$API_HOST/api/v1/bounties?status=open&sort=available&limit=5&offset=5"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open&q=proof"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open&sort=awards&limit=5"
 ```
@@ -50,11 +51,12 @@ available slot counts.
 Use `sort` to choose the bounty order: `newest` is the default, `reward` sorts
 by per-award reward, `available` sorts by the remaining MRWK pool, and `awards`
 sorts by remaining award slots. Use `limit` from `1` to `200` to cap returned
-rows after filtering and sorting.
+rows after filtering and sorting. Use `offset` from `0` upward to skip rows
+after the same filtering and sorting step.
 
 Use `/api/v1/bounties/summary` with the same optional `status`, `q`, `sort`, and
-`limit` filters when an agent only needs capacity totals instead of full bounty
-rows:
+`limit` and `offset` filters when an agent only needs capacity totals instead
+of full bounty rows:
 
 ```json
 {
@@ -179,11 +181,13 @@ Read recent ledger entries and inspect one entry:
 
 ```bash
 curl -s "$API_HOST/api/v1/ledger?limit=10"
+curl -s "$API_HOST/api/v1/ledger?limit=10&offset=10"
 curl -s "$API_HOST/api/v1/ledger/<sequence>"
 ```
 
 Ledger entries use the internal immutable sequence number as the API path key.
-Recent-list and single-entry responses share the same shape:
+Recent-list queries accept `limit` from `1` to `200` and `offset` from `0`
+upward. Recent-list and single-entry responses share the same shape:
 
 ```json
 {

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -51,8 +51,8 @@ available slot counts.
 Use `sort` to choose the bounty order: `newest` is the default, `reward` sorts
 by per-award reward, `available` sorts by the remaining MRWK pool, and `awards`
 sorts by remaining award slots. Use `limit` from `1` to `200` to cap returned
-rows after filtering and sorting. Use `offset` from `0` upward to skip rows
-after the same filtering and sorting step.
+rows after filtering and sorting. Use `offset` from `0` through SQLite's signed
+integer maximum to skip rows after the same filtering and sorting step.
 
 Use `/api/v1/bounties/summary` with the same optional `status`, `q`, `sort`, and
 `limit` and `offset` filters when an agent only needs capacity totals instead
@@ -187,7 +187,8 @@ curl -s "$API_HOST/api/v1/ledger/<sequence>"
 
 Ledger entries use the internal immutable sequence number as the API path key.
 Recent-list queries accept `limit` from `1` to `200` and `offset` from `0`
-upward. Recent-list and single-entry responses share the same shape:
+through SQLite's signed integer maximum. Recent-list and single-entry responses
+share the same shape:
 
 ```json
 {

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -50,6 +50,44 @@ def test_ledger_api_rejects_out_of_range_limits(sqlite_url: str, limit: str) -> 
     assert response.status_code == 422
 
 
+def test_ledger_api_honors_offset(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        first = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=201,
+            issue_url="https://github.com/ramimbo/mergework/issues/201",
+            title="Older ledger row",
+            reward_mrwk="25",
+            acceptance="Ledger offset should skip newest rows.",
+        )
+        second = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=202,
+            issue_url="https://github.com/ramimbo/mergework/issues/202",
+            title="Newer ledger row",
+            reward_mrwk="25",
+            acceptance="Ledger offset should return later pages.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    newest = client.get("/api/v1/ledger?limit=1")
+    shifted = client.get("/api/v1/ledger?limit=1&offset=1")
+    exhausted = client.get("/api/v1/ledger?limit=1&offset=99")
+    invalid = client.get("/api/v1/ledger?offset=-1")
+
+    assert newest.status_code == 200
+    assert shifted.status_code == 200
+    assert [entry["reference"] for entry in newest.json()] == [second.issue_url]
+    assert [entry["reference"] for entry in shifted.json()] == [first.issue_url]
+    assert exhausted.json() == []
+    assert invalid.status_code == 422
+
+
 def test_head_requests_match_get_routes_without_body(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -78,6 +78,7 @@ def test_ledger_api_honors_offset(sqlite_url: str) -> None:
     newest = client.get("/api/v1/ledger?limit=1")
     shifted = client.get("/api/v1/ledger?limit=1&offset=1")
     exhausted = client.get("/api/v1/ledger?limit=1&offset=99")
+    max_valid = client.get("/api/v1/ledger?offset=9223372036854775807")
     invalid = client.get("/api/v1/ledger?offset=-1")
     oversized = client.get("/api/v1/ledger?offset=9999999999999999999999999999999999999999")
 
@@ -86,6 +87,8 @@ def test_ledger_api_honors_offset(sqlite_url: str) -> None:
     assert [entry["reference"] for entry in newest.json()] == [second.issue_url]
     assert [entry["reference"] for entry in shifted.json()] == [first.issue_url]
     assert exhausted.json() == []
+    assert max_valid.status_code == 200
+    assert max_valid.json() == []
     assert invalid.status_code == 422
     assert oversized.status_code == 422
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -79,6 +79,7 @@ def test_ledger_api_honors_offset(sqlite_url: str) -> None:
     shifted = client.get("/api/v1/ledger?limit=1&offset=1")
     exhausted = client.get("/api/v1/ledger?limit=1&offset=99")
     invalid = client.get("/api/v1/ledger?offset=-1")
+    oversized = client.get("/api/v1/ledger?offset=9999999999999999999999999999999999999999")
 
     assert newest.status_code == 200
     assert shifted.status_code == 200
@@ -86,6 +87,7 @@ def test_ledger_api_honors_offset(sqlite_url: str) -> None:
     assert [entry["reference"] for entry in shifted.json()] == [first.issue_url]
     assert exhausted.json() == []
     assert invalid.status_code == 422
+    assert oversized.status_code == 422
 
 
 def test_head_requests_match_get_routes_without_body(sqlite_url: str) -> None:

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -295,11 +295,18 @@ def test_bounty_api_limit_caps_filtered_rows(sqlite_url: str) -> None:
 
     limited = client.get("/api/v1/bounties?status=open&limit=2")
     summary = client.get("/api/v1/bounties/summary?status=open&limit=2")
+    shifted = client.get("/api/v1/bounties?status=open&limit=1&offset=1")
+    shifted_summary = client.get("/api/v1/bounties/summary?status=open&limit=1&offset=1")
+    exhausted = client.get("/api/v1/bounties?status=open&limit=2&offset=99")
 
     assert [item["id"] for item in limited.json()] == [third.id, second.id]
+    assert [item["id"] for item in shifted.json()] == [second.id]
     assert summary.json()["bounties_shown"] == 2
     assert summary.json()["open_awards"] == 2
+    assert shifted_summary.json()["bounties_shown"] == 1
+    assert shifted_summary.json()["open_awards"] == 1
     assert first.id not in [item["id"] for item in limited.json()]
+    assert exhausted.json() == []
 
 
 def test_bounty_api_limit_rejects_out_of_range_values(sqlite_url: str) -> None:
@@ -311,5 +318,7 @@ def test_bounty_api_limit_rejects_out_of_range_values(sqlite_url: str) -> None:
 
     assert client.get("/api/v1/bounties?limit=0").status_code == 422
     assert client.get("/api/v1/bounties?limit=201").status_code == 422
+    assert client.get("/api/v1/bounties?offset=-1").status_code == 422
     assert client.get("/api/v1/bounties/summary?limit=0").status_code == 422
     assert client.get("/api/v1/bounties/summary?limit=201").status_code == 422
+    assert client.get("/api/v1/bounties/summary?offset=-1").status_code == 422

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -318,6 +318,7 @@ def test_bounty_api_limit_rejects_out_of_range_values(sqlite_url: str) -> None:
 
     assert client.get("/api/v1/bounties?limit=0").status_code == 422
     assert client.get("/api/v1/bounties?limit=201").status_code == 422
+    assert client.get("/api/v1/bounties?offset=9223372036854775807").status_code == 200
     assert client.get("/api/v1/bounties?offset=-1").status_code == 422
     assert (
         client.get("/api/v1/bounties?offset=9999999999999999999999999999999999999999").status_code
@@ -325,6 +326,7 @@ def test_bounty_api_limit_rejects_out_of_range_values(sqlite_url: str) -> None:
     )
     assert client.get("/api/v1/bounties/summary?limit=0").status_code == 422
     assert client.get("/api/v1/bounties/summary?limit=201").status_code == 422
+    assert client.get("/api/v1/bounties/summary?offset=9223372036854775807").status_code == 200
     assert client.get("/api/v1/bounties/summary?offset=-1").status_code == 422
     assert (
         client.get(

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -319,6 +319,16 @@ def test_bounty_api_limit_rejects_out_of_range_values(sqlite_url: str) -> None:
     assert client.get("/api/v1/bounties?limit=0").status_code == 422
     assert client.get("/api/v1/bounties?limit=201").status_code == 422
     assert client.get("/api/v1/bounties?offset=-1").status_code == 422
+    assert (
+        client.get("/api/v1/bounties?offset=9999999999999999999999999999999999999999").status_code
+        == 422
+    )
     assert client.get("/api/v1/bounties/summary?limit=0").status_code == 422
     assert client.get("/api/v1/bounties/summary?limit=201").status_code == 422
     assert client.get("/api/v1/bounties/summary?offset=-1").status_code == 422
+    assert (
+        client.get(
+            "/api/v1/bounties/summary?offset=9999999999999999999999999999999999999999"
+        ).status_code
+        == 422
+    )

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -91,6 +91,7 @@ def test_api_examples_document_ledger_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 
     assert "/api/v1/ledger?limit=10" in examples
+    assert "/api/v1/ledger?limit=10&offset=10" in examples
     assert "/api/v1/ledger/<sequence>" in examples
     assert '"sequence": 329' in examples
     assert '"type": "bounty_reserve"' in examples
@@ -102,6 +103,7 @@ def test_api_examples_document_ledger_response_shape() -> None:
     )
     assert '"proof_hash": null' in examples
     assert "bounty-payment ledger entries" in examples
+    assert "Recent-list queries accept `limit` from `1` to `200`" in examples
 
 
 def test_api_examples_document_auth_me_response_shape() -> None:
@@ -118,6 +120,7 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
 
     assert "/api/v1/bounties?status=open" in examples
     assert "/api/v1/bounties?status=open&sort=available&limit=5" in examples
+    assert "/api/v1/bounties?status=open&sort=available&limit=5&offset=5" in examples
     assert "/api/v1/bounties/summary?status=open&q=proof" in examples
     assert "/api/v1/bounties/summary?status=open&sort=awards&limit=5" in examples
     assert "status` can be omitted or set to" in examples
@@ -126,6 +129,7 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert "`available` sorts by the remaining MRWK pool" in examples
     assert "remaining award slots" in examples
     assert "Use `limit` from `1` to `200`" in examples
+    assert "Use `offset` from `0` upward" in examples
     assert '"id": 36' in examples
     assert '"repo": "ramimbo/mergework"' in examples
     assert '"issue_number": 164' in examples
@@ -141,6 +145,7 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert "capacity totals" in examples
     assert "full bounty" in examples
     assert "same optional `status`, `q`, `sort`, and" in examples
+    assert "`limit` and `offset` filters" in examples
     assert "Use `id` for the single-bounty API path" in examples
 
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -104,6 +104,7 @@ def test_api_examples_document_ledger_response_shape() -> None:
     assert '"proof_hash": null' in examples
     assert "bounty-payment ledger entries" in examples
     assert "Recent-list queries accept `limit` from `1` to `200`" in examples
+    assert "through SQLite's signed integer maximum" in examples
 
 
 def test_api_examples_document_auth_me_response_shape() -> None:
@@ -129,7 +130,7 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert "`available` sorts by the remaining MRWK pool" in examples
     assert "remaining award slots" in examples
     assert "Use `limit` from `1` to `200`" in examples
-    assert "Use `offset` from `0` upward" in examples
+    assert "Use `offset` from `0` through SQLite's signed" in examples
     assert '"id": 36' in examples
     assert '"repo": "ramimbo/mergework"' in examples
     assert '"issue_number": 164' in examples


### PR DESCRIPTION
﻿Summary:
- add validated `offset` query support to `/api/v1/bounties` and `/api/v1/bounties/summary`
- apply bounty offsets after the existing status/q filtering and sort
- add validated `offset` support to `/api/v1/ledger` after newest-first ordering
- document the new offset parameters and regression coverage

Evidence:
- Public #406 report showed `offset` was silently ignored on bounties and ledger list endpoints.
- I did not change `/api/v1/activity` here because PR #495 is already changing activity list behavior; this keeps the fix focused on endpoints without visible same-scope work.

Validation:
- `uv run --extra dev python -m pytest tests/test_bounty_api_routes.py::test_bounty_api_limit_caps_filtered_rows tests/test_bounty_api_routes.py::test_bounty_api_limit_rejects_out_of_range_values tests/test_api_mcp.py::test_ledger_api_honors_offset tests/test_docs_public_urls.py::test_api_examples_document_bounty_list_response_shape tests/test_docs_public_urls.py::test_api_examples_document_ledger_response_shape -q` -> 5 passed
- `uv run --extra dev python -m pytest -q` -> 415 passed
- `uv run --extra dev ruff format --check .` -> 79 files already formatted
- `uv run --extra dev ruff check .` -> All checks passed
- `uv run --extra dev python -m mypy app` -> Success: no issues found in 30 source files
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean; only the existing CRLF warning for `docs/api-examples.md`
- `git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offset-based pagination to bounties listing, bounties summary, and recent ledger endpoints so users can fetch subsequent pages.

* **Documentation**
  * API examples updated to show offset usage and clarify accepted limit/offset ranges and semantics.

* **Tests**
  * Added and expanded tests to validate pagination behavior, offset validation, and edge-case responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->