### PR TITLE
Refs #576: Reject control chars in wallet hex inputs

### DIFF
--- a/app/wallets.py
+++ b/app/wallets.py
@@ -11,6 +11,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 ADDRESS_RE = re.compile(r"^mrwk1[0-9a-f]{40}$")
 PUBLIC_KEY_RE = re.compile(r"^[0-9a-f]{64}$")
 SIGNATURE_RE = re.compile(r"^[0-9a-f]{128}$")
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
 
 class WalletError(ValueError):
@@ -21,7 +22,13 @@ def canonical_wallet_json(payload: dict[str, Any]) -> str:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
 
 
+def _reject_control_characters(value: str, field: str) -> None:
+    if CONTROL_CHAR_RE.search(value):
+        raise WalletError(f"{field} must not contain control characters")
+
+
 def normalize_public_key_hex(public_key_hex: str) -> str:
+    _reject_control_characters(public_key_hex, "public key")
     normalized = public_key_hex.strip().lower()
     if not PUBLIC_KEY_RE.fullmatch(normalized):
         raise WalletError("public key must be 32 bytes encoded as lowercase hex")
@@ -29,6 +36,7 @@ def normalize_public_key_hex(public_key_hex: str) -> str:
 
 
 def normalize_signature_hex(signature_hex: str) -> str:
+    _reject_control_characters(signature_hex, "signature")
     normalized = signature_hex.strip().lower()
     if not SIGNATURE_RE.fullmatch(normalized):
         raise WalletError("signature must be 64 bytes encoded as lowercase hex")
@@ -36,6 +44,7 @@ def normalize_signature_hex(signature_hex: str) -> str:
 
 
 def normalize_wallet_address(address: str) -> str:
+    _reject_control_characters(address, "MRWK wallet address")
     normalized = address.strip().lower()
     if not ADDRESS_RE.fullmatch(normalized):
         raise WalletError("invalid MRWK wallet address")

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -220,6 +220,23 @@ def test_wallet_register_api_rejects_label_control_characters(sqlite_url: str) -
     assert response.json()["detail"] == "wallet label must not contain control characters"
 
 
+@pytest.mark.parametrize("public_key_hex", ["\t{public}", "{public}\n", "\x85{public}"])
+def test_wallet_register_api_rejects_public_key_control_characters(
+    sqlite_url: str, public_key_hex: str
+) -> None:
+    create_schema(sqlite_url)
+    _, public_hex, _ = _keypair()
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/api/v1/wallets/register",
+        json={"public_key_hex": public_key_hex.format(public=public_hex)},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "public key must not contain control characters"
+
+
 def test_wallet_transfer_api_rejects_memo_control_characters(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     sender_key, sender_public, sender_address = _keypair()
@@ -252,6 +269,75 @@ def test_wallet_transfer_api_rejects_memo_control_characters(sqlite_url: str) ->
 
     assert response.status_code == 400
     assert response.json()["detail"] == "memo must not contain control characters"
+
+
+@pytest.mark.parametrize("pad", ["\t", "\n", "\x85"])
+def test_wallet_transfer_api_rejects_address_and_signature_control_characters(
+    sqlite_url: str, pad: str
+) -> None:
+    create_schema(sqlite_url)
+    sender_key, sender_public, sender_address = _keypair()
+    _, receiver_public, receiver_address = _keypair()
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _register_wallet(client, sender_public)
+    _register_wallet(client, receiver_public)
+    _fund_wallet(sqlite_url, sender_address)
+    payload = {
+        "type": "mrwk_transfer_v1",
+        "from_address": sender_address,
+        "to_address": receiver_address,
+        "amount_microunits": 1_000_000,
+        "nonce": 1,
+        "memo": "",
+    }
+    signature = _sign(sender_key, payload)
+
+    control_address = client.post(
+        "/api/v1/transfers",
+        json={
+            "from_address": f"{pad}{sender_address}",
+            "to_address": receiver_address,
+            "amount_mrwk": "1",
+            "nonce": 1,
+            "memo": "",
+            "signature_hex": signature,
+        },
+    )
+    control_to_address = client.post(
+        "/api/v1/transfers",
+        json={
+            "from_address": sender_address,
+            "to_address": f"{pad}{receiver_address}",
+            "amount_mrwk": "1",
+            "nonce": 1,
+            "memo": "",
+            "signature_hex": signature,
+        },
+    )
+    control_signature = client.post(
+        "/api/v1/transfers",
+        json={
+            "from_address": sender_address,
+            "to_address": receiver_address,
+            "amount_mrwk": "1",
+            "nonce": 1,
+            "memo": "",
+            "signature_hex": f"{pad}{signature}",
+        },
+    )
+
+    assert control_address.status_code == 400
+    assert (
+        control_address.json()["detail"]
+        == "MRWK wallet address must not contain control characters"
+    )
+    assert control_to_address.status_code == 400
+    assert (
+        control_to_address.json()["detail"]
+        == "MRWK wallet address must not contain control characters"
+    )
+    assert control_signature.status_code == 400
+    assert control_signature.json()["detail"] == "signature must not contain control characters"
 
 
 def test_wallet_api_malformed_register_requests_return_4xx(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- Reject raw control characters in wallet public-key, signature, and MRWK address inputs before trimming/normalization.
- Keep existing clean hex/address behavior unchanged, including ordinary leading/trailing spaces.
- Add wallet API regressions for tab/newline/C1-padded public keys plus control-character-padded transfer from-address, to-address, and signature values.

## Evidence
Before this fix, wallet hex/address normalization accepted control-character-padded inputs as clean values. A focused repro showed `/api/v1/wallets/register` returned `200 OK` for `public_key_hex` values prefixed with `\t`, suffixed with `\n`, and prefixed with C1 `\x85`. The same normalization path also accepted control-character-padded transfer addresses and signatures after trimming.

## Distinctness
- Covers wallet hex-material and MRWK address normalization in `app/wallets.py` only.
- Does not overlap PR #608 (`/wallets?q=...`), PR #609 (`/wallets/{address}?type=...`), PR #610 (`/accounts/{account}?tx_type=...`), PR #614 JSON integer parsing, PR #617 MRWK amount parsing, or PR #572 public search-query validation.
- Submission quality gate passed and reported no similar open PRs.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_wallet_api.py::test_wallet_register_api_rejects_public_key_control_characters tests/test_wallet_api.py::test_wallet_transfer_api_rejects_address_and_signature_control_characters -q` -> 6 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest tests/test_wallet_api.py tests/test_wallets.py -q` -> 50 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m pytest -q` -> 488 passed, 1 warning
- `uv run --extra dev ruff check app/wallets.py tests/test_wallet_api.py` -> passed
- `uv run --extra dev ruff format --check app/wallets.py tests/test_wallet_api.py` -> 2 files already formatted
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python -m mypy app/wallets.py` -> success
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean
- submission quality gate -> PASS, no similar open PRs found

No private keys, wallet private material, tokens, signatures, production mutation, admin access, price/liquidity/exchange/bridge/off-ramp claims, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registration and transfer endpoints now reject inputs containing hidden/control characters (tabs, newlines, non-printable bytes), returning clear validation errors so malformed or tampered cryptographic fields are not accepted.

* **Tests**
  * Added comprehensive tests ensuring registration and transfer flows return proper 400 responses with precise error messages when control characters are present in public keys, addresses, or signatures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->