### PR TITLE
Bounty #427: Add bounty detail contributor links

### DIFF
--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -45,6 +45,19 @@
     <h2 id="acceptance-heading">What has to be true</h2>
     <p>{{ bounty.acceptance }}</p>
   </section>
+
+  <section class="acceptance-card" aria-labelledby="contributor-links-heading">
+    <p class="eyebrow">Contributor links</p>
+    <h2 id="contributor-links-heading">Inspect this bounty</h2>
+    <ul>
+      <li><a href="/api/v1/bounties/{{ bounty.id }}">Bounty JSON</a></li>
+      <li><a href="/api/v1/bounties/{{ bounty.id }}/attempts">Active attempts JSON</a></li>
+      <li><a href="/api/v1/bounties/{{ bounty.id }}/attempts?include_expired=true">All attempts JSON</a></li>
+      {% if issue_url %}
+      <li><a href="{{ issue_url }}">Source issue</a></li>
+      {% endif %}
+    </ul>
+  </section>
 </section>
 
 <section>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -295,6 +295,11 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert "<span>Issue</span>" in response.text
     assert "100 MRWK" in response.text
     assert "What has to be true" in response.text
+    assert "Inspect this bounty" in response.text
+    assert f'href="/api/v1/bounties/{bounty.id}"' in response.text
+    assert f'href="/api/v1/bounties/{bounty.id}/attempts"' in response.text
+    assert f'href="/api/v1/bounties/{bounty.id}/attempts?include_expired=true"' in response.text
+    assert 'href="https://github.com/ramimbo/mergework/issues/4"' in response.text
     assert "Focused PR improves status, reward, issue link, and acceptance text." in response.text
 
     missing_response = client.get("/api/v1/bounties/999")

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
+from app.models import Bounty
 
 
 def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
@@ -313,6 +314,34 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert oversized_api_response.json()["detail"] == "bounty id is too large"
     oversized_page_response = client.get(f"/bounties/{oversized_bounty_id}")
     assert oversized_page_response.status_code == 400
+
+
+def test_bounty_detail_omits_source_issue_when_url_is_missing(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = Bounty(
+            repo="ramimbo/mergework",
+            issue_number=5,
+            issue_url="",
+            title="Bounty without an external issue",
+            reward_microunits=50_000_000,
+            reserved_microunits=50_000_000,
+            acceptance="This bounty has no external issue link.",
+        )
+        session.add(bounty)
+        session.flush()
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(f"/bounties/{bounty_id}")
+
+    assert response.status_code == 200
+    assert "Inspect this bounty" in response.text
+    assert f'href="/api/v1/bounties/{bounty_id}"' in response.text
+    assert f'href="/api/v1/bounties/{bounty_id}/attempts"' in response.text
+    assert "Source issue" not in response.text
 
 
 def test_bounty_detail_shows_accepted_award_history(sqlite_url: str) -> None:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -341,6 +341,7 @@ def test_bounty_detail_omits_source_issue_when_url_is_missing(sqlite_url: str) -
     assert "Inspect this bounty" in response.text
     assert f'href="/api/v1/bounties/{bounty_id}"' in response.text
     assert f'href="/api/v1/bounties/{bounty_id}/attempts"' in response.text
+    assert f'href="/api/v1/bounties/{bounty_id}/attempts?include_expired=true"' in response.text
     assert "Source issue" not in response.text
 
 


### PR DESCRIPTION
## Summary

Bounty #427 focused public workflow improvement: the bounty detail page now includes a contributor-links section with direct machine-readable routes for the same bounty.

- Adds links from `/bounties/{id}` to `/api/v1/bounties/{id}`.
- Adds links to active attempts JSON and all attempts JSON for the bounty.
- Keeps the source GitHub issue link visible in the same inspection cluster.
- Covers the rendered page output in `tests/test_bounty_pages.py`.

This is distinct from the existing ledger-entry navigation work and the attempts API limit work: it is a page-level bounty-detail navigation improvement that helps contributors verify bounty data and collision state before starting work.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_bounty_pages.py::test_bounty_detail_highlights_action_fields tests/test_bounty_pages.py::test_bounty_detail_shows_accepted_award_history -q` -> 2 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_bounty_pages.py tests/test_bounty_attempts.py -q` -> 14 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 414 passed
- `uv run --extra dev ruff check tests/test_bounty_pages.py` -> passed
- `uv run --extra dev ruff format --check tests/test_bounty_pages.py` -> passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No wallet material, private keys, tokens, signatures, payout/off-ramp claims, private data, or private security details are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Contributor links" card on the bounty detail page with links to inspect the bounty and view attempts in JSON; conditionally shows a "Source issue" link when an external issue URL exists.

* **Tests**
  * Added tests confirming the inspect/attempts links appear and that the "Source issue" link is omitted when the external issue URL is missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->