### PR TITLE
Bounty #427: Add docs endpoint shortcuts

### DIFF
--- a/app/templates/docs.html
+++ b/app/templates/docs.html
@@ -16,6 +16,7 @@
   <ul class="doc-list">
     <li><a href="/api/v1/status">API status</a></li>
     <li><a href="/api/docs">OpenAPI docs</a></li>
+    <li><a href="/openapi.json">OpenAPI JSON schema</a></li>
     <li><a href="/api/v1/bounties">Bounty API</a></li>
     <li><a href="/activity">Activity dashboard</a></li>
     <li><a href="/api/v1/activity">Activity API</a></li>
@@ -28,6 +29,13 @@
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/agent-guide.md">Agent usage</a></li>
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/api-examples.md">Public API examples</a></li>
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/ledger.md">Ledger details</a></li>
+  </ul>
+  <h2>Machine-readable shortcuts</h2>
+  <ul class="doc-list">
+    <li><a href="/api/v1/bounties?status=open&amp;sort=available">Open bounties by available MRWK</a></li>
+    <li><a href="/api/v1/bounties/summary?status=open">Open bounty summary</a></li>
+    <li><a href="/api/v1/activity?limit=20">Latest accepted-work activity JSON</a></li>
+    <li><a href="https://mcp.mrwk.ltclab.site/mcp">MCP JSON-RPC endpoint</a></li>
   </ul>
   <h2>Payout access</h2>
   <p>MRWK balances can live on native <code>mrwk1</code> wallet addresses. A wallet signs transfer, GitHub-link, and claim payloads with its private key; the server verifies signatures and records accepted movements in the explorer.</p>

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1543,8 +1543,13 @@ def test_docs_page_lists_live_ltclab_urls(sqlite_url: str) -> None:
     assert "docs/paid-bounties.md" in docs
     assert "docs/api-examples.md" in docs
     assert "OpenAPI docs" in docs
+    assert 'href="/openapi.json">OpenAPI JSON schema</a>' in docs
     assert 'href="/activity"' in docs
     assert 'href="/api/v1/activity"' in docs
+    assert 'href="/api/v1/bounties?status=open&amp;sort=available"' in docs
+    assert 'href="/api/v1/bounties/summary?status=open"' in docs
+    assert 'href="/api/v1/activity?limit=20"' in docs
+    assert 'href="https://mcp.mrwk.ltclab.site/mcp"' in docs
     assert "SwaggerUIBundle" in api_docs
 
 


### PR DESCRIPTION
## Summary

Bounty #427 / Refs #427.

This adds a focused machine-readable shortcuts section to the public `/docs` page so contributors and agents can jump directly from the docs hub to the OpenAPI schema, open-bounty queue, open-bounty summary, latest accepted-work activity JSON, and the MCP JSON-RPC endpoint.

## Before / After

Before: `/docs` linked to general docs and some API pages, but users still had to know or manually compose the exact machine-readable endpoints for schema discovery, open bounty prioritization, activity JSON, and MCP calls.

After: `/docs` exposes those exact entry points in one coherent section while keeping the existing documentation links unchanged.

## Evidence

- Distinct from existing #427 account, wallet, ledger, bounty-list, bounty-detail, proof, and activity workflow PRs; this targets the docs hub and machine-readable endpoint discovery.
- Live bounty preflight for internal bounty `73` / issue `#427`: `status=open`, `awards_remaining=2`, `available_mrwk=250`, and active attempts `[]`.
- Scope: 2 files, +13/-0.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest tests/test_api_mcp.py::test_docs_page_lists_live_ltclab_urls -q` -> 1 passed
- `./.venv/bin/python -m ruff check tests/test_api_mcp.py` -> passed
- `./.venv/bin/python -m ruff format --check tests/test_api_mcp.py` -> 1 file already formatted
- `git diff --check` -> clean

## Safety

No wallet material, private keys, cookies, OAuth state, access tokens, signatures, private data, price/off-ramp claims, liquidity claims, exchange claims, bridge promises, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OpenAPI JSON schema link to the docs page.
  * Introduced new "Machine-readable shortcuts" section featuring API query shortcuts and MCP JSON-RPC endpoint documentation links.

* **Tests**
  * Updated test coverage to verify new documentation links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->