### PR TITLE
Docs: complete agent-readable bounty template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -1,8 +1,13 @@
 name: MRWK bounty
 description: Propose work that may receive an MRWK bounty.
-title: "[bounty] "
+title: "MRWK bounty: <amount> MRWK - <short scope>"
 labels: ["mrwk:bounty"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Use the stable bounty shape from `docs/bounty-rules.md` so humans, GitHub search, API clients, and MCP agents can parse the reward, scope, evidence, and exclusions.
+        Keep public MRWK wording work-based: no price, investment, exchange, liquidity, bridge, cash-out, or fabricated payout claims.
   - type: textarea
     id: work
     attributes:
@@ -29,5 +34,37 @@ body:
     attributes:
       label: Acceptance criteria
       description: Explain what must be true before mrwk:accepted is applied.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or tests required
+      description: List the commands, URLs, screenshots, logs, reproduction steps, or checked surfaces needed for review.
+      placeholder: |
+        - Command or URL:
+        - Expected behavior:
+        - Observed behavior or required screenshot/GIF/video:
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: List duplicate, broad rewrite, typo-only, style-only, speculative tokenomics, private-security-detail, or unrelated work that does not qualify.
+      placeholder: |
+        - No broad rewrites.
+        - No speculative price, liquidity, bridge, exchange, cash-out, or payout claims.
+        - No private secrets or security exploit details in public artifacts.
+    validations:
+      required: true
+  - type: textarea
+    id: duplicate_stale_rules
+    attributes:
+      label: Duplicate and stale work rules
+      description: Explain how maintainers will treat overlapping claims, abandoned attempts, or submissions that no longer match current behavior.
+      placeholder: |
+        Duplicate work is judged by the first useful, reviewable submission that matches the bounty criteria.
+        Stale claims may be released or ignored when they lack reviewable evidence or no longer match current repository behavior.
     validations:
       required: true

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -4,12 +4,22 @@
 
 1. Create or choose a GitHub issue.
 2. Decide the MRWK amount using the reference tiers.
-3. Add acceptance text that explains what counts as useful accepted work.
-4. Set `max_awards` to the number of separate payouts allowed. Use `1` for
+3. Use the agent-readable bounty post template in
+   [docs/bounty-rules.md](bounty-rules.md). Keep the issue title in the form
+   `MRWK bounty: <amount> MRWK - <short scope>` and repeat the reward plus
+   `max_awards` in the body.
+4. Add acceptance text that explains what counts as useful accepted work, which
+   files, routes, APIs, docs, or behaviors are in scope, and what evidence or
+   tests a reviewer needs before `mrwk:accepted` or an admin payout is recorded.
+5. Add explicit out-of-scope, duplicate-work, stale-work, and public artifact
+   cautions. Do not include price, investment, exchange, liquidity, bridge,
+   cash-out, fabricated payout, private security detail, secret, or token claims
+   in public bounty text.
+6. Set `max_awards` to the number of separate payouts allowed. Use `1` for
    a single-award bounty.
-5. Use `/admin` or `POST /api/v1/bounties` with an admin token.
+7. Use `/admin` or `POST /api/v1/bounties` with an admin token.
    Multi-award bounties reserve `reward_mrwk * max_awards`.
-6. Add `mrwk:bounty` to the GitHub issue.
+8. Add `mrwk:bounty` to the GitHub issue.
 
 ## Accept Work
 

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -62,6 +62,70 @@ Use the smallest template that makes the claim reviewable. Delete fields that do
 not apply, but keep the evidence specific enough that a maintainer can reproduce
 the work without reading unrelated context.
 
+## Agent-Readable Bounty Post Template
+
+Maintainers should post MRWK bounties with stable headings so humans, GitHub
+search, public API clients, and MCP agents can extract the same scope and reward
+facts without guessing. Put the amount in the issue title and repeat it in the
+body.
+
+Issue title:
+
+```text
+MRWK bounty: <amount> MRWK - <short scope>
+```
+
+Issue body:
+
+```text
+## MRWK Bounty
+
+Reward: `<amount> MRWK per accepted award`
+Max awards: `<number>`
+
+## Work Needed
+
+Describe the useful accepted work in concrete, bounded terms.
+
+## Acceptance Criteria
+
+- Link the expected issue, PR, review, report, or proof surface.
+- State the files, routes, APIs, docs, or behaviors that must be changed or checked.
+- Explain what must be true before `mrwk:accepted` or an admin payout is recorded.
+
+## How To Submit
+
+Open a focused PR or public comment that links this issue with
+`Bounty #<issue number>` or `Refs #<issue number>`.
+
+## Evidence or Tests Required
+
+- List the exact commands, URLs, screenshots, logs, or reproduction steps needed.
+- Include expected and observed behavior for reviews, smoke checks, and bug reports.
+- Keep private security details, secrets, wallet recovery data, and admin tokens out
+  of public artifacts.
+
+## Out of Scope
+
+- List duplicate, broad rewrite, typo-only, style-only, speculative tokenomics,
+  private-security-detail, price, liquidity, bridge, exchange, cash-out, or unrelated
+  changes that do not qualify.
+
+## Duplicate and Stale Work Rules
+
+- Duplicate work is judged by the first useful, reviewable submission that matches
+  the bounty criteria.
+- Stale claims may be released or ignored when they do not include reviewable
+  evidence or no longer match current repository behavior.
+```
+
+Agents need these fields because GitHub issue search, the public bounty API, and
+MCP bounty tools expose title, issue URL, `reward_mrwk`, `max_awards`,
+`awards_remaining`, labels, and public comments. Stable headings let agents match
+the human bounty text to those machine-readable fields, avoid duplicate claims,
+and produce focused evidence without inventing payout, price, exchange, liquidity,
+bridge, or acceptance claims.
+
 PR or fix claim:
 
 ```text

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -76,6 +76,20 @@ def _squash(text: str) -> str:
     return " ".join(text.split())
 
 
+def _template_field_block(template: str, field_id: str) -> str:
+    marker = f"id: {field_id}"
+    if marker not in template:
+        return ""
+    block = template.split(marker, 1)[1]
+    next_field = block.find("\n    id: ")
+    return block if next_field == -1 else block[:next_field]
+
+
+def _template_field_is_required(template: str, field_id: str) -> bool:
+    block = _template_field_block(template, field_id)
+    return "validations:" in block and "required: true" in block
+
+
 def main() -> int:
     ok = True
     for relative in REQUIRED:
@@ -134,10 +148,10 @@ def main() -> int:
             if phrase not in bounty_template:
                 print(f"bounty issue template missing required phrase: {phrase}")
                 ok = False
-        required_tail = bounty_template.split("id: out_of_scope", 1)[-1]
-        if "required: true" not in required_tail.split("id: duplicate_stale_rules", 1)[0]:
-            print("bounty issue template out_of_scope field must be required")
-            ok = False
+        for field_id in ("evidence", "out_of_scope", "duplicate_stale_rules"):
+            if not _template_field_is_required(bounty_template, field_id):
+                print(f"bounty issue template {field_id} field must be required")
+                ok = False
     if ok:
         print("docs smoke ok")
         return 0

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -46,6 +46,12 @@ REQUIRED_PUBLIC_PHRASES = {
         ("creating or releasing an attempt requires the GitHub-authenticated browser session"),
     ],
     "docs/bounty-rules.md": [
+        "## Agent-Readable Bounty Post Template",
+        "MRWK bounty: <amount> MRWK - <short scope>",
+        "## Evidence or Tests Required",
+        "## Out of Scope",
+        "## Duplicate and Stale Work Rules",
+        "GitHub issue search, the public bounty API, and MCP bounty tools",
         "## Submission Evidence Templates",
         "PR or fix claim:",
         "Review claim:",
@@ -112,6 +118,26 @@ def main() -> int:
     elif "expected pr size:" not in pr_template.read_text(encoding="utf-8").lower():
         print("pull request template must ask for expected PR size")
         ok = False
+    bounty_issue_template = ROOT / ".github/ISSUE_TEMPLATE/bounty.yml"
+    if not bounty_issue_template.exists():
+        print("missing bounty issue template: .github/ISSUE_TEMPLATE/bounty.yml")
+        ok = False
+    else:
+        bounty_template = bounty_issue_template.read_text(encoding="utf-8").lower()
+        for phrase in [
+            "mrwk bounty: <amount> mrwk - <short scope>",
+            "id: evidence",
+            "evidence or tests required",
+            "id: out_of_scope",
+            "id: duplicate_stale_rules",
+        ]:
+            if phrase not in bounty_template:
+                print(f"bounty issue template missing required phrase: {phrase}")
+                ok = False
+        required_tail = bounty_template.split("id: out_of_scope", 1)[-1]
+        if "required: true" not in required_tail.split("id: duplicate_stale_rules", 1)[0]:
+            print("bounty issue template out_of_scope field must be required")
+            ok = False
     if ok:
         print("docs smoke ok")
         return 0

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.docs_smoke import REQUIRED
+from scripts.docs_smoke import REQUIRED, _template_field_is_required
 
 
 def test_readme_lists_live_ltclab_urls() -> None:
@@ -284,6 +284,20 @@ def test_agent_guide_explains_internal_bounty_ids() -> None:
 
 def test_docs_smoke_covers_public_api_examples() -> None:
     assert "docs/api-examples.md" in REQUIRED
+
+
+def test_docs_smoke_requires_bounty_evidence_exclusion_and_duplicate_fields() -> None:
+    template = Path(".github/ISSUE_TEMPLATE/bounty.yml").read_text(encoding="utf-8").lower()
+
+    assert _template_field_is_required(template, "evidence")
+    assert _template_field_is_required(template, "out_of_scope")
+    assert _template_field_is_required(template, "duplicate_stale_rules")
+    assert not _template_field_is_required(
+        template.replace("id: evidence", "id: optional_evidence", 1), "evidence"
+    )
+    assert not _template_field_is_required(
+        template.replace("required: true", "required: false", 1), "work"
+    )
 
 
 def test_contributing_names_docs_smoke_for_public_docs_changes() -> None:


### PR DESCRIPTION
Refs #456

## Summary
- add a canonical agent-readable MRWK bounty post template to the bounty rules
- update the GitHub bounty issue form so amount, evidence/tests, out-of-scope, duplicate, and stale-work rules are explicit required fields
- expand the admin runbook posting checklist and protect the new template shape with docs smoke checks

## Evidence
Compared this change against the current repository surfaces named in the bounty:
- `docs/bounty-rules.md`: existing submission evidence templates and payout wording
- `docs/admin-runbook.md`: maintainer bounty posting and acceptance flow
- `.github/ISSUE_TEMPLATE/bounty.yml`: current issue form fields
- `scripts/docs_smoke.py`: existing public documentation checks
- public API/MCP bounty fields documented in project docs: title, issue URL, `reward_mrwk`, `max_awards`, `awards_remaining`, labels, and public comments

This version keeps the template copy-pasteable and uses stable headings:
- `## MRWK Bounty`
- `## Work Needed`
- `## Acceptance Criteria`
- `## How To Submit`
- `## Evidence or Tests Required`
- `## Out of Scope`
- `## Duplicate and Stale Work Rules`

After reviewer feedback, the current head also verifies that `evidence`, `out_of_scope`, and `duplicate_stale_rules` are all individually required fields.

## Test Evidence
- `python scripts/docs_smoke.py` -> `docs smoke ok`
- `python -m pytest tests/test_docs_public_urls.py tests/test_check_agents.py -q` -> `26 passed`
- `python -m ruff check scripts/docs_smoke.py tests/test_docs_public_urls.py` -> `All checks passed!`
- `python -m ruff format --check scripts/docs_smoke.py tests/test_docs_public_urls.py` -> `2 files already formatted`
- `git diff --check` -> clean

## Out of Scope
- no tokenomics, price, liquidity, exchange, bridge, cash-out, payout, wallet, or private-security-detail changes
- no broad rewrite of bounty rules, ledger behavior, or payout logic
