### PR TITLE
Support MCP lifecycle basics

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -131,6 +131,8 @@ async def handle_mcp_request(
             },
         }
     if method == "notifications/initialized":
+        if response_id is not None:
+            return _jsonrpc_error(response_id, -32600, "invalid request")
         return Response(status_code=202)
     if method == "ping":
         return {"jsonrpc": "2.0", "id": response_id, "result": {}}

--- a/app/mcp.py
+++ b/app/mcp.py
@@ -11,6 +11,7 @@ from app.ledger.service import LedgerError
 
 MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
 DEFAULT_PROTOCOL_VERSION = "2025-06-18"
+SUPPORTED_PROTOCOL_VERSIONS = {DEFAULT_PROTOCOL_VERSION}
 SERVER_INFO = {"name": "MergeWork MCP", "version": "0.1.0"}
 
 MCP_TOOLS: list[dict[str, Any]] = [
@@ -118,9 +119,17 @@ async def handle_mcp_request(
         if not isinstance(params, dict):
             return _jsonrpc_error(response_id, -32602, "invalid params")
         requested_version = params.get("protocolVersion")
-        protocol_version = (
-            requested_version if isinstance(requested_version, str) else DEFAULT_PROTOCOL_VERSION
-        )
+        if (
+            isinstance(requested_version, str)
+            and requested_version not in SUPPORTED_PROTOCOL_VERSIONS
+        ):
+            error = _jsonrpc_error(response_id, -32602, "Unsupported protocol version")
+            error["error"]["data"] = {
+                "supported": sorted(SUPPORTED_PROTOCOL_VERSIONS),
+                "requested": requested_version,
+            }
+            return error
+        protocol_version = DEFAULT_PROTOCOL_VERSION
         return {
             "jsonrpc": "2.0",
             "id": response_id,

--- a/app/mcp.py
+++ b/app/mcp.py
@@ -5,11 +5,13 @@ from collections.abc import Callable
 from typing import Any
 
 from fastapi import HTTPException, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 
 from app.ledger.service import LedgerError
 
 MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
+DEFAULT_PROTOCOL_VERSION = "2025-06-18"
+SERVER_INFO = {"name": "MergeWork MCP", "version": "0.1.0"}
 
 MCP_TOOLS: list[dict[str, Any]] = [
     {
@@ -100,7 +102,7 @@ def _tool_result_response(response_id: Any, tool_result: str | dict[str, Any]) -
 
 async def handle_mcp_request(
     request: Request, database_url: str, call_tool: MCPToolHandler
-) -> dict[str, Any] | JSONResponse:
+) -> dict[str, Any] | JSONResponse | Response:
     try:
         payload = await request.json()
     except ValueError:
@@ -111,6 +113,28 @@ async def handle_mcp_request(
 
     response_id = payload.get("id")
     method = payload.get("method")
+    if method == "initialize":
+        params = payload.get("params", {})
+        if not isinstance(params, dict):
+            return _jsonrpc_error(response_id, -32602, "invalid params")
+        requested_version = params.get("protocolVersion")
+        protocol_version = (
+            requested_version if isinstance(requested_version, str) else DEFAULT_PROTOCOL_VERSION
+        )
+        return {
+            "jsonrpc": "2.0",
+            "id": response_id,
+            "result": {
+                "protocolVersion": protocol_version,
+                "capabilities": {"tools": {}},
+                "serverInfo": SERVER_INFO,
+            },
+        }
+    if method == "notifications/initialized":
+        return Response(status_code=202)
+    if method == "ping":
+        return {"jsonrpc": "2.0", "id": response_id, "result": {}}
+
     if method == "tools/list":
         return {"jsonrpc": "2.0", "id": response_id, "result": {"tools": MCP_TOOLS}}
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -270,6 +270,37 @@ def test_mcp_initialize_defaults_protocol_version(
     assert response.json()["result"]["protocolVersion"] == expected_version
 
 
+@pytest.mark.parametrize("protocol_version", ["1900-01-01", "not-a-version"])
+def test_mcp_initialize_rejects_unsupported_protocol_version(
+    sqlite_url: str, protocol_version: str
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 42,
+            "method": "initialize",
+            "params": {"protocolVersion": protocol_version},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 42,
+        "error": {
+            "code": -32602,
+            "message": "Unsupported protocol version",
+            "data": {
+                "supported": ["2025-06-18"],
+                "requested": protocol_version,
+            },
+        },
+    }
+
+
 def test_mcp_initialize_rejects_invalid_params(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -235,6 +235,57 @@ def test_mcp_initialize_advertises_tool_capability(sqlite_url: str) -> None:
     }
 
 
+@pytest.mark.parametrize(
+    ("payload", "expected_version"),
+    [
+        ({"jsonrpc": "2.0", "id": 42, "method": "initialize"}, "2025-06-18"),
+        (
+            {
+                "jsonrpc": "2.0",
+                "id": 42,
+                "method": "initialize",
+                "params": {"capabilities": {}},
+            },
+            "2025-06-18",
+        ),
+        (
+            {
+                "jsonrpc": "2.0",
+                "id": 42,
+                "method": "initialize",
+                "params": {"protocolVersion": 20250618},
+            },
+            "2025-06-18",
+        ),
+    ],
+)
+def test_mcp_initialize_defaults_protocol_version(
+    sqlite_url: str, payload: dict[str, object], expected_version: str
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post("/mcp", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["result"]["protocolVersion"] == expected_version
+
+
+def test_mcp_initialize_rejects_invalid_params(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 42, "method": "initialize", "params": []},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 42,
+        "error": {"code": -32602, "message": "invalid params"},
+    }
+
+
 def test_mcp_initialized_notification_returns_accepted(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
@@ -245,6 +296,22 @@ def test_mcp_initialized_notification_returns_accepted(sqlite_url: str) -> None:
 
     assert response.status_code == 202
     assert response.content == b""
+
+
+def test_mcp_initialized_request_returns_jsonrpc_error(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 44, "method": "notifications/initialized"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 44,
+        "error": {"code": -32600, "message": "invalid request"},
+    }
 
 
 def test_mcp_ping_returns_empty_result(sqlite_url: str) -> None:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -206,6 +206,56 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert "100000000" in balance["result"]["content"][0]["text"]
 
 
+def test_mcp_initialize_advertises_tool_capability(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 42,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1.0"},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 42,
+        "result": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "MergeWork MCP", "version": "0.1.0"},
+        },
+    }
+
+
+def test_mcp_initialized_notification_returns_accepted(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+    )
+
+    assert response.status_code == 202
+    assert response.content == b""
+
+
+def test_mcp_ping_returns_empty_result(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post("/mcp", json={"jsonrpc": "2.0", "id": 43, "method": "ping"})
+
+    assert response.status_code == 200
+    assert response.json() == {"jsonrpc": "2.0", "id": 43, "result": {}}
+
+
 def test_mcp_list_bounty_attempts_reports_active_and_expired(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     now = datetime.now(UTC)


### PR DESCRIPTION
## Summary

Refs #406.

This adds a focused compatibility fix for the public MCP JSON-RPC endpoint: `/mcp` now responds to the standard `initialize` request with protocol version, tool capability, and server info before clients call `tools/list` or `tools/call`. It also accepts the follow-up `notifications/initialized` lifecycle notification with an empty `202` response and supports the optional `ping` health check.

## Evidence

Live public preflight on 2026-05-28 showed:

```text
POST https://mcp.mrwk.ltclab.site/mcp
{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}

-> HTTP 200
{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"unknown method"}}

POST https://mcp.mrwk.ltclab.site/mcp
{"jsonrpc":"2.0","method":"notifications/initialized"}

-> HTTP 200
{"jsonrpc":"2.0","id":null,"error":{"code":-32601,"message":"unknown method"}}

POST https://mcp.mrwk.ltclab.site/mcp
{"jsonrpc":"2.0","id":9,"method":"ping"}

-> HTTP 200
{"jsonrpc":"2.0","id":9,"error":{"code":-32601,"message":"unknown method"}}
```

That is awkward for generic MCP clients because the MCP lifecycle starts with an `initialize` exchange followed by an initialized notification before normal operation, and the protocol also defines a lightweight ping utility. The project already advertises an MCP host and supports `tools/list` / `tools/call`; this PR keeps that behavior and adds the missing lifecycle/basic utility responses.

## Scope

- Adds a minimal `initialize` branch in `app/mcp.py`.
- Returns:
  - requested `protocolVersion` when supplied, otherwise a default;
  - `capabilities: {"tools": {}}`;
  - `serverInfo` for MergeWork MCP.
- Accepts `notifications/initialized` as a no-body `202` lifecycle notification.
- Returns an empty JSON-RPC result for `ping`.
- Adds a regression test in `tests/test_api_mcp.py`.
- Does not change existing tool names, tool execution, wallet behavior, ledger behavior, public docs, auth, payment, or deployment configuration.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py::test_mcp_initialize_advertises_tool_capability tests\test_api_mcp.py::test_mcp_initialized_notification_returns_accepted tests\test_api_mcp.py::test_mcp_ping_returns_empty_result tests\test_api_mcp.py::test_mcp_tools_list_and_call tests\test_api_mcp.py::test_mcp_rejects_malformed_requests_without_500 -q` -> 5 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py -q` -> 79 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `.\.venv\Scripts\python.exe -m ruff check app\mcp.py tests\test_api_mcp.py` -> passed
- `.\.venv\Scripts\python.exe -m ruff format --check app\mcp.py tests\test_api_mcp.py` -> 2 files already formatted
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m mypy app\mcp.py` -> success
- `git diff --check` -> clean

## Safety

No private data, cookies, admin tokens, wallet material, signatures, OAuth state, deployment secrets, price/off-ramp claims, liquidity claims, exchange claims, bridge promises, or fabricated payout claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Model Context Protocol (MCP) endpoints: initialize (with protocol negotiation and clear errors for unsupported or invalid params), notifications/initialized (accepted as 202 when no id), and ping (returns empty success result). Server advertises tool capabilities and server info during initialization.

* **Tests**
  * Added tests covering initialize payloads, protocol-version defaulting/validation, invalid-params and unsupported-version errors, initialized notification handling, and ping response.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->