### PR TITLE
Refs #406: Accept colon bounty references

### DIFF
--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -8,7 +8,10 @@ import sys
 from collections import defaultdict
 from typing import Any
 
-BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+#(\d+)", re.IGNORECASE)
+BOUNTY_REF_RE = re.compile(
+    r"\b(?:bounty|refs?|fixes|closes|claims?)(?:\s+#|\s*:\s*#)(\d+)",
+    re.IGNORECASE,
+)
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
 UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
 GH_TIMEOUT_SECONDS = 30

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -11,7 +11,10 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
-BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+#(\d+)", re.IGNORECASE)
+BOUNTY_REF_RE = re.compile(
+    r"\b(?:bounty|refs?|fixes|closes|claims?)(?:\s+#|\s*:\s*#)(\d+)",
+    re.IGNORECASE,
+)
 EVIDENCE_RE = re.compile(
     r"\b(pytest|ruff|mypy|validation|verified|test evidence|checks? passed)\b",
     re.IGNORECASE,

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -127,6 +127,26 @@ def test_pr_queue_health_accepts_claim_command_reference() -> None:
     assert report["missing_bounty_references"] == []
 
 
+def test_pr_queue_health_accepts_colon_bounty_reference() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [
+                {
+                    "number": 8,
+                    "title": "Harden bounty submission checks",
+                    "body": "Bounty: #310",
+                    "merge_state": "clean",
+                    "labels": [],
+                }
+            ],
+        }
+    )
+
+    assert report["summary"]["missing_bounty_references"] == 0
+    assert report["missing_bounty_references"] == []
+
+
 def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     report = analyze_queue(
         {

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -66,6 +66,32 @@ def test_submission_quality_gate_accepts_claim_command_reference() -> None:
     } in result["checks"]
 
 
+def test_submission_quality_gate_accepts_colon_bounty_reference() -> None:
+    result = evaluate_submission(
+        {
+            "submission_text": """
+            Summary:
+            Harden the bounty submission checks.
+
+            Refs: #319
+
+            Validation:
+            - pytest passed.
+            """,
+            "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [],
+        }
+    )
+
+    assert result["status"] == "pass"
+    assert result["bounty_reference"] == 319
+    assert {
+        "name": "bounty_reference",
+        "status": "pass",
+        "message": "found bounty reference #319",
+    } in result["checks"]
+
+
 def test_submission_quality_gate_fails_missing_reference() -> None:
     result = evaluate_submission(
         {


### PR DESCRIPTION
Bounty #406

## Summary
- Accept colon-separated bounty references such as `Refs: #406` and `Bounty: #406` in the submission quality gate and PR queue health tools.
- Keep the existing `Refs #406`, `Bounty #406`, `Fixes #406`, `Closes #406`, and `/claim #406` forms working.
- Add focused regressions for both reference parsers.

## Evidence
- Before this change, local parser readback returned no bounty refs for `Refs: #406` in `scripts/submission_quality_gate.py` and `scripts/pr_queue_health.py`.
- The scripts already tell contributors to include `Bounty #<issue>`, `Refs #<issue>`, or `/claim #<issue>`; the colon form is a common Markdown/PR-body variant of the same reference and should not be flagged as missing.
- Open PR search for this colon-reference parsing edge did not show a matching active fix.
- Live bounty preflight for #406 / internal bounty 66 showed `status=open`, `awards_remaining=15`, and no active attempts.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv312/bin/python -m pytest tests/test_submission_quality_gate.py::test_submission_quality_gate_accepts_colon_bounty_reference tests/test_pr_queue_health.py::test_pr_queue_health_accepts_colon_bounty_reference -q` -> 2 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv312/bin/python -m pytest tests/test_submission_quality_gate.py tests/test_pr_queue_health.py -q` -> 34 passed
- `.venv312/bin/python -m ruff check scripts/submission_quality_gate.py scripts/pr_queue_health.py tests/test_submission_quality_gate.py tests/test_pr_queue_health.py` -> passed
- `.venv312/bin/python -m ruff format --check scripts/submission_quality_gate.py scripts/pr_queue_health.py tests/test_submission_quality_gate.py tests/test_pr_queue_health.py` -> 4 files already formatted
- `.venv312/bin/python -m mypy scripts/submission_quality_gate.py scripts/pr_queue_health.py` -> success
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv312/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No private keys, seed material, secrets, private vulnerability details, deployment credentials, price claims, exchange claims, liquidity claims, bridge promises, off-ramp promises, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bounty references now support alternative formatting using colon notation (e.g., "Bounty: `#310`") in addition to the existing whitespace format.

* **Tests**
  * Added test coverage for the new colon-based bounty reference format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->