### PR TITLE
Refs #581: Add claim inventory report

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -139,7 +139,8 @@ python scripts/claim_inventory.py --repo ramimbo/mergework --format markdown
 ```
 
 The live command uses read-only `gh issue list/view` and `gh pr list/view`
-calls plus public MergeWork API reads. It does not write GitHub comments, labels,
+calls plus public MergeWork API reads, including exact paid-award rows from
+`/api/v1/activity` `recent[]`. It does not write GitHub comments, labels,
 issue edits, admin-token API calls, local database queries, payout actions, or
 private deployment reads. Use `--api-host` to point at another public API host
 when reviewing staging-like public data:

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -128,6 +128,47 @@ post comments. It reports missing bounty references, closed or exhausted bounty
 references, dirty or unknown merge state, `mrwk:needs-info`, and likely duplicate
 PR scope within the same bounty issue.
 
+### Claim Inventory
+
+Use the claim-inventory report when a busy bounty round needs a public,
+read-only reconciliation pass across issue comments, PR comments, PR reviews,
+and already-paid public proof data:
+
+```bash
+python scripts/claim_inventory.py --repo ramimbo/mergework --format markdown
+```
+
+The live command uses read-only `gh issue list/view` and `gh pr list/view`
+calls plus public MergeWork API reads. It does not write GitHub comments, labels,
+issue edits, admin-token API calls, local database queries, payout actions, or
+private deployment reads. Use `--api-host` to point at another public API host
+when reviewing staging-like public data:
+
+```bash
+python scripts/claim_inventory.py \
+  --repo ramimbo/mergework \
+  --api-host https://api.mrwk.ltclab.site \
+  --format json
+```
+
+For offline payout reviews, save fixture data and run:
+
+```bash
+python scripts/claim_inventory.py --input claim-inventory.json --format markdown
+```
+
+Each output row includes `source_url`, `bounty_issue`, internal `bounty_id`
+when known, `claimant`, `source_type`, `duplicate_key`, `likely_status`, and a
+`proof_url` when the public activity/proof data already paid that source. The
+`likely_status` enum is:
+
+- `already_paid`: public proof data maps the source URL to an existing proof.
+- `unpaid_candidate`: the source looks like a live unpaid claim for a known bounty.
+- `duplicate_candidate`: another source shares the same bounty/source duplicate key.
+- `missing_bounty_ref`: the source looks claim-like but has no bounty reference.
+- `unknown_bounty`: the source references a bounty absent from the public API/fixture.
+- `ignored_or_unclear`: the source is public but not clearly actionable.
+
 For offline checks, save fixture data and run:
 
 ```bash

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -161,6 +161,9 @@ python scripts/claim_inventory.py --input claim-inventory.json --format markdown
 Each output row includes `source_url`, `bounty_issue`, internal `bounty_id`
 when known, `claimant`, `source_type`, `duplicate_key`, `likely_status`, and a
 `proof_url` when the public activity/proof data already paid that source. The
+report uses the parent PR URL when GitHub returns a review/comment object
+without its own item URL, so use `source_type` and `claimant` to disambiguate
+those rare rows. The
 `likely_status` enum is:
 
 - `already_paid`: public proof data maps the source URL to an existing proof.

--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -138,10 +138,15 @@ def _bounty_index(data: dict[str, Any]) -> dict[int, dict[str, Any]]:
 def _proof_sources(data: dict[str, Any], api_host: str) -> dict[str, str]:
     proof_by_source: dict[str, str] = {}
     proof_rows: list[Any] = []
-    for key in ("proofs", "accepted_awards", "activity"):
+    for key in ("proofs", "accepted_awards", "activity", "recent"):
         raw = data.get(key)
         if isinstance(raw, list):
             proof_rows.extend(raw)
+        elif isinstance(raw, dict):
+            for nested_key in ("contributors", "recent"):
+                nested = raw.get(nested_key)
+                if isinstance(nested, list):
+                    proof_rows.extend(nested)
     contributors = data.get("contributors")
     if isinstance(contributors, list):
         proof_rows.extend(contributors)
@@ -418,6 +423,9 @@ def load_public_api_state(api_host: str) -> dict[str, Any]:
         contributors = activity.get("contributors")
         if isinstance(contributors, list):
             data["contributors"] = contributors
+        recent = activity.get("recent")
+        if isinstance(recent, list):
+            data["recent"] = recent
     return data
 
 

--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -22,7 +22,7 @@ GH_TIMEOUT_SECONDS = 30
 GH_LIMIT = 200
 GITHUB_URL_RE = re.compile(
     r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/"
-    r"(?:issues|pull)/\d+(?:#[A-Za-z0-9_.-]+-\d+)?"
+    r"(?:issues|pull)/\d+(?:#[A-Za-z0-9_.-]+)?"
 )
 CLAIM_WORD_RE = re.compile(
     r"(^|\s)(/claim|/attempt|claim(?:ing)?|reviewed|verification|smoke[- ]check|"

--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -447,7 +447,11 @@ def load_live_inventory(repo: str, api_host: str) -> dict[str, Any]:
     )
     issues: list[dict[str, Any]] = []
     for issue in issue_list:
