### PR TITLE
Bounty #427: Add ledger entry navigation

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -53,6 +53,25 @@ def wallet_page_context(session: Session, address: str) -> dict[str, Any]:
     }
 
 
+def ledger_entry_page_context(
+    sequence: int, api_ledger_entry: Callable[[int], dict[str, Any]]
+) -> dict[str, Any]:
+    entry = api_ledger_entry(sequence)
+    previous_sequence = entry["sequence"] - 1 if entry["sequence"] > 1 else None
+    next_sequence = entry["sequence"] + 1
+    try:
+        api_ledger_entry(next_sequence)
+    except HTTPException as exc:
+        if exc.status_code != 404:
+            raise
+        next_sequence = None
+    return {
+        "entry": entry,
+        "previous_sequence": previous_sequence,
+        "next_sequence": next_sequence,
+    }
+
+
 def register_public_routes(
     app: FastAPI,
     *,
@@ -91,7 +110,7 @@ def register_public_routes(
     @app.get("/ledger/{sequence}", response_class=HTMLResponse)
     def ledger_entry_page(request: Request, sequence: int) -> HTMLResponse:
         return templates.TemplateResponse(
-            request, "ledger_entry.html", {"entry": api_ledger_entry(sequence)}
+            request, "ledger_entry.html", ledger_entry_page_context(sequence, api_ledger_entry)
         )
 
     @app.get("/wallets", response_class=HTMLResponse)

--- a/app/templates/ledger_entry.html
+++ b/app/templates/ledger_entry.html
@@ -6,6 +6,12 @@
   {% set type_class = entry.type | replace("_", "-") %}
   <h1>#{{ entry.sequence }} <span class="ledger-type ledger-type--{{ type_class }}">{{ entry.type | replace("_", " ") | title }}</span></h1>
   <p class="lead">{{ entry.amount_mrwk }} MRWK</p>
+  <nav class="actions detail-actions" aria-label="Ledger entry navigation">
+    <a href="/ledger">All ledger entries</a>
+    {% if previous_sequence %}<a href="/ledger/{{ previous_sequence }}">Previous entry</a>{% endif %}
+    {% if next_sequence %}<a href="/ledger/{{ next_sequence }}">Next entry</a>{% endif %}
+    <a href="/api/v1/ledger/{{ entry.sequence }}">Entry JSON</a>
+  </nav>
   <div class="meta-grid">
     {% if entry.type == "bounty_reserve" %}
     <article>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -415,6 +415,11 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert "Bounty Payment" in ledger_entry_page.text
     assert "Bounty scan status" in ledger_entry_page.text
     assert "Award paid" in ledger_entry_page.text
+    assert 'aria-label="Ledger entry navigation"' in ledger_entry_page.text
+    assert 'href="/ledger">All ledger entries</a>' in ledger_entry_page.text
+    assert f'href="/ledger/{payment_sequence - 1}">Previous entry</a>' in ledger_entry_page.text
+    assert f'href="/api/v1/ledger/{payment_sequence}">Entry JSON</a>' in ledger_entry_page.text
+    assert f'href="/ledger/{payment_sequence + 1}">Next entry</a>' in ledger_entry_page.text
     assert client.get("/api/v1/ledger/0").status_code == 400
     assert client.get("/ledger/0").status_code == 400
 

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -420,6 +420,16 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert f'href="/ledger/{payment_sequence - 1}">Previous entry</a>' in ledger_entry_page.text
     assert f'href="/api/v1/ledger/{payment_sequence}">Entry JSON</a>' in ledger_entry_page.text
     assert f'href="/ledger/{payment_sequence + 1}">Next entry</a>' in ledger_entry_page.text
+    genesis_page = client.get("/ledger/1")
+    assert genesis_page.status_code == 200
+    assert 'href="/ledger">All ledger entries</a>' in genesis_page.text
+    assert 'href="/ledger/0">Previous entry</a>' not in genesis_page.text
+    assert 'href="/ledger/2">Next entry</a>' in genesis_page.text
+    latest_sequence = client.get("/api/v1/ledger?limit=1").json()[0]["sequence"]
+    latest_page = client.get(f"/ledger/{latest_sequence}")
+    assert latest_page.status_code == 200
+    assert f'href="/ledger/{latest_sequence - 1}">Previous entry</a>' in latest_page.text
+    assert f'href="/ledger/{latest_sequence + 1}">Next entry</a>' not in latest_page.text
     assert client.get("/api/v1/ledger/0").status_code == 400
     assert client.get("/ledger/0").status_code == 400
 


### PR DESCRIPTION
## Summary

Refs #427 / Bounty #427.

This adds focused navigation to public ledger entry detail pages so contributors and maintainers can audit adjacent ledger entries without manually editing URLs.

- `/ledger/{sequence}` now shows links back to the full ledger, previous entry, next entry when it exists, and the matching `/api/v1/ledger/{sequence}` JSON.
- The change reuses the existing `actions` styling and does not alter REST API output.
- Added rendered-page assertions for the ledger detail navigation.

## Before / after

Before: ledger detail pages showed hashes and account/proof links, but users had to manually edit the URL to inspect adjacent hash-chain entries or find the JSON endpoint.

After: the detail page exposes direct previous/next ledger navigation and an entry JSON shortcut in the page header area.

No screenshot artifact is attached because this is a small functional navigation addition using the existing action-link style, not a visual layout redesign.

## Evidence

- Distinct from current #427 ledger list work: this targets `/ledger/{sequence}` detail navigation, not `/ledger` row limits or type filters.
- Live bounty preflight for internal bounty `73` / issue `#427`: `status=open`, `awards_remaining=2`, `available_mrwk=250`, and active attempts `[]`.
- Open PR search for ledger detail navigation / previous-next entry did not show a duplicate.
- Scope: 3 files, +31/-1.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable -q` -> 1 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_bounty_pages.py tests/test_public_routes.py tests/test_api_mcp.py::test_ledger_api_rejects_out_of_range_limits -q` -> 11 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 414 passed
- `uv run --extra dev ruff check app/public_routes.py tests/test_bounty_pages.py` -> passed
- `uv run --extra dev ruff format --check app/public_routes.py tests/test_bounty_pages.py` -> 2 files already formatted
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev mypy app/public_routes.py` -> success
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

## Safety

No wallet material, private keys, cookies, OAuth state, access tokens, signatures, private data, price/off-ramp claims, liquidity claims, exchange claims, bridge promises, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ledger entry pages now include previous/next navigation with proper boundary handling.
  * Pages include a direct link to the JSON representation of any ledger entry.

* **Tests**
  * Expanded tests verify navigation UI, presence of an "All ledger entries" link, boundary behavior for first/latest entries, and the JSON link.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->