### PR TITLE
Refs #426: Document no-ledger account empty state

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -312,6 +312,30 @@ For `treasury:` and `reserve:` accounts, `github_login` is `null` and
 `transfer_status` explains that direct MRWK wallet transfers are only available
 for registered `mrwk1` addresses.
 
+Valid account identifiers that have no ledger rows still return HTTP 200 with
+`exists: false`, zero balances, and empty accepted-work fields. The public HTML
+account page mirrors that empty state with "no ledger activity" and no
+transactions:
+
+```json
+{
+  "account": "github:mw-smoke-no-ledger-20260527",
+  "ledger_address": "github:mw-smoke-no-ledger-20260527",
+  "github_login": "mw-smoke-no-ledger-20260527",
+  "exists": false,
+  "balance_mrwk": "0",
+  "transfer_status": "Claim GitHub balances from /me after linking a registered mrwk1 wallet.",
+  "accepted_work": {
+    "accepted_awards": 0,
+    "accepted_mrwk": "0",
+    "latest_ledger_sequence": null,
+    "latest_submission_url": null,
+    "latest_proof_hash": null,
+    "latest_proof_url": null
+  }
+}
+```
+
 Read the proof-backed accepted-work list for a single account:
 
 ```bash

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -82,6 +82,10 @@ def test_api_examples_document_account_response_shape() -> None:
     assert '"github_login": "tatelyman"' in examples
     assert '"exists": true' in examples
     assert '"balance_mrwk": "395"' in examples
+    assert '"account": "github:mw-smoke-no-ledger-20260527"' in examples
+    assert '"exists": false' in examples
+    assert '"accepted_awards": 0' in examples
+    assert "no ledger activity" in examples
     assert "Claim GitHub balances from /me" in examples
     assert "treasury:" in examples
     assert "registered `mrwk1` addresses" in examples


### PR DESCRIPTION
Bounty #426

## Summary
- Document the public empty-state contract for valid account identifiers with no ledger rows.
- Add an API example showing HTTP 200, `exists: false`, zero balance, and empty accepted-work fields.
- Guard the docs example with `tests/test_docs_public_urls.py`.

## Evidence
- Live unauthenticated checks at 2026-05-27 showed:
  - `GET https://api.mrwk.ltclab.site/api/v1/accounts/github:mw-smoke-no-ledger-20260527` -> HTTP 200 JSON with `exists=false`, `balance_mrwk="0"`, and accepted-work zero/null fields.
  - `GET https://api.mrwk.ltclab.site/api/v1/accounts/github:mw-smoke-no-ledger-20260527/accepted-work` -> HTTP 200 JSON with summary zero and `accepted_work=[]`.
  - `GET https://mrwk.ltclab.site/accounts/github:mw-smoke-no-ledger-20260527` -> HTTP 200 HTML showing `0 MRWK`, "This account has no ledger activity yet.", "No proof-backed accepted work for this account yet.", and "No ledger entries yet."
- Current code already exposes this behavior through `account_api_context`, `account_accepted_work_context`, and `account_page_context` in `app/accounts.py`.
- The prior public API/MCP examples bounty round is closed; #426 is the current open documentation bounty.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv312/bin/python -m pytest tests/test_docs_public_urls.py::test_api_examples_document_account_response_shape -q` -> 1 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv312/bin/python -m pytest tests/test_docs_public_urls.py -q` -> 23 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv312/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `.venv312/bin/python -m ruff check tests/test_docs_public_urls.py` -> passed
- `git diff --check` -> clean

No private keys, seed material, cookies, OAuth state, access tokens, signatures, secrets, price claims, liquidity claims, exchange claims, bridge promises, off-ramp promises, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified API behavior: valid account identifiers return HTTP 200 status even when accounts have no ledger entries, zero balances, or transaction history. Added example response demonstrating this state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->