### PR TITLE
Add contributor shortcuts to me page

### DIFF
--- a/app/me.py
+++ b/app/me.py
@@ -9,14 +9,17 @@ from app.ledger.service import format_mrwk, get_balance, linked_wallet_for_githu
 
 def me_page_context(session: Session, login: str | None) -> dict[str, Any]:
     github_balance_mrwk = "0"
+    github_account = ""
     linked_wallet_address = ""
     if login:
-        github_balance_mrwk = format_mrwk(get_balance(session, f"github:{login}"))
+        github_account = f"github:{login}"
+        github_balance_mrwk = format_mrwk(get_balance(session, github_account))
         linked_wallet = linked_wallet_for_github(session, login)
         if linked_wallet:
             linked_wallet_address = linked_wallet.address
     return {
         "github_login": login,
+        "github_account": github_account,
         "github_balance_mrwk": github_balance_mrwk,
         "linked_wallet_address": linked_wallet_address,
     }

--- a/app/templates/me.html
+++ b/app/templates/me.html
@@ -7,6 +7,14 @@
   {% if github_login %}
   <p class="lead">Signed in as {{ github_login }}.</p>
   <p class="notice"><code>github:{{ github_login }}</code> has {{ github_balance_mrwk }} MRWK available to claim.</p>
+  <div class="actions" aria-label="Contributor account shortcuts">
+    <a href="/accounts/{{ github_account }}">Ledger account</a>
+    <a href="/activity?q={{ github_account | urlencode }}">Accepted work</a>
+    <a href="/api/v1/accounts/{{ github_account }}">Account JSON</a>
+    {% if linked_wallet_address %}
+    <a href="/wallets/{{ linked_wallet_address }}">Linked wallet</a>
+    {% endif %}
+  </div>
   <form method="post" action="/auth/logout" class="inline-form">
     <button type="submit">Sign out</button>
   </form>

--- a/tests/test_me_page.py
+++ b/tests/test_me_page.py
@@ -30,6 +30,7 @@ def test_me_page_context_defaults_for_anonymous_user(sqlite_url: str) -> None:
 
     assert context == {
         "github_login": None,
+        "github_account": "",
         "github_balance_mrwk": "0",
         "linked_wallet_address": "",
     }
@@ -55,6 +56,7 @@ def test_me_page_context_reports_balance_and_linked_wallet(sqlite_url: str) -> N
 
     assert context == {
         "github_login": "alice",
+        "github_account": "github:alice",
         "github_balance_mrwk": "4",
         "linked_wallet_address": address,
     }

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -567,6 +567,9 @@ def test_me_page_shows_signed_in_github_claim_balance(sqlite_url: str, monkeypat
     assert "Signed in as alice." in me
     assert "github:alice" in me
     assert "4 MRWK available to claim" in me
+    assert 'href="/accounts/github:alice"' in me
+    assert 'href="/activity?q=github%3Aalice"' in me
+    assert 'href="/api/v1/accounts/github:alice"' in me
 
 
 def test_wallet_pages_do_not_require_manual_nonce(sqlite_url: str, monkeypatch) -> None:
@@ -659,6 +662,7 @@ def test_me_page_prefills_claim_address_for_linked_wallet(sqlite_url: str, monke
     me = client.get("/me").text
 
     assert f'value="{address}"' in me
+    assert f'href="/wallets/{address}"' in me
     assert "Claim form is prefilled with your linked wallet." in me
 
 


### PR DESCRIPTION
Bounty #427

Summary:
- add signed-in `/me` shortcuts to the contributor ledger account, accepted-work activity search, account JSON, and linked wallet detail when available
- keep the change scoped to the authenticated contributor workflow where users decide how to inspect or claim GitHub balance
- cover the rendered links and context shape with focused tests

Evidence:
- before this change, `/me` showed `github:<login>` balance and linked-wallet state, but users had to manually compose `/accounts/github:<login>`, `/activity?q=github:<login>`, or `/api/v1/accounts/github:<login>` URLs to inspect public history and machine-readable account state
- this is distinct from account-detail and wallet-detail shortcut work because it starts from the signed-in contributor page and connects the claim/linking workflow to the public inspection workflow
- live bounty #73 / issue #427 preflight returned `status=open`, `awards_remaining=2`, `available_mrwk=250`, and no active attempts
- no wallet material, private keys, cookies, OAuth state, access tokens, signatures, browser storage, private data, price claims, liquidity claims, exchange claims, bridge promises, or fabricated payout claims are included
- no screenshot attached because this is a small navigation-link addition, not a visual layout redesign; rendered HTML assertions cover the behavior

Verification:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_me_page.py tests/test_wallet_api.py::test_me_page_shows_signed_in_github_claim_balance tests/test_wallet_api.py::test_me_page_prefills_claim_address_for_linked_wallet -q` -> 4 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_me_page.py tests/test_wallet_api.py tests/test_account_routes.py tests/test_activity.py -q` -> 40 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 414 passed
- `uv run --extra dev ruff check app/me.py tests/test_me_page.py tests/test_wallet_api.py` -> passed
- `uv run --extra dev ruff format --check app/me.py tests/test_me_page.py tests/test_wallet_api.py` -> passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev mypy app/me.py` -> success
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Contributor account shortcuts" section on the profile page with links to ledger account, activity, and account information.
  * Profile page now displays a linked wallet link when a wallet address is available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->