### PR TITLE
Refs #576: Align webhook runbook max-limit example

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -145,7 +145,7 @@ missing submitters, exhausted bounties, and already-paid submissions without
 guessing from GitHub labels alone.
 Use `limit` to control the number of delivery rows returned (`1` to `200`,
 default `50`), for example:
-`/api/v1/admin/webhook-events?status=missing_submitter&limit=100`.
+`/api/v1/admin/webhook-events?status=missing_submitter&limit=200`.
 
 ### PR Queue Health
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -106,6 +106,14 @@ def test_api_examples_document_auth_me_response_shape() -> None:
     assert "Unauthenticated requests return" in examples
 
 
+def test_admin_runbook_documents_webhook_event_limit_cap() -> None:
+    runbook = Path("docs/admin-runbook.md").read_text(encoding="utf-8")
+
+    assert "Use `limit` to control the number of delivery rows returned (`1` to `200`" in runbook
+    assert "/api/v1/admin/webhook-events?status=missing_submitter&limit=200" in runbook
+    assert "/api/v1/admin/webhook-events?status=missing_submitter&limit=100" not in runbook
+
+
 def test_api_examples_document_bounty_list_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
Bounty #576

Summary:
- update the admin runbook webhook-events example to use the documented maximum `limit=200` instead of `limit=100`
- add a docs regression test so the runbook keeps the `1` to `200` cap and max-limit example aligned

Evidence:
- `/api/v1/admin/webhook-events` is bounded at `limit=1..200` in the API route.
- The runbook already documented the `1` to `200` range but the copy-paste example still used `limit=100`, which could make operators miss the true max-row inspection path before retrying labels or checking payout outcomes.
- This is docs/test only and is distinct from #606: #606 aligns the `/admin` HTML page selector/query validation, while this PR aligns the admin-token API runbook example.

Validation:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_docs_public_urls.py::test_admin_runbook_documents_webhook_event_limit_cap -q` -> 1 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_docs_public_urls.py -q` -> 24 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --extra dev python -m ruff check tests/test_docs_public_urls.py` -> passed
- `uv run --extra dev python -m ruff format --check tests/test_docs_public_urls.py` -> 1 file already formatted
- `git diff --check` -> clean

No private data, secrets, admin token values, wallet material, production mutation, price, liquidity, exchange, bridge, off-ramp, or fabricated payout claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated webhook-events API documentation with increased limit parameters for status queries
* **Tests**
  * Added test to verify webhook event limit documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->