### PR TITLE
Refs #576: Use ASCII punctuation on activity page

### DIFF
--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -13,7 +13,7 @@
   </div>
 </form>
 {% if query %}
-<p class="notice">Showing accepted work matching “{{ query }}”.</p>
+<p class="notice">Showing accepted work matching "{{ query }}".</p>
 {% endif %}
 <nav class="actions detail-actions" aria-label="Activity inspection links">
   <a href="/api/v1/activity{% if query %}?q={{ query | urlencode }}{% endif %}">View JSON activity</a>
@@ -92,7 +92,7 @@
             {% set bounty_issue_url = safe_public_url(row.bounty_issue_url) %}
             <dd>
               {% if row.bounty_url %}<a href="{{ row.bounty_url }}">Bounty #{{ row.bounty_id }}</a>{% endif %}
-              {% if row.bounty_url and bounty_issue_url %} · {% endif %}
+              {% if row.bounty_url and bounty_issue_url %} - {% endif %}
               {% if bounty_issue_url %}<a href="{{ bounty_issue_url }}">{{ row.bounty_repo }} #{{ row.bounty_issue_number }}</a>{% elif not row.bounty_url %}-{% endif %}
             </dd>
           </div>

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -242,14 +242,14 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
 
     assert filtered.status_code == 200
     assert 'value="bob"' in filtered.text
-    assert "Showing accepted work matching “bob”." in filtered.text
+    assert 'Showing accepted work matching "bob".' in filtered.text
     assert 'href="/api/v1/activity?q=bob">View JSON activity</a>' in filtered.text
     assert 'href="/activity">Clear</a>' in filtered.text
     assert "No contributors match this search." not in filtered.text
     assert "No accepted work matches this search." not in filtered.text
     assert issue_ref.status_code == 200
     assert 'value="#12"' in issue_ref.text
-    assert "Showing accepted work matching “#12”." in issue_ref.text
+    assert 'Showing accepted work matching "#12".' in issue_ref.text
     assert 'href="/api/v1/activity?q=%2312">View JSON activity</a>' in issue_ref.text
     assert "github:bob" in issue_ref.text
 
@@ -257,7 +257,7 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
 
     assert no_match.status_code == 200
     assert 'value="alice"' in no_match.text
-    assert "Showing accepted work matching “alice”." in no_match.text
+    assert 'Showing accepted work matching "alice".' in no_match.text
     assert "No contributors match this search." in no_match.text
     assert "No accepted work matches this search." in no_match.text
     assert "No accepted bounty payments yet." not in no_match.text


### PR DESCRIPTION
Refs #576

Summary:
- Replace curly quotes in the activity search notice with ASCII quotes.
- Replace the centered dot between bounty links with an ASCII hyphen.
- Update the activity page regression test to assert the ASCII-rendered copy.

Why:
Some plain HTTP clients and test output can show UTF-8 punctuation as mojibake. Keeping this small activity-page copy ASCII avoids the rendering glitch without changing behavior.

Validation:
- python -m pytest tests/test_activity.py tests/test_activity_routes.py -q -> 4 passed
- python -m pytest -q -> 448 passed
- python -m ruff check tests/test_activity.py -> passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Search results notice now uses standard straight quotation marks (e.g., "query") for clearer, consistent display.
  * Separator between bounty-related links in recent accepted work changed from a centered dot to a dash-like " - " for improved readability and spacing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->