### PR TITLE
Refs #576: Reject control chars in JSON integer fields

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -146,6 +146,10 @@ def _parse_int(value: Any, field: str) -> int:
     if isinstance(value, int):
         return value
     if isinstance(value, str):
+        if any(ord(char) < 32 or ord(char) == 127 for char in value):
+            raise HTTPException(
+                status_code=400, detail=f"{field} must not contain control characters"
+            )
         clean = value.strip()
         if clean and clean.lstrip("+-").isdigit():
             try:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -134,6 +134,40 @@ def test_wallet_transfer_api_rejects_replayed_signed_body(sqlite_url: str) -> No
     assert second.json()["detail"] == "invalid nonce"
 
 
+def test_wallet_transfer_api_rejects_control_character_nonce_string(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    sender_key, sender_public, sender_address = _keypair()
+    _, receiver_public, receiver_address = _keypair()
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _register_wallet(client, sender_public)
+    _register_wallet(client, receiver_public)
+    _fund_wallet(sqlite_url, sender_address)
+
+    payload = wallet_transfer_payload(
+        from_address=sender_address,
+        to_address=receiver_address,
+        amount_microunits=1_000_000,
+        nonce=1,
+        memo="",
+    )
+
+    response = client.post(
+        "/api/v1/transfers",
+        json={
+            "from_address": sender_address,
+            "to_address": receiver_address,
+            "amount_mrwk": "1",
+            "nonce": "\t1",
+            "memo": "",
+            "signature_hex": _sign(sender_key, payload),
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "nonce must not contain control characters"
+    assert client.get(f"/api/v1/wallets/{receiver_address}").json()["balance_mrwk"] == "0"
+
+
 @pytest.mark.parametrize(
     ("body_overrides", "payload_overrides", "expected_detail"),
     [


### PR DESCRIPTION
## Summary

- reject raw control characters in shared JSON integer parsing before trimming string values
- keep clean integer strings and JSON integers accepted
- add a wallet transfer regression proving `nonce="\t1"` no longer succeeds even with a signature for nonce `1`

## Evidence

Before this fix, the public wallet transfer API accepted a control-character-padded integer string after `strip()`: `POST /api/v1/transfers` with `nonce="\t1"` and a valid signature for nonce `1` returned HTTP 200 and created a transfer. That makes the submitted body less strict than the signed canonical integer payload.

This PR rejects C0/DEL control characters in `_parse_int()` before whitespace normalization, so shared JSON body integer fields fail closed with a bounded `400` such as `nonce must not contain control characters`.

## Validation

- `tests/test_wallet_api.py::test_wallet_transfer_api_rejects_control_character_nonce_string` -> 1 passed, 1 warning
- focused wallet transfer tests -> 6 passed, 1 warning
- `tests/test_wallet_api.py` -> 34 passed, 1 warning
- full pytest -> 483 passed, 1 warning
- `ruff check app/main.py tests/test_wallet_api.py` -> passed
- `ruff format --check app/main.py tests/test_wallet_api.py` -> 2 files already formatted
- `mypy app/main.py` -> success
- `scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No private data, wallet private material, tokens, admin access, production mutation, price/liquidity/exchange/bridge/off-ramp claims, or fabricated payout claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced API input validation to reject strings containing ASCII control characters, returning a 400 error response to prevent invalid requests from being processed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->