### PR TITLE
Align bounty reference parser verbs

### DIFF
--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -8,7 +8,14 @@ import sys
 from collections import defaultdict
 from typing import Any
 
-BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+#(\d+)", re.IGNORECASE)
+BOUNTY_REF_RE = re.compile(
+    r"\b(?:bounty|refs?|references?|fix(?:e[sd])?|close[sd]?|claims?|resolve[sd]?)\s+#(\d+)",
+    re.IGNORECASE,
+)
+BOUNTY_REF_HELP = (
+    "No Bounty #<issue>, Refs #<issue>, Fixes #<issue>, "
+    "Resolves #<issue>, References #<issue>, or /claim #<issue> found"
+)
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
 UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
 GH_TIMEOUT_SECONDS = 30
@@ -116,7 +123,7 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
                 _issue(
                     pr,
                     "missing_bounty_reference",
-                    "No Bounty #<issue>, Refs #<issue>, or /claim #<issue> found",
+                    BOUNTY_REF_HELP,
                 )
             )
         for ref in pr["refs"]:

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -11,7 +11,14 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import urlopen
 
-BOUNTY_REF_RE = re.compile(r"\b(?:bounty|refs?|fixes|closes|claims?)\s+#(\d+)", re.IGNORECASE)
+BOUNTY_REF_RE = re.compile(
+    r"\b(?:bounty|refs?|references?|fix(?:e[sd])?|close[sd]?|claims?|resolve[sd]?)\s+#(\d+)",
+    re.IGNORECASE,
+)
+BOUNTY_REF_HELP = (
+    "submission text must include Bounty #<issue>, Refs #<issue>, Fixes #<issue>, "
+    "Resolves #<issue>, References #<issue>, or /claim #<issue>"
+)
 EVIDENCE_RE = re.compile(
     r"\b(pytest|ruff|mypy|validation|verified|test evidence|checks? passed)\b",
     re.IGNORECASE,
@@ -220,7 +227,7 @@ def evaluate_submission(data: dict[str, Any]) -> dict[str, Any]:
             _check(
                 "bounty_reference",
                 "fail",
-                "submission text must include Bounty #<issue>, Refs #<issue>, or /claim #<issue>",
+                BOUNTY_REF_HELP,
             )
         )
     else:

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -127,6 +127,43 @@ def test_pr_queue_health_accepts_claim_command_reference() -> None:
     assert report["missing_bounty_references"] == []
 
 
