### PR TITLE
Refs #576: Reject control chars in MRWK amounts

### DIFF
--- a/app/ledger/service.py
+++ b/app/ledger/service.py
@@ -38,7 +38,7 @@ MICRO_UNITS = 1_000_000
 GENESIS_SUPPLY_MICRO = 100_000_000 * MICRO_UNITS
 SQLITE_INTEGER_MAX = 2**63 - 1
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
-CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 MRWK_AMOUNT_RE = re.compile(r"^-?\d+(?:\.\d+)?$")
 PUBLIC_DNS_LABEL_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$", re.I)
 IPV4_DOTTED_QUAD_RE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
@@ -49,7 +49,10 @@ class LedgerError(RuntimeError):
 
 
 def parse_mrwk_amount(amount: str | int | Decimal) -> int:
-    amount_text = str(amount).strip()
+    raw_amount_text = str(amount)
+    if CONTROL_CHAR_RE.search(raw_amount_text):
+        raise LedgerError("invalid MRWK amount")
+    amount_text = raw_amount_text.strip()
     if not MRWK_AMOUNT_RE.fullmatch(amount_text):
         raise LedgerError("invalid MRWK amount")
     if "." in amount_text and len(amount_text.rsplit(".", 1)[1]) > 6:

--- a/app/treasury.py
+++ b/app/treasury.py
@@ -117,8 +117,9 @@ def _canonical_payload(action: str, payload: dict[str, Any]) -> dict[str, Any]:
             raise LedgerError("issue_number is too large")
         if max_awards > 1_000:
             raise LedgerError("max_awards is too large")
-        reward_mrwk = str(_required_payload_value(payload, "reward_mrwk")).strip()
-        parse_mrwk_amount(reward_mrwk)
+        raw_reward_mrwk = str(_required_payload_value(payload, "reward_mrwk"))
+        parse_mrwk_amount(raw_reward_mrwk)
+        reward_mrwk = raw_reward_mrwk.strip()
         return {
             "repo": _clean_string(_required_payload_value(payload, "repo"), "repo", 200).lower(),
             "issue_number": issue_number,

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -965,6 +965,12 @@ def test_amount_parser_rejects_non_decimal_notation() -> None:
         parse_mrwk_amount("-1")
 
 
+@pytest.mark.parametrize("amount", ("\t1", "1\n", "1\r", "1\x85"))
+def test_amount_parser_rejects_control_characters(amount: str) -> None:
+    with pytest.raises(LedgerError, match="invalid MRWK amount"):
+        parse_mrwk_amount(amount)
+
+
 @pytest.mark.parametrize("amount", ("1.0000000", "0.0000010", "0.1000000"))
 def test_amount_parser_rejects_more_than_six_decimal_places(amount: str) -> None:
     with pytest.raises(LedgerError, match="MRWK supports at most 6 decimal places"):

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -102,6 +102,20 @@ def test_admin_bounty_creation_creates_public_delayed_proposal(
     assert detail.json()["payload_hash"] == body["payload_hash"]
 
 
+def test_admin_bounty_creation_rejects_control_character_reward_amount(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _client(sqlite_url, monkeypatch)
+    payload = _bounty_payload(issue_number=79, reward_mrwk="\t25")
+
+    response = client.post("/api/v1/bounties", headers=ADMIN_HEADERS, json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "invalid MRWK amount"
+    with session_scope(sqlite_url) as session:
+        assert session.scalar(select(func.count(TreasuryProposal.id))) == 0
+
+
 def test_treasury_proposals_list_newest_first(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Reject raw C0/C1 control characters in MRWK amount strings before trimming/parsing.
- Make create-bounty treasury canonicalization validate the submitted `reward_mrwk` text before storing the trimmed canonical value.
- Add parser and create-bounty regression coverage for control-character-padded amounts.

## Distinctness
- Covers MRWK amount string parsing/canonicalization only.
- Does not overlap PR #614 JSON integer parsing, PR #616 attempt source URL validation, or the wallet/account/bounty/admin/MCP filter-control fixes.

## Validation
- RED before fix: `tests/test_security.py::test_amount_parser_rejects_control_characters` failed because `\t1`, `1\n`, and `1\r` parsed successfully.
- RED before fix: `tests/test_treasury_proposals.py::test_admin_bounty_creation_rejects_control_character_reward_amount` failed with `200 OK` and created a proposal for `reward_mrwk="\t25"`.
- Addressed CodeRabbit review by expanding the shared control-character guard to reject C1 controls (`\x80-\x9f`) as well as C0 controls.
- `uv run pytest tests/test_security.py::test_amount_parser_rejects_control_characters tests/test_treasury_proposals.py::test_admin_bounty_creation_rejects_control_character_reward_amount` -> 5 passed, 1 warning
- `uv run pytest` -> 487 passed, 1 warning
- `uv run ruff check app/ledger/service.py app/treasury.py tests/test_security.py tests/test_treasury_proposals.py` -> passed
- `uv run ruff format --check app/ledger/service.py app/treasury.py tests/test_security.py tests/test_treasury_proposals.py` -> 4 files already formatted
- `uv run mypy app/ledger/service.py app/treasury.py` -> success
- `uv run python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No private data, wallet material, tokens, signatures, admin token values, production mutation, price/liquidity/exchange/bridge/off-ramp claims, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened MRWK amount validation to reject a wider range of ASCII control characters (including high-ASCII controls) and now validates the raw input before trimming whitespace.
* **Tests**
  * Added unit tests covering control-character rejections (tab, newline, carriage return, and other controls).
  * Added integration test ensuring bounty creation rejects invalid MRWK amounts with proper error responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/617?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->