### PR TITLE
Refs #580: Link GitHub balances to claim flow

### DIFF
--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -6,6 +6,11 @@
   <h1><code>{{ account.account }}</code></h1>
   <p class="lead">{{ account.balance_mrwk }} MRWK</p>
   <p>{% if account.exists %}This account exists on the ledger.{% else %}This account has no ledger activity yet.{% endif %}</p>
+  {% if account.github_login and account.balance_mrwk != "0" %}
+  <p class="notice">
+    This GitHub account has MRWK available. If this is you, <a href="/me">sign in to link a wallet and claim the balance</a>.
+  </p>
+  {% endif %}
   <dl>
     <dt>Ledger address</dt>
     <dd><code>{{ account.ledger_address }}</code></dd>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -543,6 +543,27 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Link a wallet" in me
 
 
+def test_account_page_links_github_balance_to_claim_flow(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        add_ledger_entry(
+            session,
+            entry_type="test_github_balance",
+            from_account=TREASURY_ACCOUNT,
+            to_account="github:alice",
+            amount_microunits=7_000_000,
+            reference="test-github-claim-cta",
+        )
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    account_page = client.get("/accounts/github:alice")
+
+    assert account_page.status_code == 200
+    assert "This GitHub account has MRWK available" in account_page.text
+    assert 'href="/me">sign in to link a wallet and claim the balance</a>' in account_page.text
+
+
 def test_me_page_shows_signed_in_github_claim_balance(sqlite_url: str, monkeypatch) -> None:
     monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
     create_schema(sqlite_url)


### PR DESCRIPTION
Refs #580

## Summary
- Add a clear claim CTA on public `github:*` account pages when the account has a non-zero MRWK balance.
- Point contributors to `/me` so they can sign in, link a wallet, and claim their GitHub-held balance.
- Add regression coverage for the account-page claim path.

## Why
After a bounty is paid to `github:<login>`, the account page shows the balance and transfer status, but the next action is easier to miss. This makes the contributor claim workflow easier to discover from the public account page.

## Tests
- `./.venv/bin/python -m pytest -q tests/test_wallet_api.py tests/test_api_mcp.py::test_explorer_links_ledger_proof_and_account --tb=short`
- `./.venv/bin/python -m ruff format --check tests/test_wallet_api.py`
- `./.venv/bin/python -m ruff check tests/test_wallet_api.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users with GitHub-linked accounts now see a notice on their account page when they have available MRWK balances to claim. The notice prompts them to sign in and link a wallet to access their balance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->