### PR TITLE
Refs #576: Reject control chars in wallet search

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from typing import Any
 from urllib.parse import urlencode
@@ -22,6 +23,8 @@ from app.status import (
     FUTURE_PATH_BOUNDARY,
     UNSUPPORTED_PUBLIC_PATHS_SUMMARY,
 )
+
+CONTROL_CHARACTER_RE = r"[\x00-\x1f\x7f]"
 
 
 def _bounties_api_url(
@@ -66,6 +69,8 @@ def public_bounties_context(
 
 
 def wallets_page_context(session: Session, q: str | None = None) -> dict[str, Any]:
+    if q is not None and re.search(CONTROL_CHARACTER_RE, q):
+        raise HTTPException(status_code=400, detail="q must not contain control characters")
     query_text = q.strip() if q is not None else ""
     query = select(Wallet)
     if query_text:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -580,6 +580,16 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Link a wallet" in me
 
 
+def test_wallet_search_rejects_control_characters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/wallets", params={"q": "\t"})
+
+    assert response.status_code == 400
+    assert "q must not contain control characters" in response.text
+
+
 def test_me_page_shows_signed_in_github_claim_balance(sqlite_url: str, monkeypatch) -> None:
     monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
     create_schema(sqlite_url)


### PR DESCRIPTION
## Summary

- Reject raw control characters in the public `/wallets?q=...` search query before trimming.
- Add a regression for tab-only wallet search returning a bounded 400 instead of being treated as an empty search.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/test_wallet_api.py::test_wallet_search_rejects_control_characters tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows -q` -> 2 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/test_wallet_api.py -q` -> 34 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m ruff check app/public_routes.py tests/test_wallet_api.py` -> passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m ruff format --check app/public_routes.py tests/test_wallet_api.py` -> 2 files already formatted
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m mypy app/public_routes.py` -> success
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No private data, wallet material, production mutation, price/liquidity/exchange/bridge/off-ramp claim, or fabricated payout claim is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * API now rejects wallet search requests containing control characters with an HTTP 400 error.

* **Tests**
  * Added test coverage for control character validation in wallet search.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->