### PR TITLE
Ignore native bounty ids in queue refs

### DIFF
--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -9,7 +9,8 @@ from collections import defaultdict
 from typing import Any
 
 BOUNTY_REF_RE = re.compile(
-    r"(?:(?<!live )(?<!mrwk )\bbounty|\b(?:issues?|refs?|fixes|closes|claims?))\s+#(\d+)",
+    r"(?:(?<!live )(?<!mrwk )(?<!native )(?<!internal )\bbounty"
+    r"|\b(?:issues?|refs?|fixes|closes|claims?))\s+#(\d+)",
     re.IGNORECASE,
 )
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -8,7 +8,10 @@ import sys
 from collections import defaultdict
 from typing import Any
 
-BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+#(\d+)", re.IGNORECASE)
+BOUNTY_REF_RE = re.compile(
+    r"(?:(?<!live )(?<!mrwk )\bbounty|\b(?:issues?|refs?|fixes|closes|claims?))\s+#(\d+)",
+    re.IGNORECASE,
+)
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
 UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
 GH_TIMEOUT_SECONDS = 30
@@ -116,7 +119,7 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
                 _issue(
                     pr,
                     "missing_bounty_reference",
-                    "No Bounty #<issue>, Refs #<issue>, or /claim #<issue> found",
+                    "No Bounty #<issue>, Issue #<issue>, Refs #<issue>, or /claim #<issue> found",
                 )
             )
         for ref in pr["refs"]:

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -51,7 +51,9 @@ def _scope_key(raw: dict[str, Any]) -> str:
 def _bounty_refs(raw: dict[str, Any]) -> list[int]:
     explicit = raw.get("bounty_refs")
     if isinstance(explicit, list):
-        explicit_refs = [item for item in explicit if isinstance(item, int)]
+        explicit_refs = [
+            item for item in explicit if isinstance(item, int) and not isinstance(item, bool)
+        ]
         if explicit_refs:
             return sorted(set(explicit_refs))
     text = "\n".join(

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -9,11 +9,8 @@ from collections import defaultdict
 from typing import Any
 
 BOUNTY_REF_RE = re.compile(
-    r"\b(?P<keyword>bounty|issues?|refs?|fixes|closes|claims?)\s+#(?P<number>\d+)",
-    re.IGNORECASE,
-)
-NATIVE_BOUNTY_PREFIX_RE = re.compile(
-    r"(?:^|[^A-Za-z0-9_])(?:live|mrwk|native|internal)\s+$",
+    r"\b(?:(?P<native_prefix>live|mrwk|native|internal)\s+)?"
+    r"(?P<keyword>bounty|issues?|refs?|fixes|closes|claims?)\s+#(?P<number>\d+)",
     re.IGNORECASE,
 )
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
@@ -62,11 +59,9 @@ def _bounty_refs(raw: dict[str, Any]) -> list[int]:
         for key in ("title", "body", "description")
         if raw.get(key) is not None
     )
-    refs: set[int] = set()
+    refs = set()
     for match in BOUNTY_REF_RE.finditer(text):
-        if match.group("keyword").lower() == "bounty" and NATIVE_BOUNTY_PREFIX_RE.search(
-            text[: match.start()]
-        ):
+        if match.group("native_prefix") and match.group("keyword").lower() == "bounty":
             continue
         refs.add(int(match.group("number")))
     return sorted(refs)

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -9,8 +9,11 @@ from collections import defaultdict
 from typing import Any
 
 BOUNTY_REF_RE = re.compile(
-    r"(?:(?<!live )(?<!mrwk )(?<!native )(?<!internal )\bbounty"
-    r"|\b(?:issues?|refs?|fixes|closes|claims?))\s+#(\d+)",
+    r"\b(?P<keyword>bounty|issues?|refs?|fixes|closes|claims?)\s+#(?P<number>\d+)",
+    re.IGNORECASE,
+)
+NATIVE_BOUNTY_PREFIX_RE = re.compile(
+    r"(?:^|[^A-Za-z0-9_])(?:live|mrwk|native|internal)\s+$",
     re.IGNORECASE,
 )
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
@@ -59,7 +62,14 @@ def _bounty_refs(raw: dict[str, Any]) -> list[int]:
         for key in ("title", "body", "description")
         if raw.get(key) is not None
     )
-    return sorted({int(match) for match in BOUNTY_REF_RE.findall(text)})
+    refs: set[int] = set()
+    for match in BOUNTY_REF_RE.finditer(text):
+        if match.group("keyword").lower() == "bounty" and NATIVE_BOUNTY_PREFIX_RE.search(
+            text[: match.start()]
+        ):
+            continue
+        refs.add(int(match.group("number")))
+    return sorted(refs)
 
 
 def _is_open_bounty(raw: dict[str, Any]) -> bool:

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -51,15 +51,15 @@ def _scope_key(raw: dict[str, Any]) -> str:
 def _bounty_refs(raw: dict[str, Any]) -> list[int]:
     explicit = raw.get("bounty_refs")
     if isinstance(explicit, list):
