### PR TITLE
Refs #576: Harden proof and ledger links

### DIFF
--- a/app/templates/ledger.html
+++ b/app/templates/ledger.html
@@ -47,7 +47,7 @@
           <dt>Reference</dt>
           <dd>
             {% if reference_url %}
-              <a href="{{ reference_url }}">{{ entry.reference | replace("https://github.com/", "") }}</a>
+              <a href="{{ reference_url }}" rel="nofollow noopener">{{ entry.reference | replace("https://github.com/", "") }}</a>
             {% elif entry.reference %}
               <code>{{ entry.reference }}</code>
             {% else %}

--- a/app/templates/ledger_entry.html
+++ b/app/templates/ledger_entry.html
@@ -47,7 +47,7 @@
     <dd>{% if entry.to %}<a href="/accounts/{{ entry.to }}">{{ entry.to }}</a>{% else %}-{% endif %}</dd>
     <dt>Reference</dt>
     {% set reference_url = safe_public_url(entry.reference) %}
-    <dd>{% if reference_url %}<a href="{{ reference_url }}">{{ entry.reference }}</a>{% else %}{{ entry.reference }}{% endif %}</dd>
+    <dd>{% if reference_url %}<a href="{{ reference_url }}" rel="nofollow noopener">{{ entry.reference }}</a>{% else %}{{ entry.reference }}{% endif %}</dd>
     <dt>Previous hash</dt>
     <dd><code>{{ entry.previous_hash }}</code></dd>
     <dt>Entry hash</dt>

--- a/app/templates/ledger_entry.html
+++ b/app/templates/ledger_entry.html
@@ -47,7 +47,7 @@
     <dd>{% if entry.to %}<a href="/accounts/{{ entry.to }}">{{ entry.to }}</a>{% else %}-{% endif %}</dd>
     <dt>Reference</dt>
     {% set reference_url = safe_public_url(entry.reference) %}
-    <dd>{% if reference_url %}<a href="{{ reference_url }}" rel="nofollow noopener">{{ entry.reference }}</a>{% else %}{{ entry.reference }}{% endif %}</dd>
+    <dd>{% if reference_url %}<a href="{{ reference_url }}" rel="nofollow noopener">{{ entry.reference }}</a>{% elif entry.reference %}{{ entry.reference }}{% else %}-{% endif %}</dd>
     <dt>Previous hash</dt>
     <dd><code>{{ entry.previous_hash }}</code></dd>
     <dt>Entry hash</dt>

--- a/app/templates/proof.html
+++ b/app/templates/proof.html
@@ -10,7 +10,7 @@
     <article>
       <span>Bounty issue</span>
       {% set issue_card_url = safe_public_url("https://github.com/" ~ proof.repo ~ "/issues/" ~ proof.issue_number) %}
-      <strong>{% if issue_card_url %}<a href="{{ issue_card_url }}">{{ proof.repo }} #{{ proof.issue_number }}</a>{% else %}{{ proof.repo }} #{{ proof.issue_number }}{% endif %}</strong>
+      <strong>{% if issue_card_url %}<a href="{{ issue_card_url }}" rel="nofollow noopener">{{ proof.repo }} #{{ proof.issue_number }}</a>{% else %}{{ proof.repo }} #{{ proof.issue_number }}{% endif %}</strong>
     </article>
     <article>
       <span>MergeWork bounty</span>
@@ -33,7 +33,7 @@
   <dl>
     <dt>Issue</dt>
     {% set issue_url = safe_public_url("https://github.com/" ~ proof.repo ~ "/issues/" ~ proof.issue_number) %}
-    <dd>{% if issue_url %}<a href="{{ issue_url }}">{{ proof.repo }} #{{ proof.issue_number }}</a>{% else %}{{ proof.repo }} #{{ proof.issue_number }}{% endif %}</dd>
+    <dd>{% if issue_url %}<a href="{{ issue_url }}" rel="nofollow noopener">{{ proof.repo }} #{{ proof.issue_number }}</a>{% else %}{{ proof.repo }} #{{ proof.issue_number }}{% endif %}</dd>
     <dt>MergeWork bounty</dt>
     <dd><a href="/bounties/{{ proof.bounty_id }}">#{{ proof.bounty_id }}</a></dd>
     <dt>Accepted by</dt>
