### PR TITLE
Refs #576: Honor treasury proposal list limit

### DIFF
--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from sqlalchemy import select
 
 from app.db import session_scope
@@ -44,10 +44,12 @@ def register_treasury_routes(
     json_object: Any,
 ) -> None:
     @app.get("/api/v1/treasury/proposals")
-    def api_treasury_proposals() -> list[dict[str, Any]]:
+    def api_treasury_proposals(
+        limit: Annotated[int, Query(ge=1, le=200)] = 100,
+    ) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
             proposals = session.scalars(
-                select(TreasuryProposal).order_by(TreasuryProposal.id.desc()).limit(100)
+                select(TreasuryProposal).order_by(TreasuryProposal.id.desc()).limit(limit)
             ).all()
             return [proposal_to_dict(proposal) for proposal in proposals]
 

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -119,6 +119,28 @@ def test_treasury_proposals_list_newest_first(
     assert [proposal["id"] for proposal in listed.json()] == [second["id"], first["id"]]
 
 
+def test_treasury_proposals_list_honors_limit(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _client(sqlite_url, monkeypatch)
+    first = client.post(
+        "/api/v1/bounties", headers=ADMIN_HEADERS, json=_bounty_payload(issue_number=72)
+    ).json()
+    second = client.post(
+        "/api/v1/bounties", headers=ADMIN_HEADERS, json=_bounty_payload(issue_number=73)
+    ).json()
+
+    limited = client.get("/api/v1/treasury/proposals?limit=1")
+    too_small = client.get("/api/v1/treasury/proposals?limit=0")
+    too_large = client.get("/api/v1/treasury/proposals?limit=201")
+
+    assert limited.status_code == 200
+    assert [proposal["id"] for proposal in limited.json()] == [second["id"]]
+    assert first["id"] not in [proposal["id"] for proposal in limited.json()]
+    assert too_small.status_code == 422
+    assert too_large.status_code == 422
+
+
 def test_direct_proposal_creation_requires_admin_token(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
﻿## Summary
- Add a validated `limit` query parameter to `GET /api/v1/treasury/proposals`, defaulting to the existing 100-row behavior and accepting `1..200` like the other public list APIs.
- Keep newest-first proposal ordering unchanged while letting agents and smoke checks request only the newest rows.
- Add regression coverage for `limit=1` and FastAPI boundary rejection at `limit=0` and `limit=201`.

## Evidence
Bounty #576 is open with 11 award slots remaining and no active attempts on internal bounty id 83 at the time of submission.

Before this fix, the public treasury proposal route always applied `.limit(100)` internally and ignored a caller-supplied `?limit=1`, so API consumers could not narrow the proposal list even though similar public list endpoints expose validated limits. This is a focused post-treasury-deploy API consistency fix; it does not overlap the recent wallet/account control-character PRs, admin webhook limit PRs, public link hardening, punctuation, or docs-only treasury proposal examples.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests/test_treasury_proposals.py::test_treasury_proposals_list_honors_limit tests/test_treasury_proposals.py::test_treasury_proposals_list_newest_first -q` -> 2 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests/test_treasury_proposals.py -q` -> 24 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest -q` -> 483 passed
- `.\.venv\Scripts\python.exe -m ruff check app/treasury_routes.py tests/test_treasury_proposals.py` -> passed
- `.\.venv\Scripts\python.exe -m ruff format --check app/treasury_routes.py tests/test_treasury_proposals.py` -> 2 files already formatted
- `.\.venv\Scripts\python.exe -m mypy app\treasury_routes.py app\treasury.py` -> success
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

Refs #576

No private data, wallet material, cookies, tokens, OAuth state, signatures, admin token values, production mutation, price/liquidity/exchange/bridge/off-ramp claims, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Treasury proposals listing now supports a configurable `limit` query parameter, allowing users to specify how many proposals appear in results. The limit accepts values between 1 and 200, with a default of 100.

* **Tests**
  * Added test coverage for the new limit parameter, including validation of boundary conditions and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/611?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->