### PR TITLE
Refs #576: Harden static GitHub links

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -13,7 +13,7 @@
         {% if site_context == "ltc_lab" %}
         <a href="#projects">Projects</a>
         <a href="https://mrwk.ltclab.site">MRWK</a>
-        <a href="https://github.com/ramimbo/mergework">GitHub</a>
+        <a href="https://github.com/ramimbo/mergework" rel="nofollow noopener">GitHub</a>
         {% else %}
         <a href="/bounties">Bounties</a>
         <a href="/activity">Activity</a>

--- a/app/templates/docs.html
+++ b/app/templates/docs.html
@@ -22,12 +22,12 @@
     <li><a href="/api/v1/ledger">Ledger API</a></li>
     <li><a href="/wallets">Wallets</a></li>
     <li><a href="/transfer">Transfer UI</a></li>
-    <li><a href="https://github.com/ramimbo/mergework/discussions/16">Paid bounty discussion</a></li>
-    <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/bounty-rules.md">Bounty rules</a></li>
-    <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/paid-bounties.md">Payment proof guide</a></li>
-    <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/agent-guide.md">Agent usage</a></li>
-    <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/api-examples.md">Public API examples</a></li>
-    <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/ledger.md">Ledger details</a></li>
+    <li><a href="https://github.com/ramimbo/mergework/discussions/16" rel="nofollow noopener">Paid bounty discussion</a></li>
+    <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/bounty-rules.md" rel="nofollow noopener">Bounty rules</a></li>
+    <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/paid-bounties.md" rel="nofollow noopener">Payment proof guide</a></li>
+    <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/agent-guide.md" rel="nofollow noopener">Agent usage</a></li>
+    <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/api-examples.md" rel="nofollow noopener">Public API examples</a></li>
+    <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/ledger.md" rel="nofollow noopener">Ledger details</a></li>
   </ul>
   <h2>Current transfer paths</h2>
   <p>Supported MRWK transfer paths today are:</p>

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -52,17 +52,15 @@ def test_docs_page_marks_static_github_links_as_untrusted(sqlite_url: str) -> No
     page = client.get("/docs")
 
     assert page.status_code == 200
-    assert (
-        'href="https://github.com/ramimbo/mergework/discussions/16" rel="nofollow noopener"'
-    ) in page.text
-    assert (
-        'href="https://github.com/ramimbo/mergework/blob/main/docs/bounty-rules.md" '
-        'rel="nofollow noopener"'
-    ) in page.text
-    assert (
-        'href="https://github.com/ramimbo/mergework/blob/main/docs/api-examples.md" '
-        'rel="nofollow noopener"'
-    ) in page.text
+    for url in (
+        "https://github.com/ramimbo/mergework/discussions/16",
+        "https://github.com/ramimbo/mergework/blob/main/docs/bounty-rules.md",
+        "https://github.com/ramimbo/mergework/blob/main/docs/paid-bounties.md",
+        "https://github.com/ramimbo/mergework/blob/main/docs/agent-guide.md",
+        "https://github.com/ramimbo/mergework/blob/main/docs/api-examples.md",
+        "https://github.com/ramimbo/mergework/blob/main/docs/ledger.md",
+    ):
+        assert f'href="{url}" rel="nofollow noopener"' in page.text
 
 
 def test_ltc_lab_header_marks_github_nav_link_as_untrusted(sqlite_url: str) -> None:

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from fastapi.testclient import TestClient
+
+from app.main import create_app
 from app.public_routes import public_bounties_context
 
 
@@ -41,3 +44,31 @@ def test_public_bounties_context_preserves_limited_json_results_url() -> None:
     context = public_bounties_context([], status=None, q="issue #580", sort="newest", limit=25)
 
     assert context["api_results_url"] == "/api/v1/bounties?q=issue+%23580&limit=25"
+
+
+def test_docs_page_marks_static_github_links_as_untrusted(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    page = client.get("/docs")
+
+    assert page.status_code == 200
+    assert (
+        'href="https://github.com/ramimbo/mergework/discussions/16" rel="nofollow noopener"'
+    ) in page.text
+    assert (
+        'href="https://github.com/ramimbo/mergework/blob/main/docs/bounty-rules.md" '
+        'rel="nofollow noopener"'
+    ) in page.text
+    assert (
+        'href="https://github.com/ramimbo/mergework/blob/main/docs/api-examples.md" '
+        'rel="nofollow noopener"'
+    ) in page.text
+
+
+def test_ltc_lab_header_marks_github_nav_link_as_untrusted(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    page = client.get("/", headers={"host": "ltclab.site"})
+
+    assert page.status_code == 200
+    assert ('href="https://github.com/ramimbo/mergework" rel="nofollow noopener"') in page.text


### PR DESCRIPTION
## Summary

Refs #576.

This adds the existing public-link hygiene treatment (`rel="nofollow noopener"`) to static GitHub links that are rendered from the public shell/docs templates.

## Evidence / Distinctness

Current public templates already apply `rel="nofollow noopener"` on several dynamic GitHub issue links, for example bounty detail/list links. A fresh check found static GitHub links in these surfaces did not have the same treatment:

- LTC Lab header GitHub nav link in `app/templates/base.html`
- `/docs` GitHub discussion and repository-document links in `app/templates/docs.html`

This is intentionally distinct from the current account/activity link PR #586: this PR does not touch dynamic account/activity links or the failing account-page assertions in that branch. It only covers static public navigation/docs links that remain unmodified on `main`.

## Scope

- Adds `rel="nofollow noopener"` to the static GitHub nav link shown in the LTC Lab header.
- Adds `rel="nofollow noopener"` to static GitHub documentation/discussion links on `/docs`.
- Adds rendered-route regression tests for `/docs` and the LTC Lab host header path.
- No wallet, ledger, payout, exchange, bridge, price, liquidity, auth, admin, webhook, or deployment behavior changes.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_public_routes.py -q` -> 3 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_public_routes.py tests/test_hub.py -q` -> 7 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 450 passed
- `uv run --extra dev python -m ruff check tests/test_public_routes.py` -> passed
- `uv run --extra dev python -m ruff format --check tests/test_public_routes.py` -> passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m mypy app/public_routes.py app/main.py` -> success
- `git diff --check` -> clean

## Safety

No private keys, wallet material, cookies, tokens, OAuth state, signatures, private vulnerability details, deployment credentials, MRWK price claims, exchange claims, bridge claims, liquidity claims, off-ramp claims, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * External GitHub links in the site navigation and project docs now include security attributes (rel="nofollow noopener") to control link behavior.

* **Tests**
  * Added tests verifying GitHub links on the docs and home pages render with the new security attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->