### PR TITLE
Refs #576: Reject control chars in admin webhook filters

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from typing import Any
 
+from fastapi import HTTPException
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.ledger.service import CONTROL_CHAR_RE
 from app.models import WebhookEvent
 from app.treasury import propose_treasury_action
 
@@ -23,6 +25,10 @@ WEBHOOK_OUTCOME_SCAN_ORDER = {
 def normalize_webhook_status_filter(status: str | None) -> str | None:
     if status is None:
         return None
+    if CONTROL_CHAR_RE.search(status):
+        raise HTTPException(
+            status_code=400, detail="webhook status must not contain control characters"
+        )
     normalized = status.strip().lower()
     return normalized or None
 

--- a/tests/test_admin_helpers.py
+++ b/tests/test_admin_helpers.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime, timedelta
 
+import pytest
+from fastapi import HTTPException
 from sqlalchemy import func, select
 
 from app.admin import (
@@ -38,6 +40,14 @@ def test_normalize_webhook_status_filter_trims_and_lowers() -> None:
     assert normalize_webhook_status_filter(None) is None
     assert normalize_webhook_status_filter("   ") is None
     assert normalize_webhook_status_filter(" Missing_Submitter ") == "missing_submitter"
+
+
+def test_normalize_webhook_status_filter_rejects_control_characters() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        normalize_webhook_status_filter("missing_submitter\t")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "webhook status must not contain control characters"
 
 
 def test_list_webhook_events_filters_and_serializes_safe_fields(sqlite_url: str) -> None:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -209,6 +209,7 @@ def test_admin_page_renders_safe_webhook_events_for_cookie_admin(
     client.cookies.set("mrwk_admin", _signed_value("alice", "test-cookie-secret"))
     all_events = client.get("/admin?webhook_limit=10")
     filtered = client.get("/admin?webhook_status= missing_submitter &webhook_limit=10")
+    control_char_filter = client.get("/admin?webhook_status=%09&webhook_limit=10")
     limited = client.get("/admin?webhook_limit=1")
     too_large = client.get("/admin?webhook_limit=101")
 
@@ -242,6 +243,8 @@ def test_admin_page_renders_safe_webhook_events_for_cookie_admin(
     assert "bounty_not_found" in filtered.text
     assert "a" * 64 in filtered.text
     assert "secret-payload-body" not in filtered.text
+    assert control_char_filter.status_code == 400
+    assert "webhook status must not contain control characters" in control_char_filter.text
     assert limited.status_code == 200
     assert limited.text.count("<tr>") == 2
     assert too_large.status_code == 422
@@ -428,6 +431,10 @@ def test_admin_webhook_events_api_lists_and_filters_processing_outcomes(
         "/api/v1/admin/webhook-events?status= Missing_Submitter ",
         headers={"x-mergework-admin-token": "admin-token-for-tests"},
     )
+    control_char_filter = client.get(
+        "/api/v1/admin/webhook-events?status=%09",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
     limited = client.get(
         "/api/v1/admin/webhook-events?limit=1",
         headers={"x-mergework-admin-token": "admin-token-for-tests"},
@@ -452,6 +459,10 @@ def test_admin_webhook_events_api_lists_and_filters_processing_outcomes(
             "created_at": filtered.json()[0]["created_at"],
         }
     ]
+    assert control_char_filter.status_code == 400
+    assert control_char_filter.json() == {
+        "detail": "webhook status must not contain control characters"
+    }
     assert limited.status_code == 200
     assert len(limited.json()) == 1
     assert too_large.status_code == 422


### PR DESCRIPTION
## Summary

- reject raw control characters in admin webhook status filters before trimming
- preserve the existing whitespace-trim/lowercase behavior for normal status filters
- add regression coverage for both the admin HTML page and admin webhook-events API

## Evidence

Before this change, admin webhook status filters accepted raw control-character input after normalization:

- `GET /api/v1/admin/webhook-events?status=%09&limit=10` returned the normal event list
- `GET /api/v1/admin/webhook-events?status=missing_submitter%09&limit=10` matched `missing_submitter`

That made control-character input behave like a clean or empty filter instead of failing closed. This PR validates the raw status string first and returns a bounded `400` with `webhook status must not contain control characters`.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_admin_helpers.py::test_normalize_webhook_status_filter_rejects_control_characters tests/test_security.py::test_admin_page_renders_safe_webhook_events_for_cookie_admin tests/test_security.py::test_admin_webhook_events_api_lists_and_filters_processing_outcomes -q` -> 3 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_admin_helpers.py tests/test_security.py -q` -> 57 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 483 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m ruff check app/admin.py tests/test_admin_helpers.py tests/test_security.py` -> passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m ruff format --check app/admin.py tests/test_admin_helpers.py tests/test_security.py` -> 3 files already formatted
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m mypy app/admin.py` -> success
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `949c5afeaedfd962925774fc0ec7a0c10a4795d2`

## Safety

No private data, admin token values, wallet material, production mutation, private security details, price/liquidity/exchange/bridge/off-ramp claims, or fabricated payout claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook status filtering now validates input more strictly, rejecting strings containing control characters and returning a 400 error response with a descriptive message.

* **Tests**
  * Added validation tests to verify webhook status filter handling in the admin interface and API endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->