### PR TITLE
Refs #576: Mark public service links untrusted

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,7 +12,7 @@
       <nav>
         {% if site_context == "ltc_lab" %}
         <a href="#projects">Projects</a>
-        <a href="https://mrwk.ltclab.site">MRWK</a>
+        <a href="https://mrwk.ltclab.site" rel="nofollow noopener">MRWK</a>
         <a href="https://github.com/ramimbo/mergework" rel="nofollow noopener">GitHub</a>
         {% else %}
         <a href="/bounties">Bounties</a>

--- a/app/templates/docs.html
+++ b/app/templates/docs.html
@@ -7,10 +7,10 @@
   <p class="lead">MRWK starts as a native project coin on the MergeWork ledger and measures accepted contribution value inside the project.</p>
   <h2>Live sites</h2>
   <ul class="doc-list">
-    <li><a href="https://ltclab.site">LTC Lab</a></li>
-    <li><a href="https://mrwk.ltclab.site">MergeWork</a></li>
-    <li><a href="https://api.mrwk.ltclab.site">MergeWork API host</a></li>
-    <li><a href="https://mcp.mrwk.ltclab.site">MergeWork MCP host</a></li>
+    <li><a href="https://ltclab.site" rel="nofollow noopener">LTC Lab</a></li>
+    <li><a href="https://mrwk.ltclab.site" rel="nofollow noopener">MergeWork</a></li>
+    <li><a href="https://api.mrwk.ltclab.site" rel="nofollow noopener">MergeWork API host</a></li>
+    <li><a href="https://mcp.mrwk.ltclab.site" rel="nofollow noopener">MergeWork MCP host</a></li>
   </ul>
   <h2>Project docs</h2>
   <ul class="doc-list">

--- a/app/templates/hub.html
+++ b/app/templates/hub.html
@@ -9,9 +9,9 @@
     <a href="/bounties">View bounties</a>
     <a href="/ledger">Open explorer</a>
     <a href="/wallets">Create wallet</a>
-    <a href="https://ltclab.site">LTC Lab</a>
-    <a href="https://api.mrwk.ltclab.site">API host</a>
-    <a href="https://mcp.mrwk.ltclab.site">MCP host</a>
+    <a href="https://ltclab.site" rel="nofollow noopener">LTC Lab</a>
+    <a href="https://api.mrwk.ltclab.site" rel="nofollow noopener">API host</a>
+    <a href="https://mcp.mrwk.ltclab.site" rel="nofollow noopener">MCP host</a>
   </div>
 </section>
 <section class="grid">

--- a/app/templates/ltc_lab.html
+++ b/app/templates/ltc_lab.html
@@ -16,10 +16,10 @@
     {% for project in projects %}
     <article>
       <p class="eyebrow">{{ project.status }}</p>
-      <h2><a href="{{ project.href }}">{{ project.name }}</a></h2>
+      <h2><a href="{{ project.href }}" rel="nofollow noopener">{{ project.name }}</a></h2>
       <p>{{ project.tagline }}</p>
       <div class="actions">
-        <a href="{{ project.href }}">Open project</a>
+        <a href="{{ project.href }}" rel="nofollow noopener">Open project</a>
       </div>
     </article>
     {% endfor %}

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -53,6 +53,10 @@ def test_docs_page_marks_static_github_links_as_untrusted(sqlite_url: str) -> No
 
     assert page.status_code == 200
     for url in (
+        "https://ltclab.site",
+        "https://mrwk.ltclab.site",
+        "https://api.mrwk.ltclab.site",
+        "https://mcp.mrwk.ltclab.site",
         "https://github.com/ramimbo/mergework/discussions/16",
         "https://github.com/ramimbo/mergework/blob/main/docs/bounty-rules.md",
         "https://github.com/ramimbo/mergework/blob/main/docs/paid-bounties.md",
@@ -69,4 +73,33 @@ def test_ltc_lab_header_marks_github_nav_link_as_untrusted(sqlite_url: str) -> N
     page = client.get("/", headers={"host": "ltclab.site"})
 
     assert page.status_code == 200
+    assert ('href="https://mrwk.ltclab.site" rel="nofollow noopener"') in page.text
     assert ('href="https://github.com/ramimbo/mergework" rel="nofollow noopener"') in page.text
+
+
+def test_hub_marks_static_service_links_as_untrusted(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    page = client.get("/")
+
+    assert page.status_code == 200
+    for url in (
+        "https://ltclab.site",
+        "https://api.mrwk.ltclab.site",
+        "https://mcp.mrwk.ltclab.site",
+    ):
+        assert f'href="{url}" rel="nofollow noopener"' in page.text
+
+
+def test_ltc_lab_project_links_are_marked_untrusted(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    page = client.get("/", headers={"host": "ltclab.site"})
+
+    assert page.status_code == 200
+    for url in (
+        "https://mrwk.ltclab.site",
+        "https://api.mrwk.ltclab.site",
+        "https://mcp.mrwk.ltclab.site",
+    ):
+        assert f'href="{url}" rel="nofollow noopener"' in page.text


### PR DESCRIPTION
## Summary
- Add rel="nofollow noopener" to public service-host links on the MergeWork hub, docs live-sites list, and LTC Lab project/nav links.
- Extend public route regression coverage so the rendered pages keep static host links marked consistently with the existing external-link treatment.

## Distinctness for Bounty #576
- This covers non-GitHub service-host links: ltclab.site, mrwk.ltclab.site, api.mrwk.ltclab.site, and mcp.mrwk.ltclab.site.
- It does not overlap the account/activity dynamic-link PR #586, the header/docs GitHub-link PR #590, the ledger/proof PR #592, or the bounty-detail PR #594.

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_public_routes.py -q -> 6 passed, 1 warning
- uv run --extra dev python -m ruff check tests/test_public_routes.py -> passed
- uv run --extra dev python -m ruff format --check tests/test_public_routes.py -> already formatted
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py -> docs smoke ok
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q -> 484 passed, 1 warning
- git diff --check -> clean
- git diff --no-ext-diff upstream/main...HEAD | gitleaks stdin --no-banner --redact --exit-code 1 -> no leaks

No private keys, wallet material, cookies, tokens, OAuth state, signatures, private vulnerability details, deployment credentials, MRWK price claims, exchange claims, bridge claims, liquidity claims, off-ramp claims, or fabricated payout claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security for all external links by adding protective attributes to prevent tabnabbing attacks and ensure safer link handling across the application.

* **Tests**
  * Expanded test coverage to verify that external links include proper security attributes for improved link safety and security validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->