### PR TITLE
Refs #406: Support offset on bounty attempts API

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -97,6 +97,7 @@ def list_bounty_attempts(
     *,
     include_expired: bool = False,
     limit: int | None = None,
+    offset: int = 0,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     now = _as_utc(now or _utc_now())
@@ -104,6 +105,8 @@ def list_bounty_attempts(
     if not include_expired:
         query = query.where(*_active_attempt_conditions(bounty.id, now))
     query = query.order_by(BountyAttempt.created_at.desc(), BountyAttempt.id.desc())
+    if offset:
+        query = query.offset(offset)
     if limit is not None:
         query = query.limit(limit)
     attempts = session.scalars(query).all()
@@ -148,7 +151,11 @@ def register_bounty_attempt_routes(
         return submitter_account
 
     @app.get("/api/v1/bounties/{bounty_id}/attempts")
-    def api_bounty_attempts(bounty_id: int, include_expired: bool = Query(False)) -> dict[str, Any]:
+    def api_bounty_attempts(
+        bounty_id: int,
+        include_expired: bool = Query(False),
+        offset: int = Query(0, ge=0),
+    ) -> dict[str, Any]:
         bounty_id = positive_bounty_id(bounty_id)
         now = _utc_now()
         with session_scope(db_url) as session:
@@ -156,7 +163,7 @@ def register_bounty_attempt_routes(
             if bounty is None:
                 raise HTTPException(status_code=404, detail="bounty not found")
             listing = list_bounty_attempts(
-                session, bounty, include_expired=include_expired, now=now
+                session, bounty, include_expired=include_expired, offset=offset, now=now
             )
             return {
                 "bounty_id": bounty_id,

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -113,6 +113,13 @@ def test_bounty_attempts_register_list_duplicate_and_release(sqlite_url: str, mo
         "github:alice"
     ]
 
+    negative_offset = client.get(f"/api/v1/bounties/{bounty.id}/attempts?offset=-1")
+    assert negative_offset.status_code == 422
+
+    beyond_offset = client.get(f"/api/v1/bounties/{bounty.id}/attempts?offset=99")
+    assert beyond_offset.status_code == 200
+    assert beyond_offset.json()["attempts"] == []
+
     wrong_submitter = client.post(
         f"/api/v1/bounty-attempts/{first_attempt['id']}/release",
         json={"submitter_account": "github:bob"},

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -107,6 +107,12 @@ def test_bounty_attempts_register_list_duplicate_and_release(sqlite_url: str, mo
         "github:alice",
     ]
 
+    offset_visible = client.get(f"/api/v1/bounties/{bounty.id}/attempts?offset=1")
+    assert offset_visible.status_code == 200
+    assert [attempt["submitter_account"] for attempt in offset_visible.json()["attempts"]] == [
+        "github:alice"
+    ]
+
     wrong_submitter = client.post(
         f"/api/v1/bounty-attempts/{first_attempt['id']}/release",
         json={"submitter_account": "github:bob"},


### PR DESCRIPTION
## Summary
- add a validated `offset` query parameter to `GET /api/v1/bounties/{id}/attempts`
- apply the offset after the existing newest-first ordering and active/expired filtering
- add regression coverage showing `offset=1` skips the newest active attempt, `offset=-1` is rejected, and an out-of-range offset returns an empty attempts list

## Evidence
- Confusion, missing step, stale example, or bug this addresses: public list endpoints are gaining pagination, but the bounty-attempt coordination endpoint only exposed the first ordered slice; clients could not skip already-seen attempt rows.
- Bounty capacity and active attempts/open PRs checked: bounty #406 / internal bounty 66 was open with awards remaining when the PR was opened; duplicate search found PR #491 covering attempt `limit`, while this PR covers the distinct `offset` behavior.
- Intended files or surfaces: `app/bounty_attempts.py` and `tests/test_bounty_attempts.py` only.
- Expected PR size: small, focused API/test patch.
- Out of scope: no attempt creation changes, no authentication changes, no payout or ledger changes, no docs rewrite.

## Test Evidence
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_bounty_attempts.py -q` (7 passed)
- [x] `uv run --extra dev ruff check app/bounty_attempts.py tests/test_bounty_attempts.py`
- [x] `uv run --extra dev ruff format --check app/bounty_attempts.py tests/test_bounty_attempts.py`
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m mypy app/bounty_attempts.py`
- [x] `git diff --check`

## Bounty
Refs #406

## Public Artifact Hygiene
No private data, wallet material, signatures, payout claims, price claims, off-ramp claims, or security-sensitive details are included.