### PR TITLE
[codex] Add activity JSON shortcut

### DIFF
--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -15,6 +15,9 @@
 {% if query %}
 <p class="notice">Showing accepted work matching “{{ query }}”.</p>
 {% endif %}
+<nav class="actions detail-actions" aria-label="Activity inspection links">
+  <a href="/api/v1/activity{% if query %}?q={{ query | urlencode }}{% endif %}">View JSON activity</a>
+</nav>
 
 <section class="grid">
   <article><strong>{{ totals.accepted_awards }}</strong><span>accepted awards</span></article>

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -250,6 +250,7 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert issue_ref.status_code == 200
     assert 'value="#12"' in issue_ref.text
     assert "Showing accepted work matching “#12”." in issue_ref.text
+    assert 'href="/api/v1/activity?q=%2312">View JSON activity</a>' in issue_ref.text
     assert "github:bob" in issue_ref.text
 
     no_match = client.get("/activity?q=alice")

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -227,6 +227,8 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert "github:bob" in paid.text
     assert "75 MRWK" in paid.text
     assert 'role="search"' in paid.text
+    assert 'aria-label="Activity inspection links"' in paid.text
+    assert 'href="/api/v1/activity">View JSON activity</a>' in paid.text
     assert 'name="q"' in paid.text
     assert f'href="/bounties/{bounty.id}">Bounty #{bounty.id}</a>' in paid.text
     assert "Latest bounty" in paid.text
@@ -241,6 +243,7 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert filtered.status_code == 200
     assert 'value="bob"' in filtered.text
     assert "Showing accepted work matching “bob”." in filtered.text
+    assert 'href="/api/v1/activity?q=bob">View JSON activity</a>' in filtered.text
     assert 'href="/activity">Clear</a>' in filtered.text
     assert "No contributors match this search." not in filtered.text
     assert "No accepted work matches this search." not in filtered.text


### PR DESCRIPTION
## Summary
- Add a direct activity-page link to the matching `/api/v1/activity` JSON feed.
- Preserve the current search query in the JSON link so contributors can inspect the same filtered result set without manually editing URLs.
- Cover unfiltered, plain filtered, and encoded issue-reference filtered activity-page rendering in tests.

Refs #580.

## Evidence

### Confusion/bug addressed
The public `/activity` page and `/api/v1/activity` feed show the same accepted-work activity surface, but contributors had to manually rewrite the URL to inspect the exact machine-readable result set for the current page.

### Bounty capacity checked
Bounty #580 remains open as the active site UX and functional-improvements round, and the maintainer's latest update leaves 2 slots remaining after the paid #596 update.

### Intended files/surfaces
- `app/templates/activity.html`: add the activity-page JSON inspection link.
- `tests/test_activity.py`: cover unfiltered, filtered, and encoded `#12` search-link behavior.

### Expected PR size
Small focused UI/template behavior plus regression tests only.

### Out of scope
No wallet material, private keys, cookies, OAuth state, access tokens, signatures, private data, payout actions, deployment changes, price/liquidity/exchange/off-ramp claims, bridge promises, or fabricated payout claims.

## Validation
- `.venv/bin/python -m pytest tests/test_activity.py -q` -> 3 passed
- `.venv/bin/python -m ruff check tests/test_activity.py` -> passed
- `.venv/bin/python -m ruff format --check tests/test_activity.py` -> 1 file already formatted
- `.venv/bin/python -m mypy app/activity.py` -> success
- `.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean merge tree
