### PR TITLE
[codex] Link wallet list GitHub accounts

### DIFF
--- a/app/templates/wallets.html
+++ b/app/templates/wallets.html
@@ -48,7 +48,9 @@
         <td><a href="/wallets/{{ wallet.address }}"><code>{{ wallet.address }}</code></a></td>
         <td>{{ wallet.label or "-" }}</td>
         <td>{{ wallet.balance_mrwk }} MRWK</td>
-        <td>{{ wallet.github_login or "-" }}</td>
+        <td>
+          {% if wallet.github_login %}<a href="/accounts/github:{{ wallet.github_login }}">{{ wallet.github_login }}</a>{% else %}-{% endif %}
+        </td>
         <td>{{ wallet.nonce }}</td>
       </tr>
       {% else %}

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -557,6 +557,8 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Main smoke wallet" in main_search
     assert "Funded smoke wallet" not in main_search
     assert "alice-smoke" in github_search
+    assert 'href="/accounts/github:alice-smoke">alice-smoke</a>' in wallets
+    assert 'href="/accounts/github:alice-smoke">alice-smoke</a>' in github_search
     assert "No registered wallets match this search." in no_wallet_match
     assert "To claim GitHub bounty balance" in detail
     assert "No activity yet" in detail

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -559,6 +559,13 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "alice-smoke" in github_search
     assert 'href="/accounts/github:alice-smoke">alice-smoke</a>' in wallets
     assert 'href="/accounts/github:alice-smoke">alice-smoke</a>' in github_search
+    funded_row_start = wallets.index(
+        f'<a href="/wallets/{funded_address}"><code>{funded_address}</code></a>'
+    )
+    funded_row = wallets[funded_row_start : wallets.index("</tr>", funded_row_start)]
+    assert "<td>Funded smoke wallet</td>" in funded_row
+    assert "<td>\n          -\n        </td>" in funded_row
+    assert "/accounts/github:" not in funded_row
     assert "No registered wallets match this search." in no_wallet_match
     assert "To claim GitHub bounty balance" in detail
     assert "No activity yet" in detail


### PR DESCRIPTION
## Summary
- turn linked GitHub logins on `/wallets` into account-page links
- keep unlinked wallets showing `-`
- cover the registered-wallets list and filtered search rendering in the wallet page test

Refs #580.

## Before / After
Before: the registered-wallets table showed linked GitHub logins as plain text, so contributors and maintainers had to manually compose `/accounts/github:<login>` to inspect the account balance, accepted work, and ledger rows.

After: the GitHub column links directly to the matching public account page while preserving the existing wallet search behavior.

## Distinctness
This targets the registered-wallets list table. It is distinct from wallet-detail shortcuts (#492), account-detail shortcuts (#483), contributor `/me` shortcuts (#543), and the activity JSON link (#591), because it starts from `/wallets` search/list results and improves the linked-wallet-to-account inspection path.

## Validation
- `.venv/bin/python -m pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows -q` -> 1 passed
- `.venv/bin/python -m pytest tests/test_wallet_api.py -q` -> 33 passed
- `.venv/bin/python -m pytest -q` -> 454 passed
- `.venv/bin/python -m ruff check .` -> passed
- `.venv/bin/python -m ruff format --check .` -> 83 files already formatted
- `.venv/bin/python -m mypy app` -> success
- `.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

## Notes
No wallet material, private keys, cookies, OAuth state, access tokens, signatures, private data, price/liquidity/exchange/off-ramp claims, bridge promises, or fabricated payout claims are included. No screenshot attached because this is a rendered-link behavior change, not a visual layout redesign.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallets table now turns GitHub logins into links to their account pages; wallets without a GitHub login show “-”.

* **Tests**
  * Updated tests to verify GitHub-linked wallets render account links and that wallets without a GitHub claim (e.g., funded wallets) do not.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->