### PR TITLE
Refs #576: Reject control chars in activity search

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import FastAPI, Query, Request
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
@@ -19,10 +19,16 @@ def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Temp
     @app.get("/api/v1/activity")
     def api_activity(q: str | None = Query(None)) -> dict[str, Any]:
         with session_scope(db_url) as session:
-            return activity_context(session, q)
+            try:
+                return activity_context(session, q)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @app.get("/activity", response_class=HTMLResponse)
     def activity_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:
         with session_scope(db_url) as session:
-            context = activity_context(session, q)
+            try:
+                context = activity_context(session, q)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
         return templates.TemplateResponse(request, "activity.html", context)

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
@@ -11,6 +12,8 @@ from sqlalchemy.orm import Session
 from app.ledger.reconciliation import AcceptedPayoutCheck
 from app.ledger.service import format_mrwk, get_balance
 from app.models import Bounty, LedgerEntry, Proof, Wallet, WalletTransfer
+
+ACTIVITY_QUERY_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
 
 def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
@@ -165,7 +168,11 @@ def _activity_row(entry: LedgerEntry, proof: Proof) -> dict[str, Any] | None:
 
 
 def _activity_search_query(query: str | None) -> str:
-    return (query or "").strip().lower()
+    if query is None:
+        return ""
+    if ACTIVITY_QUERY_CONTROL_CHAR_RE.search(query):
+        raise ValueError("activity query must not contain control characters")
+    return query.strip().lower()
 
 
 def _activity_hash_issue_query(query: str) -> str | None:

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -192,6 +192,18 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
         assert invalid_hash_query["recent"] == []
 
 
+def test_activity_routes_reject_query_control_characters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    for route in ("/api/v1/activity", "/activity"):
+        for query in ("\talice", "alice\n", "alice\x85"):
+            response = client.get(route, params={"q": query})
+
+            assert response.status_code == 400
+            assert "activity query must not contain control characters" in response.text
+
+
 def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))


### PR DESCRIPTION
## Summary
- Reject raw C0/DEL/C1 control characters in activity search `q` before trimming/lowercasing.
- Return bounded HTTP 400 from both `/api/v1/activity` and `/activity` when malformed query text is submitted.
- Add regression coverage for tab, newline, and C1-padded queries on both routes.

## Evidence
Bounty #576 is open. Before this change, `q="\talice"` on `/api/v1/activity` and `/activity` returned 200 and normalized to clean `alice`, so raw control-character-padded search text was accepted as if it were clean.

This is distinct from the existing wallet/account/bounty/MCP/admin/webhook/JSON/MRWK amount/wallet hex control-character PRs because it covers only the public accepted-work activity search query.

## Validation
- `uv run --extra dev python -m pytest tests/test_activity.py::test_activity_routes_reject_query_control_characters -q` -> 1 passed, 1 warning
- `uv run --extra dev python -m pytest tests/test_activity.py tests/test_activity_routes.py -q` -> 5 passed, 1 warning
- `uv run --extra dev python -m pytest -q` -> 483 passed, 1 warning
- `uv run --extra dev ruff check app/activity.py app/serializers.py tests/test_activity.py` -> passed
- `uv run --extra dev ruff format --check app/activity.py app/serializers.py tests/test_activity.py` -> passed
- `uv run --extra dev mypy app/activity.py app/serializers.py` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No private data, wallet material, tokens, signatures, admin access, production mutation, price/liquidity/exchange/bridge/off-ramp claims, or private security details are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Activity search now validates and properly rejects queries containing control characters, returning an appropriate error message instead of crashing the request.
  * Enhanced error handling for invalid activity search queries across all endpoints.

* **Tests**
  * Added tests to verify control character validation is enforced for activity search queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/620?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->