### PR TITLE
Refs #406: Add public discovery routes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from typing import Annotated, Any
 from urllib.parse import urlsplit, urlunsplit
+from xml.sax.saxutils import escape as xml_escape
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response
@@ -88,6 +89,23 @@ API_DOCS_CSP = (
     "worker-src 'self' blob:"
 )
 API_DOCS_PATHS = {"/api/docs", "/api/redoc"}
+PUBLIC_SITEMAP_PATHS = (
+    "/",
+    "/docs",
+    "/bounties",
+    "/activity",
+    "/ledger",
+    "/wallets",
+    "/transfer",
+    "/me",
+    "/api/docs",
+    "/api/v1/status",
+)
+FAVICON_SVG = """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#0e7c66"/>
+  <path d="M16 42V18h7l9 13 9-13h7v24h-7V29L34 39h-4l-7-10v13z" fill="#fff"/>
+</svg>
+"""
 
 
 def _request_was_forwarded_https(request: Request) -> bool:
@@ -316,6 +334,31 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             return data
 
     register_activity_routes(app, db_url=db_url, templates=templates)
+
+    @app.get("/robots.txt", include_in_schema=False)
+    def robots_txt() -> Response:
+        sitemap_url = f"{settings.public_base_url}/sitemap.xml"
+        body = f"User-agent: *\nAllow: /\nSitemap: {sitemap_url}\n"
+        return Response(body, media_type="text/plain; charset=utf-8")
+
+    @app.get("/sitemap.xml", include_in_schema=False)
+    def sitemap_xml() -> Response:
+        base_url = settings.public_base_url.rstrip("/")
+        urlset = "\n".join(
+            f"  <url><loc>{xml_escape(base_url + path)}</loc></url>"
+            for path in PUBLIC_SITEMAP_PATHS
+        )
+        body = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+            f"{urlset}\n"
+            "</urlset>\n"
+        )
+        return Response(body, media_type="application/xml; charset=utf-8")
+
+    @app.get("/favicon.ico", include_in_schema=False)
+    def favicon() -> Response:
+        return Response(FAVICON_SVG, media_type="image/svg+xml")
 
     @app.post("/webhooks/github")
     async def github_webhook(request: Request) -> JSONResponse:

--- a/app/main.py
+++ b/app/main.py
@@ -337,7 +337,8 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/robots.txt", include_in_schema=False)
     def robots_txt() -> Response:
-        sitemap_url = f"{settings.public_base_url}/sitemap.xml"
+        base_url = settings.public_base_url.rstrip("/")
+        sitemap_url = f"{base_url}/sitemap.xml"
         body = f"User-agent: *\nAllow: /\nSitemap: {sitemap_url}\n"
         return Response(body, media_type="text/plain; charset=utf-8")
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{% if site_context == "ltc_lab" %}LTC Lab{% else %}MergeWork{% endif %}{% endblock %}</title>
+    <link rel="icon" href="/favicon.ico" type="image/svg+xml">
     <link rel="stylesheet" href="/static/style.css">
   </head>
   <body>

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -76,6 +76,38 @@ def test_head_requests_match_get_routes_without_body(sqlite_url: str) -> None:
     assert post_only.headers["allow"] == "POST"
 
 
