### PR TITLE
Refs #406: Guard nested proof metadata control chars

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -201,11 +201,25 @@ def _clean_optional_account_id(value: str | None, field: str) -> str | None:
     return _clean_required_text(value, field, 128)
 
 
+def _reject_metadata_control_chars(value: Any, path: str) -> None:
+    if isinstance(value, str):
+        if CONTROL_CHAR_RE.search(value):
+            raise LedgerError(f"{path} must not contain control characters")
+        return
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if isinstance(key, str) and CONTROL_CHAR_RE.search(key):
+                raise LedgerError(f"{path} key must not contain control characters")
+            _reject_metadata_control_chars(child, f"{path}.{key}")
+        return
+    if isinstance(value, list):
+        for index, child in enumerate(value):
+            _reject_metadata_control_chars(child, f"{path}[{index}]")
+
+
 def _clean_proof_metadata(verifier_result: dict[str, Any]) -> dict[str, Any]:
     clean = dict(verifier_result)
-    for key, value in clean.items():
-        if isinstance(value, str) and CONTROL_CHAR_RE.search(value):
-            raise LedgerError(f"verifier_result.{key} must not contain control characters")
+    _reject_metadata_control_chars(clean, "verifier_result")
     try:
         canonical_json(clean)
     except (TypeError, ValueError) as exc:

--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -219,9 +219,11 @@ def _reject_metadata_control_chars(value: Any, path: str) -> None:
 
 def _clean_proof_metadata(verifier_result: dict[str, Any]) -> dict[str, Any]:
     clean = dict(verifier_result)
-    _reject_metadata_control_chars(clean, "verifier_result")
     try:
+        _reject_metadata_control_chars(clean, "verifier_result")
         canonical_json(clean)
