### PR TITLE
Refs #576: Reject control chars in forwarded proto redirects

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Annotated, Any
 from urllib.parse import urlsplit, urlunsplit
@@ -89,11 +90,14 @@ API_DOCS_CSP = (
     "worker-src 'self' blob:"
 )
 API_DOCS_PATHS = {"/api/docs", "/api/redoc"}
+FORWARDED_PROTO_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
 
 def _request_was_forwarded_https(request: Request) -> bool:
     forwarded_proto = request.headers.get("x-forwarded-proto", "")
     if forwarded_proto:
+        if FORWARDED_PROTO_CONTROL_RE.search(forwarded_proto):
+            return False
         return forwarded_proto.split(",", 1)[0].strip().lower() == "https"
     return request.url.scheme == "https"
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 
 import pytest
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
-from app.main import create_app
+from app.main import _request_was_forwarded_https, create_app
 from app.models import BountyAttempt, Proof
 
 
@@ -146,6 +147,45 @@ def test_trailing_slash_redirects_keep_forwarded_https_scheme(sqlite_url: str) -
     assert (
         api_host.headers["location"] == f"https://api.mrwk.ltclab.site/api/v1/bounties/{bounty.id}"
     )
+
+
+def test_forwarded_https_redirect_rejects_control_character_proto(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=576,
+            issue_url="https://github.com/ramimbo/mergework/issues/576",
+            title="Forwarded proto robustness bounty",
+            reward_mrwk="50",
+            acceptance="Forwarded redirect handling should reject malformed proxy headers.",
+        )
+
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="http://mrwk.ltclab.site",
+    )
+
+    response = client.get(
+        f"/bounties/{bounty.id}/",
+        headers={"x-forwarded-proto": "\thttps"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 307
+    assert response.headers["location"] == f"http://mrwk.ltclab.site/bounties/{bounty.id}"
+
+
+@pytest.mark.parametrize("forwarded_proto", ["\x85https", "https\x85"])
+def test_forwarded_https_helper_rejects_c1_control_characters(forwarded_proto: str) -> None:
+    request = SimpleNamespace(
+        headers={"x-forwarded-proto": forwarded_proto},
+        url=SimpleNamespace(scheme="http"),
+    )
+
+    assert _request_was_forwarded_https(request) is False
 
 
 def test_account_api_rejects_empty_account_path(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary

- reject raw control characters in `X-Forwarded-Proto` before trusting forwarded HTTPS redirects
- keep normal clean `x-forwarded-proto: https` trailing-slash redirects unchanged
- add regression coverage for a tab-prefixed proto value so malformed proxy headers fail closed

## Distinctness

Bounty #576 small-fix submission. This covers only forwarded HTTPS redirect preservation in `app/main.py`.

It does not overlap the open control-character fixes for bounty filters, wallet/account filters, MCP arguments, admin webhook filters, JSON integer parsing, bounty attempt URLs, or public search queries.

## Validation

- `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_trailing_slash_redirects_keep_forwarded_https_scheme tests/test_api_mcp.py::test_forwarded_https_redirect_rejects_control_character_proto -q` -> 2 passed, 1 warning
- `uv run --extra dev ruff check app/main.py tests/test_api_mcp.py` -> passed
- `uv run --extra dev ruff format --check app/main.py tests/test_api_mcp.py` -> 2 files already formatted
- `uv run --extra dev mypy app/main.py` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No private data, wallet material, tokens, signatures, admin access, production mutation, price/liquidity/exchange/bridge/off-ramp claims, private security details, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header validation so malformed HTTPS forwarding directives with control characters are rejected, ensuring redirects and scheme detection fall back to the request URL and preventing improper handling of malformed headers.

* **Tests**
  * Added end-to-end and unit tests covering proxy-header robustness and redirect behavior when forwarded-proto contains control characters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->