-        if not isinstance(issue, dict) or not _is_bounty_issue(issue):
+        if (
+            not isinstance(issue, dict)
+            or not isinstance(issue.get("number"), int)
+            or not _is_bounty_issue(issue)
+        ):
             continue
         issue_view = _run_gh_json(
             [
@@ -479,7 +483,7 @@ def load_live_inventory(repo: str, api_host: str) -> dict[str, Any]:
     )
     pull_requests: list[dict[str, Any]] = []
     for pr in prs:
-        if not isinstance(pr, dict):
+        if not isinstance(pr, dict) or not isinstance(pr.get("number"), int):
             continue
         pr_view = _run_gh_json(
             [

--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -310,15 +310,23 @@ def analyze_inventory(data: dict[str, Any], *, api_host: str = DEFAULT_API_HOST)
     bounties = _bounty_index(data)
     proof_by_source = _proof_sources(data, api_host)
     surfaces = _raw_surfaces(data)
-    keys = [
-        _duplicate_key(
-            str(surface.get("text") or ""),
-            _normalize_url(str(surface.get("source_url") or "")),
-            _first_bounty_ref(str(surface.get("text") or ""), surface.get("fallback_bounty_issue")),
+    keys: list[str] = []
+    for surface in surfaces:
+        text = str(surface.get("text") or "")
+        source_url = _normalize_url(str(surface.get("source_url") or ""))
+        fallback_bounty_issue = surface.get("fallback_bounty_issue")
+        if not source_url or not _is_candidate(
+            text,
+            parent_is_bounty=fallback_bounty_issue is not None,
+        ):
+            continue
+        keys.append(
+            _duplicate_key(
+                text,
+                source_url,
+                _first_bounty_ref(text, fallback_bounty_issue),
+            )
         )
-        for surface in surfaces
-        if _normalize_url(str(surface.get("source_url") or ""))
-    ]
     duplicate_counts = Counter(keys)
     rows: list[ClaimRow] = []
     seen_sources: set[tuple[str, str]] = set()
@@ -384,6 +392,13 @@ def format_markdown_report(report: dict[str, Any]) -> str:
 
 
 def _run_gh_json(args: list[str]) -> Any:
+    if args[:2] == ["gh", "api"]:
+        for flag in ("--method", "-X"):
+            if flag not in args:
+                continue
+            index = args.index(flag)
+            if index + 1 >= len(args) or args[index + 1].upper() not in {"GET", "HEAD"}:
+                raise RuntimeError(f"refusing non-read-only gh api command: {' '.join(args)}")
     if any(arg in {"issue", "pr"} for arg in args) and any(
         arg in {"comment", "edit", "close", "reopen", "merge", "review"} for arg in args
     ):
@@ -405,6 +420,30 @@ def _run_gh_json(args: list[str]) -> Any:
             f"gh command failed with exit {exc.returncode}: {' '.join(args)}\n{exc.stderr}"
         ) from exc
     return json.loads(completed.stdout)
+
+
+def _load_pr_review_comments(repo: str, pr_number: int) -> list[dict[str, Any]]:
+    raw_comments = _run_gh_json(
+        [
+            "gh",
+            "api",
+            f"repos/{repo}/pulls/{pr_number}/comments?per_page=100",
+        ]
+    )
+    comments: list[dict[str, Any]] = []
+    if not isinstance(raw_comments, list):
+        return comments
+    for item in raw_comments:
+        if not isinstance(item, dict):
+            continue
+        comments.append(
+            {
+                "url": item.get("html_url") or item.get("url"),
+                "author": item.get("user"),
+                "body": item.get("body"),
+            }
+        )
+    return comments
 
 
 def _get_json(url: str) -> Any:
@@ -501,6 +540,8 @@ def load_live_inventory(repo: str, api_host: str) -> dict[str, Any]:
                 "number,title,url,body,author,labels,comments,reviews",
             ]
         )
+        if isinstance(pr_view, dict):
+            pr_view["review_comments"] = _load_pr_review_comments(repo, pr["number"])
         pull_requests.append(pr_view)
     public_state = load_public_api_state(api_host)
     public_state.update({"issues": issues, "pull_requests": pull_requests})

--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -1,0 +1,523 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from collections import Counter
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.bounty_refs import BOUNTY_REF_RE
+
+DEFAULT_API_HOST = "https://api.mrwk.ltclab.site"
+GH_TIMEOUT_SECONDS = 30
+GH_LIMIT = 200
+GITHUB_URL_RE = re.compile(
+    r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/"
+    r"(?:issues|pull)/\d+(?:#[A-Za-z0-9_.-]+-\d+)?"
+)
+CLAIM_WORD_RE = re.compile(
+    r"(^|\s)(/claim|/attempt|claim(?:ing)?|reviewed|verification|smoke[- ]check|"
+    r"accepted|paid|proof)(\b|\s|:)",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class ClaimRow:
+    source_url: str
+    bounty_issue: int | None
+    bounty_id: int | None
+    claimant: str
+    source_type: str
+    duplicate_key: str
+    likely_status: str
+    proof_url: str | None = None
+
+
+def _author_login(raw: Any) -> str:
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, dict):
+        login = raw.get("login")
+        if isinstance(login, str) and login:
+            return login
+    return "unknown"
+
+
+def _label_names(raw: dict[str, Any]) -> list[str]:
+    labels = raw.get("labels", [])
+    names: list[str] = []
+    if not isinstance(labels, list):
+        return names
+    for label in labels:
+        if isinstance(label, str):
+            names.append(label)
+        elif isinstance(label, dict) and isinstance(label.get("name"), str):
+            names.append(label["name"])
+    return names
+
+
+def _normalize_url(url: str) -> str:
+    clean = str(url or "").strip()
+    if not clean:
+        return ""
+    return clean.rstrip(".,)")
+
+
+def _github_urls(text: str) -> list[str]:
+    seen: set[str] = set()
+    urls: list[str] = []
+    for match in GITHUB_URL_RE.findall(text or ""):
+        url = _normalize_url(match)
+        if url and url not in seen:
+            seen.add(url)
+            urls.append(url)
+    return urls
+
+
+def _bounty_refs(text: str) -> list[int]:
+    refs: set[int] = set()
+    for match in BOUNTY_REF_RE.findall(text or ""):
+        try:
+            refs.add(int(match))
+        except ValueError:
+            continue
+    return sorted(refs)
+
+
+def _is_bounty_issue(issue: dict[str, Any]) -> bool:
+    title = str(issue.get("title") or "").lower()
+    labels = {label.lower() for label in _label_names(issue)}
+    return "mrwk:bounty" in labels or "bounty" in title
+
+
+def _is_candidate(text: str, *, parent_is_bounty: bool = False) -> bool:
+    if not text:
+        return parent_is_bounty
+    return bool(CLAIM_WORD_RE.search(text) or _bounty_refs(text) or _github_urls(text))
+
+
+def _first_bounty_ref(text: str, fallback: int | None) -> int | None:
+    refs = _bounty_refs(text)
+    return refs[0] if refs else fallback
+
+
+def _status_value(raw: dict[str, Any]) -> str:
+    return str(raw.get("status") or raw.get("state") or "").lower()
+
+
+def _bounty_index(data: dict[str, Any]) -> dict[int, dict[str, Any]]:
+    index: dict[int, dict[str, Any]] = {}
+    for item in data.get("bounties", []):
+        if not isinstance(item, dict):
+            continue
+        issue = item.get("issue_number", item.get("number"))
+        try:
+            issue_number = int(issue)
+        except (TypeError, ValueError):
+            continue
+        bounty_id = item.get("id", item.get("bounty_id"))
+        normalized = dict(item)
+        try:
+            normalized["bounty_id"] = int(bounty_id) if bounty_id is not None else None
+        except (TypeError, ValueError):
+            normalized["bounty_id"] = None
+        index[issue_number] = normalized
+    return index
+
+
+def _proof_sources(data: dict[str, Any], api_host: str) -> dict[str, str]:
+    proof_by_source: dict[str, str] = {}
+    proof_rows: list[Any] = []
+    for key in ("proofs", "accepted_awards", "activity"):
+        raw = data.get(key)
+        if isinstance(raw, list):
+            proof_rows.extend(raw)
+    contributors = data.get("contributors")
+    if isinstance(contributors, list):
+        proof_rows.extend(contributors)
+    for item in proof_rows:
+        if not isinstance(item, dict):
+            continue
+        source = _normalize_url(
+            str(
+                item.get("source_url")
+                or item.get("submission_url")
+                or item.get("latest_submission_url")
+                or ""
+            )
+        )
+        proof = str(item.get("proof_url") or item.get("latest_proof_url") or "")
+        if not source or not proof:
+            continue
+        if proof.startswith("/"):
+            proof = f"{api_host.rstrip('/')}{proof}"
+        proof_by_source[source] = proof
+    return proof_by_source
+
+
+def _proof_for_surface(text: str, source_url: str, proof_by_source: dict[str, str]) -> str | None:
+    proof_url = proof_by_source.get(source_url)
+    if proof_url:
+        return proof_url
+    for linked_url in _github_urls(text):
+        proof_url = proof_by_source.get(linked_url)
+        if proof_url:
+            return proof_url
+    return None
+
+
+def _duplicate_key(text: str, source_url: str, bounty_issue: int | None) -> str:
+    linked_urls = [url for url in _github_urls(text) if url != source_url]
+    core = linked_urls[0] if linked_urls else source_url
+    return f"{bounty_issue or 'unknown'}:{core}"
+
+
+def _surface_row(
+    *,
+    text: str,
+    source_url: str,
+    claimant: str,
+    source_type: str,
+    fallback_bounty_issue: int | None,
+    bounties: dict[int, dict[str, Any]],
+    proof_by_source: dict[str, str],
+    duplicate_counts: Counter[str],
+) -> ClaimRow | None:
+    source_url = _normalize_url(source_url)
+    parent_is_bounty = fallback_bounty_issue is not None
+    if not source_url or not _is_candidate(text, parent_is_bounty=parent_is_bounty):
+        return None
+    bounty_issue = _first_bounty_ref(text, fallback_bounty_issue)
+    duplicate_key = _duplicate_key(text, source_url, bounty_issue)
+    proof_url = _proof_for_surface(text, source_url, proof_by_source)
+    bounty = bounties.get(bounty_issue) if bounty_issue is not None else None
+    bounty_id = bounty.get("bounty_id") if bounty else None
+    if proof_url:
+        likely_status = "already_paid"
+    elif bounty_issue is None:
+        likely_status = "missing_bounty_ref"
+    elif bounty is None:
+        likely_status = "unknown_bounty"
+    elif duplicate_counts[duplicate_key] > 1:
+        likely_status = "duplicate_candidate"
+    elif not CLAIM_WORD_RE.search(text):
+        likely_status = "ignored_or_unclear"
+    else:
+        likely_status = "unpaid_candidate"
+    return ClaimRow(
+        source_url=source_url,
+        bounty_issue=bounty_issue,
+        bounty_id=bounty_id,
+        claimant=claimant,
+        source_type=source_type,
+        duplicate_key=duplicate_key,
+        likely_status=likely_status,
+        proof_url=proof_url,
+    )
+
+
+def _raw_surfaces(data: dict[str, Any]) -> list[dict[str, Any]]:
+    surfaces: list[dict[str, Any]] = []
+    for issue in data.get("issues", []):
+        if not isinstance(issue, dict):
+            continue
+        parent_issue = int(issue["number"]) if isinstance(issue.get("number"), int) else None
+        parent_is_bounty = _is_bounty_issue(issue)
+        if parent_is_bounty:
+            surfaces.append(
+                {
+                    "text": "\n".join(
+                        [str(issue.get("title") or ""), str(issue.get("body") or "")]
+                    ),
+                    "source_url": issue.get("url"),
+                    "claimant": _author_login(issue.get("author")),
+                    "source_type": "bounty_issue",
+                    "fallback_bounty_issue": parent_issue,
+                }
+            )
+        comments = issue.get("comments", [])
+        if isinstance(comments, list):
+            for comment in comments:
+                if not isinstance(comment, dict):
+                    continue
+                surfaces.append(
+                    {
+                        "text": str(comment.get("body") or ""),
+                        "source_url": comment.get("url"),
+                        "claimant": _author_login(comment.get("author")),
+                        "source_type": "bounty_issue_comment",
+                        "fallback_bounty_issue": parent_issue if parent_is_bounty else None,
+                    }
+                )
+    for pr in data.get("pull_requests", []):
+        if not isinstance(pr, dict):
+            continue
+        pr_text = "\n".join([str(pr.get("title") or ""), str(pr.get("body") or "")])
+        pr_bounty_issue = _first_bounty_ref(pr_text, None)
+        surfaces.append(
+            {
+                "text": pr_text,
+                "source_url": pr.get("url"),
+                "claimant": _author_login(pr.get("author")),
+                "source_type": "pull_request",
+                "fallback_bounty_issue": pr_bounty_issue,
+            }
+        )
+        for key, source_type in (
+            ("comments", "pull_request_comment"),
+            ("reviews", "pull_request_review"),
+            ("review_comments", "pull_request_review_comment"),
+        ):
+            raw_items = pr.get(key, [])
+            if not isinstance(raw_items, list):
+                continue
+            for item in raw_items:
+                if not isinstance(item, dict):
+                    continue
+                text = str(item.get("body") or item.get("state") or "")
+                surfaces.append(
+                    {
+                        "text": text,
+                        "source_url": item.get("url") or pr.get("url"),
+                        "claimant": _author_login(item.get("author")),
+                        "source_type": source_type,
+                        "fallback_bounty_issue": _first_bounty_ref(text, pr_bounty_issue),
+                    }
+                )
+    return surfaces
+
+
+def analyze_inventory(data: dict[str, Any], *, api_host: str = DEFAULT_API_HOST) -> dict[str, Any]:
+    bounties = _bounty_index(data)
+    proof_by_source = _proof_sources(data, api_host)
+    surfaces = _raw_surfaces(data)
+    keys = [
+        _duplicate_key(
+            str(surface.get("text") or ""),
+            _normalize_url(str(surface.get("source_url") or "")),
+            _first_bounty_ref(str(surface.get("text") or ""), surface.get("fallback_bounty_issue")),
+        )
+        for surface in surfaces
+        if _normalize_url(str(surface.get("source_url") or ""))
+    ]
+    duplicate_counts = Counter(keys)
+    rows: list[ClaimRow] = []
+    seen_sources: set[tuple[str, str]] = set()
+    for surface in surfaces:
+        row = _surface_row(
+            text=str(surface.get("text") or ""),
+            source_url=str(surface.get("source_url") or ""),
+            claimant=str(surface.get("claimant") or "unknown"),
+            source_type=str(surface.get("source_type") or "unknown"),
+            fallback_bounty_issue=surface.get("fallback_bounty_issue"),
+            bounties=bounties,
+            proof_by_source=proof_by_source,
+            duplicate_counts=duplicate_counts,
+        )
+        if row is None:
+            continue
+        identity = (row.source_url, row.source_type)
+        if identity in seen_sources:
+            continue
+        seen_sources.add(identity)
+        rows.append(row)
+    rows.sort(key=lambda item: (item.bounty_issue or 0, item.duplicate_key, item.source_url))
+    status_counts = Counter(row.likely_status for row in rows)
+    return {
+        "summary": {
+            "rows": len(rows),
+            "bounty_issues": len(bounties),
+            "already_paid": status_counts["already_paid"],
+            "unpaid_candidate": status_counts["unpaid_candidate"],
+            "duplicate_candidate": status_counts["duplicate_candidate"],
+            "missing_bounty_ref": status_counts["missing_bounty_ref"],
+            "unknown_bounty": status_counts["unknown_bounty"],
+            "ignored_or_unclear": status_counts["ignored_or_unclear"],
+        },
+        "likely_status_enum": [
+            "already_paid",
+            "unpaid_candidate",
+            "duplicate_candidate",
+            "missing_bounty_ref",
+            "unknown_bounty",
+            "ignored_or_unclear",
+        ],
+        "rows": [asdict(row) for row in rows],
+    }
+
+
+def format_markdown_report(report: dict[str, Any]) -> str:
+    lines = ["## Claim Inventory", ""]
+    for key, value in report["summary"].items():
+        lines.append(f"- **{key.replace('_', ' ')}**: {value}")
+    lines.append("")
+    lines.append("| Status | Bounty | Claimant | Type | Source | Proof |")
+    lines.append("| --- | ---: | --- | --- | --- | --- |")
+    for row in report["rows"]:
+        bounty = row["bounty_issue"] if row["bounty_issue"] is not None else ""
+        source = f"[source]({row['source_url']})"
+        proof = f"[proof]({row['proof_url']})" if row.get("proof_url") else ""
+        lines.append(
+            f"| `{row['likely_status']}` | {bounty} | {row['claimant']} | "
+            f"{row['source_type']} | {source} | {proof} |"
+        )
+    return "\n".join(lines)
+
+
+def _run_gh_json(args: list[str]) -> Any:
+    if any(arg in {"issue", "pr"} for arg in args) and any(
+        arg in {"comment", "edit", "close", "reopen", "merge", "review"} for arg in args
+    ):
+        raise RuntimeError(f"refusing non-read-only gh command: {' '.join(args)}")
+    try:
+        completed = subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"gh command failed with exit {exc.returncode}: {' '.join(args)}\n{exc.stderr}"
+        ) from exc
+    return json.loads(completed.stdout)
+
+
+def _get_json(url: str) -> Any:
+    request = urllib.request.Request(url, headers={"accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=GH_TIMEOUT_SECONDS) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError) as exc:
+        raise RuntimeError(f"public API request failed: {url}") from exc
+
+
+def load_public_api_state(api_host: str) -> dict[str, Any]:
+    host = api_host.rstrip("/")
+    bounties = _get_json(f"{host}/api/v1/bounties?limit={GH_LIMIT}")
+    activity = _get_json(f"{host}/api/v1/activity?limit={GH_LIMIT}")
+    data: dict[str, Any] = {}
+    if isinstance(bounties, list):
+        data["bounties"] = bounties
+    if isinstance(activity, dict):
+        contributors = activity.get("contributors")
+        if isinstance(contributors, list):
+            data["contributors"] = contributors
+    return data
+
+
+def load_live_inventory(repo: str, api_host: str) -> dict[str, Any]:
+    issue_list = _run_gh_json(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(GH_LIMIT),
+            "--json",
+            "number,title,url,labels,author",
+        ]
+    )
+    issues: list[dict[str, Any]] = []
+    for issue in issue_list:
+        if not isinstance(issue, dict) or not _is_bounty_issue(issue):
+            continue
+        issue_view = _run_gh_json(
+            [
+                "gh",
+                "issue",
+                "view",
+                str(issue["number"]),
+                "--repo",
+                repo,
+                "--json",
+                "number,title,url,body,labels,author,comments",
+            ]
+        )
+        issues.append(issue_view)
+    prs = _run_gh_json(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(GH_LIMIT),
+            "--json",
+            "number,title,url,body,author,labels",
+        ]
+    )
+    pull_requests: list[dict[str, Any]] = []
+    for pr in prs:
+        if not isinstance(pr, dict):
+            continue
+        pr_view = _run_gh_json(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(pr["number"]),
+                "--repo",
+                repo,
+                "--json",
+                "number,title,url,body,author,labels,comments,reviews",
+            ]
+        )
+        pull_requests.append(pr_view)
+    public_state = load_public_api_state(api_host)
+    public_state.update({"issues": issues, "pull_requests": pull_requests})
+    return public_state
+
+
+def _load_input(path: str) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("claim inventory input must be a JSON object")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Inventory public MergeWork claim surfaces and payout status."
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--input", help="Read public claim fixture JSON.")
+    source.add_argument("--repo", help="Collect live public state with read-only gh calls.")
+    parser.add_argument("--api-host", default=DEFAULT_API_HOST)
+    parser.add_argument("--format", choices=["json", "markdown"], default="markdown")
+    args = parser.parse_args(argv)
+
+    data = _load_input(args.input) if args.input else load_live_inventory(args.repo, args.api_host)
+    report = analyze_inventory(data, api_host=args.api_host)
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(format_markdown_report(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -120,7 +120,11 @@ def _bounty_index(data: dict[str, Any]) -> dict[int, dict[str, Any]]:
     for item in data.get("bounties", []):
         if not isinstance(item, dict):
             continue
-        issue = item.get("issue_number", item.get("number"))
+        issue = item.get("issue_number")
+        if issue is None:
+            issue = item.get("number")
+        if not isinstance(issue, str | int):
+            continue
         try:
             issue_number = int(issue)
         except (TypeError, ValueError):

--- a/tests/test_claim_inventory.py
+++ b/tests/test_claim_inventory.py
@@ -96,6 +96,26 @@ def _fixture() -> dict[str, object]:
                         "body": "Reviewed the fixture mode and markdown output.",
                     }
                 ],
