### PR TITLE
Refs #576: Reject control chars in MCP clean filters

### DIFF
--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -9,7 +9,13 @@ from app.accounts import normalized_account, normalized_wallet_address
 from app.bounty_attempts import list_bounty_attempts
 from app.bounty_sorting import normalize_bounty_sort, sort_bounties
 from app.db import session_scope
-from app.ledger.service import format_mrwk, get_balance, register_wallet, submit_wallet_transfer
+from app.ledger.service import (
+    CONTROL_CHAR_RE,
+    format_mrwk,
+    get_balance,
+    register_wallet,
+    submit_wallet_transfer,
+)
 from app.ledger_views import ledger_entry_to_dict
 from app.mcp_work_proof import (
     generic_work_proof_guidance_json,
@@ -76,6 +82,8 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             return None
         if not isinstance(value, str):
             raise ValueError(f"{field} must be a string")
+        if CONTROL_CHAR_RE.search(value):
+            raise ValueError(f"{field} must not contain control characters")
         clean = value.strip()
         return clean or None
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -56,6 +56,56 @@ def test_submit_work_proof_repo_selector_matches_stored_repo_case(sqlite_url: st
 
 
 @pytest.mark.parametrize(
+    ("arguments", "message"),
+    [
+        ({"status": "\t"}, "status must not contain control characters"),
+        ({"sort": "reward\n"}, "sort must not contain control characters"),
+        ({"q": "proof\r"}, "q must not contain control characters"),
+    ],
+)
+def test_list_bounties_rejects_control_character_filters(
+    sqlite_url: str, arguments: dict[str, object], message: str
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=390,
+            issue_url="https://github.com/ramimbo/mergework/issues/390",
+            title="Code health bounty",
+            reward_mrwk="200",
+            acceptance="Extract a coherent subsystem from app.main.",
+        )
+
+    with pytest.raises(ValueError, match=message):
+        call_mcp_tool(sqlite_url, "list_bounties", arguments)
+
+
+def test_submit_work_proof_rejects_control_character_repo_selector(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=390,
+            issue_url="https://github.com/ramimbo/mergework/issues/390",
+            title="Code health bounty",
+            reward_mrwk="200",
+            acceptance="Extract a coherent subsystem from app.main.",
+        )
+
+    with pytest.raises(ValueError, match="repo must not contain control characters"):
+        call_mcp_tool(
+            sqlite_url,
+            "submit_work_proof",
+            {"issue_number": 390, "repo": "ramimbo/mergework\n"},
+        )
+
+
+@pytest.mark.parametrize(
     ("tool_name", "arguments", "message"),
     [
         ("list_bounties", {"status": "blocked"}, "status must be one of"),


### PR DESCRIPTION
## Summary
- reject raw control characters in MCP optional clean-string arguments before trimming
- cover `list_bounties` `status`/`sort`/`q` filters and `submit_work_proof` repo selector regressions

## Distinctness
- covers MCP tool argument handling only
- does not overlap PR #608 (`/wallets?q=...`), PR #609 (`/wallets/{address}?type=...`), PR #610 (`/accounts/{account}?tx_type=...`), or public route/query validation work

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_mcp_tools.py -q` -> 9 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_mcp_tools.py tests/test_api_mcp.py -q` -> 91 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 486 passed, 1 warning
- `uv run --extra dev ruff check app/mcp_tools.py tests/test_mcp_tools.py` -> passed
- `uv run --extra dev ruff format --check app/mcp_tools.py tests/test_mcp_tools.py` -> 2 files already formatted
- `uv run --extra dev mypy app/mcp_tools.py` -> success
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No private data, wallet material, tokens, signatures, live mutations, admin access, price/liquidity/exchange/bridge/off-ramp claims, or fabricated payout claims were used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation for bounty list filtering (status, sort, query fields) and work proof submission to reject requests containing invalid control characters.

* **Tests**
  * Added comprehensive test coverage validating control character rejection across tool inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->