### PR TITLE
Refs #576: Reject control chars in account transaction filters

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -9,7 +9,7 @@ from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
 from app.db import session_scope
-from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
+from app.ledger.service import CONTROL_CHAR_RE, TREASURY_ACCOUNT, format_mrwk, get_balance
 from app.ledger_views import account_ledger_transactions
 from app.models import Account
 from app.path_params import SQLITE_INTEGER_MAX
@@ -124,6 +124,10 @@ def account_accepted_work_context(session: Session, account: str) -> dict[str, A
 
 
 def _transaction_type_filter(tx_type: str | None) -> tuple[str, str | None]:
+    if tx_type is not None and CONTROL_CHAR_RE.search(tx_type):
+        raise HTTPException(
+            status_code=400, detail="transaction type must not contain control characters"
+        )
     selected = (tx_type or "all").strip().lower()
     if selected in {"", "all"}:
         return "all", None

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -140,6 +140,7 @@ def test_account_page_filters_transactions_by_type(sqlite_url: str) -> None:
     payments = client.get("/accounts/github:alice?tx_type=bounty_payment")
     claims = client.get("/accounts/github:alice?tx_type=github_claim")
     invalid = client.get("/accounts/github:alice?tx_type=bogus")
+    control_char = client.get("/accounts/github:alice?tx_type=%09")
 
     assert all_rows.status_code == 200
     assert "Transaction type filters" in all_rows.text
@@ -159,6 +160,9 @@ def test_account_page_filters_transactions_by_type(sqlite_url: str) -> None:
 
     assert invalid.status_code == 400
     assert "transaction type must be one of" in invalid.text
+
+    assert control_char.status_code == 400
+    assert "transaction type must not contain control characters" in control_char.text
 
 
 def test_normalized_account_keeps_existing_account_validation_boundaries() -> None:


### PR DESCRIPTION
## Summary
- reject raw control characters in `/accounts/{account}?tx_type=...` before trimming the transaction-type filter
- add regression coverage so `tx_type=%09` returns a bounded 400 instead of falling back to the all-transactions view

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_account_routes.py::test_account_page_filters_transactions_by_type -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_account_routes.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff check app/accounts.py tests/test_account_routes.py`
- `uv run --extra dev ruff format --check app/accounts.py tests/test_account_routes.py`
- `uv run --extra dev mypy app/accounts.py`
- `uv run --extra dev python scripts/docs_smoke.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction type filter validation now rejects inputs containing control characters and responds with HTTP 400 and a descriptive error message.

* **Tests**
  * Added test coverage for control character validation in the transaction type filter endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->