### PR TITLE
Refs #406: Skip stale bounty refs in webhook payouts

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -13,7 +13,7 @@ from app.ledger.service import (
     pay_bounty,
     resolve_payout_account,
 )
-from app.models import WebhookEvent
+from app.models import Bounty, WebhookEvent
 
 ACCEPTED_LABEL = "mrwk:accepted"
 ISSUE_NUMBER_BOUNDARY = r"(?![A-Za-z0-9_-])"
@@ -116,6 +116,10 @@ def _github_issue_number(value: Any) -> int | None:
     return value
 
 
+def _bounty_accepts_awards(bounty: Bounty) -> bool:
+    return bounty.status == "open" and bounty.awards_paid < bounty.max_awards
+
+
 def _handle_accepted_issue_label(
     database_url: str,
     payload: dict[str, Any],
@@ -198,11 +202,22 @@ def _handle_accepted_issue_label(
     with session_scope(database_url) as session:
         bounty = None
         bounty_issue_number = None
+        first_found_bounty = None
+        first_found_issue_number = None
         for candidate in bounty_issue_numbers:
-            bounty = find_bounty_by_issue(session, repo, candidate)
-            if bounty is not None:
+            candidate_bounty = find_bounty_by_issue(session, repo, candidate)
+            if candidate_bounty is None:
+                continue
+            if first_found_bounty is None:
+                first_found_bounty = candidate_bounty
+                first_found_issue_number = candidate
+            if _bounty_accepts_awards(candidate_bounty):
+                bounty = candidate_bounty
                 bounty_issue_number = candidate
                 break
+        if bounty is None:
+            bounty = first_found_bounty
+            bounty_issue_number = first_found_issue_number
         if bounty is None:
             session.add(
                 WebhookEvent(

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -5,7 +5,13 @@ import hmac
 import json
 
 from app.db import create_schema, session_scope
-from app.ledger.service import create_bounty, ensure_genesis, get_balance, register_wallet
+from app.ledger.service import (
+    close_bounty,
+    create_bounty,
+    ensure_genesis,
+    get_balance,
+    register_wallet,
+)
 from app.models import WebhookEvent
 from app.webhooks.github import handle_github_webhook, verify_github_signature
 
@@ -838,6 +844,72 @@ def test_accepted_pr_label_pays_full_github_issue_url_reference(sqlite_url: str)
     assert result["status"] == "paid"
     with session_scope(sqlite_url) as session:
         assert get_balance(session, "github:reviewer") == 25_000_000
+
+
+def test_accepted_pr_label_skips_closed_bounty_for_later_open_reference(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "labeled",
+            "label": {"name": "mrwk:accepted"},
+            "pull_request": {
+                "number": 13,
+                "html_url": "https://github.com/ramimbo/mergework/pull/13",
+                "body": "Fixes #3\n\nBounty #4",
+                "user": {"login": "reviewer"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "maintainer"},
+        },
+        separators=(",", ":"),
+    ).encode()
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        closed_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=3,
+            issue_url="https://github.com/ramimbo/mergework/issues/3",
+            title="Closed stale bounty",
+            reward_mrwk="40",
+            acceptance="Already closed bounty should not block later open refs.",
+        )
+        close_bounty(
+            session,
+            bounty_id=closed_bounty.id,
+            closed_by="maintainer",
+            reference="https://github.com/ramimbo/mergework/issues/3#close",
+        )
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=4,
+            issue_url="https://github.com/ramimbo/mergework/issues/4",
+            title="Current open bounty",
+            reward_mrwk="25",
+            acceptance="Accepted PR can mention stale refs before the bounty target.",
+        )
+
+    result = handle_github_webhook(
+        sqlite_url,
+        {
+            "X-GitHub-Delivery": "delivery-closed-then-open-pr",
+            "X-GitHub-Event": "pull_request",
+            "X-Hub-Signature-256": _signature("secret", body),
+        },
+        body,
+        "secret",
+    )
+
+    assert result["status"] == "paid"
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:reviewer") == 25_000_000
+        event = session.get(WebhookEvent, "delivery-closed-then-open-pr")
+        assert event is not None
+        assert event.processed_status == "paid"
 
 
 def test_accepted_maintainer_issue_label_requires_manual_payout(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- make accepted-label webhook payout selection skip closed or exhausted bounty references when a later referenced bounty is still payable
- preserve the old failure behavior when no referenced bounty has award capacity
- add a regression for a PR body that mentions a closed stale bounty before the current open bounty target

## Why
A valid accepted PR body can mention an older issue with a closed MRWK bounty, then identify the current bounty target later in the body. Before this change, the webhook picked the first matching bounty row and failed with `bounty_is_not_open` instead of paying the later open bounty.

Distinctness for Bounty #406: this is not another parser-form change or native/internal bounty-id guard. It handles the selection step after parsing real GitHub bounty references, specifically closed/exhausted refs before a payable ref.

## Validation
- `./.venv/Scripts/python.exe -m pytest tests/test_webhooks.py -q` -> 19 passed
- `./.venv/Scripts/python.exe -m pytest tests/test_security.py::test_admin_page_renders_safe_webhook_events_for_cookie_admin tests/test_security.py::test_admin_webhook_events_api_lists_and_filters_processing_outcomes tests/test_security.py::test_signed_webhook_with_invalid_json_is_rejected tests/test_security.py::test_duplicate_webhook_delivery_with_different_payload_is_rejected tests/test_security.py::test_webhook_rejects_unapproved_accepted_labeler -q` -> 5 passed
- `./.venv/Scripts/python.exe -m pytest -q` -> 415 passed
- `./.venv/Scripts/python.exe -m ruff check .` -> passed
- `./.venv/Scripts/python.exe -m ruff format --check .` -> 79 files already formatted
- `./.venv/Scripts/python.exe -m mypy app` -> success, no issues found in 30 source files
- `git diff --check` -> clean

Refs #406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* GitHub webhook now intelligently selects bounties that remain eligible for additional awards when processing labeled pull requests, improving reward assignment accuracy.

## Tests
* Added comprehensive test coverage to verify correct webhook behavior when multiple bounties exist with varying eligibility statuses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->