+def test_public_discovery_routes_are_bounded_and_use_public_origin(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    robots = client.get("/robots.txt")
+    assert robots.status_code == 200
+    assert robots.headers["content-type"].startswith("text/plain")
+    assert robots.text == (
+        "User-agent: *\nAllow: /\nSitemap: https://mrwk.ltclab.site/sitemap.xml\n"
+    )
+
+    sitemap = client.get("/sitemap.xml")
+    assert sitemap.status_code == 200
+    assert sitemap.headers["content-type"].startswith("application/xml")
+    assert "<loc>https://mrwk.ltclab.site/</loc>" in sitemap.text
+    assert "<loc>https://mrwk.ltclab.site/docs</loc>" in sitemap.text
+    assert "<loc>https://mrwk.ltclab.site/api/v1/status</loc>" in sitemap.text
+    assert "http://testserver" not in sitemap.text
+
+    favicon = client.get("/favicon.ico")
+    assert favicon.status_code == 200
+    assert favicon.headers["content-type"].startswith("image/svg+xml")
+    assert b"<svg" in favicon.content
+
+    assert client.head("/robots.txt").content == b""
+    assert client.head("/sitemap.xml").content == b""
+    assert client.head("/favicon.ico").content == b""
+
+
 def test_trailing_slash_redirects_keep_forwarded_https_scheme(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -103,6 +103,11 @@ def test_public_discovery_routes_are_bounded_and_use_public_origin(sqlite_url: s
     assert favicon.headers["content-type"].startswith("image/svg+xml")
     assert b"<svg" in favicon.content
 
+    openapi_paths = client.get("/openapi.json").json()["paths"]
+    assert "/robots.txt" not in openapi_paths
+    assert "/sitemap.xml" not in openapi_paths
+    assert "/favicon.ico" not in openapi_paths
+
     assert client.head("/robots.txt").content == b""
     assert client.head("/sitemap.xml").content == b""
     assert client.head("/favicon.ico").content == b""

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -113,6 +113,25 @@ def test_public_discovery_routes_are_bounded_and_use_public_origin(sqlite_url: s
     assert client.head("/favicon.ico").content == b""
 
 
+def test_public_discovery_routes_normalize_public_base_url(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_PUBLIC_BASE_URL", "https://mrwk.example.test/")
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    robots = client.get("/robots.txt")
+    assert "Sitemap: https://mrwk.example.test/sitemap.xml\n" in robots.text
+    assert "https://mrwk.example.test//sitemap.xml" not in robots.text
+
+    sitemap = client.get("/sitemap.xml")
+    assert "<loc>https://mrwk.example.test/</loc>" in sitemap.text
+    assert "<loc>https://mrwk.example.test//docs</loc>" not in sitemap.text
+
+
 def test_trailing_slash_redirects_keep_forwarded_https_scheme(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Refs #406

## Summary
- Add bounded public discovery routes for `/robots.txt`, `/sitemap.xml`, and `/favicon.ico`.
- Link the base template to `/favicon.ico` so browsers stop probing a missing icon path.
- Keep the sitemap conservative: stable public entry points only, using `MERGEWORK_PUBLIC_BASE_URL` rather than the request/test host.

## Evidence
Live production smoke before the fix, using unauthenticated public requests only:
- `GET https://mrwk.ltclab.site/robots.txt` -> HTTP 404 JSON `{"detail":"Not Found"}`
- `GET https://mrwk.ltclab.site/sitemap.xml` -> HTTP 404 JSON `{"detail":"Not Found"}`
- `GET https://mrwk.ltclab.site/favicon.ico` -> HTTP 404 JSON `{"detail":"Not Found"}`
- API-host discovery routes also returned bounded JSON 404s.

This is a small browser/crawler polish fix: standard discovery URLs should either exist intentionally or fail closed. The current behavior is bounded, but it creates routine browser 404 noise and gives crawlers/agents no sitemap entry point for public docs, bounties, ledger, wallet, and status pages.

Live bounty preflight for #406 / internal bounty 66 showed `status=open`, `awards_remaining=15`, and no active attempts.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py::test_public_discovery_routes_are_bounded_and_use_public_origin tests\test_api_mcp.py::test_head_requests_match_get_routes_without_body -q` -> 2 passed
- `.\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py tests\test_hub.py -q` -> 81 passed
- `.\.venv\Scripts\python.exe -m pytest -q` -> 415 passed
- `.\.venv\Scripts\python.exe -m ruff check .` -> passed
- `.\.venv\Scripts\python.exe -m ruff format --check .` -> 79 files already formatted
- `.\.venv\Scripts\python.exe -m mypy app` -> success
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No secrets, wallet material, private keys, tokens, cookies, OAuth state, private data, production mutation, price claims, liquidity claims, exchange claims, bridge promises, or private security details are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /sitemap.xml, /robots.txt, and /favicon.ico endpoints to improve SEO and site discoverability
  * Added favicon link in site header
  * Discovery endpoints use a configured public base URL and normalize it to avoid malformed or double-slash URLs

* **Tests**
  * Added tests verifying discovery endpoints return correct content and headers, respond to HEAD with empty bodies, are excluded from the API schema, and respect base URL normalization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->