### PR TITLE
Refs #576: Reject control chars in attempt source URLs

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -11,7 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.db import session_scope
-from app.ledger.service import LedgerError, validate_public_url
+from app.ledger.service import CONTROL_CHAR_RE, LedgerError, validate_public_url
 from app.models import Bounty, BountyAttempt
 
 DEFAULT_ATTEMPT_TTL_SECONDS = 24 * 60 * 60
@@ -183,6 +183,10 @@ def register_bounty_attempt_routes(
             source = ""
         if not isinstance(source, str):
             raise HTTPException(status_code=400, detail="source_url must be a string")
+        if CONTROL_CHAR_RE.search(source):
+            raise HTTPException(
+                status_code=400, detail="source_url must not contain control characters"
+            )
         source = source.strip()
         try:
             source_url = validate_public_url(source) if source else None

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -172,6 +172,41 @@ def test_bounty_attempts_accept_empty_body_defaults_to_login(sqlite_url: str, mo
     assert released.json()["attempt"]["status"] == "released"
 
 
+def test_bounty_attempt_source_url_rejects_raw_control_characters(
+    sqlite_url: str, monkeypatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", COOKIE_SECRET)
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=328,
+            issue_url="https://github.com/ramimbo/mergework/issues/328",
+            title="Attempt source URL validation",
+            reward_mrwk="50",
+            max_awards=1,
+            acceptance="Attempt source URLs should be validated before normalization.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _set_login(client, "alice")
+
+    response = client.post(
+        f"/api/v1/bounties/{bounty.id}/attempts",
+        json={
+            "source_url": "\thttps://github.com/ramimbo/mergework/pull/616",
+            "ttl_seconds": 3600,
+        },
+    )
+
+    assert response.status_code == 400
+    assert "control character" in response.json()["detail"].lower()
+    with session_scope(sqlite_url) as session:
+        assert session.scalars(select(BountyAttempt)).all() == []
+
+
 def test_single_award_bounty_warns_when_active_attempt_uses_available_slot(
     sqlite_url: str, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Reject raw control characters in bounty-attempt `source_url` before trimming and public URL validation.
- Add regression coverage for a tab-prefixed GitHub PR URL that previously created an attempt as if the URL were clean.

## Distinctness
- Covers the authenticated bounty-attempt `source_url` field only.
- Does not overlap the recent wallet/account/bounty/admin/MCP filter-control fixes, JSON integer parsing, public search-query work, or link-hardening PRs.

## Validation
- RED before fix: `tests/test_bounty_attempts.py::test_bounty_attempt_source_url_rejects_raw_control_characters` failed with `201 Created` instead of `400`.
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_bounty_attempts.py::test_bounty_attempt_source_url_rejects_raw_control_characters -q` -> 1 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_bounty_attempts.py -q` -> 8 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 483 passed, 1 warning
- `uv run --extra dev ruff check .` -> passed
- `uv run --extra dev ruff check app/bounty_attempts.py tests/test_bounty_attempts.py` -> passed
- `uv run --extra dev ruff format --check app/bounty_attempts.py tests/test_bounty_attempts.py` -> 2 files already formatted
- `uv run --extra dev mypy app/bounty_attempts.py` -> success
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No private data, wallet material, tokens, signatures, admin access, production mutation, price/liquidity/exchange/bridge/off-ramp claims, or fabricated payout claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject bounty attempt source URLs containing control characters. The API now returns a clear error message (HTTP 400) when control characters are detected in URLs, preventing invalid data submission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->