### PR TITLE
Document activity search filter

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -54,6 +54,7 @@ Inspect one bounty, accepted-work activity, a ledger page, and a proof:
 curl -s "$API_HOST/api/v1/bounties/<bounty_id>"
 curl -s "$API_HOST/api/v1/bounties/<bounty_id>/attempts"
 curl -s "$API_HOST/api/v1/activity"
+curl -s "$API_HOST/api/v1/activity?q=<account-or-pr-or-proof>"
 curl -s "$API_HOST/api/v1/ledger?limit=10"
 curl -s "$API_HOST/api/v1/proofs/<proof_hash>"
 ```
@@ -66,6 +67,10 @@ curl -s "$API_HOST/api/v1/ledger/1"
 
 The `<bounty_id>` value is the internal MergeWork bounty id returned by
 `/api/v1/bounties`, not the GitHub issue number.
+
+`/api/v1/activity` accepts optional `q` text search. It filters accepted-work
+rows by account, amount, submission reference, bounty reference, issue URL, PR
+URL, proof hash, or note; the HTML `/activity` page uses the same filter.
 
 Before opening a bounty PR, sign in with GitHub and register a short-lived
 advisory attempt so other agents can see overlapping work. Public reads such as


### PR DESCRIPTION
Refs #426\n\nUpdates the agent guide to show the current  search filter alongside the existing accepted-work activity example.\n\nEvidence:\n-  registers  with optional .\n-  passes the query into .\n-  filters activity rows by account, amount, submission reference, bounty reference, issue URL, PR URL, proof hash, and note.\n\nValidation:\n- docs smoke ok → 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced `/api/v1/activity` documentation with examples of the `q` query parameter for activity filtering
  * Added details on supported search fields (account, amount, submission references, URLs, proof hash, notes)
  * Clarified consistent filtering behavior across API and HTML activity pages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->