### PR TITLE
Bounty #427: Add keyboard skip link and focus styles

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -25,6 +25,33 @@ body {
   color: var(--text);
   font: 16px/1.5 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible,
+main:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 3px;
+}
+.skip-link {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 0 0 6px 0;
+  color: var(--accent);
+  font-weight: 700;
+  left: 0;
+  padding: 10px 14px;
+  position: absolute;
+  top: 0;
+  transform: translateY(-120%);
+  transition: transform .12s ease;
+  z-index: 20;
+}
+.skip-link:focus {
+  transform: translateY(0);
+}
 header {
   display: flex;
   justify-content: space-between;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,9 +7,10 @@
     <link rel="stylesheet" href="/static/style.css">
   </head>
   <body>
+    <a class="skip-link" href="#content">Skip to content</a>
     <header>
       <a class="brand" href="/">{% if site_context == "ltc_lab" %}LTC Lab{% else %}MergeWork <span>MRWK</span>{% endif %}</a>
-      <nav>
+      <nav aria-label="Primary navigation">
         {% if site_context == "ltc_lab" %}
         <a href="#projects">Projects</a>
         <a href="https://mrwk.ltclab.site">MRWK</a>
@@ -26,6 +27,6 @@
         {% endif %}
       </nav>
     </header>
-    <main>{% block content %}{% endblock %}</main>
+    <main id="content" tabindex="-1">{% block content %}{% endblock %}</main>
   </body>
 </html>

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
 from app.hub import (
     host_without_port,
     is_ltc_lab_host,
     ltc_lab_context,
     mergework_hub_context,
 )
+from app.main import create_app
 
 
 def test_host_without_port_normalizes_host_headers() -> None:
@@ -47,3 +52,23 @@ def test_mergework_hub_context_preserves_status_and_base_url() -> None:
         "status": status,
         "public_base_url": "https://mrwk.ltclab.site",
     }
+
+
+def test_public_shell_exposes_keyboard_skip_link(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert '<a class="skip-link" href="#content">Skip to content</a>' in response.text
+    assert '<nav aria-label="Primary navigation">' in response.text
+    assert '<main id="content" tabindex="-1">' in response.text
+
+
+def test_public_styles_define_visible_focus_state() -> None:
+    css = Path("app/static/style.css").read_text(encoding="utf-8")
+
+    assert ".skip-link:focus" in css
+    assert "transform: translateY(0);" in css
+    assert "a:focus-visible" in css
+    assert "outline: 3px solid var(--accent);" in css


### PR DESCRIPTION
/claim #427

Bounty #427

Summary:
- add a site-wide skip-to-content link before the header
- label the primary navigation and expose a focus target on main content
- add visible keyboard focus styles for common interactive elements

Evidence / distinctness:
- This targets global keyboard navigation and accessibility, not the existing #427 work around bounty, wallet, ledger, proof, account filters, or links.
- I did not find an open equivalent PR adding a skip link or shared focus-navigation treatment.
- The normal mouse layout is unchanged because the skip link is hidden until focused.

Validation:
- `uv run --extra dev python -m pytest tests/test_hub.py tests/test_public_routes.py -q` -> 7 passed
- `uv run --extra dev python -m pytest -q` -> 416 passed
- `uv run --extra dev ruff check app tests/test_hub.py` -> passed
- `uv run --extra dev ruff format --check tests/test_hub.py` -> passed
- `git diff --check` -> passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skip-to-content link for improved keyboard navigation
  * Enhanced keyboard focus visibility with consistent outline styling across interactive elements

* **Tests**
  * Added test coverage for accessibility features including skip link presence and focus styling verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->