### PR TITLE
Refs #576: Reject control chars in treasury proposals

### DIFF
--- a/app/treasury.py
+++ b/app/treasury.py
@@ -69,16 +69,20 @@ def _required_payload_value(payload: dict[str, Any], field: str) -> Any:
     return value
 
 
+def _contains_control_character(value: str) -> bool:
+    return any(ord(char) < 32 or ord(char) == 127 or 0x80 <= ord(char) <= 0x9F for char in value)
+
+
 def _clean_string(value: Any, field: str, max_length: int = 500) -> str:
     if not isinstance(value, str):
         raise LedgerError(f"{field} must be a string")
+    if _contains_control_character(value):
+        raise LedgerError(f"{field} must not contain control characters")
     clean = value.strip()
     if not clean:
         raise LedgerError(f"{field} is required")
     if len(clean) > max_length:
         raise LedgerError(f"{field} is too long")
-    if any(ord(char) < 32 or ord(char) == 127 for char in clean):
-        raise LedgerError(f"{field} must not contain control characters")
     return clean
 
 
@@ -94,6 +98,8 @@ def _payload_int(value: Any, field: str) -> int:
     if isinstance(value, int):
         return value
     if isinstance(value, str):
+        if _contains_control_character(value):
+            raise LedgerError(f"{field} must not contain control characters")
         clean = value.strip()
         if clean and clean.lstrip("+-").isdigit():
             try:

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -136,6 +136,42 @@ def test_direct_proposal_creation_requires_admin_token(
     assert body["payload"]["issue_number"] == 78
 
 
+@pytest.mark.parametrize(
+    ("body", "expected_detail"),
+    [
+        (
+            {"action": "\tcreate_bounty", "payload": _bounty_payload(issue_number=179)},
+            "action must not contain control characters",
+        ),
+        (
+            {
+                "action": "create_bounty",
+                "payload": {**_bounty_payload(issue_number=180), "issue_number": "\t180"},
+            },
+            "issue_number must not contain control characters",
+        ),
+        (
+            {
+                "action": "create_bounty",
+                "payload": {**_bounty_payload(issue_number=181), "title": "Proposal\x85Title"},
+            },
+            "title must not contain control characters",
+        ),
+    ],
+)
+def test_treasury_proposal_creation_rejects_raw_control_characters(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch, body: dict[str, object], expected_detail: str
+) -> None:
+    client = _client(sqlite_url, monkeypatch)
+
+    response = client.post("/api/v1/treasury/proposals", headers=ADMIN_HEADERS, json=body)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == expected_detail
+    with session_scope(sqlite_url) as session:
+        assert session.scalar(select(func.count(TreasuryProposal.id))) == 0
+
+
 def test_proposal_execution_requires_admin_delay_and_is_idempotent(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -633,6 +669,47 @@ def test_machine_challenge_after_execution_is_rejected_without_mutating_status(
     assert detail.status_code == 200
     assert detail.json()["status"] == "executed"
     assert detail.json()["executed_at"] is not None
+
+
+@pytest.mark.parametrize(
+    ("challenge_body", "expected_detail"),
+    [
+        (
+            {"challenge_type": "\tsubjective_note", "reason": "Needs more explanation."},
+            "challenge_type must not contain control characters",
+        ),
+        (
+            {"challenge_type": "subjective_note", "reason": "\x85Needs more explanation."},
+            "reason must not contain control characters",
+        ),
+    ],
+)
+def test_treasury_challenges_reject_raw_control_characters(
+    sqlite_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+    challenge_body: dict[str, str],
+    expected_detail: str,
+) -> None:
+    client = _client(sqlite_url, monkeypatch)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        _seed_accepted_work(session, "alice")
+    proposal = client.post(
+        "/api/v1/bounties",
+        headers=ADMIN_HEADERS,
+        json=_bounty_payload(issue_number=81, reward_mrwk="2"),
+    ).json()
+    client.cookies.set("mrwk_user", signed_value("alice", "test-cookie-secret"))
+
+    response = client.post(
+        f"/api/v1/treasury/proposals/{proposal['id']}/challenges",
+        json=challenge_body,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == expected_detail
+    with session_scope(sqlite_url) as session:
+        assert session.scalar(select(func.count(TreasuryChallenge.id))) == 0
 
 
 def test_close_bounty_rejects_missing_bounty_before_proposal_creation(


### PR DESCRIPTION
## Summary
- Reject raw C0/DEL/C1 control characters in treasury proposal action and payload-string fields before trimming/canonicalization.
- Reject raw control characters in treasury proposal integer-string fields before parsing.
- Add regression coverage for proposal creation and challenge creation so malformed action, issue number, title, challenge type, and reason text fail before persistence.

## Evidence
Bounty #576 is open. Before this change, a request such as `action="\tcreate_bounty"` to `/api/v1/treasury/proposals` was accepted as clean `create_bounty` and created a pending proposal. The same raw-control-character-before-trim pattern also existed for treasury proposal payload integers/strings and challenge strings.

This is distinct from the existing wallet/account/bounty/MCP/admin webhook/JSON integer/MRWK amount/wallet hex/activity control-character PRs because it covers treasury proposal and challenge canonicalization in `app/treasury.py`.

## Validation
- `uv run --extra dev python -m pytest tests/test_treasury_proposals.py::test_treasury_proposal_creation_rejects_raw_control_characters tests/test_treasury_proposals.py::test_treasury_challenges_reject_raw_control_characters -q` -> 5 passed, 1 warning
- `uv run --extra dev python -m pytest tests/test_treasury_proposals.py -q` -> 28 passed, 1 warning
- `uv run --extra dev python -m pytest -q` -> 487 passed, 1 warning
- `uv run --extra dev ruff check .` -> passed
- `uv run --extra dev ruff format --check app/treasury.py tests/test_treasury_proposals.py` -> passed
- `uv run --extra dev mypy app/treasury.py app/treasury_routes.py` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean
- `git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main` -> clean

No private data, wallet material, tokens, signatures, admin token values, production mutation, price/liquidity/exchange/bridge/off-ramp claims, or private security details are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Treasury proposal and challenge submission endpoints now validate input fields and reject requests containing control characters, returning appropriate error responses.

* **Tests**
  * Added parametrized test coverage to verify that treasury endpoints properly reject submissions with control characters and maintain data integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->