### PR TITLE
Docs: add agent-readable bounty post template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -1,6 +1,6 @@
 name: MRWK bounty
 description: Propose work that may receive an MRWK bounty.
-title: "[bounty] "
+title: "MRWK bounty: <amount> MRWK - <short scope>"
 labels: ["mrwk:bounty"]
 body:
   - type: textarea
@@ -28,6 +28,18 @@ body:
     id: acceptance
     attributes:
       label: Acceptance criteria
-      description: Explain what must be true before mrwk:accepted is applied.
+      description: Explain what must be true before mrwk:accepted is applied. Include required evidence and relevant tests.
     validations:
       required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or tests required
+      description: List commands, files, URLs, screenshots, API responses, CI checks, or review evidence submitters should include.
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: List duplicate, broad, typo-only, stale, speculative, private-detail, or unrelated work that does not qualify.

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -4,12 +4,15 @@
 
 1. Create or choose a GitHub issue.
 2. Decide the MRWK amount using the reference tiers.
-3. Add acceptance text that explains what counts as useful accepted work.
-4. Set `max_awards` to the number of separate payouts allowed. Use `1` for
+3. Use the agent-readable template in [bounty-rules.md](bounty-rules.md#agent-readable-bounty-post-template).
+   Keep the issue title amount-visible, for example `MRWK bounty: 150 MRWK - docs smoke check`.
+4. Add acceptance text that explains what counts as useful accepted work, what
+   evidence is required, and what is out of scope.
+5. Set `max_awards` to the number of separate payouts allowed. Use `1` for
    a single-award bounty.
-5. Use `/admin` or `POST /api/v1/bounties` with an admin token.
+6. Use `/admin` or `POST /api/v1/bounties` with an admin token.
    Multi-award bounties reserve `reward_mrwk * max_awards`.
-6. Add `mrwk:bounty` to the GitHub issue.
+7. Add `mrwk:bounty` to the GitHub issue.
 
 ## Accept Work
 

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -56,6 +56,60 @@ After accepted work is paid, MergeWork records a public ledger proof. Public
 payment updates should point to those proofs and keep any private security or
 operational details out of public metadata.
 
+
+## Agent-Readable Bounty Post Template
+
+Maintainers should use stable headings so humans, GitHub automation, API
+clients, and MCP agents can parse bounty scope without guessing. Keep the
+GitHub issue title amount-visible, for example:
+
+```text
+MRWK bounty: <amount> MRWK - <short scope>
+```
+
+Copy this body when posting a new bounty:
+
+```text
+## MRWK Bounty
+
+Reward: `<amount> MRWK per accepted award`
+Max awards: `<number>`
+
+## Work Needed
+
+Describe the smallest useful work that qualifies. Name the target docs, API, UI,
+script, issue, PR, or behavior.
+
+## Acceptance Criteria
+
+- Open a focused PR, review, issue comment, or report that links this bounty
+  with `Bounty #<issue>` or `Refs #<issue>`.
+- Include concrete evidence such as changed files, commands run, screenshots,
+  API responses, CI status, public behavior checked, or exact files inspected.
+- Run the relevant tests or explain why no test applies.
+- Existing checks pass or the submission clearly documents unrelated failures.
+- Public MRWK wording avoids investment claims, price claims, fabricated payout
+  claims, liquidity claims, exchange claims, bridge promises, private keys, seed
+  material, secrets, credentials, and private vulnerability details.
+
+## How To Submit
+
+Open the PR or comment with the evidence above. A maintainer must apply
+`mrwk:accepted` or record an admin payout before payment.
+
+## Out of Scope
+
+List duplicate, broad rewrite, typo-only, style-only, stale, speculative,
+private-security-detail, or unrelated work that does not qualify.
+```
+
+The required fields map to MergeWork surfaces as follows: GitHub issues expose
+the title, reward, max awards, labels, and submission links; the public API and
+MCP tools expose `reward_mrwk`, `max_awards`, `awards_remaining`, issue URL,
+reference formats, claim command, and attempt endpoint; maintainers use the same
+fields to reserve funds, review evidence, prevent duplicates, and reconcile
+proof-backed payouts.
+
 ## Submission Evidence Templates
 
 Use the smallest template that makes the claim reviewable. Delete fields that do


### PR DESCRIPTION
Refs #456

## Summary
- add a copy-pasteable agent-readable bounty post template to `docs/bounty-rules.md`
- update the maintainer runbook to point bounty posters at that template and keep the amount visible in titles
- expand the bounty issue form with evidence/test and out-of-scope fields

## Evidence
Compared against:
- `docs/bounty-rules.md` existing submission evidence templates and payout flow
- `docs/admin-runbook.md` existing post/accept bounty workflow
- `.github/ISSUE_TEMPLATE/bounty.yml` current fields
- `docs/api-examples.md` public API/MCP bounty fields: `reward_mrwk`, `max_awards`, `awards_remaining`, `issue_url`, reference formats, claim command, attempt endpoint

## Validation
- `python3 scripts/docs_smoke.py` → `docs smoke ok`
- `git diff --check` → pass

## Out of scope
- no tokenomics, price, liquidity, bridge, payout, or private-security-detail changes
- no broad rewrite of bounty rules or admin payout flow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bounty submission templates with improved structure for defining work requirements, acceptance criteria, and out-of-scope items
  * Enhanced bounty posting guidance with clearer checklists and required fields
  * Introduced standardized agent-readable bounty post template with consistent section headings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->