### PR TITLE
Add canonical proof URL on proof pages

### DIFF
--- a/app/templates/proof.html
+++ b/app/templates/proof.html
@@ -26,6 +26,11 @@
       <code class="hash">{{ proof_hash }}</code>
     </article>
     <article>
+      <span>Canonical proof URL</span>
+      <strong><a href="/proofs/{{ proof_hash }}">/proofs/{{ proof_hash[:12] }}</a></strong>
+      <code class="hash">/proofs/{{ proof_hash }}</code>
+    </article>
+    <article>
       <span>Ledger hash</span>
       <code class="hash">{{ proof.ledger_hash }}</code>
     </article>
@@ -49,6 +54,8 @@
     <dt>Submission</dt>
     {% set submission_url = safe_public_url(proof.submission_url) %}
     <dd>{% if submission_url %}<a href="{{ submission_url }}">{{ proof.submission_url }}</a>{% else %}{{ proof.submission_url }}{% endif %}</dd>
+    <dt>Canonical proof URL</dt>
+    <dd><a href="/proofs/{{ proof_hash }}"><code>/proofs/{{ proof_hash }}</code></a></dd>
   </dl>
   {% if proof.kind == "bounty_payment" %}
   <div class="section-head">

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -617,6 +617,8 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert "MergeWork bounty" in proof_page.text
     assert f'href="/bounties/{bounty.id}"' in proof_page.text
     assert f'href="/ledger/{payment_sequence}"' in proof_page.text
+    assert "Canonical proof URL" in proof_page.text
+    assert f'href="/proofs/{proof_hash}"><code>/proofs/{proof_hash}</code></a>' in proof_page.text
     assert "Related activity" in proof_page.text
     assert 'href="/activity?q=github%3Acontributor"' in proof_page.text
     assert f'href="/activity?q={proof_hash}"' in proof_page.text
@@ -626,6 +628,10 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     uppercase_proof_page = client.get(f"/proofs/{proof_hash.upper()}")
     assert uppercase_proof_page.status_code == 200
     assert f'<code class="hash">{proof_hash}</code>' in uppercase_proof_page.text
+    assert (
+        f'href="/proofs/{proof_hash}"><code>/proofs/{proof_hash}</code></a>'
+        in uppercase_proof_page.text
+    )
     assert f'<code class="hash">{proof_hash.upper()}</code>' not in uppercase_proof_page.text
 
     missing_proof = client.get(f"/api/v1/proofs/{'0' * 64}")


### PR DESCRIPTION
Focused Bounty #580 UX/functional improvement: proof pages now expose a canonical normalized proof URL in the top proof summary and detail list, so public payment proofs are easier to cite, copy, and cross-check after following uppercase or mixed-case proof links.\n\nDistinctness: this targets the individual proof page citation surface. It does not overlap the activity JSON shortcut, bounty-list JSON shortcut, wallet/account navigation shortcuts, activity search/docs changes, or broader proof-to-activity navigation work already present.\n\nValidation:\n- python -m pytest tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable -q -> 1 passed\n- python -m pytest tests/test_bounty_pages.py tests/test_public_routes.py -q -> 13 passed\n- python -m ruff format --check tests\\test_bounty_pages.py -> passed\n- python -m ruff check tests\\test_bounty_pages.py -> passed\n- git diff --check -> clean, with Windows LF/CRLF warning only\n\nNo wallet material, private keys, cookies, OAuth state, access tokens, signatures, private data, deployment changes, price/liquidity/exchange/off-ramp claims, bridge promises, or fabricated payout claims are included.\n\nRefs #580

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proof detail pages now display a canonical proof URL section with both a shortened and complete proof hash reference, visible in both the metadata grid and details list.

* **Tests**
  * Updated tests to verify correct rendering of canonical proof URLs on proof detail pages, including uppercase hash handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->