### PR TITLE
Refs #426: Document treasury proposal API examples

### DIFF
--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -221,6 +221,52 @@ Unauthenticated requests return a public session shape with a `null` login:
 }
 ```
 
+Read pending or executed treasury proposals:
+
+```bash
+curl -s "$API_HOST/api/v1/treasury/proposals"
+curl -s "$API_HOST/api/v1/treasury/proposals/<proposal_id>"
+```
+
+Treasury proposal reads are public. The list endpoint returns the newest 100
+proposals first, and the detail endpoint returns one proposal by internal
+proposal id:
+
+```json
+{
+  "id": 2,
+  "type": "treasury_proposal",
+  "action": "create_bounty",
+  "status": "pending",
+  "payload_hash": "3d0292a4265d81afadbdfe24bdd76cbb463cc49b1717d38fe9ec3595906f659d",
+  "payload": {
+    "repo": "ramimbo/mergework",
+    "issue_number": 597,
+    "issue_url": "https://github.com/ramimbo/mergework/issues/597",
+    "title": "MRWK bounty: 75 MRWK - post-deploy treasury proposal verification",
+    "reward_mrwk": "75",
+    "max_awards": 8,
+    "acceptance": "Accepted work must verify or improve the live post-#458 treasury proposal workflow."
+  },
+  "proposed_by": "api-token",
+  "executed_by": null,
+  "proposed_at": "2026-05-28T20:27:20.476851",
+  "executes_after": "2026-05-29T20:27:20.476851",
+  "executed_at": null,
+  "executed_ledger_sequence": null,
+  "result": {},
+  "challenges": []
+}
+```
+
+`action` is one of `create_bounty`, `pay_bounty`, or `close_bounty`. Pending
+proposals can execute only after `executes_after`; executed proposals include
+`executed_at`, `executed_ledger_sequence`, and a result object such as the
+created bounty or proof-backed payout. `POST /api/v1/treasury/proposals` and
+`POST /api/v1/treasury/proposals/<proposal_id>/execute` require the admin
+token. `POST /api/v1/treasury/proposals/<proposal_id>/challenges` requires a
+GitHub-authenticated session with accepted MRWK work.
+
 Read recent ledger entries and inspect one entry:
 
 ```bash

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -98,6 +98,23 @@ def test_api_examples_document_auth_me_response_shape() -> None:
     assert "Unauthenticated requests return" in examples
 
 
+def test_api_examples_document_treasury_proposal_response_shape() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/treasury/proposals" in examples
+    assert "/api/v1/treasury/proposals/<proposal_id>" in examples
+    assert '"type": "treasury_proposal"' in examples
+    assert '"action": "create_bounty"' in examples
+    assert '"status": "pending"' in examples
+    assert '"payload_hash":' in examples
+    assert '"executes_after":' in examples
+    assert '"executed_ledger_sequence": null' in examples
+    assert '"challenges": []' in examples
+    assert "`create_bounty`, `pay_bounty`, or `close_bounty`" in examples
+    assert "admin token" in examples
+    assert "GitHub-authenticated session with accepted MRWK work" in examples
+
+
 def test_api_examples_document_bounty_list_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Refs #426

## Summary
- Add public treasury proposal list/detail examples to `docs/api-examples.md`.
- Document the response fields for pending/executed proposals, action values, admin-only proposal creation/execution, and accepted-work challenge gating.
- Add a docs regression test so the treasury proposal response shape stays covered.

## Evidence checked
- Compared the public read endpoints and auth boundaries against `app/treasury_routes.py`.
- Compared action names, proposal timing, execution fields, and challenge requirements against `app/treasury.py` and `tests/test_treasury_proposals.py`.
- Checked the live public proposal shape for the post-#458 treasury proposal flow without using admin tokens, wallet secrets, payout details, or mutations.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/test_docs_public_urls.py::test_api_examples_document_treasury_proposal_response_shape -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/test_docs_public_urls.py -q`
- `.venv/bin/python -m ruff check docs/api-examples.md tests/test_docs_public_urls.py`
- `.venv/bin/python -m ruff format --check tests/test_docs_public_urls.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python scripts/docs_smoke.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive API documentation for reading treasury proposals, including available endpoints and response field specifications. Documentation clarifies public access for list and detail reads versus admin-token requirements for other operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->