### PR TITLE
Accept resolve and reference verbs in bounty checks

### DIFF
--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -8,7 +8,10 @@ import sys
 from collections import defaultdict
 from typing import Any
 
-BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+#(\d+)", re.IGNORECASE)
+BOUNTY_REF_RE = re.compile(
+    r"\b(?:bounty|refs?|references?|fixes|closes|claims?|resolves?)\s+#(\d+)",
+    re.IGNORECASE,
+)
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
 UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
 GH_TIMEOUT_SECONDS = 30

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -11,7 +11,10 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
-BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+#(\d+)", re.IGNORECASE)
+BOUNTY_REF_RE = re.compile(
+    r"\b(?:bounty|refs?|references?|fixes|closes|claims?|resolves?)\s+#(\d+)",
+    re.IGNORECASE,
+)
 EVIDENCE_RE = re.compile(
     r"\b(pytest|ruff|mypy|validation|verified|test evidence|checks? passed)\b",
     re.IGNORECASE,

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -127,6 +127,33 @@ def test_pr_queue_health_accepts_claim_command_reference() -> None:
     assert report["missing_bounty_references"] == []
 
 
+def test_pr_queue_health_accepts_resolve_and_reference_words() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [
+                {
+                    "number": 8,
+                    "title": "Harden bounty submission checks",
+                    "body": "Resolves #310",
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+                {
+                    "number": 9,
+                    "title": "Harden bounty queue checks",
+                    "body": "References #310",
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+            ],
+        }
+    )
+
+    assert report["summary"]["missing_bounty_references"] == 0
+    assert report["missing_bounty_references"] == []
+
+
 def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     report = analyze_queue(
         {

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -66,6 +66,28 @@ def test_submission_quality_gate_accepts_claim_command_reference() -> None:
     } in result["checks"]
 
 
+def test_submission_quality_gate_accepts_resolve_and_reference_words() -> None:
+    for text in ("Resolves #319", "Reference #319", "References #319"):
+        result = evaluate_submission(
+            {
+                "submission_text": f"""
+                Summary:
+                Harden the bounty reference parser.
+
+                {text}
+
+                Validation:
+                - pytest passed.
+                """,
+                "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+                "pull_requests": [],
+            }
+        )
+
+        assert result["status"] == "pass"
+        assert result["bounty_reference"] == 319
+
+
 def test_submission_quality_gate_fails_missing_reference() -> None:
     result = evaluate_submission(
         {


### PR DESCRIPTION
## Summary
- accept `Resolve(s) #N` and `Reference(s) #N` bounty refs in submission and queue health checks
- align the local quality scripts with the webhook parser, which already supports these GitHub-style linking verbs
- add regression coverage for both scripts

Refs #406

## Validation
- `.\\.venv\\Scripts\\python.exe -m pytest tests\\test_submission_quality_gate.py tests\\test_pr_queue_health.py -q` -> 34 passed
- `.\\.venv\\Scripts\\python.exe -m ruff check scripts\\submission_quality_gate.py scripts\\pr_queue_health.py tests\\test_submission_quality_gate.py tests\\test_pr_queue_health.py` -> passed
- `.\\.venv\\Scripts\\python.exe -m ruff format --check scripts\\submission_quality_gate.py scripts\\pr_queue_health.py tests\\test_submission_quality_gate.py tests\\test_pr_queue_health.py` -> 4 files already formatted
- `.\\.venv\\Scripts\\python.exe -m mypy scripts\\submission_quality_gate.py scripts\\pr_queue_health.py` -> success
- `.\\.venv\\Scripts\\python.exe -m pytest -q` -> 416 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request and submission processing now recognize "references" and "resolves" keywords when linking to bounties.

* **Tests**
  * Added test coverage for new keyword recognition patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->