### PR TITLE
Normalize remaining public punctuation

### DIFF
--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -81,7 +81,7 @@
             {% set issue_url = safe_public_url(work.issue_url) %}
             <dd>
               {% if work.bounty_url %}<a href="{{ work.bounty_url }}">Bounty #{{ work.bounty_id }}</a>{% endif %}
-              {% if work.bounty_url and issue_url %} · {% endif %}
+              {% if work.bounty_url and issue_url %} - {% endif %}
               {% if issue_url %}<a href="{{ issue_url }}">{{ work.repo }} #{{ work.issue_number }}</a>{% elif not work.bounty_url %}-{% endif %}
             </dd>
           </div>

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -28,7 +28,7 @@
   <a href="/bounties?status=paid{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
   <a href="/bounties?status=closed{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
 </nav>
-{% if query_text %}<p>Showing matches for “{{ query_text }}”.</p>{% endif %}
+{% if query_text %}<p>Showing matches for "{{ query_text }}".</p>{% endif %}
 <section class="bounty-list-summary" aria-label="Bounty list summary">
   <article>
     <span>Bounties shown</span>
@@ -56,12 +56,12 @@
     <p class="bounty-card-meta">
       {% set issue_url = safe_public_url(bounty.issue_url) %}
       {% if issue_url %}
-      <a href="{{ issue_url }}" rel="nofollow noopener">{{ bounty.repo }} #{{ bounty.issue_number }}</a> ·
+      <a href="{{ issue_url }}" rel="nofollow noopener">{{ bounty.repo }} #{{ bounty.issue_number }}</a> -
       {% else %}
-      {{ bounty.repo }} #{{ bounty.issue_number }} ·
+      {{ bounty.repo }} #{{ bounty.issue_number }} -
       {% endif %}
-      <strong>{{ bounty.reward_mrwk }} MRWK</strong> per award ·
-      {{ bounty.available_mrwk }} MRWK still available ·
+      <strong>{{ bounty.reward_mrwk }} MRWK</strong> per award -
+      {{ bounty.available_mrwk }} MRWK still available -
       {{ bounty.awards_remaining }}/{{ bounty.max_awards }} awards open
     </p>
     <p>{{ bounty.acceptance }}</p>

--- a/app/templates/wallets.html
+++ b/app/templates/wallets.html
@@ -38,7 +38,7 @@
     </div>
   </form>
   {% if query_text %}
-  <p class="notice">Showing wallets matching “{{ query_text }}”.</p>
+  <p class="notice">Showing wallets matching "{{ query_text }}".</p>
   {% endif %}
   <table>
     <thead><tr><th>Address</th><th>Label</th><th>Balance</th><th>GitHub</th><th>Signed actions</th></tr></thead>

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 from fastapi.testclient import TestClient
 
 from app.accounts import account_api_context, account_page_context, normalized_account
@@ -93,6 +95,11 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     assert "github:bob" in page_response.text
     assert "25 MRWK" in page_response.text
     assert '<p class="reference-cell">' in page_response.text
+    assert re.search(
+        rf">Bounty #{bounty.id}</a>\s+-\s+"
+        r'<a href="https://github.com/ramimbo/mergework/issues/178">',
+        page_response.text,
+    )
     assert f'href="/proofs/{proof.hash}"' in page_response.text
 
 

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -233,7 +233,7 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     text_search = client.get("/bounties?q=proof+inspection")
     assert text_search.status_code == 200
     assert "Search bounties" in text_search.text
-    assert "Showing matches for “proof inspection”." in text_search.text
+    assert 'Showing matches for "proof inspection".' in text_search.text
     assert "Improve public bounty discovery" in text_search.text
     assert "Internal admin cleanup" not in text_search.text
     assert 'href="/bounties?status=open&q=proof%20inspection"' in text_search.text
@@ -248,7 +248,7 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
 
     hash_issue_page = client.get("/bounties?q=%2365")
     assert hash_issue_page.status_code == 200
-    assert "Showing matches for “#65”." in hash_issue_page.text
+    assert 'Showing matches for "#65".' in hash_issue_page.text
     assert "Internal admin cleanup" in hash_issue_page.text
     assert "Improve public bounty discovery" not in hash_issue_page.text
 

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -554,6 +554,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Main smoke wallet" in wallets
     assert "Main smoke wallet" in detail
     assert "Search wallets" in wallets
+    assert 'Showing wallets matching "Main".' in main_search
     assert "Main smoke wallet" in main_search
     assert "Funded smoke wallet" not in main_search
     assert "alice-smoke" in github_search


### PR DESCRIPTION
## Summary

- Normalize the remaining non-activity public-template punctuation to ASCII quotes and hyphen separators.
- Add regression assertions for wallet search notices, bounty search notices, and account accepted-work reference separators.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: CodeRabbit's follow-up on PR #588 flagged the same smart-quote and middle-dot readability issue outside the activity-page slice.
- Bounty capacity and active attempts/open PRs checked: #576 is open and currently has remaining awards; PR #588 is scoped to activity.html, so this patch keeps to wallet/account/bounty surfaces.
- Intended files or surfaces: app/templates/wallets.html, app/templates/account.html, app/templates/bounties.html, and focused page tests.
- Expected PR size: Small, six files, copy-only template changes plus assertions.
- Out of scope: activity.html, which is already covered by PR #588; wallet actions, signing, payments, exchanges, or private data.

## Test Evidence

- [x] `python -m ruff format --check .`
- [x] `python -m ruff check .`
- [ ] `mypy app` (not needed for template-copy-only change)
- [x] `python -m pytest tests/test_bounty_pages.py tests/test_wallet_api.py tests/test_account_routes.py -q` (47 passed)
- [x] `python scripts/docs_smoke.py`

## MRWK

Refs #576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Changed bounty display separators from a middle dot to a hyphen for clearer reading.
  * Standardized straight double quotes for search/result messages on bounty, wallet, and account pages.

* **Tests**
  * Updated tests to match the new UI formatting and added an assertion to verify bounty links are rendered on the account page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->