+                "review_comments": [
+                    {
+                        "url": "https://github.com/ramimbo/mergework/pull/581#discussion_r1",
+                        "author": {"login": "inline-reviewer"},
+                        "body": "The markdown claim row still looks traceable.",
+                    }
+                ],
+            },
+            {
+                "number": 582,
+                "title": "Refs #581: Add another inventory report",
+                "url": "https://github.com/ramimbo/mergework/pull/582",
+                "author": {"login": "jakerated-r"},
+                "body": "Claiming another read-only report.",
+                "comments": [
+                    {
+                        "author": {"login": "maintainer"},
+                        "body": "Looks fine.",
+                    }
+                ],
             },
             {
                 "number": 999,
@@ -143,6 +163,13 @@ def test_claim_inventory_classifies_required_statuses(tmp_path, capsys) -> None:
         rows["https://github.com/ramimbo/mergework/pull/1000"]["likely_status"] == "unknown_bounty"
     )
     assert rows["https://github.com/ramimbo/mergework/pull/581"]["bounty_id"] == 87
+    assert (
+        rows["https://github.com/ramimbo/mergework/pull/581#discussion_r1"]["source_type"]
+        == "pull_request_review_comment"
+    )
+    assert (
+        rows["https://github.com/ramimbo/mergework/pull/582"]["likely_status"] == "unpaid_candidate"
+    )
     assert (
         rows["https://github.com/ramimbo/mergework/issues/578#issuecomment-3"]["source_type"]
         == "bounty_issue_comment"
@@ -219,6 +246,14 @@ def test_claim_inventory_live_mode_uses_read_only_calls(monkeypatch) -> None:
                 "comments": [],
                 "reviews": [],
             }
