### PR TITLE
Refs #576: Harden bounty detail external links

### DIFF
--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -35,7 +35,7 @@
       <span>Issue</span>
       <strong>
         {% if issue_url %}
-          <a href="{{ issue_url }}">{{ bounty.repo }} #{{ bounty.issue_number }}</a>
+          <a href="{{ issue_url }}" rel="nofollow noopener">{{ bounty.repo }} #{{ bounty.issue_number }}</a>
         {% else %}
           {{ bounty.repo }} #{{ bounty.issue_number }}
         {% endif %}
@@ -95,7 +95,7 @@
           <div class="ledger-field ledger-field--reference reference-cell">
             <dt>Submission</dt>
             {% set submission_url = safe_public_url(award.submission_url) %}
-            <dd>{% if submission_url %}<a href="{{ submission_url }}">{{ award.submission_url | replace("https://github.com/", "") }}</a>{% elif award.submission_url %}<code>{{ award.submission_url }}</code>{% else %}-{% endif %}</dd>
+            <dd>{% if submission_url %}<a href="{{ submission_url }}" rel="nofollow noopener">{{ award.submission_url | replace("https://github.com/", "") }}</a>{% elif award.submission_url %}<code>{{ award.submission_url }}</code>{% else %}-{% endif %}</dd>
           </div>
           <div class="ledger-field ledger-field--proof">
             <dt>Proof</dt>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -490,7 +490,9 @@ def test_bounty_detail_shows_accepted_award_history(sqlite_url: str) -> None:
     assert "Accepted work" in page.text
     assert "2/3 awards paid" in page.text
     assert "1 still open" in page.text
-    assert 'href="https://github.com/ramimbo/mergework/pull/202"' in page.text
+    assert (
+        'href="https://github.com/ramimbo/mergework/pull/202" rel="nofollow noopener"' in page.text
+    )
     assert f'href="/proofs/{second_proof.hash}"' in page.text
     assert f'href="/ledger/{second_proof.ledger_sequence}"' in page.text
     assert "/accounts/github:bob" in page.text


### PR DESCRIPTION
Refs #576

## Summary

- Adds `rel="nofollow noopener"` to the bounty-detail source-issue link in the summary card.
- Adds `rel="nofollow noopener"` to accepted-work submission links on bounty detail pages.
- Extends the rendered-page regression so accepted award submission links keep the hardened external-link treatment.

## Distinctness

This is scoped to `app/templates/bounty_detail.html` accepted-work/source links. It does not overlap the static header/docs link PR, account/activity dynamic-link PR, ledger/proof external-link PR, wallet-account shortcut PR, or activity JSON shortcut PR.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_bounty_pages.py::test_bounty_detail_highlights_action_fields tests/test_bounty_pages.py::test_bounty_detail_shows_accepted_award_history -q` -> 2 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_bounty_pages.py -q` -> 12 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 454 passed, 1 warning
- `uv run --extra dev python -m ruff check .` -> passed
- `uv run --extra dev python -m ruff format --check .` -> 83 files already formatted
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m mypy app/public_routes.py app/bounty_api.py app/serializers.py` -> success
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean
- `git diff --no-ext-diff origin/main...HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks

No private keys, wallet material, cookies, tokens, OAuth state, signatures, private vulnerability details, deployment credentials, MRWK price claims, exchange claims, bridge claims, liquidity claims, off-ramp claims, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for outbound links in bounty detail pages by adding protective attributes that prevent referrer information leakage and restrict window access for external links, including source issue URLs and accepted award submissions.

* **Tests**
  * Updated test coverage to verify that link security attributes are correctly applied to bounty proof links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->