### PR TITLE
Refs #406: Align script bounty reference verbs

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Helper scripts for MergeWork maintenance checks."""

--- a/scripts/bounty_refs.py
+++ b/scripts/bounty_refs.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import re
+
+LINKED_BOUNTY_VERBS = r"bounty|claims?|close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?"
+BOUNTY_REF_RE = re.compile(
+    rf"\b(?:{LINKED_BOUNTY_VERBS})\s+#(\d+)(?![A-Za-z0-9_-])",
+    re.IGNORECASE,
+)

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -6,7 +6,11 @@ import re
 import subprocess
 import sys
 from collections import defaultdict
+from pathlib import Path
 from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.bounty_refs import BOUNTY_REF_RE
 

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -8,11 +8,8 @@ import sys
 from collections import defaultdict
 from typing import Any
 
-LINKED_BOUNTY_VERBS = r"bounty|claims?|close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?"
-BOUNTY_REF_RE = re.compile(
-    rf"\b(?:{LINKED_BOUNTY_VERBS})\s+#(\d+)(?![A-Za-z0-9_-])",
-    re.IGNORECASE,
-)
+from scripts.bounty_refs import BOUNTY_REF_RE
+
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
 UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
 GH_TIMEOUT_SECONDS = 30

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -8,7 +8,11 @@ import sys
 from collections import defaultdict
 from typing import Any
 
-BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+#(\d+)", re.IGNORECASE)
+LINKED_BOUNTY_VERBS = r"bounty|claims?|close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?"
+BOUNTY_REF_RE = re.compile(
+    rf"\b(?:{LINKED_BOUNTY_VERBS})\s+#(\d+)(?![A-Za-z0-9_-])",
+    re.IGNORECASE,
+)
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
 UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
 GH_TIMEOUT_SECONDS = 30
@@ -116,7 +120,8 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
                 _issue(
                     pr,
                     "missing_bounty_reference",
-                    "No Bounty #<issue>, Refs #<issue>, or /claim #<issue> found",
+                    "No bounty reference such as Bounty #<issue>, Refs #<issue>, "
+                    "Fixes #<issue>, or /claim #<issue> found",
                 )
             )
         for ref in pr["refs"]:

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -7,9 +7,13 @@ import subprocess
 import sys
 from datetime import UTC, datetime, timedelta
 from difflib import SequenceMatcher
+from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.bounty_refs import BOUNTY_REF_RE
 

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -11,11 +11,8 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
-LINKED_BOUNTY_VERBS = r"bounty|claims?|close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?"
-BOUNTY_REF_RE = re.compile(
-    rf"\b(?:{LINKED_BOUNTY_VERBS})\s+#(\d+)(?![A-Za-z0-9_-])",
-    re.IGNORECASE,
-)
+from scripts.bounty_refs import BOUNTY_REF_RE
+
 EVIDENCE_RE = re.compile(
     r"\b(pytest|ruff|mypy|validation|verified|test evidence|checks? passed)\b",
     re.IGNORECASE,

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -11,7 +11,11 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
-BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+#(\d+)", re.IGNORECASE)
+LINKED_BOUNTY_VERBS = r"bounty|claims?|close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?"
+BOUNTY_REF_RE = re.compile(
+    rf"\b(?:{LINKED_BOUNTY_VERBS})\s+#(\d+)(?![A-Za-z0-9_-])",
+    re.IGNORECASE,
+)
 EVIDENCE_RE = re.compile(
     r"\b(pytest|ruff|mypy|validation|verified|test evidence|checks? passed)\b",
     re.IGNORECASE,
@@ -220,7 +224,8 @@ def evaluate_submission(data: dict[str, Any]) -> dict[str, Any]:
             _check(
                 "bounty_reference",
                 "fail",
-                "submission text must include Bounty #<issue>, Refs #<issue>, or /claim #<issue>",
+                "submission text must include a bounty reference such as "
+                "Bounty #<issue>, Refs #<issue>, Fixes #<issue>, or /claim #<issue>",
             )
         )
     else:

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -127,6 +127,63 @@ def test_pr_queue_health_accepts_claim_command_reference() -> None:
     assert report["missing_bounty_references"] == []
 
 
+def test_pr_queue_health_accepts_github_linking_keywords() -> None:
+    references = (
+        "Bounty #310",
+        "Ref #310",
+        "Refs #310",
+        "Reference #310",
+        "References #310",
+        "Fix #310",
+        "Fixes #310",
+        "Fixed #310",
+        "Close #310",
+        "Closes #310",
+        "Closed #310",
+        "Resolve #310",
+        "Resolves #310",
+        "Resolved #310",
+    )
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [
+                {
+                    "number": index,
+                    "title": f"Harden bounty queue checks {index}",
+                    "body": reference,
+                    "merge_state": "clean",
+                    "labels": [],
+                }
+                for index, reference in enumerate(references, start=1)
+            ],
+        }
+    )
+
+    assert report["summary"]["missing_bounty_references"] == 0
+    assert report["missing_bounty_references"] == []
+
+
+def test_pr_queue_health_rejects_linking_keyword_issue_suffix() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [
+                {
+                    "number": 8,
+                    "title": "Harden bounty queue checks",
+                    "body": "Fixes #310abc",
+                    "merge_state": "clean",
+                    "labels": [],
+                }
+            ],
+        }
+    )
+
+    assert report["summary"]["missing_bounty_references"] == 1
+    assert report["missing_bounty_references"][0]["pull_request"] == 8
+
+
 def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     report = analyze_queue(
         {
@@ -183,7 +240,8 @@ def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     assert "### Missing bounty references" in markdown
     assert (
         "- [PR #2](https://github.com/ramimbo/mergework/pull/2): "
-        "Improve bounty filters (No Bounty #<issue>, Refs #<issue>, or /claim #<issue> found)"
+        "Improve bounty filters (No bounty reference such as Bounty #<issue>, "
+        "Refs #<issue>, Fixes #<issue>, or /claim #<issue> found)"
     ) in markdown
     assert "### Dirty or unstable merge state" in markdown
     assert "Merge state is dirty" in markdown

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -130,6 +130,8 @@ def test_pr_queue_health_accepts_claim_command_reference() -> None:
 def test_pr_queue_health_accepts_github_linking_keywords() -> None:
     references = (
         "Bounty #310",
+        "Claim #310",
+        "Claims #310",
         "Ref #310",
         "Refs #310",
         "Reference #310",

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -166,7 +166,8 @@ def test_pr_queue_health_accepts_github_linking_keywords() -> None:
     assert report["missing_bounty_references"] == []
 
 
-def test_pr_queue_health_rejects_linking_keyword_issue_suffix() -> None:
+@pytest.mark.parametrize("reference", ("Fixes #310abc", "Fixes #310_abc", "Fixes #310-abc"))
+def test_pr_queue_health_rejects_linking_keyword_issue_suffix(reference: str) -> None:
     report = analyze_queue(
         {
             "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 1}],
@@ -174,7 +175,7 @@ def test_pr_queue_health_rejects_linking_keyword_issue_suffix() -> None:
                 {
                     "number": 8,
                     "title": "Harden bounty queue checks",
-                    "body": "Fixes #310abc",
+                    "body": reference,
                     "merge_state": "clean",
                     "labels": [],
                 }

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
 from scripts import pr_queue_health
 from scripts.pr_queue_health import analyze_queue, format_markdown_report, format_text_report, main
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
@@ -82,6 +86,19 @@ def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
     assert exit_code == 1
     output = json.loads(capsys.readouterr().out)
     assert output["summary"]["pull_requests"] == 4
+
+
+def test_pr_queue_health_script_entrypoint_loads_shared_parser() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/pr_queue_health.py", "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout
 
 
 def test_pr_queue_health_text_report_is_pasteable() -> None:

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -66,6 +66,59 @@ def test_submission_quality_gate_accepts_claim_command_reference() -> None:
     } in result["checks"]
 
 
+def test_submission_quality_gate_accepts_github_linking_keywords() -> None:
+    references = (
+        "Bounty #319",
+        "Ref #319",
+        "Refs #319",
+        "Reference #319",
+        "References #319",
+        "Fix #319",
+        "Fixes #319",
+        "Fixed #319",
+        "Close #319",
+        "Closes #319",
+        "Closed #319",
+        "Resolve #319",
+        "Resolves #319",
+        "Resolved #319",
+    )
+    for reference in references:
+        result = evaluate_submission(
+            {
+                "submission_text": f"""
+                Summary:
+                Harden the bounty reference parser.
+
+                {reference}
+
+                Validation:
+                - pytest passed.
+                """,
+                "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+                "pull_requests": [],
+            }
+        )
+
+        assert result["status"] == "pass", reference
+        assert result["bounty_reference"] == 319
+
+
+def test_submission_quality_gate_rejects_linking_keyword_issue_suffix() -> None:
+    result = evaluate_submission(
+        {
+            "submission_text": (
+                "Summary: add validation\n\nFixes #319abc\n\nValidation: pytest passed"
+            ),
+            "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [],
+        }
+    )
+
+    assert result["status"] == "fail"
+    assert result["bounty_reference"] is None
+
+
 def test_submission_quality_gate_fails_missing_reference() -> None:
     result = evaluate_submission(
         {
@@ -80,7 +133,8 @@ def test_submission_quality_gate_fails_missing_reference() -> None:
         "name": "bounty_reference",
         "status": "fail",
         "message": (
-            "submission text must include Bounty #<issue>, Refs #<issue>, or /claim #<issue>"
+            "submission text must include a bounty reference such as "
+            "Bounty #<issue>, Refs #<issue>, Fixes #<issue>, or /claim #<issue>"
         ),
     }
 

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import subprocess
 
+import pytest
+
 from scripts import submission_quality_gate
 from scripts.submission_quality_gate import evaluate_submission, main
 
@@ -106,11 +108,12 @@ def test_submission_quality_gate_accepts_github_linking_keywords() -> None:
         assert result["bounty_reference"] == 319
 
 
-def test_submission_quality_gate_rejects_linking_keyword_issue_suffix() -> None:
+@pytest.mark.parametrize("reference", ("Fixes #319abc", "Fixes #319_abc", "Fixes #319-abc"))
+def test_submission_quality_gate_rejects_linking_keyword_issue_suffix(reference: str) -> None:
     result = evaluate_submission(
         {
             "submission_text": (
-                "Summary: add validation\n\nFixes #319abc\n\nValidation: pytest passed"
+                f"Summary: add validation\n\n{reference}\n\nValidation: pytest passed"
             ),
             "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
             "pull_requests": [],

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -69,6 +69,8 @@ def test_submission_quality_gate_accepts_claim_command_reference() -> None:
 def test_submission_quality_gate_accepts_github_linking_keywords() -> None:
     references = (
         "Bounty #319",
+        "Claim #319",
+        "Claims #319",
         "Ref #319",
         "Refs #319",
         "Reference #319",

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
 from scripts import submission_quality_gate
 from scripts.submission_quality_gate import evaluate_submission, main
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_submission_quality_gate_passes_open_bounty_with_evidence(capsys, tmp_path) -> None:
@@ -40,6 +44,19 @@ def test_submission_quality_gate_passes_open_bounty_with_evidence(capsys, tmp_pa
     input_path.write_text(json.dumps(fixture), encoding="utf-8")
     assert main(["--input", str(input_path), "--format", "json"]) == 0
     assert json.loads(capsys.readouterr().out)["status"] == "pass"
+
+
+def test_submission_quality_gate_script_entrypoint_loads_shared_parser() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/submission_quality_gate.py", "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout
 
 
 def test_submission_quality_gate_accepts_claim_command_reference() -> None:


### PR DESCRIPTION
## Summary
- align the submission quality gate and PR queue health bounty-reference regexes with the webhook's GitHub linking verb families
- accept `fix/fixes/fixed`, `close/closes/closed`, `resolve/resolves/resolved`, `ref(s)`, `reference(s)`, `bounty`, and `/claim` style references
- add suffix-boundary regressions so suffixed references such as `Fixes #<issue>abc`, `Fixes #<issue>_abc`, and `Fixes #<issue>-abc` do not get parsed as issue references
- keep both direct script entrypoints working after the shared parser extraction

Refs #406

## Validation
- `./.venv/bin/python scripts/pr_queue_health.py --help` -> ok
- `./.venv/bin/python scripts/submission_quality_gate.py --help` -> ok
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest tests/test_submission_quality_gate.py tests/test_pr_queue_health.py -q` -> 42 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest -q` -> 424 passed
- `./.venv/bin/python -m ruff check scripts/pr_queue_health.py scripts/submission_quality_gate.py tests/test_pr_queue_health.py tests/test_submission_quality_gate.py` -> passed
- `./.venv/bin/python -m ruff format --check scripts/pr_queue_health.py scripts/submission_quality_gate.py tests/test_pr_queue_health.py tests/test_submission_quality_gate.py` -> 4 files already formatted
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m mypy scripts/bounty_refs.py scripts/submission_quality_gate.py scripts/pr_queue_health.py` -> success
- `git diff --check` -> clean