+        if args[:2] == ["gh", "api"]:
+            return [
+                {
+                    "html_url": "https://github.com/ramimbo/mergework/pull/582#discussion_r123",
+                    "user": {"login": "reviewer"},
+                    "body": "Inline review claim evidence for #581.",
+                }
+            ]
         raise AssertionError(args)
 
     monkeypatch.setattr(claim_inventory, "_run_gh_json", fake_run_gh_json)
@@ -235,14 +270,24 @@ def test_claim_inventory_live_mode_uses_read_only_calls(monkeypatch) -> None:
     data = claim_inventory.load_live_inventory("ramimbo/mergework", "https://api.example.test")
 
     assert data["bounties"][0]["id"] == 87
+    assert data["pull_requests"][0]["review_comments"] == [
+        {
+            "url": "https://github.com/ramimbo/mergework/pull/582#discussion_r123",
+            "author": {"login": "reviewer"},
+            "body": "Inline review claim evidence for #581.",
+        }
+    ]
     allowed_prefixes = {
         ("gh", "issue", "list"),
         ("gh", "issue", "view"),
         ("gh", "pr", "list"),
         ("gh", "pr", "view"),
+        ("gh", "api"),
     }
     assert calls, "expected at least one gh invocation"
-    assert all(tuple(call[:3]) in allowed_prefixes for call in calls), calls
+    assert all(
+        tuple(call[:3]) in allowed_prefixes or tuple(call[:2]) in allowed_prefixes for call in calls
+    ), calls
 
 
 def test_claim_inventory_script_entrypoint_loads_shared_parser() -> None:

