### PR TITLE
Add rel attributes to public GitHub links

### DIFF
--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -11,7 +11,7 @@
     <dd><code>{{ account.ledger_address }}</code></dd>
     {% if account.github_login %}
     <dt>GitHub profile</dt>
-    <dd><a href="https://github.com/{{ account.github_login }}">@{{ account.github_login }}</a></dd>
+    <dd><a href="https://github.com/{{ account.github_login }}" rel="nofollow noopener">@{{ account.github_login }}</a></dd>
     {% endif %}
     <dt>Send status</dt>
     <dd>{{ account.transfer_status }}</dd>
@@ -47,7 +47,7 @@
   <p class="reference-cell">
     Latest accepted work:
     {% if latest_submission_url %}
-    <a href="{{ latest_submission_url }}">{{ accepted_summary.latest_submission_url | replace("https://github.com/", "") }}</a>
+    <a href="{{ latest_submission_url }}" rel="nofollow noopener">{{ accepted_summary.latest_submission_url | replace("https://github.com/", "") }}</a>
     {% else %}
     <code>{{ accepted_summary.latest_submission_url }}</code>
     {% endif %}
@@ -82,13 +82,13 @@
             <dd>
               {% if work.bounty_url %}<a href="{{ work.bounty_url }}">Bounty #{{ work.bounty_id }}</a>{% endif %}
               {% if work.bounty_url and issue_url %} · {% endif %}
-              {% if issue_url %}<a href="{{ issue_url }}">{{ work.repo }} #{{ work.issue_number }}</a>{% elif not work.bounty_url %}-{% endif %}
+              {% if issue_url %}<a href="{{ issue_url }}" rel="nofollow noopener">{{ work.repo }} #{{ work.issue_number }}</a>{% elif not work.bounty_url %}-{% endif %}
             </dd>
           </div>
           <div class="ledger-field ledger-field--reference reference-cell">
             <dt>Submission</dt>
             {% set submission_url = safe_public_url(work.submission_url) %}
-            <dd>{% if submission_url %}<a href="{{ submission_url }}">{{ work.submission_url | replace("https://github.com/", "") }}</a>{% elif work.submission_url %}<code>{{ work.submission_url }}</code>{% else %}-{% endif %}</dd>
+            <dd>{% if submission_url %}<a href="{{ submission_url }}" rel="nofollow noopener">{{ work.submission_url | replace("https://github.com/", "") }}</a>{% elif work.submission_url %}<code>{{ work.submission_url }}</code>{% else %}-{% endif %}</dd>
           </div>
           <div class="ledger-field ledger-field--proof">
             <dt>Proof</dt>

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -40,12 +40,12 @@
           <div class="ledger-field ledger-field--reference reference-cell">
             <dt>Latest work</dt>
             {% set latest_submission_url = safe_public_url(contributor.latest_submission_url) %}
-            <dd>{% if latest_submission_url %}<a href="{{ latest_submission_url }}">{{ contributor.latest_submission_url | replace("https://github.com/", "") }}</a>{% else %}<code>{{ contributor.latest_submission_url }}</code>{% endif %}</dd>
+            <dd>{% if latest_submission_url %}<a href="{{ latest_submission_url }}" rel="nofollow noopener">{{ contributor.latest_submission_url | replace("https://github.com/", "") }}</a>{% else %}<code>{{ contributor.latest_submission_url }}</code>{% endif %}</dd>
           </div>
           <div class="ledger-field ledger-field--reference reference-cell">
             <dt>Latest bounty</dt>
             {% set latest_bounty_issue_url = safe_public_url(contributor.latest_bounty_issue_url) %}
-            <dd>{% if latest_bounty_issue_url %}<a href="{{ latest_bounty_issue_url }}">{{ contributor.latest_bounty_repo }} #{{ contributor.latest_bounty_issue_number }}</a>{% else %}-{% endif %}</dd>
+            <dd>{% if latest_bounty_issue_url %}<a href="{{ latest_bounty_issue_url }}" rel="nofollow noopener">{{ contributor.latest_bounty_repo }} #{{ contributor.latest_bounty_issue_number }}</a>{% else %}-{% endif %}</dd>
           </div>
           <div class="ledger-field ledger-field--proof">
             <dt>Latest proof</dt>
@@ -90,13 +90,13 @@
             <dd>
               {% if row.bounty_url %}<a href="{{ row.bounty_url }}">Bounty #{{ row.bounty_id }}</a>{% endif %}
               {% if row.bounty_url and bounty_issue_url %} · {% endif %}