-        refs = [item for item in explicit if isinstance(item, int)]
-        if refs:
-            return sorted(set(refs))
+        explicit_refs = [item for item in explicit if isinstance(item, int)]
+        if explicit_refs:
+            return sorted(set(explicit_refs))
     text = "\n".join(
         str(raw.get(key) or "")
         for key in ("title", "body", "description")
         if raw.get(key) is not None
     )
-    refs = set()
+    refs: set[int] = set()
     for match in BOUNTY_REF_RE.finditer(text):
         if match.group("native_prefix") and match.group("keyword").lower() == "bounty":
             continue

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -150,6 +150,15 @@ def test_pr_queue_health_ignores_native_bounty_ids_when_issue_ref_is_present() -
                     "labels": [],
                 },
                 {
+                    "number": 528,
+                    "title": "Ignore spaced live bounty evidence ids",
+                    "body": (
+                        "Evidence: live  bounty #66 and live\tbounty #67 both map to issue #406."
+                    ),
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+                {
                     "number": 526,
                     "title": "Ignore native #406 evidence ids",
                     "body": (
@@ -175,45 +184,31 @@ def test_pr_queue_health_ignores_native_bounty_ids_when_issue_ref_is_present() -
     assert report["missing_bounty_references"] == []
 
 
-def test_pr_queue_health_does_not_accept_native_only_bounty_id() -> None:
+def test_pr_queue_health_requires_issue_ref_when_only_native_bounty_id_is_present() -> None:
     report = analyze_queue(
         {
-            "bounties": [{"number": 406, "state": "OPEN", "awards_remaining": 1}],
+            "bounties": [{"number": 406, "state": "OPEN", "awards_remaining": 16}],
             "pull_requests": [
                 {
-                    "number": 530,
-                    "title": "Fix edge case",
-                    "body": "Evidence: live  bounty #66 preflight check passed.",
+                    "number": 529,
+                    "title": "Needs GitHub issue reference",
+                    "body": "Evidence: live bounty #66 returned status=open.",
                     "merge_state": "clean",
                     "labels": [],
-                }
+                },
+                {
+                    "number": 530,
+                    "title": "Longer words still count as bounty refs",
+                    "body": "Evidence: relive bounty #406 returned status=open.",
+                    "merge_state": "clean",
+                    "labels": [],
+                },
             ],
         }
     )
 
     assert report["summary"]["missing_bounty_references"] == 1
-    assert report["missing_bounty_references"][0]["reason"] == "missing_bounty_reference"
-    assert report["closed_bounty_references"] == []
-
-
-def test_pr_queue_health_keeps_non_native_bounty_words() -> None:
-    report = analyze_queue(
-        {
-            "bounties": [{"number": 66, "state": "OPEN", "awards_remaining": 1}],
-            "pull_requests": [
-                {
-                    "number": 531,
-                    "title": "Fix relive wording",
-                    "body": "Evidence: relive bounty #66 still names a GitHub bounty issue.",
-                    "merge_state": "clean",
-                    "labels": [],
-                }
-            ],
-        }
-    )
-
-    assert report["summary"]["missing_bounty_references"] == 0
-    assert report["summary"]["closed_bounty_references"] == 0
+    assert report["missing_bounty_references"][0]["pull_request"] == 529
 
 
 def test_pr_queue_health_markdown_report_includes_required_sections() -> None:

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -127,6 +127,38 @@ def test_pr_queue_health_accepts_claim_command_reference() -> None:
     assert report["missing_bounty_references"] == []
 
 
+def test_pr_queue_health_ignores_native_bounty_ids_when_issue_ref_is_present() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 406, "state": "OPEN", "awards_remaining": 16}],
+            "pull_requests": [
+                {
+                    "number": 524,
+                    "title": "Refs #406: Reject malformed IPv4 public URLs",
+                    "body": (
+                        "Focused #406 small fix. Evidence: live bounty #66 / issue #406 "
+                        "preflight returned status=open."
+                    ),
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+                {
+                    "number": 525,
+                    "title": "Guard another #406 edge case",
+                    "body": "MRWK bounty #66 maps to issue #406.",
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+            ],
+        }
+    )
+
+    assert report["summary"]["closed_bounty_references"] == 0
+    assert report["summary"]["missing_bounty_references"] == 0
+    assert report["closed_bounty_references"] == []
+    assert report["missing_bounty_references"] == []
+
+
 def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     report = analyze_queue(
         {
@@ -183,7 +215,8 @@ def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     assert "### Missing bounty references" in markdown
     assert (
         "- [PR #2](https://github.com/ramimbo/mergework/pull/2): "
-        "Improve bounty filters (No Bounty #<issue>, Refs #<issue>, or /claim #<issue> found)"
+        "Improve bounty filters "
+        "(No Bounty #<issue>, Issue #<issue>, Refs #<issue>, or /claim #<issue> found)"
     ) in markdown
     assert "### Dirty or unstable merge state" in markdown
     assert "Merge state is dirty" in markdown

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -127,6 +127,36 @@ def test_pr_queue_health_accepts_claim_command_reference() -> None:
     assert report["missing_bounty_references"] == []
 
 
+def test_pr_queue_health_ignores_boolean_explicit_bounty_refs() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 406, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [
+                {
+                    "number": 531,
+                    "title": "Boolean refs are not issue refs",
+                    "body": "",
+                    "bounty_refs": [True, False],
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+                {
+                    "number": 532,
+                    "title": "Valid explicit issue ref still counts",
+                    "body": "",
+                    "bounty_refs": [True, 406],
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+            ],
+        }
+    )
+
+    assert report["summary"]["missing_bounty_references"] == 1
+    assert report["missing_bounty_references"][0]["pull_request"] == 531
+    assert report["closed_bounty_references"] == []
+
+
 def test_pr_queue_health_ignores_native_bounty_ids_when_issue_ref_is_present() -> None:
     report = analyze_queue(
         {

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -175,6 +175,47 @@ def test_pr_queue_health_ignores_native_bounty_ids_when_issue_ref_is_present() -
     assert report["missing_bounty_references"] == []
 
 
+def test_pr_queue_health_does_not_accept_native_only_bounty_id() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 406, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [
+                {
+                    "number": 530,
+                    "title": "Fix edge case",
+                    "body": "Evidence: live  bounty #66 preflight check passed.",
+                    "merge_state": "clean",
+                    "labels": [],
+                }
+            ],
+        }
+    )
+
+    assert report["summary"]["missing_bounty_references"] == 1
+    assert report["missing_bounty_references"][0]["reason"] == "missing_bounty_reference"
+    assert report["closed_bounty_references"] == []
+
+
+def test_pr_queue_health_keeps_non_native_bounty_words() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 66, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [
+                {
+                    "number": 531,
+                    "title": "Fix relive wording",
+                    "body": "Evidence: relive bounty #66 still names a GitHub bounty issue.",
+                    "merge_state": "clean",
+                    "labels": [],
+                }
+            ],
+        }
+    )
+
+    assert report["summary"]["missing_bounty_references"] == 0
+    assert report["summary"]["closed_bounty_references"] == 0
+
+
 def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     report = analyze_queue(
         {

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -149,6 +149,22 @@ def test_pr_queue_health_ignores_native_bounty_ids_when_issue_ref_is_present() -
                     "merge_state": "clean",
                     "labels": [],
                 },
+                {
+                    "number": 526,
+                    "title": "Ignore native #406 evidence ids",
+                    "body": (
+                        "Evidence: native bounty #66 / issue #406 preflight returned status=open."
+                    ),
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+                {
+                    "number": 527,
+                    "title": "Ignore internal #406 evidence ids",
+                    "body": "Evidence: internal bounty #66, issue #406 is the GitHub bounty.",
+                    "merge_state": "clean",
+                    "labels": [],
+                },
             ],
         }
     )