--- a/tests/test_claim_inventory.py
+++ b/tests/test_claim_inventory.py
@@ -235,9 +235,14 @@ def test_claim_inventory_live_mode_uses_read_only_calls(monkeypatch) -> None:
     data = claim_inventory.load_live_inventory("ramimbo/mergework", "https://api.example.test")
 
     assert data["bounties"][0]["id"] == 87
-    flat_calls = " ".join(" ".join(call) for call in calls)
-    forbidden = (" comment ", " edit ", " close ", " reopen ", " merge ", " review ")
-    assert not any(word in f" {flat_calls} " for word in forbidden)
+    allowed_prefixes = {
+        ("gh", "issue", "list"),
+        ("gh", "issue", "view"),
+        ("gh", "pr", "list"),
+        ("gh", "pr", "view"),
+    }
+    assert calls, "expected at least one gh invocation"
+    assert all(tuple(call[:3]) in allowed_prefixes for call in calls), calls
 
 
 def test_claim_inventory_script_entrypoint_loads_shared_parser() -> None:

--- a/tests/test_claim_inventory.py
+++ b/tests/test_claim_inventory.py
@@ -23,6 +23,15 @@ def _fixture() -> dict[str, object]:
                 "proof_url": "/proofs/abc123",
             }
         ],
+        "recent": [
+            {
+                "submission_url": "https://github.com/ramimbo/mergework/issues/578#issuecomment-4",
+                "proof_url": "/proofs/recent-paid",
+                "bounty_issue_number": 578,
+                "bounty_id": 85,
+                "ledger_sequence": 42,
+            }
+        ],
         "issues": [
             {
                 "number": 578,
@@ -57,6 +66,11 @@ def _fixture() -> dict[str, object]:
                             "https://github.com/ramimbo/mergework/pull/533#issuecomment-2 "
                             "works on the public activity page."
                         ),
+                    },
+                    {
+                        "url": "https://github.com/ramimbo/mergework/issues/578#issuecomment-4",
+                        "author": {"login": "recent-winner"},
+                        "body": "/claim https://github.com/ramimbo/mergework/pull/700",
                     },
                 ],
             }
