### PR TITLE
Bounty #427: Add proof activity search links

### DIFF
--- a/app/templates/proof.html
+++ b/app/templates/proof.html
@@ -50,6 +50,36 @@
     {% set submission_url = safe_public_url(proof.submission_url) %}
     <dd>{% if submission_url %}<a href="{{ submission_url }}">{{ proof.submission_url }}</a>{% else %}{{ proof.submission_url }}{% endif %}</dd>
   </dl>
+  {% if proof.kind == "bounty_payment" %}
+  <div class="section-head">
+    <h2>Related activity</h2>
+    <p>Open accepted-work searches for this proof, recipient, bounty, or submission.</p>
+  </div>
+  <div class="meta-grid">
+    <article>
+      <span>Recipient activity</span>
+      <strong>
+        <a href="/activity?q={{ proof.to_account | urlencode }}">Search {{ proof.to_account }}</a>
+      </strong>
+    </article>
+    <article>
+      <span>Proof activity</span>
+      <strong><a href="/activity?q={{ proof_hash | urlencode }}">Search proof hash</a></strong>
+    </article>
+    <article>
+      <span>Bounty activity</span>
+      <strong>
+        <a href="/activity?q={{ proof.bounty_id | urlencode }}">Search bounty #{{ proof.bounty_id }}</a>
+      </strong>
+    </article>
+    <article>
+      <span>Submission activity</span>
+      <strong>
+        <a href="/activity?q={{ proof.submission_url | urlencode }}">Search submission</a>
+      </strong>
+    </article>
+  </div>
+  {% endif %}
   <pre>{{ proof | tojson(indent=2) }}</pre>
 </section>
 {% endblock %}

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -433,6 +433,11 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert "MergeWork bounty" in proof_page.text
     assert f'href="/bounties/{bounty.id}"' in proof_page.text
     assert f'href="/ledger/{payment_sequence}"' in proof_page.text
+    assert "Related activity" in proof_page.text
+    assert 'href="/activity?q=github%3Acontributor"' in proof_page.text
+    assert f'href="/activity?q={proof_hash}"' in proof_page.text
+    assert f'href="/activity?q={bounty.id}"' in proof_page.text
+    assert 'href="/activity?q=https%3A//github.com/ramimbo/mergework/pull/99"' in proof_page.text
 
     uppercase_proof_page = client.get(f"/proofs/{proof_hash.upper()}")
     assert uppercase_proof_page.status_code == 200


### PR DESCRIPTION
Bounty #427: Add proof activity search links

Summary:
- Public bounty payment proof pages now show a Related activity section with accepted-work searches for recipient, proof hash, bounty id, and submission URL.
- This turns an accepted proof into direct audit and navigation entry points without copying account, hash, bounty, or submission values by hand.
- The change is distinct from PR #467, which collapses raw proof JSON; this adds proof-to-activity navigation.

Before/after:
- Before: proof pages linked to the account, bounty, ledger entry, and submission, but accepted-work activity search required manual copy/paste.
- After: proof pages include direct `/activity?q=...` links for the adjacent recipient, proof, bounty, and submission audit views.

Validation:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable -q` -> 1 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests/test_bounty_pages.py -q` -> 7 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest -q` -> 414 passed
- `.\.venv\Scripts\python.exe -m ruff check .` -> passed
- `.\.venv\Scripts\python.exe -m ruff format --check tests\test_bounty_pages.py` -> passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m mypy app` -> success
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean, except Git's Windows LF-to-CRLF warning for the touched template

Refs #427

No wallet material, private keys, cookies, OAuth state, access tokens, signatures, browser storage, private data, price/liquidity/exchange/bridge/off-ramp claims, or fabricated payout claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Related activity" section to bounty proof pages that displays searchable links for the recipient account, proof hash, bounty ID, and submission URL, enabling users to quickly discover and explore all connected transactions and related activity associated with their bounty payments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->