### PR TITLE
Refs #576: Reject C1 controls in deploy settings

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -35,6 +35,10 @@ DNS_LABEL_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
 IPV4_DOTTED_QUAD_RE = re.compile(r"(?:\d{1,3}\.){3}\d{1,3}")
 
 
+def _contains_control_character(value: str) -> bool:
+    return any(ord(char) < 32 or 127 <= ord(char) < 160 for char in value)
+
+
 def _csv_env(name: str, default: str = "") -> tuple[str, ...]:
     raw_value = os.environ.get(name, default)
     if not raw_value.strip():
@@ -47,7 +51,7 @@ def _secret_errors(name: str, value: str) -> list[str]:
         return [f"{name} is required"]
     if value != value.strip():
         return [f"{name} must not include leading or trailing whitespace"]
-    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+    if _contains_control_character(value):
         return [f"{name} must not include control characters"]
     if len(value) < 32 or value.strip().lower() in WEAK_SECRET_VALUES:
         return [f"{name} must be at least 32 characters"]
@@ -62,7 +66,7 @@ def _required_env_value_errors(name: str, value: str) -> list[str]:
     errors = []
     if value != value.strip():
         errors.append(f"{name} must not include leading or trailing whitespace")
-    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+    if _contains_control_character(value):
         errors.append(f"{name} must not include control characters")
     return errors
 

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -85,6 +85,28 @@ def test_deploy_readiness_rejects_secret_whitespace_and_control_characters() -> 
     assert "MERGEWORK_COOKIE_SECRET must not include control characters" in errors
 
 
+def test_deploy_readiness_rejects_c1_control_characters() -> None:
+    errors = validate_deploy_settings(
+        _settings(
+            database_url="postgresql://mergework:password@db.example.test/merge\x85work",
+            public_base_url="https://staging\x85.mrwk.example.test",
+            github_webhook_secret="webhook-8efc3925bb8746b8a8fd3392c4c\x858e32",
+            github_oauth_client_id="client\x85id",
+            github_oauth_client_secret="oauth-7818e79f9d3a4a1d82ff0e1b9f0\x85b8e42",
+            admin_token="admin-14dcaab83bb245f2bfb5d5c21a9b\x85b55b",
+            cookie_secret="cookie-27fd1c41324a4bdcb2e4014adc3\x85a6108",
+        )
+    )
+
+    assert "MERGEWORK_DATABASE_URL must not include control characters" in errors
+    assert "MERGEWORK_PUBLIC_BASE_URL must not include control characters" in errors
+    assert "MERGEWORK_GITHUB_WEBHOOK_SECRET must not include control characters" in errors
+    assert "MERGEWORK_GITHUB_OAUTH_CLIENT_ID must not include control characters" in errors
+    assert "MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET must not include control characters" in errors
+    assert "MERGEWORK_ADMIN_TOKEN must not include control characters" in errors
+    assert "MERGEWORK_COOKIE_SECRET must not include control characters" in errors
+
+
 def test_deploy_readiness_rejects_non_persistent_sqlite_database_urls() -> None:
     memory_errors = validate_deploy_settings(_settings(database_url="sqlite:///:memory:"))
     driver_memory_errors = validate_deploy_settings(


### PR DESCRIPTION
Refs #576

## Summary
- Add a deploy-settings control-character helper that rejects C0, DEL, and C1 controls.
- Apply it to required deploy values and secret validation.
- Add regression coverage for internal C1 controls in database URL, public base URL, OAuth client ID, and deploy secrets.

## Evidence
Before the fix, a local probe showed internal `\x85` values in deploy strings such as `MERGEWORK_ADMIN_TOKEN`, `MERGEWORK_GITHUB_OAUTH_CLIENT_ID`, and `MERGEWORK_DATABASE_URL` did not produce the existing control-character validation error.

## Validation
- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py::test_deploy_readiness_rejects_c1_control_characters -q` -> 1 passed
- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py -q` -> 28 passed
- `uv run --extra dev python -m pytest -q` -> 483 passed, 1 warning
- `uv run --extra dev ruff check app/config.py tests/test_deploy_readiness.py` -> passed
- `uv run --extra dev ruff format --check app/config.py tests/test_deploy_readiness.py` -> 2 files already formatted
- `uv run --extra dev mypy app/config.py` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

No private data, secrets, admin token values, wallet material, production mutation, price/liquidity/exchange/bridge/off-ramp claims, or fabricated payout claims are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for configuration settings to reject a broader range of control characters in sensitive values such as database URLs, webhook secrets, OAuth credentials, authentication tokens, and cookie settings. This prevents potential security issues and configuration problems caused by invalid control characters in these critical settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/623?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->