@@ -110,6 +124,14 @@ def test_claim_inventory_classifies_required_statuses(tmp_path, capsys) -> None:
         == "already_paid"
     )
     assert (
+        rows["https://github.com/ramimbo/mergework/issues/578#issuecomment-4"]["likely_status"]
+        == "already_paid"
+    )
+    assert (
+        rows["https://github.com/ramimbo/mergework/issues/578#issuecomment-4"]["proof_url"]
+        == "https://api.example.test/proofs/recent-paid"
+    )
+    assert (
         rows["https://github.com/ramimbo/mergework/issues/578#issuecomment-2"]["likely_status"]
         == "duplicate_candidate"
     )
@@ -138,7 +160,7 @@ def test_claim_inventory_classifies_required_statuses(tmp_path, capsys) -> None:
     input_path.write_text(json.dumps(_fixture()), encoding="utf-8")
     assert main(["--input", str(input_path), "--format", "json"]) == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["summary"]["already_paid"] == 1
+    assert output["summary"]["already_paid"] == 2
 
 
 def test_claim_inventory_markdown_report_is_pasteable() -> None:
@@ -206,6 +228,7 @@ def test_claim_inventory_live_mode_uses_read_only_calls(monkeypatch) -> None:
         lambda api_host: {
             "bounties": [{"id": 87, "issue_number": 581, "status": "open", "awards_remaining": 1}],
             "proofs": [],
+            "recent": [],
         },
     )
 

