### PR TITLE
Accept colon-form bounty references in webhook payouts

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -19,7 +19,7 @@ ACCEPTED_LABEL = "mrwk:accepted"
 ISSUE_NUMBER_BOUNDARY = r"(?![A-Za-z0-9_-])"
 MAX_SQLITE_INTEGER = 2**63 - 1
 LINKED_ISSUE_RE = re.compile(
-    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?|bounty)\s+"
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?|bounty)(?:\s+|\s*:\s*)"
     rf"(?:(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(?P<repo_number>\d+){ISSUE_NUMBER_BOUNDARY}"
     rf"|#(?P<number>\d+){ISSUE_NUMBER_BOUNDARY})",
     re.IGNORECASE,

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -193,11 +193,16 @@ def test_accepted_pr_label_pays_pr_author_for_colon_bounty_reference(
         )
 
     result = handle_github_webhook(sqlite_url, headers, body, "secret")
+    replay = handle_github_webhook(sqlite_url, headers, body, "secret")
 
     assert result["status"] == "paid"
+    assert replay == {"status": "duplicate", "processed_status": "paid"}
     with session_scope(sqlite_url) as session:
         assert get_balance(session, "github:contributor") == 150_000_000
         assert get_balance(session, "github:maintainer") == 0
+        event = session.get(WebhookEvent, "delivery-pr-colon-bounty-ref")
+        assert event is not None
+        assert event.processed_status == "paid"
 
 
 def test_accepted_issue_event_for_pull_request_does_not_pay_matching_bounty(

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -155,6 +155,51 @@ def test_accepted_pr_label_pays_pr_author_for_linked_bounty_issue(sqlite_url: st
         assert get_balance(session, "github:maintainer") == 0
 
 
+def test_accepted_pr_label_pays_pr_author_for_colon_bounty_reference(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "labeled",
+            "label": {"name": "mrwk:accepted"},
+            "pull_request": {
+                "number": 9,
+                "html_url": "https://github.com/ramimbo/mergework/pull/9",
+                "body": "Bounty: #3",
+                "user": {"login": "contributor"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "maintainer"},
+        },
+        separators=(",", ":"),
+    ).encode()
+    headers = {
+        "X-GitHub-Delivery": "delivery-pr-colon-bounty-ref",
+        "X-GitHub-Event": "pull_request",
+        "X-Hub-Signature-256": _signature("secret", body),
+    }
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=3,
+            issue_url="https://github.com/ramimbo/mergework/issues/3",
+            title="Wallet transfer validation tests",
+            reward_mrwk="150",
+            acceptance="PR adds focused wallet transfer failure tests.",
+        )
+
+    result = handle_github_webhook(sqlite_url, headers, body, "secret")
+
+    assert result["status"] == "paid"
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:contributor") == 150_000_000
+        assert get_balance(session, "github:maintainer") == 0
+
+
 def test_accepted_issue_event_for_pull_request_does_not_pay_matching_bounty(
     sqlite_url: str,
 ) -> None:


### PR DESCRIPTION
## Summary
- allow accepted PR label webhook parsing to recognize colon-form bounty references like `Bounty: #406` and `Refs: #406`
- keep existing space-separated references working
- add a regression test that pays the PR author from a `Bounty: #3` PR body

## Bounty
- #406

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_webhooks.py -q`
- `uv run --extra dev ruff check app/webhooks/github.py tests/test_webhooks.py`
- `uv run --extra dev ruff format --check app/webhooks/github.py tests/test_webhooks.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m mypy app/webhooks/github.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounty references now accept a colon (e.g., "Bounty: `#3`") or whitespace after keywords, improving issue-link recognition.

* **Tests**
  * Added test coverage to confirm colon-style bounty references are recognized, processed, and result in correct payment handling and duplicate detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->