### PR TITLE
Refs #580: Add bounty list JSON shortcut

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any
+from urllib.parse import urlencode
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
@@ -16,6 +17,21 @@ from app.ledger_views import account_ledger_transaction_types, account_ledger_tr
 from app.models import Wallet
 from app.path_params import proof_hash_from_path
 from app.serializers import bounty_list_summary, wallet_to_dict
+
+
+def _bounties_api_url(
+    status: str | None, query_text: str, selected_sort: str, limit: int | None
+) -> str:
+    params: list[tuple[str, str]] = []
+    if status:
+        params.append(("status", status))
+    if query_text:
+        params.append(("q", query_text))
+    if selected_sort != "newest":
+        params.append(("sort", selected_sort))
+    if limit is not None:
+        params.append(("limit", str(limit)))
+    return f"/api/v1/bounties?{urlencode(params)}" if params else "/api/v1/bounties"
 
 
 def public_bounties_context(
@@ -40,6 +56,7 @@ def public_bounties_context(
         "sort_options": BOUNTY_SORT_LABELS,
         "selected_limit": limit,
         "limit_options": limit_options,
+        "api_results_url": _bounties_api_url(selected_status, query_text, selected_sort, limit),
     }
 
 

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -43,6 +43,9 @@
     <strong>{{ summary.open_pool_mrwk }} MRWK</strong>
   </article>
 </section>
+<p class="notice">
+  <a href="{{ api_results_url }}">View JSON results</a>
+</p>
 <div class="list">
   {% for bounty in bounties %}
   <article class="bounty-card bounty-card--{{ bounty.status }}">

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -55,6 +55,7 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert "Bounties shown" in all_rows.text
     assert "Awards open" in all_rows.text
     assert "Open reward pool" in all_rows.text
+    assert 'href="/api/v1/bounties">View JSON results</a>' in all_rows.text
     assert "1</strong>" in all_rows.text
     assert "50 MRWK</strong>" in all_rows.text
     assert "50 MRWK still available" in all_rows.text
@@ -65,6 +66,7 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert "Open public bounty" not in paid_rows.text
     assert f'href="/bounties/{paid_bounty.id}"' in paid_rows.text
     assert 'href="/bounties?status=paid"' in paid_rows.text
+    assert 'href="/api/v1/bounties?status=paid">View JSON results</a>' in paid_rows.text
     assert "0 MRWK</strong>" in paid_rows.text
 
     paid_rows_uppercase = client.get("/bounties?status=PAID")
@@ -177,6 +179,10 @@ def test_bounties_page_honors_limit_filter(sqlite_url: str) -> None:
         in filtered_limited_page.text
     )
     assert 'href="/bounties?sort=reward&limit=2">Clear search</a>' in filtered_limited_page.text
+    assert (
+        'href="/api/v1/bounties?q=public&amp;sort=reward&amp;limit=2">View JSON results</a>'
+        in filtered_limited_page.text
+    )
 
     invalid_limit = client.get("/bounties?limit=0")
     assert invalid_limit.status_code == 422

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -33,4 +33,11 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
         },
         "selected_limit": None,
         "limit_options": (10, 25, 50, 100, 200),
+        "api_results_url": "/api/v1/bounties?status=open&q=proof&sort=reward",
     }
+
+
+def test_public_bounties_context_preserves_limited_json_results_url() -> None:
+    context = public_bounties_context([], status=None, q="issue #580", sort="newest", limit=25)
+
+    assert context["api_results_url"] == "/api/v1/bounties?q=issue+%23580&limit=25"


### PR DESCRIPTION
Refs #580

## Summary
- Add a `View JSON results` shortcut to the public `/bounties` page.
- Preserve the active bounty list filters in the API link: `status`, `q`, non-default `sort`, and `limit`.
- Cover the context URL builder and rendered bounty page links with regression tests.

## Why
The human bounty list already supports status filters, text search, sorting, and row limits. The matching API endpoint already supports the same workflow, but contributors and maintainers had to manually rewrite `/bounties?...` into `/api/v1/bounties?...` to inspect the machine-readable result set. This adds the missing bridge from the public list to the exact JSON result set being viewed.

## Distinctness
- Does not overlap PR #591, which adds a JSON shortcut for accepted-work activity.
- Does not overlap PR #593, which links wallet-list GitHub accounts.
- Does not overlap PR #595, which adds a GitHub-balance claim CTA on account pages.
- Does not overlap the proof-page UX attempt noted on #580.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_public_routes.py tests/test_bounty_pages.py::test_bounties_page_renders_and_filters_by_status tests/test_bounty_pages.py::test_bounties_page_honors_limit_filter -q` -> 4 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_bounty_pages.py tests/test_public_routes.py -q` -> 14 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 478 passed, 1 warning
- `uv run --extra dev ruff check app/public_routes.py tests/test_public_routes.py tests/test_bounty_pages.py` -> passed
- `uv run --extra dev ruff format --check app/public_routes.py tests/test_public_routes.py tests/test_bounty_pages.py` -> 3 files already formatted
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m mypy app/public_routes.py` -> success
- `git diff --check` -> clean

No private data, wallet material, credentials, production mutation, fund movement, MRWK price/off-ramp claims, exchange/liquidity claims, bridge claims, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "View JSON results" link on the bounties page that allows users to view the API data in JSON format while respecting all active filters, sorting preferences, and pagination limits.

* **Tests**
  * Enhanced test coverage to verify JSON result link generation with various filter, sort, and pagination combinations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->