--- a/tests/test_claim_inventory.py
+++ b/tests/test_claim_inventory.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts import claim_inventory
+from scripts.claim_inventory import analyze_inventory, format_markdown_report, main
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _fixture() -> dict[str, object]:
+    return {
+        "bounties": [
+            {"id": 85, "issue_number": 578, "status": "open", "awards_remaining": 30},
+            {"id": 87, "issue_number": 581, "status": "open", "awards_remaining": 1},
+        ],
+        "proofs": [
+            {
+                "source_url": "https://github.com/ramimbo/mergework/pull/452#pullrequestreview-1",
+                "proof_url": "/proofs/abc123",
+            }
+        ],
+        "issues": [
+            {
+                "number": 578,
+                "title": "MRWK bounty: review open MergeWork PRs with evidence",
+                "url": "https://github.com/ramimbo/mergework/issues/578",
+                "labels": ["mrwk:bounty"],
+                "author": {"login": "ramimbo"},
+                "comments": [
+                    {
+                        "url": "https://github.com/ramimbo/mergework/issues/578#issuecomment-1",
+                        "author": {"login": "eliasx45"},
+                        "body": (
+                            "/claim "
+                            "https://github.com/ramimbo/mergework/pull/452#pullrequestreview-1\n"
+                            "Reviewed PR #452 with tests."
+                        ),
+                    },
+                    {
+                        "url": "https://github.com/ramimbo/mergework/issues/578#issuecomment-2",
+                        "author": {"login": "other-reviewer"},
+                        "body": (
+                            "/claim "
+                            "https://github.com/ramimbo/mergework/pull/533#issuecomment-2\n"
+                            "Duplicate review claim."
+                        ),
+                    },
+                    {
+                        "url": "https://github.com/ramimbo/mergework/issues/578#issuecomment-3",
+                        "author": {"login": "smoke-checker"},
+                        "body": (
+                            "Smoke-check claim: "
+                            "https://github.com/ramimbo/mergework/pull/533#issuecomment-2 "
+                            "works on the public activity page."
+                        ),
+                    },
+                ],
+            }
+        ],
+        "pull_requests": [
+            {
+                "number": 581,
+                "title": "Refs #581: Add claim inventory report",
+                "url": "https://github.com/ramimbo/mergework/pull/581",
+                "author": {"login": "jakerated-r"},
+                "body": "Refs #581\n\nAdds scripts/claim_inventory.py.",
+                "comments": [
+                    {
+                        "url": "https://github.com/ramimbo/mergework/pull/581#issuecomment-1",
+                        "author": {"login": "reviewer"},
+                        "body": "Looks good after docs smoke.",
+                    }
+                ],
+                "reviews": [
+                    {
+                        "url": "https://github.com/ramimbo/mergework/pull/581#pullrequestreview-9",
+                        "author": {"login": "reviewer"},
+                        "body": "Reviewed the fixture mode and markdown output.",
+                    }
+                ],
+            },
+            {
+                "number": 999,
+                "title": "Small cleanup with no bounty link",
+                "url": "https://github.com/ramimbo/mergework/pull/999",
+                "author": {"login": "unknown"},
+                "body": "Claiming this small cleanup, but no bounty reference is included.",
+            },
+            {
+                "number": 1000,
+                "title": "Refs #9999: unknown bounty",
+                "url": "https://github.com/ramimbo/mergework/pull/1000",
+                "author": {"login": "unknown"},
+                "body": "Refs #9999\n\nValidation: pytest passed.",
+            },
+        ],
+    }
+
+
+def test_claim_inventory_classifies_required_statuses(tmp_path, capsys) -> None:
+    report = analyze_inventory(_fixture(), api_host="https://api.example.test")
+
+    rows = {row["source_url"]: row for row in report["rows"]}
+    assert (
+        rows["https://github.com/ramimbo/mergework/issues/578#issuecomment-1"]["likely_status"]
+        == "already_paid"
+    )
+    assert (
+        rows["https://github.com/ramimbo/mergework/issues/578#issuecomment-2"]["likely_status"]
+        == "duplicate_candidate"
+    )
+    assert (
+        rows["https://github.com/ramimbo/mergework/pull/999"]["likely_status"]
+        == "missing_bounty_ref"
+    )
+    assert (
+        rows["https://github.com/ramimbo/mergework/pull/1000"]["likely_status"] == "unknown_bounty"
+    )
+    assert rows["https://github.com/ramimbo/mergework/pull/581"]["bounty_id"] == 87
+    assert (
+        rows["https://github.com/ramimbo/mergework/issues/578#issuecomment-3"]["source_type"]
+        == "bounty_issue_comment"
+    )
+    assert set(report["likely_status_enum"]) >= {
+        "already_paid",
+        "unpaid_candidate",
+        "duplicate_candidate",
+        "missing_bounty_ref",
+        "unknown_bounty",
+        "ignored_or_unclear",
+    }
+
+    input_path = tmp_path / "claims.json"
+    input_path.write_text(json.dumps(_fixture()), encoding="utf-8")
+    assert main(["--input", str(input_path), "--format", "json"]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["summary"]["already_paid"] == 1
+
+
+def test_claim_inventory_markdown_report_is_pasteable() -> None:
+    markdown = format_markdown_report(analyze_inventory(_fixture()))
+
+    assert "## Claim Inventory" in markdown
+    assert "| Status | Bounty | Claimant | Type | Source | Proof |" in markdown
+    assert "`already_paid`" in markdown
+    assert "https://api.mrwk.ltclab.site/proofs/abc123" in markdown
+
+
+def test_claim_inventory_live_mode_uses_read_only_calls(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run_gh_json(args: list[str]) -> object:
+        calls.append(args)
+        if args[:3] == ["gh", "issue", "list"]:
+            return [
+                {
+                    "number": 581,
+                    "title": "MRWK bounty: claim inventory",
+                    "url": "https://github.com/ramimbo/mergework/issues/581",
+                    "labels": [{"name": "mrwk:bounty"}],
+                    "author": {"login": "ramimbo"},
+                }
+            ]
+        if args[:3] == ["gh", "issue", "view"]:
+            return {
+                "number": 581,
+                "title": "MRWK bounty: claim inventory",
+                "url": "https://github.com/ramimbo/mergework/issues/581",
+                "body": "Reward: 500 MRWK",
+                "labels": [{"name": "mrwk:bounty"}],
+                "author": {"login": "ramimbo"},
+                "comments": [],
+            }
+        if args[:3] == ["gh", "pr", "list"]:
+            return [
+                {
+                    "number": 582,
+                    "title": "Refs #581: Add inventory",
+                    "url": "https://github.com/ramimbo/mergework/pull/582",
+                    "body": "Refs #581",
+                    "author": {"login": "bot"},
+                    "labels": [],
+                }
+            ]
+        if args[:3] == ["gh", "pr", "view"]:
+            return {
+                "number": 582,
+                "title": "Refs #581: Add inventory",
+                "url": "https://github.com/ramimbo/mergework/pull/582",
+                "body": "Refs #581",
+                "author": {"login": "bot"},
+                "labels": [],
+                "comments": [],
+                "reviews": [],
+            }
+        raise AssertionError(args)
+
+    monkeypatch.setattr(claim_inventory, "_run_gh_json", fake_run_gh_json)
+    monkeypatch.setattr(
+        claim_inventory,
+        "load_public_api_state",
+        lambda api_host: {
+            "bounties": [{"id": 87, "issue_number": 581, "status": "open", "awards_remaining": 1}],
+            "proofs": [],
+        },
+    )
+
+    data = claim_inventory.load_live_inventory("ramimbo/mergework", "https://api.example.test")
+
+    assert data["bounties"][0]["id"] == 87
+    flat_calls = " ".join(" ".join(call) for call in calls)
+    forbidden = (" comment ", " edit ", " close ", " reopen ", " merge ", " review ")
+    assert not any(word in f" {flat_calls} " for word in forbidden)
+
+
+def test_claim_inventory_script_entrypoint_loads_shared_parser() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/claim_inventory.py", "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout

--- a/tests/test_claim_inventory.py
+++ b/tests/test_claim_inventory.py
@@ -21,7 +21,11 @@ def _fixture() -> dict[str, object]:
             {
                 "source_url": "https://github.com/ramimbo/mergework/pull/452#pullrequestreview-1",
                 "proof_url": "/proofs/abc123",
-            }
+            },
+            {
+                "source_url": "https://github.com/ramimbo/mergework/pull/581#discussion_r1",
+                "proof_url": "/proofs/discussion-r1",
+            },
         ],
         "recent": [
             {
@@ -168,6 +172,10 @@ def test_claim_inventory_classifies_required_statuses(tmp_path, capsys) -> None:
         == "pull_request_review_comment"
     )
     assert (
+        rows["https://github.com/ramimbo/mergework/pull/581#discussion_r1"]["proof_url"]
+        == "https://api.example.test/proofs/discussion-r1"
+    )
+    assert (
         rows["https://github.com/ramimbo/mergework/pull/582"]["likely_status"] == "unpaid_candidate"
     )
     assert (
@@ -187,7 +195,7 @@ def test_claim_inventory_classifies_required_statuses(tmp_path, capsys) -> None:
     input_path.write_text(json.dumps(_fixture()), encoding="utf-8")
     assert main(["--input", str(input_path), "--format", "json"]) == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["summary"]["already_paid"] == 2
+    assert output["summary"]["already_paid"] == 3
 
 
 def test_claim_inventory_markdown_report_is_pasteable() -> None:


### PR DESCRIPTION
## Summary

Refs #581.

Adds a read-only public claim inventory report for maintainers:

- `scripts/claim_inventory.py` with offline `--input` fixture mode and live `--repo` mode
- public MergeWork API lookup through configurable `--api-host`
- JSON and Markdown output
- normalized rows with `source_url`, `bounty_issue`, `bounty_id`, `claimant`, `source_type`, `duplicate_key`, `likely_status`, and `proof_url`
- status enum: `already_paid`, `unpaid_candidate`, `duplicate_candidate`, `missing_bounty_ref`, `unknown_bounty`, `ignored_or_unclear`
- admin runbook usage notes and read-only guardrails

## Evidence

### MRWK bounty reference

- Bounty issue: #581
- Scope: focused claim inventory tool with offline/live modes, JSON/Markdown output, public API proof/status lookup, admin runbook usage, and tests for duplicate claims, paid proofs, missing refs, review/comment surfaces, and read-only live collection.

### Behavior evidence

- Duplicate counting now uses the same candidate gate as emitted report rows, so dropped/noisy surfaces cannot inflate `duplicate_candidate` status.
- Live mode collects public inline PR review comments through read-only `gh api repos/{repo}/pulls/{number}/comments?per_page=100` and normalizes them into `review_comments`.
- `#discussion_r...` URL fragments are preserved so proof lookup can match inline review-comment URLs exactly.
- Live read-only smoke produced 407 public rows, including 26 `pull_request_review_comment` rows and 26 preserved `#discussion_r...` source URLs.

### Safety / scope evidence

- The script is read-only. It uses `gh issue list/view`, `gh pr list/view`, read-only `gh api` GET calls, and public API GET requests only.
- `_run_gh_json()` rejects non-GET/non-HEAD `gh api --method/-X` calls.
- It does not post comments, edit issues, apply labels, use admin tokens, read the database, execute payouts, or include private deploy state.
- No private keys, wallet material, cookies, OAuth state, access tokens, signatures, admin tokens, private vulnerability details, price claims, liquidity claims, exchange claims, bridge promises, off-ramp claims, or fabricated payout claims are included.

## Test Evidence

- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_claim_inventory.py -q` -> 4 passed
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 452 passed, 1 warning
- [x] `uv run --extra dev ruff check scripts/claim_inventory.py tests/test_claim_inventory.py docs/admin-runbook.md` -> passed
- [x] `uv run --extra dev ruff format --check scripts/claim_inventory.py tests/test_claim_inventory.py` -> passed
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m mypy app scripts/claim_inventory.py` -> success, 31 source files
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- [x] `git diff --check` -> clean
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/claim_inventory.py --repo ramimbo/mergework --format json` -> 407 public rows, 26 `pull_request_review_comment` rows, 26 `#discussion_r...` source URLs preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a claim-inventory tool to detect and classify public claim surfaces across issues, PRs, reviews and comments; outputs JSON or Markdown, supports live queries or offline fixtures, and uses read-only collection.

* **Documentation**
  * New operational guidance on running the inventory, output formats, flags, expected output fields, and normalized status classifications.

* **Tests**
  * Added tests for classification logic, Markdown output, live-mode read-only behavior, and CLI entrypoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