### PR DESCRIPTION
Bounty #406

Summary:
- keep PR queue health focused on GitHub bounty issue references instead of native MRWK bounty ids
- ignore phrases like `live bounty #66` / `MRWK bounty #66` while still accepting `issue #406`, `Refs #406`, and `/claim #406`
- update the missing-reference copy and add regression coverage for mixed native-bounty-id plus GitHub-issue evidence text

Evidence:
- before this change, `scripts/pr_queue_health.py --repo ramimbo/mergework --format json` reported open #406/#427 PRs as `unknown_bounty_reference` for native bounty ids such as #66 and #73 when PR text included evidence like `live bounty #66 / issue #406`
- after this change, the same parser extracts the GitHub issue reference and ignores the native bounty id in those phrases
- this is distinct from claim-command parsing because it fixes mixed evidence text generated by live bounty preflight reports
- no private keys, cookies, tokens, wallet JSON, browser storage, OAuth state, signatures, private data, price claims, liquidity claims, exchange claims, or off-ramp claims are added

Verification:
- uv run --extra dev python -m pytest tests/test_pr_queue_health.py -q
- uv run --extra dev python -m pytest -q
- uv run --extra dev ruff check scripts/pr_queue_health.py tests/test_pr_queue_health.py
- uv run --extra dev ruff format --check scripts/pr_queue_health.py tests/test_pr_queue_health.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader recognition of bounty/issue reference keywords and optional native prefixes.

* **Improvements**
  * Explicit issue references now take precedence; duplicate references are de-duplicated in reports.
  * Reports add an "Issue #<issue>" wording variant.
  * Native-prefixed bounty mentions are ignored when a matching explicit issue reference exists.

* **Tests**
  * Added tests covering boolean entries being ignored, native-vs-issue precedence, and missing-issue detection; updated report formatting assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/547?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->