### PR TITLE
Document agent-friendly bounty template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -1,8 +1,24 @@
 name: MRWK bounty
 description: Propose work that may receive an MRWK bounty.
-title: "[bounty] "
+title: "MRWK bounty: <amount> MRWK - <short scope>"
 labels: ["mrwk:bounty"]
 body:
+  - type: input
+    id: reward
+    attributes:
+      label: Reward per accepted award
+      description: Repeat the issue-title amount so humans, agents, API clients, and MCP tools can parse it.
+      placeholder: "150 MRWK"
+    validations:
+      required: true
+  - type: input
+    id: max_awards
+    attributes:
+      label: Max awards
+      description: Number of separate accepted submissions that may be paid.
+      placeholder: "1"
+    validations:
+      required: true
   - type: textarea
     id: work
     attributes:
@@ -10,24 +26,33 @@ body:
       description: Describe the useful accepted work.
     validations:
       required: true
-  - type: input
-    id: reward
-    attributes:
-      label: Proposed MRWK per award
-      placeholder: "250"
-    validations:
-      required: true
-  - type: input
-    id: max_awards
-    attributes:
-      label: Max awards
-      placeholder: "1"
-    validations:
-      required: true
   - type: textarea
     id: acceptance
     attributes:
       label: Acceptance criteria
       description: Explain what must be true before mrwk:accepted is applied.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence or tests
+      description: List the proof, screenshots, commands, test output, or review notes a submitter should provide.
+      placeholder: "Run scripts/docs_smoke.py and paste the output. Link the PR or public artifact."
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: State what should not be changed or claimed for this bounty.
+    validations:
+      required: true
+  - type: textarea
+    id: duplicate_stale_rules
+    attributes:
+      label: Duplicate-work and stale-work rules
+      description: Explain how overlapping submissions are handled and when a claim is considered stale.
+      placeholder: "First accepted submission wins for single-award bounties. Rebase stale PRs before review."
     validations:
       required: true

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -4,12 +4,18 @@
 
 1. Create or choose a GitHub issue.
 2. Decide the MRWK amount using the reference tiers.
-3. Add acceptance text that explains what counts as useful accepted work.
-4. Set `max_awards` to the number of separate payouts allowed. Use `1` for
+3. Use the canonical template in [Bounty Rules](bounty-rules.md#agent-friendly-bounty-post-template).
+   The issue title should be `MRWK bounty: <amount> MRWK - <short scope>` and
+   the body should repeat `Reward` and `Max awards` as stable fields for
+   humans, GitHub search, API clients, and MCP tools.
+4. Add acceptance text that explains what counts as useful accepted work, which
+   evidence or tests are required, what is out of scope, and how duplicate or
+   stale work is handled.
+5. Set `max_awards` to the number of separate payouts allowed. Use `1` for
    a single-award bounty.
-5. Use `/admin` or `POST /api/v1/bounties` with an admin token.
+6. Use `/admin` or `POST /api/v1/bounties` with an admin token.
    Multi-award bounties reserve `reward_mrwk * max_awards`.
-6. Add `mrwk:bounty` to the GitHub issue.
+7. Add `mrwk:bounty` to the GitHub issue.
 
 ## Accept Work
 

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -56,6 +56,62 @@ After accepted work is paid, MergeWork records a public ledger proof. Public
 payment updates should point to those proofs and keep any private security or
 operational details out of public metadata.
 
+
+## Agent-Friendly Bounty Post Template
+
+Maintainers should use this short, copy-pasteable shape for public MRWK bounty
+issues. Stable headings let humans, GitHub search, API clients, and MCP tools
+parse the reward, available award slots, work scope, acceptance gate, and review
+evidence without guessing.
+
+```text
+Title: MRWK bounty: <amount> MRWK - <short scope>
+
+## MRWK Bounty
+
+Reward: `<amount> MRWK per accepted award`
+Max awards: `<number>`
+
+## Work Needed
+
+<Specific useful work. Link affected files, docs, API routes, UI screens, or
+issues. Keep the scope narrow enough for one focused PR or public artifact.>
+
+## Acceptance Criteria
+
+- <Observable condition required before `mrwk:accepted` is applied.>
+- <Required docs, tests, screenshots, review notes, or reproduction evidence.>
+- <Required comparison against current behavior or related docs when relevant.>
+
+## How To Submit
+
+Open a PR, issue comment, or linked public artifact that includes
+`Bounty #<issue number>` or `Refs #<issue number>`. Use a closing reference only
+when the bounty should close after the submission is accepted.
+
+## Evidence Or Tests
+
+- <Commands to run and paste output for.>
+- <Screenshots, API responses, ledger proof, review checklist, or reproduction
+steps maintainers need to verify the work.>
+
+## Out Of Scope
+
+- <Changes that should not be made.>
+- <Claims that should not be made publicly.>
+
+## Duplicate-Work And Stale-Work Rules
+
+Single-award bounties pay the first accepted submission only. Multi-award
+bounties pay at most `Max awards` accepted submissions. Before submitting, check
+open linked PRs, comments, and attempt reservations. Rebase or refresh stale
+work before review if the target files, APIs, or bounty text changed.
+```
+
+Public MRWK bounty text must avoid investment claims, price claims, fabricated
+payout claims, liquidity claims, exchange claims, or bridge promises. State only
+the work reward, acceptance conditions, and public proof that already exists.
+
 ## Submission Evidence Templates
 
 Use the smallest template that makes the claim reviewable. Delete fields that do


### PR DESCRIPTION
## Summary
- Adds a canonical, copy-pasteable MRWK bounty issue template with stable headings for reward, max awards, work needed, acceptance criteria, submission path, evidence/tests, out-of-scope, and duplicate/stale rules.
- Updates the maintainer runbook to point bounty posters at the canonical template and require title/body fields agents can parse.
- Expands `.github/ISSUE_TEMPLATE/bounty.yml` so new bounty issues collect evidence, out-of-scope, and duplicate/stale-work rules up front.

## Linked bounty
Bounty #456

## Evidence
Compared current bounty surfaces:
- `docs/bounty-rules.md` already had payout flow, labels, and submission evidence templates, but not a maintainer-facing bounty post template.
- `docs/admin-runbook.md` had post/accept payout steps, but not the stable title/body fields agents need before claiming work.
- `.github/ISSUE_TEMPLATE/bounty.yml` collected work, reward, max awards, and acceptance criteria, but not evidence/tests, out-of-scope, or duplicate/stale rules.
- `docs/agent-guide.md` documents API/MCP-style bounty attempt and bounty inspection flows; those flows benefit from stable public issue headings.
- Public bounty behavior expects PRs to link `Bounty #<issue>` or `Refs #<issue>` and avoid claiming accepted/paid before public proof exists.

## Tests
```text
docs smoke ok
```

## Out of scope
- No payout, ledger, API, or wallet behavior changed.
- No MRWK price, liquidity, exchange, bridge, or investment claims added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bounty creation template with new required fields for evidence/tests, out-of-scope guidance, and duplicate/stale-work handling
  * Enhanced bounty posting procedures and administrative guidance
  * Added standardized bounty template structure to improve consistency
  * Clarified acceptable language restrictions for bounty posts regarding reward claims

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->