### PR TITLE
Refs #576: Align admin webhook page limit cap

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from app.models import WebhookEvent
 from app.treasury import propose_treasury_action
 
-ADMIN_WEBHOOK_LIMIT_OPTIONS = [10, 25, 50, 100]
+ADMIN_WEBHOOK_LIMIT_OPTIONS = [10, 25, 50, 100, 200]
 WEBHOOK_OUTCOME_SCAN_ORDER = {
     "missing_submitter": 0,
     "bounty_not_found": 1,

--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -7,7 +7,11 @@ from fastapi import Depends, FastAPI, Form, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
-from app.admin import admin_page_context, create_admin_bounty_from_form
+from app.admin import (
+    ADMIN_WEBHOOK_LIMIT_OPTIONS,
+    admin_page_context,
+    create_admin_bounty_from_form,
+)
 from app.config import Settings
 from app.db import session_scope
 from app.ledger.service import LedgerError
@@ -45,7 +49,7 @@ def register_admin_routes(
     def admin_page(
         request: Request,
         webhook_status: str | None = Query(None),
-        webhook_limit: Annotated[int, Query(ge=1, le=100)] = 25,
+        webhook_limit: Annotated[int, Query(ge=1, le=max(ADMIN_WEBHOOK_LIMIT_OPTIONS))] = 25,
         proposal_id: Annotated[int | None, Query(ge=1)] = None,
     ) -> Any:
         login = admin_login_from_request(request)

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import pytest
 from fastapi.testclient import TestClient
 
+from app.db import create_schema, session_scope
 from app.main import create_app
+from app.models import WebhookEvent, utc_now
 
 
 def test_admin_login_callback_and_logout_routes_remain_registered(sqlite_url: str) -> None:
@@ -35,3 +38,39 @@ def test_admin_page_requires_oauth_config_before_redirect(sqlite_url: str) -> No
 
     assert response.status_code == 503
     assert response.json()["detail"] == "GitHub OAuth is not configured"
+
+
+def test_admin_webhook_page_allows_api_limit_cap(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        for index in range(120):
+            session.add(
+                WebhookEvent(
+                    delivery_id=f"delivery-{index:03d}",
+                    event_type="pull_request",
+                    processed_status="missing_submitter",
+                    payload_hash=f"hash-{index:03d}",
+                    created_at=utc_now(),
+                )
+            )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(
+        "/admin?webhook_status=missing_submitter&webhook_limit=200",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+    too_large = client.get(
+        "/admin?webhook_status=missing_submitter&webhook_limit=201",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+
+    assert response.status_code == 200
+    assert response.text.count('data-label="Delivery"') == 120
+    assert '<option value="200" selected>200</option>' in response.text
+    assert too_large.status_code == 422

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -210,7 +210,7 @@ def test_admin_page_renders_safe_webhook_events_for_cookie_admin(
     all_events = client.get("/admin?webhook_limit=10")
     filtered = client.get("/admin?webhook_status= missing_submitter &webhook_limit=10")
     limited = client.get("/admin?webhook_limit=1")
-    too_large = client.get("/admin?webhook_limit=101")
+    too_large = client.get("/admin?webhook_limit=201")
 
     assert unauthenticated.status_code == 302
     assert unauthenticated.headers["location"] == "/auth/github/login?next=/admin"


### PR DESCRIPTION
Bounty #576

Summary:
- raise the `/admin` webhook event page `webhook_limit` validation cap from 100 to 200
- add 200 to the admin page limit selector
- derive the route validation cap from `ADMIN_WEBHOOK_LIMIT_OPTIONS` so the selector and query validation stay in sync
- cover both the accepted 200-cap path and the rejected 201 boundary with rendered admin-page regression tests

Evidence:
- `/api/v1/admin/webhook-events` already accepts `limit=1..200`, and the admin runbook documents that public admin-token API cap.
- The `/admin` UI shows the same recent webhook-event data but rejected `webhook_limit=200` and offered no 200-row option.
- This is distinct from prior webhook-event/admin-page work because it only aligns the admin HTML page limit cap and selector with the existing API cap.
- CodeRabbit's review comments were addressed in commit `017ee8d` by using the admin limit option constant as the source of truth and adding the explicit over-cap assertion.

Validation:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 483 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_admin_routes.py tests/test_security.py::test_admin_page_renders_safe_webhook_events_for_cookie_admin -q` -> 4 passed, 1 warning
- `uv run --extra dev python scripts/check_agents.py` -> AGENTS.md ok
- `uv run --extra dev python -m ruff format --check .` -> 87 files already formatted
- `uv run --extra dev python -m ruff check .` -> passed
- `uv run --extra dev python -m mypy app` -> success
- deploy readiness check with the CI env fixture values -> passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean
- GitHub Actions `Quality, readiness, docs, and image checks` -> passing on commit `017ee8d`
- CodeRabbit -> pass / review skipped after final patch

Local Docker image build was not run because `docker` is not installed on this Mac. The hosted GitHub Actions job includes the Docker build and is passing.

No private data, secrets, admin token values, wallet material, production mutation, price, exchange, bridge, off-ramp, or fabricated payout claims are included.