### PR TITLE
Refs #406: Guard webhook native bounty ids

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -19,7 +19,8 @@ ACCEPTED_LABEL = "mrwk:accepted"
 ISSUE_NUMBER_BOUNDARY = r"(?![A-Za-z0-9_-])"
 MAX_SQLITE_INTEGER = 2**63 - 1
 LINKED_ISSUE_RE = re.compile(
-    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?|bounty)\s+"
+    r"(?:(?<!live )(?<!mrwk )(?<!native )(?<!internal )\bbounty"
+    r"|\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?|issues?))\s+"
     rf"(?:(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(?P<repo_number>\d+){ISSUE_NUMBER_BOUNDARY}"
     rf"|#(?P<number>\d+){ISSUE_NUMBER_BOUNDARY})",
     re.IGNORECASE,

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -155,6 +155,86 @@ def test_accepted_pr_label_pays_pr_author_for_linked_bounty_issue(sqlite_url: st
         assert get_balance(session, "github:maintainer") == 0
 
 
+def test_accepted_pr_label_ignores_native_bounty_ids_before_issue_ref(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    cases = [
+        (
+            "delivery-pr-live-bounty-id",
+            "Evidence: live bounty #66 / issue #406 preflight returned status=open.",
+        ),
+        (
+            "delivery-pr-native-bounty-id",
+            "Evidence: native bounty #66 maps to issue #406.",
+        ),
+        (
+            "delivery-pr-internal-bounty-id",
+            "Evidence: internal bounty #66; issue #406 is the GitHub bounty issue.",
+        ),
+    ]
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=66,
+            issue_url="https://github.com/ramimbo/mergework/issues/66",
+            title="Wrong native-id lookalike",
+            reward_mrwk="1",
+            max_awards=len(cases),
+            acceptance="This should not be selected from native MRWK bounty text.",
+        )
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=406,
+            issue_url="https://github.com/ramimbo/mergework/issues/406",
+            title="Useful bug reports and small fixes",
+            reward_mrwk="50",
+            max_awards=len(cases),
+            acceptance="Accepted PR bodies may include native MRWK ids plus the GitHub issue.",
+        )
+
+    for pull_number, (delivery_id, pr_body) in enumerate(cases, start=406):
+        body = json.dumps(
+            {
+                "action": "labeled",
+                "label": {"name": "mrwk:accepted"},
+                "pull_request": {
+                    "number": pull_number,
+                    "html_url": f"https://github.com/ramimbo/mergework/pull/{pull_number}",
+                    "body": pr_body,
+                    "user": {"login": "contributor"},
+                },
+                "repository": {"full_name": "ramimbo/mergework"},
+                "sender": {"login": "maintainer"},
+            },
+            separators=(",", ":"),
+        ).encode()
+
+        result = handle_github_webhook(
+            sqlite_url,
+            {
+                "X-GitHub-Delivery": delivery_id,
+                "X-GitHub-Event": "pull_request",
+                "X-Hub-Signature-256": _signature("secret", body),
+            },
+            body,
+            "secret",
+        )
+
+        assert result["status"] == "paid"
+
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:contributor") == 150_000_000
+        for delivery_id, _pr_body in cases:
+            event = session.get(WebhookEvent, delivery_id)
+            assert event is not None
+            assert event.processed_status == "paid"
+
+
 def test_accepted_issue_event_for_pull_request_does_not_pay_matching_bounty(
     sqlite_url: str,
 ) -> None:

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -165,6 +165,10 @@ def test_accepted_pr_label_ignores_native_bounty_ids_before_issue_ref(
             "Evidence: live bounty #66 / issue #406 preflight returned status=open.",
         ),
         (
+            "delivery-pr-mrwk-bounty-id",
+            "Evidence: MRWK bounty #66 / issue #406 should resolve to the GitHub issue.",
+        ),
+        (
             "delivery-pr-native-bounty-id",
             "Evidence: native bounty #66 maps to issue #406.",
         ),
@@ -228,7 +232,7 @@ def test_accepted_pr_label_ignores_native_bounty_ids_before_issue_ref(
         assert result["status"] == "paid"
 
     with session_scope(sqlite_url) as session:
-        assert get_balance(session, "github:contributor") == 150_000_000
+        assert get_balance(session, "github:contributor") == len(cases) * 50_000_000
         for delivery_id, _pr_body in cases:
             event = session.get(WebhookEvent, delivery_id)
             assert event is not None


### PR DESCRIPTION
## Summary
- keep accepted-label webhook payout parsing from treating live/native/internal MRWK bounty ids as GitHub issue references
- accept explicit `issue #<number>` / `issues #<number>` references in PR bodies so mixed evidence text like `live bounty #66 / issue #406` can still pay the intended GitHub bounty issue
- add regression coverage where a real GitHub issue #66 bounty exists, proving the webhook pays issue #406 instead of the native-id lookalike

## Evidence
- Existing accepted-label webhook parsing treated any `bounty #...` text as a GitHub issue reference before payout lookup.
- Live bounty preflight/evidence text often includes native MRWK ids such as `live bounty #66`, `native bounty #66`, or `internal bounty #66` beside the actual GitHub issue reference.
- In a mixed body, the wrong native id can be selected first if an issue with that number also has a bounty; otherwise a valid `issue #406` text was not parsed.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest tests/test_webhooks.py -q` -> 19 passed
- `./.venv/bin/python -m ruff check app/webhooks/github.py tests/test_webhooks.py` -> passed
- `./.venv/bin/python -m ruff format --check app/webhooks/github.py tests/test_webhooks.py` -> passed
- `./.venv/bin/python -m mypy app/webhooks/github.py` -> passed
- `git diff --check` -> clean

No private keys, cookies, tokens, wallet JSON, browser storage, OAuth state, signatures, private data, price claims, liquidity claims, exchange claims, or off-ramp claims are added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of bounty references in GitHub webhook handling to avoid false matches from native/internal bounty formats.
  * Reduced incorrect selection of lookalike bounty IDs when multiple bounties are referenced.

* **Tests**
  * Added a test ensuring labeled PR webhooks ignore native/internal bounty mentions and correctly select the intended bounty, with expected payment and processing outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->