@@ -48,7 +48,7 @@
     <dd><code>{{ proof.ledger_hash }}</code></dd>
     <dt>Submission</dt>
     {% set submission_url = safe_public_url(proof.submission_url) %}
-    <dd>{% if submission_url %}<a href="{{ submission_url }}">{{ proof.submission_url }}</a>{% else %}{{ proof.submission_url }}{% endif %}</dd>
+    <dd>{% if submission_url %}<a href="{{ submission_url }}" rel="nofollow noopener">{{ proof.submission_url }}</a>{% else %}{{ proof.submission_url }}{% endif %}</dd>
   </dl>
   {% if proof.kind == "bounty_payment" %}
   <div class="section-head">

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -576,7 +576,10 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert "Award paid" in ledger_page.text
     assert "Unused reserve released" in ledger_page.text
     assert 'class="ledger-row ledger-row--bounty-payment"' in ledger_page.text
-    assert 'href="https://github.com/ramimbo/mergework/pull/99"' in ledger_page.text
+    assert (
+        'href="https://github.com/ramimbo/mergework/pull/99" rel="nofollow noopener"'
+        in ledger_page.text
+    )
     assert f'href="/proofs/{proof_hash}">Payment proof</a>' in ledger_page.text
 
     ledger_entry_page = client.get(f"/ledger/{payment_sequence}")
@@ -589,6 +592,10 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert f'href="/ledger/{payment_sequence - 1}">Previous entry</a>' in ledger_entry_page.text
     assert f'href="/api/v1/ledger/{payment_sequence}">Entry JSON</a>' in ledger_entry_page.text
     assert f'href="/ledger/{payment_sequence + 1}">Next entry</a>' in ledger_entry_page.text
+    assert (
+        'href="https://github.com/ramimbo/mergework/pull/99" rel="nofollow noopener"'
+        in ledger_entry_page.text
+    )
     genesis_page = client.get("/ledger/1")
     assert genesis_page.status_code == 200
     assert 'href="/ledger">All ledger entries</a>' in genesis_page.text
@@ -617,6 +624,14 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert "MergeWork bounty" in proof_page.text
     assert f'href="/bounties/{bounty.id}"' in proof_page.text
     assert f'href="/ledger/{payment_sequence}"' in proof_page.text
+    assert (
+        'href="https://github.com/ramimbo/mergework/issues/23" rel="nofollow noopener"'
+        in proof_page.text
+    )
+    assert (
+        'href="https://github.com/ramimbo/mergework/pull/99" rel="nofollow noopener"'
+        in proof_page.text
+    )
     assert "Related activity" in proof_page.text
     assert 'href="/activity?q=github%3Acontributor"' in proof_page.text
     assert f'href="/activity?q={proof_hash}"' in proof_page.text

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
-from app.models import Proof
+from app.models import LedgerEntry, Proof
 
 
 def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
@@ -647,6 +647,56 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert missing_proof.status_code == 404
     assert client.get("/api/v1/proofs/not-a-proof-hash").status_code == 400
     assert client.get("/proofs/not-a-proof-hash").status_code == 400
+
+
+def test_ledger_entry_reference_fallbacks(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=24,
+            issue_url="https://github.com/ramimbo/mergework/issues/24",
+            title="Render ledger references safely",
+            reward_mrwk="50",
+            max_awards=2,
+            acceptance="Ledger detail pages should not link unsafe references.",
+        )
+        empty_reference_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:empty-reference",
+            submission_url="https://github.com/ramimbo/mergework/pull/100",
+            accepted_by="maintainer",
+            verifier_result={"result": "accepted"},
+        )
+        unsafe_reference_proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:unsafe-reference",
+            submission_url="https://github.com/ramimbo/mergework/pull/101",
+            accepted_by="maintainer",
+            verifier_result={"result": "accepted"},
+        )
+        empty_reference_entry = session.get(LedgerEntry, empty_reference_proof.ledger_sequence)
+        unsafe_reference_entry = session.get(LedgerEntry, unsafe_reference_proof.ledger_sequence)
+        assert empty_reference_entry is not None
+        assert unsafe_reference_entry is not None
+        empty_reference_entry.reference = ""
+        unsafe_reference_entry.reference = "javascript:alert(1)"
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    empty_reference_page = client.get(f"/ledger/{empty_reference_proof.ledger_sequence}")
+    assert empty_reference_page.status_code == 200
+    assert "<dt>Reference</dt>" in empty_reference_page.text
+    assert "<dd>-</dd>" in empty_reference_page.text
+
+    unsafe_reference_page = client.get(f"/ledger/{unsafe_reference_proof.ledger_sequence}")
+    assert unsafe_reference_page.status_code == 200
+    assert "javascript:alert(1)" in unsafe_reference_page.text
+    assert 'href="javascript:alert(1)"' not in unsafe_reference_page.text
 
 
 def test_bounties_list_cards_have_status_pills(sqlite_url: str) -> None:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
