### PR TITLE
Refs #406: Reject control chars in public search queries

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import FastAPI, Query, Request
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
@@ -11,8 +11,17 @@ from app.db import session_scope
 from app.serializers import activity_to_dict
 
 
+def _normalized_activity_search_query(query: str | None) -> str | None:
+    if query is None:
+        return None
+    normalized_query = query.strip()
+    if any(ord(char) < 32 or ord(char) == 127 for char in normalized_query):
+        raise HTTPException(status_code=400, detail="q must not contain control characters")
+    return normalized_query
+
+
 def activity_context(session: Session, query: str | None = None) -> dict[str, Any]:
-    return activity_to_dict(session, query)
+    return activity_to_dict(session, _normalized_activity_search_query(query))
 
 
 def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:

--- a/app/activity.py
+++ b/app/activity.py
@@ -14,10 +14,9 @@ from app.serializers import activity_to_dict
 def _normalized_activity_search_query(query: str | None) -> str | None:
     if query is None:
         return None
-    normalized_query = query.strip()
-    if any(ord(char) < 32 or ord(char) == 127 for char in normalized_query):
+    if any(ord(char) < 32 or ord(char) == 127 for char in query):
         raise HTTPException(status_code=400, detail="q must not contain control characters")
-    return normalized_query
+    return query.strip()
 
 
 def activity_context(session: Session, query: str | None = None) -> dict[str, Any]:

--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -81,6 +81,14 @@ def _ledger_http_error(exc: LedgerError) -> HTTPException:
     return HTTPException(status_code=400, detail=detail)
 
 