+    except RecursionError as exc:
+        raise LedgerError("verifier_result is too deeply nested") from exc
     except (TypeError, ValueError) as exc:
         raise LedgerError("verifier_result must be JSON serializable") from exc
     return clean

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -940,6 +940,91 @@ def test_bounty_payment_proof_rejects_control_character_metadata(sqlite_url: str
         assert get_balance(session, "github:bob") == 0
 
 
+@pytest.mark.parametrize(
+    ("verifier_result", "message"),
+    (
+        (
+            {"label": "mrwk:accepted", "details": {"note": "line1\nline2"}},
+            "verifier_result.details.note must not contain control characters",
+        ),
+        (
+            {"label": "mrwk:accepted", "checks": ["ok", "bad\rvalue"]},
+            r"verifier_result.checks\[1\] must not contain control characters",
+        ),
+        (
+            {"label": "mrwk:accepted", "details": {"bad\nkey": "safe"}},
+            "verifier_result.details key must not contain control characters",
+        ),
+    ),
+)
+def test_bounty_payment_proof_rejects_nested_control_character_metadata(
+    sqlite_url: str, verifier_result: dict[str, object], message: str
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=171,
+            issue_url="https://github.com/ramimbo/mergework/issues/171",
+            title="Nested proof metadata",
+            reward_mrwk="25",
+            acceptance="Nested verifier metadata should be public-proof safe.",
+        )
+
+        with pytest.raises(LedgerError, match=message):
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:alice",
+                submission_url="https://github.com/ramimbo/mergework/pull/171",
+                accepted_by="maintainer",
+                verifier_result=verifier_result,
+            )
+
+        assert bounty.awards_paid == 0
+        assert get_balance(session, "github:alice") == 0
+        assert session.scalars(select(Submission)).all() == []
+        assert session.scalars(select(Proof)).all() == []
+
+
+def test_bounty_payment_proof_preserves_safe_nested_metadata(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=172,
+            issue_url="https://github.com/ramimbo/mergework/issues/172",
+            title="Safe nested proof metadata",
+            reward_mrwk="25",
+            acceptance="Safe nested metadata should remain visible in public proof JSON.",
+        )
+
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/172",
+            accepted_by="maintainer",
+            verifier_result={
+                "label": "mrwk:accepted",
+                "details": {"reviewer": "maintainer", "checks": ["tests", "lint"]},
+            },
+        )
+        verifier_result = json.loads(proof.public_json)["verifier_result"]
+        submission = session.scalars(select(Submission)).one()
+
+        assert verifier_result == {
+            "label": "mrwk:accepted",
+            "details": {"reviewer": "maintainer", "checks": ["tests", "lint"]},
+        }
+        assert json.loads(submission.verifier_result) == verifier_result
+        assert get_balance(session, "github:alice") == 25_000_000
+
+
 def test_admin_payout_api_rejects_control_character_note(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -989,7 +989,7 @@ def test_bounty_payment_proof_rejects_nested_control_character_metadata(
         assert session.scalars(select(Proof)).all() == []
 
 
-def test_bounty_payment_proof_preserves_safe_nested_metadata(sqlite_url: str) -> None:
+def test_bounty_payment_proof_rejects_recursive_metadata(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
         ensure_genesis(session)
@@ -998,6 +998,38 @@ def test_bounty_payment_proof_preserves_safe_nested_metadata(sqlite_url: str) ->
             repo="ramimbo/mergework",
             issue_number=172,
             issue_url="https://github.com/ramimbo/mergework/issues/172",
+            title="Recursive proof metadata",
+            reward_mrwk="25",
+            acceptance="Recursive verifier metadata should fail with a bounded error.",
+        )
+        verifier_result: dict[str, object] = {"label": "mrwk:accepted"}
+        verifier_result["self"] = verifier_result
+
+        with pytest.raises(LedgerError, match="verifier_result is too deeply nested"):
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:alice",
+                submission_url="https://github.com/ramimbo/mergework/pull/172-recursive",
+                accepted_by="maintainer",
+                verifier_result=verifier_result,
+            )
+
+        assert bounty.awards_paid == 0
+        assert get_balance(session, "github:alice") == 0
+        assert session.scalars(select(Submission)).all() == []
+        assert session.scalars(select(Proof)).all() == []
+
+
+def test_bounty_payment_proof_preserves_safe_nested_metadata(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=173,
+            issue_url="https://github.com/ramimbo/mergework/issues/173",
             title="Safe nested proof metadata",
             reward_mrwk="25",
             acceptance="Safe nested metadata should remain visible in public proof JSON.",


### PR DESCRIPTION
## Summary
- recursively reject control characters in verifier_result strings before public proof JSON is persisted
- reject control characters in nested verifier_result object keys without echoing the unsafe key text
- cover nested dict/list rejection and safe nested metadata preservation

## Evidence
- Confusion/bug addressed: the existing proof metadata cleaner only checked top-level string values, so nested strings or nested object keys containing control characters could enter public proof JSON.
- Bounty status checked: #406 is open and has awards remaining at the time of this work.
- Intended files: app/ledger/service.py and tests/test_security.py.
- Expected PR size: small service helper plus focused security regressions.
- Out of scope: no payout execution, wallet handling, settlement setup, API schema change, or public price/exchange/bridge claims.

## Validation
- [x] PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest tests/test_security.py::test_bounty_payment_proof_rejects_control_character_metadata tests/test_security.py::test_bounty_payment_proof_rejects_nested_control_character_metadata tests/test_security.py::test_bounty_payment_proof_preserves_safe_nested_metadata -q -> 5 passed
- [x] PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest tests/test_security.py tests/test_ledger.py -q -> 74 passed
- [x] ./.venv/bin/python -m ruff check app/ledger/service.py tests/test_security.py -> passed
- [x] ./.venv/bin/python -m ruff format --check app/ledger/service.py tests/test_security.py -> 2 files already formatted
- [x] ./.venv/bin/python -m mypy app/ledger/service.py -> success
- [x] git diff --check -> clean

Refs #406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of proof/verifier metadata to reject control characters at any nesting level and to fail safely on excessively nested or self-referential structures.

* **Tests**
  * Added security tests covering nested metadata sanitization, rejection of recursive/self-referencing payloads with no payment or persisted records, and preservation of safe nested metadata with successful payout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->