-              {% if bounty_issue_url %}<a href="{{ bounty_issue_url }}">{{ row.bounty_repo }} #{{ row.bounty_issue_number }}</a>{% elif not row.bounty_url %}-{% endif %}
+              {% if bounty_issue_url %}<a href="{{ bounty_issue_url }}" rel="nofollow noopener">{{ row.bounty_repo }} #{{ row.bounty_issue_number }}</a>{% elif not row.bounty_url %}-{% endif %}
             </dd>
           </div>
           <div class="ledger-field ledger-field--reference reference-cell">
             <dt>Accepted work</dt>
             {% set submission_url = safe_public_url(row.submission_url) %}
-            <dd>{% if submission_url %}<a href="{{ submission_url }}">{{ row.submission_url | replace("https://github.com/", "") }}</a>{% else %}<code>{{ row.submission_url }}</code>{% endif %}</dd>
+            <dd>{% if submission_url %}<a href="{{ submission_url }}" rel="nofollow noopener">{{ row.submission_url | replace("https://github.com/", "") }}</a>{% else %}<code>{{ row.submission_url }}</code>{% endif %}</dd>
           </div>
           <div class="ledger-field ledger-field--proof">
             <dt>Proof</dt>

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -93,6 +93,15 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     assert "github:bob" in page_response.text
     assert "25 MRWK" in page_response.text
     assert '<p class="reference-cell">' in page_response.text
+    assert 'href="https://github.com/bob" rel="nofollow noopener"' in page_response.text
+    assert (
+        'href="https://github.com/ramimbo/mergework/pull/178" rel="nofollow noopener"'
+        in page_response.text
+    )
+    assert (
+        'href="https://github.com/ramimbo/mergework/issues/178" rel="nofollow noopener"'
+        in page_response.text
+    )
     assert f'href="/proofs/{proof.hash}"' in page_response.text
 
 

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -230,8 +230,12 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert 'name="q"' in paid.text
     assert f'href="/bounties/{bounty.id}">Bounty #{bounty.id}</a>' in paid.text
     assert "Latest bounty" in paid.text
-    assert 'href="https://github.com/ramimbo/mergework/issues/12"' in paid.text
-    assert 'href="https://github.com/ramimbo/mergework/pull/12"' in paid.text
+    assert (
+        'href="https://github.com/ramimbo/mergework/issues/12" rel="nofollow noopener"' in paid.text
+    )
+    assert (
+        'href="https://github.com/ramimbo/mergework/pull/12" rel="nofollow noopener"' in paid.text
+    )
     assert f'href="/proofs/{proof.hash}"' in paid.text
     assert "/accounts/github:bob" in paid.text
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1795,17 +1795,17 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
         "created_at": "<checked>",
     }
     assert "Claim GitHub balances from /me" in account
-    assert 'href="https://github.com/alice">@alice</a>' in account
+    assert 'href="https://github.com/alice" rel="nofollow noopener">@alice</a>' in account
     assert "Accepted work summary" in account
     assert "1</strong>\n      <span>accepted awards</span>" in account
     assert "25 MRWK</strong>\n      <span>accepted MRWK</span>" in account
     assert f'href="/proofs/{proof.hash}"' in account
-    assert 'href="https://github.com/ramimbo/mergework/pull/3"' in account
+    assert 'href="https://github.com/ramimbo/mergework/pull/3" rel="nofollow noopener"' in account
     assert 'via <a href="/ledger/3">#3</a>' in account
     assert "Accepted work" in account
     assert "Proof-backed bounty payments made to this account." in account
     assert f'href="/bounties/{bounty.id}">Bounty #{bounty.id}</a>' in account
-    assert 'href="https://github.com/ramimbo/mergework/issues/2"' in account
+    assert 'href="https://github.com/ramimbo/mergework/issues/2" rel="nofollow noopener"' in account
     assert 'href="/accounts/reserve:bounty:1"' in account
     assert 'href="/accounts/github:alice"' in account
 
@@ -1955,7 +1955,7 @@ def test_github_account_views_normalize_mixed_case_logins(sqlite_url: str) -> No
         assert account_api["balance_mrwk"] == "50"
         assert "50 MRWK" in account
         assert f"/proofs/{proof.hash}" in account
-        assert 'href="https://github.com/alice">@alice</a>' in account
+        assert 'href="https://github.com/alice" rel="nofollow noopener">@alice</a>' in account
         assert "github:alice: 50 MRWK" in balance["result"]["content"][0]["text"]
 
 


### PR DESCRIPTION
## Summary
- add `rel="nofollow noopener"` to public account/activity GitHub links
- align those pages with the existing bounty-page external-link treatment
- cover account and activity rendering with regression assertions

Refs #576

## Checks
- `python -m pytest tests/test_activity.py tests/test_account_routes.py`
- `python -m ruff format --check app tests`
- `python -m ruff check app tests`
- `python -m mypy app`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure outbound GitHub-related links on account and activity pages include rel="nofollow noopener" to improve external link handling.

* **Tests**
  * Expanded test assertions to verify the rendered account and activity pages include the updated link attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->