+def _normalized_bounty_search_query(query_text: str | None) -> str | None:
+    if query_text is None:
+        return None
+    if CONTROL_CHAR_RE.search(query_text):
+        raise HTTPException(status_code=400, detail="q must not contain control characters")
+    return query_text.strip()
+
+
 def register_bounty_api_routes(
     app: FastAPI,
     *,
@@ -114,25 +122,24 @@ def register_bounty_api_routes(
                         status_code=400, detail="status must be one of: open, paid, closed"
                     )
                 query = query.where(Bounty.status == normalized_status)
-            if query_text is not None:
-                normalized_query = query_text.strip()
-                if normalized_query:
-                    escaped_query = (
-                        normalized_query.lower()
-                        .replace("\\", "\\\\")
-                        .replace("%", "\\%")
-                        .replace("_", "\\_")
-                    )
-                    like_query = f"%{escaped_query}%"
-                    issue_number = issue_number_search_value(normalized_query)
-                    text_filter = or_(
-                        func.lower(Bounty.repo).like(like_query, escape="\\"),
-                        func.lower(Bounty.title).like(like_query, escape="\\"),
-                        func.lower(Bounty.acceptance).like(like_query, escape="\\"),
-                    )
-                    if issue_number is not None:
-                        text_filter = or_(text_filter, Bounty.issue_number == issue_number)
-                    query = query.where(text_filter)
+            normalized_query = _normalized_bounty_search_query(query_text)
+            if normalized_query:
+                escaped_query = (
+                    normalized_query.lower()
+                    .replace("\\", "\\\\")
+                    .replace("%", "\\%")
+                    .replace("_", "\\_")
+                )
+                like_query = f"%{escaped_query}%"
+                issue_number = issue_number_search_value(normalized_query)
+                text_filter = or_(
+                    func.lower(Bounty.repo).like(like_query, escape="\\"),
+                    func.lower(Bounty.title).like(like_query, escape="\\"),
+                    func.lower(Bounty.acceptance).like(like_query, escape="\\"),
+                )
+                if issue_number is not None:
+                    text_filter = or_(text_filter, Bounty.issue_number == issue_number)
+                query = query.where(text_filter)
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             sorted_bounties = sort_bounties(
                 [bounty_to_dict(bounty) for bounty in bounties], normalized_sort

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -27,6 +27,10 @@ from app.serializers import (
 
 
 def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | dict[str, Any]:
+    def reject_control_chars(field: str, value: str) -> None:
+        if any(ord(char) < 32 or ord(char) == 127 for char in value):
+            raise ValueError(f"{field} must not contain control characters")
+
     def int_arg(field: str) -> int:
         value = args[field]
         if isinstance(value, bool):
@@ -123,6 +127,7 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             query = select(Bounty).where(Bounty.status == normalized_status)
             query_text = optional_clean_str_arg("q")
             if query_text:
+                reject_control_chars("q", query_text)
                 escaped_query = (
                     query_text.lower().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
                 )

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -83,6 +83,16 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
         clean = value.strip()
         return clean or None
 
+    def optional_search_query_arg(field: str) -> str | None:
+        value = args.get(field)
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise ValueError(f"{field} must be a string")
+        reject_control_chars(field, value)
+        clean = value.strip()
+        return clean or None
+
     def output_format_arg() -> str:
         value = args.get("format", "text")
         if value is None:
@@ -125,9 +135,8 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             if normalized_status not in {"open", "paid", "closed"}:
                 raise ValueError("status must be one of: open, paid, closed")
             query = select(Bounty).where(Bounty.status == normalized_status)
-            query_text = optional_clean_str_arg("q")
+            query_text = optional_search_query_arg("q")
             if query_text:
-                reject_control_chars("q", query_text)
                 escaped_query = (
                     query_text.lower().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
                 )

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -201,11 +201,17 @@ def test_activity_rejects_control_character_search_query(sqlite_url: str) -> Non
 
     api_response = client.get("/api/v1/activity", params={"q": "\x00"})
     page_response = client.get("/activity", params={"q": "\x00"})
+    leading_tab_response = client.get("/api/v1/activity", params={"q": "\talice"})
+    trailing_newline_response = client.get("/activity", params={"q": "alice\n"})
 
     assert api_response.status_code == 400
     assert api_response.json() == {"detail": "q must not contain control characters"}
     assert page_response.status_code == 400
     assert page_response.json() == {"detail": "q must not contain control characters"}
+    assert leading_tab_response.status_code == 400
+    assert leading_tab_response.json() == {"detail": "q must not contain control characters"}
+    assert trailing_newline_response.status_code == 400
+    assert trailing_newline_response.json() == {"detail": "q must not contain control characters"}
 
 
 def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -192,6 +192,22 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
         assert invalid_hash_query["recent"] == []
 
 
+def test_activity_rejects_control_character_search_query(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    api_response = client.get("/api/v1/activity", params={"q": "\x00"})
+    page_response = client.get("/activity", params={"q": "\x00"})
+
+    assert api_response.status_code == 400
+    assert api_response.json() == {"detail": "q must not contain control characters"}
+    assert page_response.status_code == 400
+    assert page_response.json() == {"detail": "q must not contain control characters"}
+
+
 def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -541,6 +541,8 @@ def test_mcp_list_bounties_honors_sort_argument(sqlite_url: str) -> None:
         ({"limit": 101}, 35),
         ({"sort": "invalid"}, 36),
         ({"q": "\x00"}, 37),
+        ({"q": "\tDocs"}, 38),
+        ({"q": "Docs\n"}, 39),
     ],
 )
 def test_mcp_list_bounties_rejects_invalid_filters(

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -540,6 +540,7 @@ def test_mcp_list_bounties_honors_sort_argument(sqlite_url: str) -> None:
         ({"limit": 0}, 34),
         ({"limit": 101}, 35),
         ({"sort": "invalid"}, 36),
+        ({"q": "\x00"}, 37),
     ],
 )
 def test_mcp_list_bounties_rejects_invalid_filters(

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -333,6 +333,8 @@ def test_bounty_api_rejects_control_character_search_queries(sqlite_url: str) ->
 
     list_response = client.get("/api/v1/bounties?q=%00")
     summary_response = client.get("/api/v1/bounties/summary?q=%00")
+    del_list_response = client.get("/api/v1/bounties", params={"q": "\x7f"})
+    del_summary_response = client.get("/api/v1/bounties/summary", params={"q": "\x7f"})
     leading_tab_response = client.get("/api/v1/bounties", params={"q": "\tControl"})
     trailing_newline_response = client.get("/api/v1/bounties/summary", params={"q": "Control\n"})
 
@@ -340,6 +342,10 @@ def test_bounty_api_rejects_control_character_search_queries(sqlite_url: str) ->
     assert list_response.json()["detail"] == "q must not contain control characters"
     assert summary_response.status_code == 400
     assert summary_response.json()["detail"] == "q must not contain control characters"
+    assert del_list_response.status_code == 400
+    assert del_list_response.json()["detail"] == "q must not contain control characters"
+    assert del_summary_response.status_code == 400
+    assert del_summary_response.json()["detail"] == "q must not contain control characters"
     assert leading_tab_response.status_code == 400
     assert leading_tab_response.json()["detail"] == "q must not contain control characters"
     assert trailing_newline_response.status_code == 400

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -333,8 +333,14 @@ def test_bounty_api_rejects_control_character_search_queries(sqlite_url: str) ->
 
     list_response = client.get("/api/v1/bounties?q=%00")
     summary_response = client.get("/api/v1/bounties/summary?q=%00")
+    leading_tab_response = client.get("/api/v1/bounties", params={"q": "\tControl"})
+    trailing_newline_response = client.get("/api/v1/bounties/summary", params={"q": "Control\n"})
 
     assert list_response.status_code == 400
     assert list_response.json()["detail"] == "q must not contain control characters"
     assert summary_response.status_code == 400
     assert summary_response.json()["detail"] == "q must not contain control characters"
+    assert leading_tab_response.status_code == 400
+    assert leading_tab_response.json()["detail"] == "q must not contain control characters"
+    assert trailing_newline_response.status_code == 400
+    assert trailing_newline_response.json()["detail"] == "q must not contain control characters"

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -313,3 +313,28 @@ def test_bounty_api_limit_rejects_out_of_range_values(sqlite_url: str) -> None:
     assert client.get("/api/v1/bounties?limit=201").status_code == 422
     assert client.get("/api/v1/bounties/summary?limit=0").status_code == 422
     assert client.get("/api/v1/bounties/summary?limit=201").status_code == 422
+
+
+def test_bounty_api_rejects_control_character_search_queries(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=53,
+            issue_url="https://github.com/ramimbo/mergework/issues/53",
+            title="Control character bounty search",
+            reward_mrwk="5",
+            acceptance="Control characters should not widen bounty search results.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    list_response = client.get("/api/v1/bounties?q=%00")
+    summary_response = client.get("/api/v1/bounties/summary?q=%00")
+
+    assert list_response.status_code == 400
+    assert list_response.json()["detail"] == "q must not contain control characters"
+    assert summary_response.status_code == 400
+    assert summary_response.json()["detail"] == "q must not contain control characters"

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -284,6 +284,11 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
 
     control_char_page_search = client.get("/bounties", params={"q": "\x00"})
     assert control_char_page_search.status_code == 400
+    assert control_char_page_search.json()["detail"] == "q must not contain control characters"
+
+    leading_tab_page_search = client.get("/bounties", params={"q": "\tDocs"})
+    assert leading_tab_page_search.status_code == 400
+    assert leading_tab_page_search.json()["detail"] == "q must not contain control characters"
 
 
 def test_bounties_page_and_api_sort_public_rows(sqlite_url: str) -> None:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -282,6 +282,9 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     assert backslash_search.status_code == 200
     assert [row["issue_number"] for row in backslash_search.json()] == [66]
 
+    control_char_page_search = client.get("/bounties", params={"q": "\x00"})
+    assert control_char_page_search.status_code == 400
+
 
 def test_bounties_page_and_api_sort_public_rows(sqlite_url: str) -> None:
     create_schema(sqlite_url)


### PR DESCRIPTION
## Summary

- reject control characters in public `q` search parameters before they are reflected or used for filtering
- apply the validation to bounty list/summary search, accepted-work activity search, and MCP `list_bounties`
- add regression coverage for `%00` so control-character searches fail closed with bounded `400` responses on API/HTML routes and invalid-argument JSON-RPC errors on MCP

## Evidence

Live public preflight before this fix showed control-character searches were accepted on public search endpoints:

- `GET https://api.mrwk.ltclab.site/api/v1/bounties?q=%00` -> HTTP 200 and returned current bounty rows
- `GET https://api.mrwk.ltclab.site/api/v1/bounties/summary?q=%00` -> HTTP 200 with `bounties_shown=77`
- `GET https://api.mrwk.ltclab.site/api/v1/activity?q=%00` -> HTTP 200 with `query:\u0000`

That is misleading because non-empty search parameters should not silently widen to all bounty rows or reflect control characters in public JSON. The fix now rejects C0/DEL control characters with bounded `400` responses.

## Validation

- `uv run --extra dev python -m pytest tests/test_activity.py tests/test_bounty_api_routes.py tests/test_bounty_api.py tests/test_bounty_pages.py tests/test_api_mcp.py::test_mcp_list_bounties_filters_status_query_and_limit tests/test_api_mcp.py::test_mcp_list_bounties_rejects_invalid_filters -q` -> 40 passed
- `uv run --extra dev python -m pytest -q` -> 429 passed
- `uv run --extra dev ruff check app/activity.py app/bounty_api.py app/mcp_tools.py tests/test_activity.py tests/test_api_mcp.py tests/test_bounty_api_routes.py tests/test_bounty_pages.py` -> passed
- `uv run --extra dev ruff format --check app/activity.py app/bounty_api.py app/mcp_tools.py tests/test_activity.py tests/test_api_mcp.py tests/test_bounty_api_routes.py tests/test_bounty_pages.py` -> 7 files already formatted
- `uv run --extra dev python -m mypy app` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check HEAD~1..HEAD` -> clean

## Safety

No private data, cookies, tokens, wallet material, signatures, production mutation, price claims, liquidity claims, exchange claims, bridge promises, off-ramp promises, or private security details are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search inputs are now consistently validated and normalized across activity, bounty, and tool-backed listing flows: control characters are rejected with HTTP 400, queries are trimmed, and empty queries are treated as no filter.
* **Tests**
  * Added tests verifying rejection of control-character search queries for activity endpoints, bounty APIs/pages, and the MCP list-bounties tool.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->