### PR TITLE
fix: accept colon-linked bounty issue refs

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -19,7 +19,7 @@ ACCEPTED_LABEL = "mrwk:accepted"
 ISSUE_NUMBER_BOUNDARY = r"(?![A-Za-z0-9_-])"
 MAX_SQLITE_INTEGER = 2**63 - 1
 LINKED_ISSUE_RE = re.compile(
-    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?|bounty)\s+"
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?|bounty)\s*:?\s+"
     rf"(?:(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#(?P<repo_number>\d+){ISSUE_NUMBER_BOUNDARY}"
     rf"|#(?P<number>\d+){ISSUE_NUMBER_BOUNDARY})",
     re.IGNORECASE,

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -155,6 +155,48 @@ def test_accepted_pr_label_pays_pr_author_for_linked_bounty_issue(sqlite_url: st
         assert get_balance(session, "github:maintainer") == 0
 
 
+def test_accepted_pr_label_accepts_colon_after_link_keyword(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "labeled",
+            "label": {"name": "mrwk:accepted"},
+            "pull_request": {
+                "number": 9,
+                "html_url": "https://github.com/ramimbo/mergework/pull/9",
+                "body": "Refs: #406",
+                "user": {"login": "contributor"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "maintainer"},
+        },
+        separators=(",", ":"),
+    ).encode()
+    headers = {
+        "X-GitHub-Delivery": "delivery-pr-colon-linked-issue",
+        "X-GitHub-Event": "pull_request",
+        "X-Hub-Signature-256": _signature("secret", body),
+    }
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=406,
+            issue_url="https://github.com/ramimbo/mergework/issues/406",
+            title="Small focused fixes",
+            reward_mrwk="50",
+            acceptance="Accepted PRs should link back to the bounty issue.",
+        )
+
+    result = handle_github_webhook(sqlite_url, headers, body, "secret")
+
+    assert result["status"] == "paid"
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:contributor") == 50_000_000
+
+
 def test_accepted_issue_event_for_pull_request_does_not_pay_matching_bounty(
     sqlite_url: str,
 ) -> None:


### PR DESCRIPTION
## Summary
- allow webhook PR bounty references with a colon after the linking keyword, e.g. `Refs: #406`
- keep existing issue-number boundary checks for malformed suffixes
- add regression coverage proving an accepted PR label pays the linked bounty when the PR body uses the colon form

## Why
GitHub contributors commonly write references as `Refs: #123` or `Fixes: #123`. The current payout parser only accepts `Refs #123`, so a maintainer could apply `mrwk:accepted` to valid work and still get `missing_issue` if the PR body used the colon form.

## Tests
- `./.venv/bin/python -m ruff format --check app/webhooks/github.py tests/test_webhooks.py`
- `./.venv/bin/python -m ruff check app/webhooks/github.py tests/test_webhooks.py`
- `./.venv/bin/python -m pytest tests/test_webhooks.py -q`
- `./.venv/bin/python -m pytest -q`

Refs #406


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Issue reference parsing now accepts optional colons after action keywords in pull request descriptions (e.g., `Refs: 123`, `Closes: 456`), improving compatibility with common linking conventions.

* **Tests**
  * Added test coverage for colon-formatted issue references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->