@@ -562,8 +564,34 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
             closed_by="maintainer",
             reference="https://github.com/ramimbo/mergework/issues/23",
         )
+        unsafe_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=24,
+            issue_url="https://github.com/ramimbo/mergework/issues/24",
+            title="Keep rejected public URLs inert",
+            reward_mrwk="25",
+            acceptance="Rejected external URLs render as text, not links.",
+        )
+        unsafe_proof = pay_bounty(
+            session,
+            bounty_id=unsafe_bounty.id,
+            to_account="github:contributor",
+            submission_url="https://github.com/ramimbo/mergework/pull/100",
+            accepted_by="maintainer",
+            verifier_result={"result": "accepted"},
+        )
+        unsafe_payload = json.loads(unsafe_proof.public_json)
+        unsafe_payload["submission_url"] = "javascript:alert(1)"
+        unsafe_proof.public_json = json.dumps(
+            unsafe_payload,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
         proof_hash = proof.hash
         payment_sequence = proof.ledger_sequence
+        unsafe_proof_hash = unsafe_proof.hash
 
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
@@ -632,6 +660,10 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
         'href="https://github.com/ramimbo/mergework/pull/99" rel="nofollow noopener"'
         in proof_page.text
     )
+    unsafe_proof_page = client.get(f"/proofs/{unsafe_proof_hash}")
+    assert unsafe_proof_page.status_code == 200
+    assert "javascript:alert(1)" in unsafe_proof_page.text
+    assert 'href="javascript:alert(1)"' not in unsafe_proof_page.text
     assert "Related activity" in proof_page.text
     assert 'href="/activity?q=github%3Acontributor"' in proof_page.text
     assert f'href="/activity?q={proof_hash}"' in proof_page.text


### PR DESCRIPTION
## Summary
- add `rel="nofollow noopener"` to safe external references on ledger list/detail pages
- add the same treatment to proof issue and submission links
- cover rendered ledger and proof pages in the existing explorer regression

Refs #576

## Evidence
- Bounty list/detail pages already harden public GitHub issue links with `rel="nofollow noopener"`, while proof and ledger explorer links still rendered safe external references without that attribute.
- This patch only touches `app/templates/ledger.html`, `app/templates/ledger_entry.html`, `app/templates/proof.html`, and `tests/test_bounty_pages.py`.

## Validation
- `uv run --extra dev python -m pytest tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable -q` -> 1 passed, 1 warning
- `uv run --extra dev python -m pytest tests/test_bounty_pages.py -q` -> 12 passed, 1 warning
- `uv run --extra dev ruff check tests/test_bounty_pages.py` -> passed
- `uv run --extra dev ruff format --check tests/test_bounty_pages.py` -> 1 file already formatted
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean
- `git diff --no-ext-diff origin/main...HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks

## Safety
No private data, wallet material, tokens, production mutation, price/liquidity/exchange/off-ramp claims, or fabricated payout claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External GitHub and other external links now include rel="nofollow noopener" to improve safety; internal links keep prior behavior.
  * Ledger entry references without a safe URL render as plain text or a "-" placeholder instead of clickable links.

* **Tests**
  * Added/updated tests to verify safe rendering: protective link attributes are present and unsafe URLs appear as text only, not as clickable hrefs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->