+def test_pr_queue_health_accepts_github_linking_keyword_family() -> None:
+    pull_requests = [
+        {
+            "number": index,
+            "title": f"Parser probe {index}",
+            "body": text,
+            "merge_state": "clean",
+            "labels": [],
+        }
+        for index, text in enumerate(
+            (
+                "Fix #310",
+                "Fixes #310",
+                "Fixed #310",
+                "Close #310",
+                "Closes #310",
+                "Closed #310",
+                "Resolve #310",
+                "Resolves #310",
+                "Resolved #310",
+                "Reference #310",
+                "References #310",
+            ),
+            start=1,
+        )
+    ]
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": pull_requests,
+        }
+    )
+
+    assert report["summary"]["missing_bounty_references"] == 0
+    assert report["missing_bounty_references"] == []
+
+
 def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     report = analyze_queue(
         {
@@ -183,7 +220,8 @@ def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     assert "### Missing bounty references" in markdown
     assert (
         "- [PR #2](https://github.com/ramimbo/mergework/pull/2): "
-        "Improve bounty filters (No Bounty #<issue>, Refs #<issue>, or /claim #<issue> found)"
+        "Improve bounty filters (No Bounty #<issue>, Refs #<issue>, Fixes #<issue>, "
+        "Resolves #<issue>, References #<issue>, or /claim #<issue> found)"
     ) in markdown
     assert "### Dirty or unstable merge state" in markdown
     assert "Merge state is dirty" in markdown

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -66,6 +66,40 @@ def test_submission_quality_gate_accepts_claim_command_reference() -> None:
     } in result["checks"]
 
 
+def test_submission_quality_gate_accepts_github_linking_keyword_family() -> None:
+    for text in (
+        "Fix #319",
+        "Fixes #319",
+        "Fixed #319",
+        "Close #319",
+        "Closes #319",
+        "Closed #319",
+        "Resolve #319",
+        "Resolves #319",
+        "Resolved #319",
+        "Reference #319",
+        "References #319",
+    ):
+        result = evaluate_submission(
+            {
+                "submission_text": f"""
+                Summary:
+                Harden the bounty reference parser.
+
+                {text}
+
+                Validation:
+                - pytest passed.
+                """,
+                "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+                "pull_requests": [],
+            }
+        )
+
+        assert result["status"] == "pass"
+        assert result["bounty_reference"] == 319
+
+
 def test_submission_quality_gate_fails_missing_reference() -> None:
     result = evaluate_submission(
         {
@@ -80,7 +114,8 @@ def test_submission_quality_gate_fails_missing_reference() -> None:
         "name": "bounty_reference",
         "status": "fail",
         "message": (
-            "submission text must include Bounty #<issue>, Refs #<issue>, or /claim #<issue>"
+            "submission text must include Bounty #<issue>, Refs #<issue>, Fixes #<issue>, "
+            "Resolves #<issue>, References #<issue>, or /claim #<issue>"
         ),
     }
 


### PR DESCRIPTION
Bounty #406

Summary:
- mirror the webhook parser's GitHub-style issue-linking verb family in the local submission and PR queue gates
- accept `fix`, `fixes`, `fixed`, `close`, `closes`, `closed`, `resolve`, `resolves`, `resolved`, `reference`, and `references` forms while preserving existing bounty/ref/claim forms
- update missing-reference guidance and add regression coverage across both scripts

Evidence:
- `app/webhooks/github.py` already accepts close/fix/resolve/reference verb families when resolving accepted-label PR bodies to bounty issues
- the local `scripts/submission_quality_gate.py` and `scripts/pr_queue_health.py` only accepted narrower forms, so valid webhook-payable text like `Fixed #406`, `Closed #406`, or `Resolved #406` could fail preflight or appear as a missing bounty reference
- this addresses the remaining gap called out on PR #554 rather than duplicating its narrower resolve/reference-only coverage
- no private keys, cookies, tokens, wallet JSON, browser storage, OAuth state, signatures, private data, price claims, liquidity claims, exchange claims, bridge promises, or off-ramp claims are added

Validation:
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/test_submission_quality_gate.py::test_submission_quality_gate_accepts_github_linking_keyword_family tests/test_pr_queue_health.py::test_pr_queue_health_accepts_github_linking_keyword_family tests/test_submission_quality_gate.py::test_submission_quality_gate_fails_missing_reference tests/test_pr_queue_health.py::test_pr_queue_health_markdown_report_includes_required_sections -q -> 4 passed
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/test_submission_quality_gate.py tests/test_pr_queue_health.py -q -> 34 passed
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q -> 416 passed
- .venv/bin/python -m ruff check scripts/submission_quality_gate.py scripts/pr_queue_health.py tests/test_submission_quality_gate.py tests/test_pr_queue_health.py -> passed
- .venv/bin/python -m ruff format --check scripts/submission_quality_gate.py scripts/pr_queue_health.py tests/test_submission_quality_gate.py tests/test_pr_queue_health.py -> 4 files already formatted
- .venv/bin/python -m mypy scripts/submission_quality_gate.py scripts/pr_queue_health.py -> success
- git diff --check -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Bounty reference detection now recognizes a broader range of GitHub linking keywords, including "fixes", "closes", "resolves", "references", "bounty", and "claim"
  * Updated help messaging to document all supported bounty reference formats
  * Added test coverage for expanded keyword recognition

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->