### PR TITLE
Refs #576: Reject control chars in bounty filters

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -11,7 +11,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from app.admin import list_webhook_events, webhook_events_to_dict
-from app.bounty_sorting import BOUNTY_SORT_ERROR, normalize_bounty_sort, sort_bounties
+from app.bounty_sorting import normalize_bounty_sort, normalize_bounty_status, sort_bounties
 from app.config import Settings
 from app.db import session_scope
 from app.ledger.reconciliation import payout_reconciliation_summary, reconcile_accepted_payouts
@@ -104,15 +104,14 @@ def register_bounty_api_routes(
         try:
             normalized_sort = normalize_bounty_sort(sort)
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=BOUNTY_SORT_ERROR) from exc
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
         with session_scope(db_url) as session:
             query = select(Bounty)
             if status is not None:
-                normalized_status = status.strip().lower()
-                if normalized_status not in {"open", "paid", "closed"}:
-                    raise HTTPException(
-                        status_code=400, detail="status must be one of: open, paid, closed"
-                    )
+                try:
+                    normalized_status = normalize_bounty_status(status)
+                except ValueError as exc:
+                    raise HTTPException(status_code=400, detail=str(exc)) from exc
                 query = query.where(Bounty.status == normalized_status)
             if query_text is not None:
                 normalized_query = query_text.strip()

--- a/app/bounty_sorting.py
+++ b/app/bounty_sorting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from decimal import Decimal
 from typing import Any
 
@@ -13,15 +14,30 @@ BOUNTY_SORT_LABELS = {
 }
 BOUNTY_SORT_OPTIONS = tuple(BOUNTY_SORT_LABELS)
 BOUNTY_SORT_ERROR = f"sort must be one of: {', '.join(BOUNTY_SORT_OPTIONS)}"
+BOUNTY_STATUS_ERROR = "status must be one of: open, paid, closed"
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 
 
 def normalize_bounty_sort(sort: str | None) -> str:
+    if sort is not None and CONTROL_CHAR_RE.search(sort):
+        raise ValueError("sort must not contain control characters")
     normalized_sort = (sort or "").strip().lower()
     if not normalized_sort:
         return "newest"
     if normalized_sort not in BOUNTY_SORT_OPTIONS:
         raise ValueError(BOUNTY_SORT_ERROR)
     return normalized_sort
+
+
+def normalize_bounty_status(status: str | None) -> str | None:
+    if status is None:
+        return None
+    if CONTROL_CHAR_RE.search(status):
+        raise ValueError("status must not contain control characters")
+    normalized_status = status.strip().lower()
+    if normalized_status not in {"open", "paid", "closed"}:
+        raise ValueError(BOUNTY_STATUS_ERROR)
+    return normalized_status
 
 
 def sort_bounties(bounties: list[dict[str, Any]], sort: str | None) -> list[dict[str, Any]]:

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -11,7 +11,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from app.accounts import normalized_wallet_address
-from app.bounty_sorting import BOUNTY_SORT_LABELS, normalize_bounty_sort
+from app.bounty_sorting import BOUNTY_SORT_LABELS, normalize_bounty_sort, normalize_bounty_status
 from app.db import session_scope
 from app.ledger_views import account_ledger_transaction_types, account_ledger_transactions
 from app.models import Wallet
@@ -46,7 +46,7 @@ def public_bounties_context(
     sort: str | None = None,
     limit: int | None = None,
 ) -> dict[str, Any]:
-    selected_status = status.strip().lower() if status is not None else None
+    selected_status = normalize_bounty_status(status)
     query_text = q.strip() if q is not None else ""
     selected_sort = normalize_bounty_sort(sort)
     limit_options: tuple[int, ...] = (10, 25, 50, 100, 200)

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -313,3 +313,34 @@ def test_bounty_api_limit_rejects_out_of_range_values(sqlite_url: str) -> None:
     assert client.get("/api/v1/bounties?limit=201").status_code == 422
     assert client.get("/api/v1/bounties/summary?limit=0").status_code == 422
     assert client.get("/api/v1/bounties/summary?limit=201").status_code == 422
