### PR TITLE
fix: avoid wallet transfer wording for plain accounts

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -97,7 +97,9 @@ def account_transfer_status(account: str) -> str:
             "Internal ledger account. MRWK wallet transfers are only available "
             "for registered mrwk1 addresses."
         )
-    return "MRWK wallet transfers are enabled for registered mrwk1 addresses."
+    if account.startswith("mrwk1"):
+        return "MRWK wallet transfers are enabled for registered mrwk1 addresses."
+    return "MRWK wallet transfers require a registered mrwk1 address."
 
 
 def account_api_context(session: Session, account: str) -> dict[str, Any]:

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -161,6 +161,24 @@ def test_account_page_filters_transactions_by_type(sqlite_url: str) -> None:
     assert "transaction type must be one of" in invalid.text
 
 
+def test_account_api_does_not_advertise_wallet_transfers_for_plain_accounts(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/api/v1/accounts/plain-account")
+
+    assert response.status_code == 200
+    assert response.json()["account"] == "plain-account"
+    assert response.json()["transfer_status"] == (
+        "MRWK wallet transfers require a registered mrwk1 address."
+    )
+
+
 def test_normalized_account_keeps_existing_account_validation_boundaries() -> None:
     assert normalized_account(" Reserve:Bounty:001 ") == "reserve:bounty:1"
     assert normalized_account("MRWK1" + ("A" * 40)) == "mrwk1" + ("a" * 40)


### PR DESCRIPTION
## Summary
- Stops plain ledger account API responses from advertising MRWK wallet transfers as enabled.
- Keeps GitHub, internal treasury/reserve, and real `mrwk1` wallet account transfer guidance distinct.
- Adds a regression test for `/api/v1/accounts/plain-account`.

Refs #576

## Test Plan
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest -q tests/test_account_routes.py::test_account_api_does_not_advertise_wallet_transfers_for_plain_accounts --tb=short` (RED before fix, GREEN after fix)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/python -m pytest -q tests/test_account_routes.py tests/test_wallet_api.py tests/test_bounty_pages.py --tb=short` -> 51 passed
- `./.venv/bin/python -m ruff check app/accounts.py tests/test_account_routes.py`
- `./.venv/bin/python -m ruff format --check app/accounts.py tests/test_account_routes.py`
- `git diff --check`

## Bounty
Focused small-fix submission for Bounty #576. Scope is limited to account API transfer-status wording for non-wallet plain ledger accounts and its regression coverage. No private data, wallet material, live-system security testing, exchange, bridge, or off-ramp claims are involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated wallet transfer status messages to provide clearer, account-specific information about MRWK wallet transfer availability and registration requirements based on account type.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->