### PR TITLE
Refs #426: Document health response shape

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -7,9 +7,27 @@ API_HOST=https://api.mrwk.ltclab.site
 MCP_HOST=https://mcp.mrwk.ltclab.site
 ```
 
-## Status And Bounties
+## Health, Status, And Bounties
 
-Check service status and list bounties:
+Use `/health` for a small liveness and ledger-height check. It returns only the
+service identity, ticker, current ledger height, and `ok` flag, so monitors can
+poll it without downloading bounty rows:
+
+```bash
+curl -s "$API_HOST/health"
+```
+
+```json
+{
+  "ok": true,
+  "service": "mergework",
+  "ticker": "MRWK",
+  "ledger_height": 792
+}
+```
+
+Use `/api/v1/status` when an agent needs the public system counters and
+treasury snapshot, then list bounties:
 
 ```bash
 curl -s "$API_HOST/api/v1/status"

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -61,6 +61,18 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "public_key_hex" in examples
 
 
+def test_api_examples_document_health_response_shape() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert 'curl -s "$API_HOST/health"' in examples
+    assert '"ok": true' in examples
+    assert '"service": "mergework"' in examples
+    assert '"ticker": "MRWK"' in examples
+    assert '"ledger_height": 792' in examples
+    assert "liveness and ledger-height check" in examples
+    assert "without downloading bounty rows" in examples
+
+
 def test_api_examples_document_mcp_get_proof_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Refs #426

## Summary
- document `/health` in `docs/api-examples.md` as the lightweight liveness and ledger-height endpoint
- add the current public response shape with `ok`, `service`, `ticker`, and `ledger_height`
- add a docs regression so the endpoint is not only listed without its fields

## Evidence
- `app/main.py` registers `GET /health` and returns `health_status(session)`.
- `app/status.py` returns only `ok`, `service`, `ticker`, and `ledger_height` for the health endpoint.
- Live unauthenticated checks on 2026-05-28 returned HTTP 200 JSON from both public hosts:
  - `https://api.mrwk.ltclab.site/health` -> `{"ledger_height":792,"ok":true,"service":"mergework","ticker":"MRWK"}`
  - `https://mrwk.ltclab.site/health` -> same shape
- Bounty #426 / internal bounty 72 was open with 2 award slots and no active attempts before submission.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python scripts/docs_smoke.py` -> `docs smoke ok`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest tests/test_docs_public_urls.py::test_api_examples_document_health_response_shape tests/test_docs_public_urls.py::test_api_examples_document_internal_bounty_ids -q` -> `2 passed`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest tests/test_docs_public_urls.py -q` -> `24 passed`
- `./.venv/bin/python -m ruff check tests/test_docs_public_urls.py` -> passed
- `./.venv/bin/python -m ruff format --check tests/test_docs_public_urls.py` -> already formatted
- `git diff --check origin/main...HEAD` -> clean

No private data, cookies, tokens, wallet material, signatures, price claims, liquidity/exchange/off-ramp claims, bridge promises, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive `/health` API endpoint documentation including curl command example and sample JSON response with system liveness and ledger height information.
  * Reorganized API examples section naming for clearer categorization of health and status monitoring resources.

* **Tests**
  * Added automated validation test to ensure health endpoint documentation includes expected response fields and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->