### PR TITLE
Fix: honor offset parameter on bounty list endpoints

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -87,6 +87,7 @@ def register_bounty_api_routes(
         query_text: str | None = None,
         sort: str | None = None,
         limit: int | None = None,
+        offset: int | None = None,
     ) -> list[dict[str, Any]]:
         try:
             normalized_sort = normalize_bounty_sort(sort)
@@ -124,27 +125,31 @@ def register_bounty_api_routes(
             sorted_bounties = sort_bounties(
                 [bounty_to_dict(bounty) for bounty in bounties], normalized_sort
             )
-            if limit is not None:
-                return sorted_bounties[:limit]
-            return sorted_bounties
+            start = offset if offset is not None else 0
+            end = (start + limit) if limit is not None else None
+            return sorted_bounties[start:end]
 
     @app.get("/api/v1/bounties")
     def api_bounties(
         status: str | None = Query(None),
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+        offset: Annotated[int | None, Query(ge=0, le=10000)] = None,
         sort: str | None = Query(None),
     ) -> list[dict[str, Any]]:
-        return _list_bounties_by_status(status, q, sort=sort, limit=limit)
+        return _list_bounties_by_status(status, q, sort=sort, limit=limit, offset=offset)
 
     @app.get("/api/v1/bounties/summary")
     def api_bounties_summary(
         status: str | None = Query(None),
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+        offset: Annotated[int | None, Query(ge=0, le=10000)] = None,
         sort: str | None = Query(None),
     ) -> dict[str, Any]:
-        return bounty_list_summary(_list_bounties_by_status(status, q, sort=sort, limit=limit))
+        return bounty_list_summary(
+            _list_bounties_by_status(status, q, sort=sort, limit=limit, offset=offset)
+        )
 
     @app.get("/api/v1/admin/webhook-events")
     def api_admin_webhook_events(

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -106,6 +106,14 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             raise ValueError("limit must be at most 100")
         return value
 
+    def list_offset_arg() -> int:
+        if "offset" not in args or args.get("offset") is None:
+            return 0
+        value = positive_int_arg("offset")
+        if value > 10_000:
+            raise ValueError("offset must be at most 10000")
+        return value
+
     def optional_bool_arg(field: str, default: bool = False) -> bool:
         value = args.get(field, default)
         if value is None:
@@ -138,14 +146,17 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 query = query.where(text_filter)
             sort = normalize_bounty_sort(optional_clean_str_arg("sort"))
             limit = list_limit_arg()
+            offset = list_offset_arg()
             if sort == "newest":
                 newest_bounties = session.scalars(
-                    query.order_by(Bounty.id.desc()).limit(limit)
+                    query.order_by(Bounty.id.desc()).offset(offset).limit(limit)
                 ).all()
                 return json.dumps([bounty_to_dict(bounty) for bounty in newest_bounties])
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             sorted_bounties = sort_bounties([bounty_to_dict(bounty) for bounty in bounties], sort)
-            return json.dumps(sorted_bounties[:limit])
+            start = offset
+            end = start + limit
+            return json.dumps(sorted_bounties[start:end])
         if name == "get_bounty":
             bounty = session.get(Bounty, positive_int_arg("id"))
             if bounty is None:

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -58,7 +58,7 @@ def register_public_routes(
     *,
     db_url: str,
     templates: Jinja2Templates,
-    list_bounties_by_status: Callable[[str | None, str | None, str | None], list[dict[str, Any]]],
+    list_bounties_by_status: Callable[..., list[dict[str, Any]]],
     api_bounty: Callable[[int], dict[str, Any]],
     api_ledger: Callable[[], list[dict[str, Any]]],
     api_ledger_entry: Callable[[int], dict[str, Any]],
@@ -70,8 +70,10 @@ def register_public_routes(
         status: str | None = Query(None),
         q: str | None = Query(None),
         sort: str | None = Query(None),
+        limit: int | None = Query(None),
+        offset: int | None = Query(None),
     ) -> HTMLResponse:
-        bounties = list_bounties_by_status(status, q, sort)
+        bounties = list_bounties_by_status(status, q, sort, limit=limit, offset=offset)
         return templates.TemplateResponse(
             request,
             "bounties.html",

--- a/tests/test_bounty_offset.py
+++ b/tests/test_bounty_offset.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+
+from app.db import create_schema, session_scope
+from app.ledger.service import create_bounty, ensure_genesis
+from app.main import create_app
+from app.mcp_tools import call_mcp_tool
+
+
+def test_api_bounties_offset_pagination(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        for i in range(5):
+            create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=100 + i,
+                issue_url=f"https://github.com/ramimbo/mergework/issues/{100 + i}",
+                title=f"Bounty {i}",
+                reward_mrwk="10",
+                acceptance="Test acceptance.",
+            )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    all_rows = client.get("/api/v1/bounties").json()
+    assert len(all_rows) == 5
+
+    limited = client.get("/api/v1/bounties?limit=2").json()
+    assert len(limited) == 2
+    assert limited == all_rows[:2]
+
+    offset = client.get("/api/v1/bounties?limit=2&offset=2").json()
+    assert len(offset) == 2
+    assert offset == all_rows[2:4]
+
+    offset_end = client.get("/api/v1/bounties?limit=2&offset=4").json()
+    assert len(offset_end) == 1
+    assert offset_end == all_rows[4:]
+
+    offset_overshoot = client.get("/api/v1/bounties?limit=2&offset=10").json()
+    assert offset_overshoot == []
+
+    offset_zero = client.get("/api/v1/bounties?limit=2&offset=0").json()
+    assert offset_zero == all_rows[:2]
+
+
+def test_api_bounties_summary_respects_offset(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        for i in range(3):
+            create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=200 + i,
+                issue_url=f"https://github.com/ramimbo/mergework/issues/{200 + i}",
+                title=f"Summary bounty {i}",
+                reward_mrwk="20",
+                acceptance="Test acceptance.",
+            )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    full = client.get("/api/v1/bounties/summary").json()
+    assert full["bounties_shown"] == 3
+
+    limited = client.get("/api/v1/bounties/summary?limit=1&offset=1").json()
+    assert limited["bounties_shown"] == 1
+
+
+def test_public_bounties_page_offset(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        for i in range(3):
+            create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=300 + i,
+                issue_url=f"https://github.com/ramimbo/mergework/issues/{300 + i}",
+                title=f"Public bounty {i}",
+                reward_mrwk="15",
+                acceptance="Test acceptance.",
+            )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    page = client.get("/bounties?offset=1")
+    assert page.status_code == 200
+    assert "Public bounty 2" not in page.text
+    assert "Public bounty 1" in page.text
+    assert "Public bounty 0" in page.text
+
+    page_limit = client.get("/bounties?offset=1&limit=1")
+    assert page_limit.status_code == 200
+    assert "Public bounty 2" not in page_limit.text
+    assert "Public bounty 1" in page_limit.text
+    assert "Public bounty 0" not in page_limit.text
+
+
+def test_mcp_list_bounties_offset(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        for i in range(4):
+            create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=400 + i,
+                issue_url=f"https://github.com/ramimbo/mergework/issues/{400 + i}",
+                title=f"MCP bounty {i}",
+                reward_mrwk="5",
+                acceptance="Test acceptance.",
+            )
+
+    result = call_mcp_tool(sqlite_url, "list_bounties", {"status": "open", "limit": 2, "offset": 1})
+    bounties = json.loads(result)
+    assert len(bounties) == 2
+    assert bounties[0]["title"] == "MCP bounty 2"
+
+
+def test_api_bounties_rejects_negative_offset(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    response = client.get("/api/v1/bounties?offset=-1")
+    assert response.status_code == 422


### PR DESCRIPTION
Closes #406

The public API and MCP `list_bounties` tool accepted `limit` but ignored `offset`, making pagination impossible for clients that need to page through results.

Changes:
- `app/bounty_api.py`: add `offset` to `_list_bounties_by_status`, `api_bounties`, and `api_bounties_summary`
- `app/public_routes.py`: pass `limit`/`offset` through to the bounties HTML page
- `app/mcp_tools.py`: add `list_offset_arg()` and apply `offset` to MCP `list_bounties`
- `tests/test_bounty_offset.py`: regression tests for API, summary, public page, MCP tool, and negative-offset rejection

Validation:
- pytest: 441 passed
- ruff check/format: ok
- mypy app: ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offset-based pagination to bounty listings. Users can now navigate large result sets using the `offset` query parameter (0–10,000 range) across API endpoints and the web interface for improved browsing of bounties.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->