### PR TITLE
Refs #576: Reject control chars in webhook identities

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -18,6 +18,7 @@ from app.models import Bounty, WebhookEvent
 ACCEPTED_LABEL = "mrwk:accepted"
 ISSUE_NUMBER_BOUNDARY = r"(?![A-Za-z0-9_-])"
 MAX_SQLITE_INTEGER = 2**63 - 1
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 LINKED_ISSUE_RE = re.compile(
     r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?|bounty|claims?)"
     r"(?:\s+|\s*:\s*)"
@@ -96,6 +97,15 @@ def _payload_object(payload: dict[str, Any], key: str) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+def _clean_webhook_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    if CONTROL_CHAR_RE.search(value):
+        return None
+    clean = value.strip()
+    return clean or None
+
+
 def _github_issue_number_from_text(value: str) -> int | None:
     normalized = value.lstrip("0") or "0"
     if len(normalized) > len(str(MAX_SQLITE_INTEGER)):
@@ -133,13 +143,21 @@ def _handle_accepted_issue_label(
     pull_request = _payload_object(payload, "pull_request")
     labeled_item = pull_request or issue
     repo_name = _payload_object(payload, "repository").get("full_name")
-    repo = repo_name.strip() if isinstance(repo_name, str) else ""
+    repo = _clean_webhook_string(repo_name)
     issue_number = issue.get("number")
     label_name = _payload_object(payload, "label").get("name")
     label = label_name if isinstance(label_name, str) else ""
     if payload.get("action") != "labeled" or label.lower() != ACCEPTED_LABEL:
         _record_event(database_url, delivery_id, event_type, payload_hash, "ignored")
         return {"status": "ignored"}
+    if isinstance(repo_name, str) and CONTROL_CHAR_RE.search(repo_name):
+        return _record_status(
+            database_url,
+            delivery_id,
+            event_type,
+            payload_hash,
+            "malformed_repository",
+        )
     if not repo or not labeled_item:
         return _record_status(database_url, delivery_id, event_type, payload_hash, "missing_issue")
     if event_type == "issues" and "pull_request" in issue:
@@ -152,17 +170,16 @@ def _handle_accepted_issue_label(
         )
 
     user = labeled_item.get("user") or {}
-    submitter_login = user.get("login") if isinstance(user, dict) else None
-    if not isinstance(submitter_login, str) or not submitter_login.strip():
+    submitter = _clean_webhook_string(user.get("login") if isinstance(user, dict) else None)
+    if submitter is None:
         return _record_status(
             database_url, delivery_id, event_type, payload_hash, "missing_submitter"
         )
-    submitter = submitter_login.strip()
     sender = payload.get("sender") or {}
-    sender_login = sender.get("login") if isinstance(sender, dict) else None
-    if not isinstance(sender_login, str) or not sender_login.strip():
+    sender_login = _clean_webhook_string(sender.get("login") if isinstance(sender, dict) else None)
+    if sender_login is None:
         return _record_status(database_url, delivery_id, event_type, payload_hash, "missing_sender")
-    accepted_by = sender_login.strip().lower()
+    accepted_by = sender_login.lower()
     if accepted_labelers and accepted_by not in accepted_labelers:
         return _record_status(
             database_url, delivery_id, event_type, payload_hash, "unauthorized_labeler"

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -634,6 +634,81 @@ def test_accepted_label_requires_sender_login(sqlite_url: str) -> None:
         assert event.processed_status == "missing_sender"
 
 
+def test_accepted_label_rejects_control_characters_before_trimming_webhook_identity(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    cases = [
+        (
+            "delivery-control-repo",
+            {"repository": {"full_name": "\tramimbo/mergework"}},
+            "malformed_repository",
+            (),
+        ),
+        (
+            "delivery-control-submitter",
+            {"issue": {"user": {"login": "\talice"}}},
+            "missing_submitter",
+            (),
+        ),
+        (
+            "delivery-c1-sender",
+            {"sender": {"login": "\x85maintainer"}},
+            "missing_sender",
+            ("maintainer",),
+        ),
+    ]
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=44,
+            issue_url="https://github.com/ramimbo/mergework/issues/44",
+            title="Accepted issue",
+            reward_mrwk="25",
+            acceptance="Maintainer applies mrwk:accepted.",
+        )
+
+    for delivery_id, overrides, expected_status, accepted_labelers in cases:
+        payload = {
+            "action": "labeled",
+            "label": {"name": "mrwk:accepted"},
+            "issue": {
+                "number": 44,
+                "html_url": "https://github.com/ramimbo/mergework/issues/44",
+                "user": {"login": "alice"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "maintainer"},
+        }
+        for key, value in overrides.items():
+            payload[key].update(value)
+        body = json.dumps(payload, separators=(",", ":")).encode()
+
+        result = handle_github_webhook(
+            sqlite_url,
+            {
+                "X-GitHub-Delivery": delivery_id,
+                "X-GitHub-Event": "issues",
+                "X-Hub-Signature-256": _signature("secret", body),
+            },
+            body,
+            "secret",
+            accepted_labelers=accepted_labelers,
+        )
+
+        assert result == {"status": expected_status}
+
+    with session_scope(sqlite_url) as session:
+        assert get_balance(session, "github:alice") == 0
+        for delivery_id, _overrides, expected_status, _accepted_labelers in cases:
+            event = session.get(WebhookEvent, delivery_id)
+            assert event is not None
+            assert event.processed_status == expected_status
+
+
 def test_accepted_label_handles_malformed_object_fields(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     cases = [


### PR DESCRIPTION
## Summary
- reject raw C0, DEL, and C1 control characters in accepted-label webhook repository, submitter, and sender identity fields before trimming
- record malformed repository payloads before bounty lookup and keep malformed submitter/sender payloads from reaching payout or accepted-labeler checks
- add signed webhook regression coverage for tab-padded repo/submitter and C1-padded sender values

## Validation
- uv run --extra dev python -m pytest tests/test_webhooks.py::test_accepted_label_rejects_control_characters_before_trimming_webhook_identity -q
- uv run --extra dev python -m pytest tests/test_webhooks.py -q
- uv run --extra dev python -m pytest tests/test_security.py -q
- uv run --extra dev python -m pytest -q
- uv run --extra dev ruff check app/webhooks/github.py tests/test_webhooks.py
- uv run --extra dev ruff format --check app/webhooks/github.py tests/test_webhooks.py
- uv run --extra dev mypy app/webhooks/github.py
- uv run --extra dev python scripts/docs_smoke.py
- git diff --check
- git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main | wc -c -> 0

/claim #576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced webhook payload validation to detect and reject fields containing control characters.

* **Tests**
  * Added test coverage for webhook payload validation with malformed identity data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->