### PR TITLE
Refs #406: Guard malformed maintainer age metadata

### DIFF
--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -129,7 +129,14 @@ def _maintainer_activity_check(
             "warn",
             f"recent maintainer activity for bounty #{bounty_ref} could not be verified",
         )
-    max_age_days = int(bounty.get("max_maintainer_age_days", DEFAULT_MAX_MAINTAINER_AGE_DAYS))
+    try:
+        max_age_days = int(bounty.get("max_maintainer_age_days", DEFAULT_MAX_MAINTAINER_AGE_DAYS))
+    except (TypeError, ValueError):
+        return _check(
+            "maintainer_activity",
+            "warn",
+            f"recent maintainer activity for bounty #{bounty_ref} could not be verified",
+        )
     delta = now - last_activity
     age_days = max(0, int(delta.total_seconds() // 86400))
     if delta > timedelta(days=max_age_days):

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -422,6 +422,33 @@ def test_submission_quality_gate_warns_for_malformed_maintainer_age_threshold() 
     } in result["checks"]
 
 
+def test_submission_quality_gate_warns_for_none_maintainer_age_threshold() -> None:
+    result = evaluate_submission(
+        {
+            "submission_text": "Summary: add validation\n\nRefs #319\n\nValidation: pytest passed",
+            "now": "2026-05-26T12:00:00Z",
+            "bounties": [
+                {
+                    "number": 319,
+                    "state": "OPEN",
+                    "awards_remaining": 1,
+                    "last_maintainer_activity_at": "2026-05-25T12:00:00Z",
+                    "maintainer_activity_verified": True,
+                    "max_maintainer_age_days": None,
+                }
+            ],
+            "pull_requests": [],
+        }
+    )
+
+    assert result["status"] == "warn"
+    assert {
+        "name": "maintainer_activity",
+        "status": "warn",
+        "message": "recent maintainer activity for bounty #319 could not be verified",
+    } in result["checks"]
+
+
 def test_submission_quality_gate_cli_returns_failure_exit(capsys, tmp_path) -> None:
     fixture = {
         "submission_text": "Summary: missing reference\n\nValidation: pytest passed",

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -395,6 +395,33 @@ def test_submission_quality_gate_warns_when_activity_exceeds_threshold_by_second
     } in result["checks"]
 
 
+def test_submission_quality_gate_warns_for_malformed_maintainer_age_threshold() -> None:
+    result = evaluate_submission(
+        {
+            "submission_text": "Summary: add validation\n\nRefs #319\n\nValidation: pytest passed",
+            "now": "2026-05-26T12:00:00Z",
+            "bounties": [
+                {
+                    "number": 319,
+                    "state": "OPEN",
+                    "awards_remaining": 1,
+                    "last_maintainer_activity_at": "2026-05-25T12:00:00Z",
+                    "maintainer_activity_verified": True,
+                    "max_maintainer_age_days": "not-a-number",
+                }
+            ],
+            "pull_requests": [],
+        }
+    )
+
+    assert result["status"] == "warn"
+    assert {
+        "name": "maintainer_activity",
+        "status": "warn",
+        "message": "recent maintainer activity for bounty #319 could not be verified",
+    } in result["checks"]
+
+
 def test_submission_quality_gate_cli_returns_failure_exit(capsys, tmp_path) -> None:
     fixture = {
         "submission_text": "Summary: missing reference\n\nValidation: pytest passed",


### PR DESCRIPTION
## Summary

- handle malformed `max_maintainer_age_days` in the submission quality gate as an unverifiable maintainer-activity warning
- add regression coverage so external/live context cannot crash the gate with a non-integer threshold

## Evidence

Before this change, `evaluate_submission()` could raise `ValueError` when bounty context included recent maintainer activity plus a non-integer `max_maintainer_age_days` value. That bypassed the gate result entirely instead of producing the same bounded warning used for unverified or malformed maintainer-activity data.

Reproduction before fix:

```text
EXC ValueError invalid literal for int() with base 10: not-a-number
```

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest tests/test_submission_quality_gate.py -q` -> `24 passed`
- `./.venv/bin/python -m ruff check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` -> passed
- `./.venv/bin/python -m ruff format --check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` -> passed
- `git diff --check` -> clean

Refs #406


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Submission quality checks now handle invalid or missing maintainer age thresholds gracefully, returning a warning and a verification-not-possible message instead of failing.

* **Tests**
  * Added coverage to verify behavior when maintainer age threshold is malformed or absent, ensuring overall warning status and appropriate maintainer-activity messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->