### PR TITLE
Refs #576: Reject control chars in wallet type filters

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from app.accounts import normalized_wallet_address
 from app.bounty_sorting import BOUNTY_SORT_LABELS, normalize_bounty_sort
 from app.db import session_scope
+from app.ledger.service import CONTROL_CHAR_RE
 from app.ledger_views import account_ledger_transaction_types, account_ledger_transactions
 from app.models import Wallet
 from app.path_params import proof_hash_from_path
@@ -94,6 +95,10 @@ def wallet_page_context(
     wallet = session.get(Wallet, normalized_address)
     if wallet is None:
         raise HTTPException(status_code=404, detail="wallet not found")
+    if transaction_type is not None and CONTROL_CHAR_RE.search(transaction_type):
+        raise HTTPException(
+            status_code=400, detail="transaction type must not contain control characters"
+        )
     selected_transaction_type = transaction_type.strip() if transaction_type is not None else ""
     return {
         "wallet": wallet_to_dict(session, wallet),

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -539,6 +539,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     funded_detail = client.get(f"/wallets/{funded_address}").text
     funded_type_filter = client.get(f"/wallets/{funded_address}?type=test_funding").text
     funded_missing_type = client.get(f"/wallets/{funded_address}?type=bounty_payment").text
+    funded_control_type = client.get(f"/wallets/{funded_address}?type=%09")
     transfer = client.get("/transfer").text
     me = client.get("/me").text
 
@@ -574,6 +575,8 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert 'value="test_funding" selected' in funded_type_filter
     assert "Showing test_funding transactions." in funded_type_filter
     assert "No wallet transactions match this type." in funded_missing_type
+    assert funded_control_type.status_code == 400
+    assert "transaction type must not contain control characters" in funded_control_type.text
     assert "Signed transfer" in transfer
     assert "both wallets are registered" in transfer
     assert "/static/wallet.js" in transfer


### PR DESCRIPTION
## Summary
- Reject control characters in the public wallet detail `type` filter before trimming/rendering.
- Keep existing clean type-filter behavior unchanged, including unknown clean types rendering an empty filtered state.
- Add a wallet page regression for `type=%09`.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows -q` -> 1 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_wallet_api.py -q` -> 33 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 482 passed, 1 warning
- `uv run --extra dev python -m ruff check app/public_routes.py tests/test_wallet_api.py` -> passed
- `uv run --extra dev python -m ruff format --check app/public_routes.py tests/test_wallet_api.py` -> 2 files already formatted
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m mypy app/public_routes.py` -> success
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No private data, wallet material, tokens, signatures, live mutations, admin access, price/liquidity/exchange/bridge/off-ramp claims, or fabricated payout claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced wallet transaction type filtering with improved validation to reject inputs containing invalid characters, preventing processing errors and providing clearer feedback when invalid transaction types are submitted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->