### PR TITLE
Refs #580: Link account pages to JSON views

### DIFF
--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -16,6 +16,10 @@
     <dt>Send status</dt>
     <dd>{{ account.transfer_status }}</dd>
   </dl>
+  <nav class="actions" aria-label="Account inspection links">
+    <a href="/api/v1/accounts/{{ account.account }}">View account JSON</a>
+    <a href="/api/v1/accounts/{{ account.account }}/accepted-work">View accepted-work JSON</a>
+  </nav>
 </section>
 
 <section aria-labelledby="accepted-work-summary">

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -92,6 +92,12 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     assert page_response.status_code == 200
     assert "github:bob" in page_response.text
     assert "25 MRWK" in page_response.text
+    assert 'aria-label="Account inspection links"' in page_response.text
+    assert 'href="/api/v1/accounts/github:bob">View account JSON</a>' in page_response.text
+    assert (
+        'href="/api/v1/accounts/github:bob/accepted-work">View accepted-work JSON</a>'
+        in page_response.text
+    )
     assert '<p class="reference-cell">' in page_response.text
     assert f'href="/proofs/{proof.hash}"' in page_response.text
 

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -81,7 +81,7 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
 
     api_response = client.get("/api/v1/accounts/GitHub:Bob")
     accepted_response = client.get("/api/v1/accounts/github:bob/accepted-work")
-    page_response = client.get("/accounts/github:bob")
+    page_response = client.get("/accounts/GitHub:Bob")
 
     assert api_response.status_code == 200
     assert api_response.json()["account"] == "github:bob"
@@ -93,11 +93,10 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     assert "github:bob" in page_response.text
     assert "25 MRWK" in page_response.text
     assert 'aria-label="Account inspection links"' in page_response.text
-    assert 'href="/api/v1/accounts/github:bob">View account JSON</a>' in page_response.text
-    assert (
-        'href="/api/v1/accounts/github:bob/accepted-work">View accepted-work JSON</a>'
-        in page_response.text
-    )
+    assert "/api/v1/accounts/github:bob" in page_response.text
+    assert "/api/v1/accounts/github:bob/accepted-work" in page_response.text
+    assert "View account JSON" in page_response.text
+    assert "View accepted-work JSON" in page_response.text
     assert '<p class="reference-cell">' in page_response.text
     assert f'href="/proofs/{proof.hash}"' in page_response.text
 


### PR DESCRIPTION
## Summary
- Add direct JSON inspection links to public account pages.
- Link each account page to `/api/v1/accounts/{account}` and `/api/v1/accounts/{account}/accepted-work`.
- Cover the rendered links in account route tests.

Refs #580.

## Evidence

### Confusion/bug addressed
Public account pages already summarize ledger balance, transaction rows, and proof-backed accepted work, but contributors had to manually rewrite `/accounts/<account>` into the matching API URLs to inspect or cite the machine-readable account data.

### Bounty capacity checked
Bounty #580 remains open as the site UX and functional-improvements round, with the maintainer's latest payment update leaving 2 slots remaining.

### Intended files/surfaces
- `app/templates/account.html`: add account JSON and accepted-work JSON inspection links.
- `tests/test_account_routes.py`: verify both links render for a populated public account page.

### Expected PR size
Small focused public account-page navigation improvement plus regression coverage.

### Out of scope
No wallet material, private keys, cookies, OAuth state, access tokens, signatures, private data, payout actions, deployment changes, price/liquidity/exchange/off-ramp claims, bridge promises, or fabricated payout claims.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/test_account_routes.py -q` -> 4 passed
- `.venv/bin/python -m ruff check tests/test_account_routes.py` -> passed
- `.venv/bin/python -m ruff format --check tests/test_account_routes.py` -> 1 file already formatted
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `.venv/bin/python -m ruff check .` -> passed
- `.venv/bin/python -m ruff format --check .` -> 87 files already formatted
- `.venv/bin/python -m mypy app` -> success
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q` -> 480 passed
- `git diff --check` -> clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account page now shows an "Account inspection links" actions block with links to view the account JSON and the accepted-work JSON.

* **Tests**
  * Updated tests to verify the actions block, link texts ("View account JSON", "View accepted-work JSON"), and normalized API link URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->