### PR TITLE
Refs #426: Clarify authenticated attempt examples

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -84,6 +84,10 @@ login. Attempts are advisory only: they do not create payments, claim
 acceptance, mutate ledger balances, or stop maintainers from accepting useful
 work.
 
+For authenticated examples, replace `<browser-session-cookie>` with the cookie
+from a GitHub-authenticated browser session for the same account. Unauthenticated
+attempt registration and release requests return `401`.
+
 List active attempts for a bounty:
 
 ```bash
@@ -121,6 +125,7 @@ Register an attempt with a submitter identity, optional source URL, and TTL:
 
 ```bash
 curl -s -X POST "$API_HOST/api/v1/bounties/<bounty_id>/attempts" \
+  -b "<browser-session-cookie>" \
   -H "Content-Type: application/json" \
   -d '{"submitter_account":"github:tatelyman","source_url":"https://github.com/ramimbo/mergework/tree/attempt-bounty-321","ttl_seconds":86400}'
 ```
@@ -154,6 +159,7 @@ Release an active attempt when you stop working:
 
 ```bash
 curl -s -X POST "$API_HOST/api/v1/bounty-attempts/<attempt_id>/release" \
+  -b "<browser-session-cookie>" \
   -H "Content-Type: application/json" \
   -d '{"submitter_account":"github:tatelyman"}'
 ```


### PR DESCRIPTION
## Summary
- Update the advisory attempt examples in docs/api-examples.md to include the required GitHub-authenticated browser session cookie.
- State that unauthenticated attempt registration and release return 401, matching app/auth.py and app/bounty_attempts.py.

Refs #426

## Evidence
- Code checked: app/bounty_attempts.py wires attempt registration/release through require_github_login; app/auth.py returns 401 when no GitHub login is present.
- Docs alignment checked against docs/agent-guide.md, which already shows the session cookie for the same authenticated attempt flow.

## Checks
- ./.venv/bin/python scripts/docs_smoke.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API example documentation to clarify authentication requirements for attempt registration and release operations.
  * Authenticated requests now explicitly require a browser session cookie from the same GitHub account; unauthenticated requests return 401.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->