+
+
+def test_bounty_api_rejects_status_and_sort_control_characters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=53,
+            issue_url="https://github.com/ramimbo/mergework/issues/53",
+            title="Control character bounty",
+            reward_mrwk="5",
+            acceptance="Control characters should fail closed.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    status_response = client.get("/api/v1/bounties?status=%09open")
+    status_summary = client.get("/api/v1/bounties/summary?status=%09open")
+    sort_response = client.get("/api/v1/bounties?sort=%09reward")
+    sort_summary = client.get("/api/v1/bounties/summary?sort=%09reward")
+
+    assert status_response.status_code == 400
+    assert status_response.json()["detail"] == "status must not contain control characters"
+    assert status_summary.status_code == 400
+    assert status_summary.json()["detail"] == "status must not contain control characters"
+    assert sort_response.status_code == 400
+    assert sort_response.json()["detail"] == "sort must not contain control characters"
+    assert sort_summary.status_code == 400
+    assert sort_summary.json()["detail"] == "sort must not contain control characters"

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -78,6 +78,31 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert 'href="/bounties?status=paid" aria-current="page"' in paid_rows_uppercase.text
 
 
+def test_bounties_page_rejects_status_and_sort_control_characters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=52,
+            issue_url="https://github.com/ramimbo/mergework/issues/52",
+            title="Control public bounty",
+            reward_mrwk="50",
+            acceptance="Control-character filters should fail closed.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    status_page = client.get("/bounties?status=%09open")
+    sort_page = client.get("/bounties?sort=%09reward")
+
+    assert status_page.status_code == 400
+    assert "status must not contain control characters" in status_page.text
+    assert sort_page.status_code == 400
+    assert "sort must not contain control characters" in sort_page.text
+
+
 def test_bounties_summary_api_matches_public_list_filters(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
## Summary

- reject raw control characters in public bounty `status` and `sort` filters before `strip().lower()` normalization
- share bounty status normalization with the public page context so HTML and JSON routes fail closed consistently
- add regression coverage for API, summary, and public `/bounties` page requests

## Evidence

Before this fix, the bounty list accepted control-character-prefixed filters as clean values:

- `GET /api/v1/bounties?status=%09open` -> HTTP 200, filtered as `open`
- `GET /api/v1/bounties/summary?status=%09paid` -> HTTP 200
- `GET /bounties?status=%09paid` -> HTTP 200
- `GET /api/v1/bounties?sort=%09reward` -> HTTP 200, sorted as `reward`
- `GET /bounties?sort=%09reward` -> HTTP 200

This is scoped to bounty `status`/`sort` filter normalization and stays separate from public `q` search validation, wallet/account filters, MCP filters, admin webhook filters, and JSON integer parsing.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_bounty_api_routes.py::test_bounty_api_rejects_status_and_sort_control_characters tests/test_bounty_pages.py::test_bounties_page_rejects_status_and_sort_control_characters -q` -> 2 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_bounty_api_routes.py tests/test_bounty_pages.py tests/test_public_routes.py tests/test_bounty_api.py -q` -> 39 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 484 passed, 1 warning
- `uv run --extra dev ruff check app/bounty_sorting.py app/bounty_api.py app/public_routes.py tests/test_bounty_api_routes.py tests/test_bounty_pages.py` -> passed
- `uv run --extra dev ruff format --check app/bounty_sorting.py app/bounty_api.py app/public_routes.py tests/test_bounty_api_routes.py tests/test_bounty_pages.py` -> 5 files already formatted
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m mypy app/bounty_sorting.py app/bounty_api.py app/public_routes.py` -> success
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> `949c5afeaedfd962925774fc0ec7a0c10a4795d2`

No private data, cookies, OAuth state, wallet material, signatures, admin token values, production mutation, price/liquidity/exchange/bridge/off-ramp claims, or fabricated payout claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for bounty filter parameters to reject invalid control characters, preventing potential processing issues.
  * Improved error messages for invalid sort and status filters to provide clearer feedback.

* **Tests**
  * Added tests to verify control character rejection in bounty query parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->