### PR TITLE
Refs #406: Honor activity offset

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import FastAPI, Query, Request
 from fastapi.responses import HTMLResponse
@@ -11,15 +11,18 @@ from app.db import session_scope
 from app.serializers import activity_to_dict
 
 
-def activity_context(session: Session, query: str | None = None) -> dict[str, Any]:
-    return activity_to_dict(session, query)
+def activity_context(session: Session, query: str | None = None, offset: int = 0) -> dict[str, Any]:
+    return activity_to_dict(session, query, offset=offset)
 
 
 def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
     @app.get("/api/v1/activity")
-    def api_activity(q: str | None = Query(None)) -> dict[str, Any]:
+    def api_activity(
+        q: str | None = Query(None),
+        offset: Annotated[int, Query(ge=0)] = 0,
+    ) -> dict[str, Any]:
         with session_scope(db_url) as session:
-            return activity_context(session, q)
+            return activity_context(session, q, offset=offset)
 
     @app.get("/activity", response_class=HTMLResponse)
     def activity_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -184,7 +184,7 @@ def _activity_row_matches(row: dict[str, Any], query: str) -> bool:
     return any(query in str(value or "").lower() for value in searchable_values)
 
 
-def activity_to_dict(session: Session, query: str | None = None) -> dict[str, Any]:
+def activity_to_dict(session: Session, query: str | None = None, offset: int = 0) -> dict[str, Any]:
     """Build the public activity feed and contributor totals."""
     search_query = _activity_search_query(query)
     rows = session.execute(
@@ -247,7 +247,7 @@ def activity_to_dict(session: Session, query: str | None = None) -> dict[str, An
         },
         "query": search_query,
         "contributors": contributors,
-        "recent": recent[:100],
+        "recent": recent[offset : offset + 100],
     }
 
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -208,6 +208,7 @@ Read accepted-work activity summarized from proof-backed bounty payments:
 ```bash
 curl -s "$API_HOST/api/v1/activity"
 curl -s "$API_HOST/api/v1/activity?q=p3xill"
+curl -s "$API_HOST/api/v1/activity?offset=100"
 ```
 
 The optional `q` parameter filters activity rows by account, amount, submission
@@ -257,6 +258,7 @@ issue number. The response groups matching proof-backed bounty payments into
 
 `contributors` is sorted by accepted MRWK amount, while `recent` is sorted by
 newest ledger sequence and capped to the latest 100 matching rows. Use
+`offset` from `0` upward to page the `recent` rows after any `q` filter. Use
 `proof_hash` with `/api/v1/proofs/<proof_hash>` to inspect the public proof
 payload for a payment.
 

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -172,6 +172,64 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
     assert no_match["recent"] == []
 
 
+def test_activity_api_honors_offset_for_recent_rows(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=166,
+            issue_url="https://github.com/ramimbo/mergework/issues/166",
+            title="Activity offset bounty",
+            reward_mrwk="10",
+            max_awards=3,
+            acceptance="Activity offset should page recent accepted work rows.",
+        )
+        first_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/166",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        second_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:bob",
+            submission_url="https://github.com/ramimbo/mergework/pull/167",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        third_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:carol",
+            submission_url="https://github.com/ramimbo/mergework/pull/168",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/api/v1/activity?offset=1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["totals"] == {
+        "accepted_awards": 3,
+        "accepted_mrwk": "30",
+        "contributors": 3,
+    }
+    assert [row["proof_hash"] for row in payload["recent"]] == [
+        second_proof.hash,
+        first_proof.hash,
+    ]
+    assert third_proof.hash not in [row["proof_hash"] for row in payload["recent"]]
+    assert client.get("/api/v1/activity?offset=-1").status_code == 422
+
+
 def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -230,6 +230,61 @@ def test_activity_api_honors_offset_for_recent_rows(sqlite_url: str) -> None:
     assert client.get("/api/v1/activity?offset=-1").status_code == 422
 
 
+def test_activity_api_applies_query_before_offset(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=167,
+            issue_url="https://github.com/ramimbo/mergework/issues/167",
+            title="Activity filtered offset bounty",
+            reward_mrwk="10",
+            max_awards=3,
+            acceptance="Activity offset should apply after query filtering.",
+        )
+        first_carol_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:carol",
+            submission_url="https://github.com/ramimbo/mergework/pull/169",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        alice_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/170",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        second_carol_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:carol",
+            submission_url="https://github.com/ramimbo/mergework/pull/171",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/api/v1/activity?q=carol&offset=1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["totals"] == {
+        "accepted_awards": 2,
+        "accepted_mrwk": "20",
+        "contributors": 1,
+    }
+    assert [row["proof_hash"] for row in payload["recent"]] == [first_carol_proof.hash]
+    assert second_carol_proof.hash not in [row["proof_hash"] for row in payload["recent"]]
+    assert alice_proof.hash not in [row["proof_hash"] for row in payload["recent"]]
+
+
 def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -304,6 +304,7 @@ def test_api_examples_document_activity_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 
     assert "/api/v1/activity?q=p3xill" in examples
+    assert "/api/v1/activity?offset=100" in examples
     assert '"totals": {' in examples
     assert '"accepted_awards": 2' in examples
     assert '"accepted_mrwk": "115"' in examples
@@ -327,6 +328,7 @@ def test_api_examples_document_activity_response_shape() -> None:
     assert '"bounty_url": "/bounties/37"' in examples
     assert "bounty repo, bounty issue URL" in examples
     assert "newest ledger sequence" in examples
+    assert "`offset` from `0` upward" in examples
     assert "/api/v1/proofs/<proof_hash>" in examples
 
 


### PR DESCRIPTION
Fixes the `offset` half of the activity pagination gap reported in #406. `/api/v1/activity?offset=N` now skips the first N newest `recent` rows after any `q` filter, while totals and contributor rollups still describe the full matching set.

This intentionally stays separate from #495, which already covers activity `limit`, and from #532, which covers bounties/ledger offsets.

Validation:
- `pytest tests/test_activity.py tests/test_docs_public_urls.py::test_api_examples_document_activity_response_shape -q` -> 5 passed
- `ruff check app/activity.py app/serializers.py tests/test_activity.py tests/test_docs_public_urls.py`
- `ruff format --check app/activity.py app/serializers.py tests/test_activity.py tests/test_docs_public_urls.py`
- `mypy app/activity.py app/serializers.py`
- `python scripts/docs_smoke.py`
- `git diff --check`

`gitleaks` is not installed in this workspace, so I could not run the staged-diff secret scan locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity API now accepts an optional offset (default 0) to page additional batches of recent activity.

* **Behavior Changes**
  * Pagination applies after any query/filtering; overall totals and contributor totals remain unchanged by offset.

* **Documentation**
  * API docs updated with an example using offset.

* **Tests**
  * Added tests for offset behavior, validation, and query+offset interaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->