### PR TITLE
Refs #426: Document auth session flow

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -110,6 +110,10 @@ curl -s -X POST "$API_HOST/api/v1/wallets/register" \
 
 GitHub link and claim endpoints require GitHub OAuth plus a wallet signature.
 The browser flow starts at `https://mrwk.ltclab.site/auth/github/login?next=/me`.
+Check the current session with `GET /api/v1/auth/me`; unauthenticated callers
+receive `{"authenticated": false, "github_login": null}`. End a browser session
+with `POST /auth/logout`, which redirects to `/` and clears the MergeWork auth
+cookies. Do not use `GET /auth/logout` for logout side effects.
 
 ## Wallet Payloads
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -112,8 +112,8 @@ GitHub link and claim endpoints require GitHub OAuth plus a wallet signature.
 The browser flow starts at `https://mrwk.ltclab.site/auth/github/login?next=/me`.
 Check the current session with `GET /api/v1/auth/me`; unauthenticated callers
 receive `{"authenticated": false, "github_login": null}`. End a browser session
-with `POST /auth/logout`, which redirects to `/` and clears the MergeWork auth
-cookies. Do not use `GET /auth/logout` for logout side effects.
+with `POST /auth/logout`, which redirects to `/` and clears the MergeWork auth cookies.
+Do not use `GET /auth/logout` for logout side effects.
 
 ## Wallet Payloads
 

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -45,6 +45,7 @@ REQUIRED_PUBLIC_PHRASES = {
         ("Public reads such as `GET /api/v1/bounties/{id}/attempts` do not require login"),
         ("creating or releasing an attempt requires the GitHub-authenticated browser session"),
         "Check the current session with `GET /api/v1/auth/me`",
+        "clears the MergeWork auth cookies",
         "Do not use `GET /auth/logout` for logout side effects.",
     ],
     "docs/bounty-rules.md": [

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -44,6 +44,8 @@ REQUIRED_PUBLIC_PHRASES = {
     "docs/agent-guide.md": [
         ("Public reads such as `GET /api/v1/bounties/{id}/attempts` do not require login"),
         ("creating or releasing an attempt requires the GitHub-authenticated browser session"),
+        "Check the current session with `GET /api/v1/auth/me`",
+        "Do not use `GET /auth/logout` for logout side effects.",
     ],
     "docs/bounty-rules.md": [
         "## Submission Evidence Templates",

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -113,6 +113,16 @@ def test_api_examples_document_auth_me_response_shape() -> None:
     assert "Unauthenticated requests return" in examples
 
 
+def test_agent_guide_documents_auth_session_flow() -> None:
+    guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
+
+    assert "https://mrwk.ltclab.site/auth/github/login?next=/me" in guide
+    assert "GET /api/v1/auth/me" in guide
+    assert '{"authenticated": false, "github_login": null}' in guide
+    assert "POST /auth/logout" in guide
+    assert "Do not use `GET /auth/logout` for logout side effects." in guide
+
+
 def test_api_examples_document_bounty_list_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -120,6 +120,8 @@ def test_agent_guide_documents_auth_session_flow() -> None:
     assert "GET /api/v1/auth/me" in guide
     assert '{"authenticated": false, "github_login": null}' in guide
     assert "POST /auth/logout" in guide
+    assert "redirects to `/`" in guide
+    assert "clears the MergeWork auth cookies" in guide
     assert "Do not use `GET /auth/logout` for logout side effects." in guide
 
 


### PR DESCRIPTION
Refs #426

## Summary
- document the GitHub session check/logout boundaries in `docs/agent-guide.md`
- add docs smoke coverage so the agent guide keeps the auth/session guidance
- add a focused docs regression for the session flow text

## Evidence
- `app/main.py` registers `GET /api/v1/auth/me`, returning `authenticated` and `github_login` from the signed session cookie.
- `app/auth.py` registers `POST /auth/logout`, deletes `mrwk_user` and `mrwk_admin`, and redirects to `/`.
- Live unauthenticated smoke at 2026-05-27 UTC showed `GET /auth/github/callback?code=dummy&state=dummy` returns `401 {"detail":"invalid OAuth state"}`, `POST /auth/logout` returns `303 Location: /` with expired auth cookies, and `GET /auth/logout` returns `405` with no logout cookie side effects.
- This is distinct from PR #504, which only lists `GET /api/v1/auth/me`; this PR documents the end-to-end browser session boundary including logout behavior and guards it in docs smoke.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_docs_public_urls.py::test_agent_guide_documents_auth_session_flow -q` -> 1 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_docs_public_urls.py -q` -> 24 passed
- `uv run --extra dev ruff check scripts/docs_smoke.py tests/test_docs_public_urls.py` -> passed
- `uv run --extra dev ruff format --check scripts/docs_smoke.py tests/test_docs_public_urls.py` -> passed
- `git diff --check` -> clean

No cookies, OAuth callback codes, tokens, wallet material, private keys, signatures, private data, price claims, exchange claims, bridge claims, liquidity claims, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how to check current auth session via GET /api/v1/auth/me (including unauthenticated response) and how to end a browser session via POST /auth/logout (redirects to / and clears auth cookies); added a warning not to rely on GET /auth/logout for logout side effects.
* **Tests**
  * Added a documentation smoke test to verify the above session and logout guidance is present.
* **Chores**
  * Updated doc validation to require those public-facing phrases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->