### PR TITLE
Add treasury reserve capacity status

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -6,7 +6,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.models import WebhookEvent
-from app.treasury import propose_treasury_action
+from app.treasury import propose_treasury_action, treasury_status
 
 ADMIN_WEBHOOK_LIMIT_OPTIONS = [10, 25, 50, 100]
 WEBHOOK_OUTCOME_SCAN_ORDER = {
@@ -95,6 +95,7 @@ def admin_page_context(
         "webhook_limit": webhook_limit,
         "webhook_limit_options": ADMIN_WEBHOOK_LIMIT_OPTIONS,
         "webhook_status": normalized_status,
+        "treasury_status": treasury_status(session),
     }
 
 

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -22,6 +22,57 @@
 </section>
 
 <section class="detail">
+  <p class="eyebrow">Treasury</p>
+  <h2>Treasury reserve capacity</h2>
+  <div class="bounty-list-summary" aria-label="Treasury reserve capacity summary">
+    <article>
+      <span>24h cap</span>
+      <strong>{{ treasury_status.reserve_cap_mrwk }} MRWK</strong>
+    </article>
+    <article>
+      <span>Reserved in window</span>
+      <strong>{{ treasury_status.executed_reserve_24h_mrwk }} MRWK</strong>
+    </article>
+    <article>
+      <span>Pending creates</span>
+      <strong>{{ treasury_status.pending_create_reserve_mrwk }} MRWK</strong>
+    </article>
+    <article>
+      <span>Available create reserve</span>
+      <strong>{{ treasury_status.available_create_reserve_mrwk }} MRWK</strong>
+    </article>
+  </div>
+  {% if treasury_status.next_capacity_release_at %}
+  <p>Next reserve capacity release: <time datetime="{{ treasury_status.next_capacity_release_at }}">{{ treasury_status.next_capacity_release_at }}</time>.</p>
+  {% else %}
+  <p>No recent reserve entries are currently limiting create-bounty capacity.</p>
+  {% endif %}
+  {% if treasury_status.pending_create_bounties %}
+  <h3>Pending create-bounty proposals</h3>
+  <table class="webhook-table">
+    <thead>
+      <tr>
+        <th>Proposal</th>
+        <th>Issue</th>
+        <th>Reserve</th>
+        <th>Executes after</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for proposal in treasury_status.pending_create_bounties %}
+      <tr>
+        <td data-label="Proposal"><a href="/api/v1/treasury/proposals/{{ proposal.proposal_id }}">#{{ proposal.proposal_id }}</a></td>
+        <td data-label="Issue"><a href="{{ proposal.issue_url }}">{{ proposal.title }}</a></td>
+        <td data-label="Reserve">{{ proposal.reserve_mrwk }} MRWK</td>
+        <td data-label="Executes after">{{ proposal.executes_after }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
+</section>
+
+<section class="detail">
   <p class="eyebrow">Webhooks</p>
   <h2>Recent delivery outcomes</h2>
   {% if webhook_status_summary %}

--- a/app/treasury.py
+++ b/app/treasury.py
@@ -433,6 +433,72 @@ def _epoch_reserved_microunits(session: Session, now: datetime) -> int:
     return int(amount or 0)
 
 
+def _recent_bounty_reserve_entries(session: Session, now: datetime) -> list[LedgerEntry]:
+    since = now - TREASURY_EPOCH_WINDOW
+    return list(
+        session.scalars(
+            select(LedgerEntry)
+            .where(
+                LedgerEntry.entry_type == "bounty_reserve",
+                LedgerEntry.from_account == TREASURY_ACCOUNT,
+                LedgerEntry.created_at >= since,
+            )
+            .order_by(LedgerEntry.created_at.asc(), LedgerEntry.sequence.asc())
+        ).all()
+    )
+
+
+def treasury_status(session: Session) -> dict[str, Any]:
+    now = _db_now()
+    recent_reserves = _recent_bounty_reserve_entries(session, now)
+    executed_reserve = sum(entry.amount_microunits for entry in recent_reserves)
+    pending_create_bounties: list[dict[str, Any]] = []
+    pending_create_reserve = 0
+    for proposal, payload in _pending_action_payloads(session, "create_bounty"):
+        reserve = parse_mrwk_amount(str(payload["reward_mrwk"])) * int(payload["max_awards"])
+        pending_create_reserve += reserve
+        pending_create_bounties.append(
+            {
+                "proposal_id": proposal.id,
+                "issue_number": int(payload["issue_number"]),
+                "issue_url": str(payload["issue_url"]),
+                "title": str(payload["title"]),
+                "reward_mrwk": str(payload["reward_mrwk"]),
+                "max_awards": int(payload["max_awards"]),
+                "reserve_mrwk": format_mrwk(reserve),
+                "proposed_at": _db_utc(proposal.proposed_at).isoformat(),
+                "executes_after": _db_utc(proposal.executes_after).isoformat(),
+            }
+        )
+    available = max(TREASURY_EPOCH_RESERVE_CAP_MICRO - executed_reserve - pending_create_reserve, 0)
+    release_times = [
+        _db_utc(entry.created_at) + TREASURY_EPOCH_WINDOW
+        for entry in recent_reserves
+        if _db_utc(entry.created_at) + TREASURY_EPOCH_WINDOW > now
+    ]
+    next_capacity_release_at = min(release_times).isoformat() if release_times else None
+    return {
+        "type": "treasury_status",
+        "epoch_window_hours": int(TREASURY_EPOCH_WINDOW.total_seconds() // 3600),
+        "reserve_cap_mrwk": format_mrwk(TREASURY_EPOCH_RESERVE_CAP_MICRO),
+        "executed_reserve_24h_mrwk": format_mrwk(executed_reserve),
+        "pending_create_reserve_mrwk": format_mrwk(pending_create_reserve),
+        "available_create_reserve_mrwk": format_mrwk(available),
+        "next_capacity_release_at": next_capacity_release_at,
+        "pending_create_bounties": pending_create_bounties,
+        "recent_reserves": [
+            {
+                "ledger_sequence": entry.sequence,
+                "amount_mrwk": format_mrwk(entry.amount_microunits),
+                "reference": entry.reference,
+                "created_at": _db_utc(entry.created_at).isoformat(),
+                "expires_at": (_db_utc(entry.created_at) + TREASURY_EPOCH_WINDOW).isoformat(),
+            }
+            for entry in recent_reserves
+        ],
+    }
+
+
 def _payout_response_from_proof(proof: Proof) -> dict[str, Any]:
     data = json.loads(proof.public_json)
     if not isinstance(data, dict) or data.get("kind") != "bounty_payment":

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -15,6 +15,7 @@ from app.treasury import (
     execute_treasury_proposal,
     proposal_to_dict,
     propose_treasury_action,
+    treasury_status,
 )
 
 
@@ -50,6 +51,11 @@ def register_treasury_routes(
                 select(TreasuryProposal).order_by(TreasuryProposal.id.desc()).limit(100)
             ).all()
             return [proposal_to_dict(proposal) for proposal in proposals]
+
+    @app.get("/api/v1/treasury/status")
+    def api_treasury_status() -> dict[str, Any]:
+        with session_scope(db_url) as session:
+            return treasury_status(session)
 
     @app.get("/api/v1/treasury/proposals/{proposal_id}")
     def api_treasury_proposal(proposal_id: int) -> dict[str, Any]:

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -34,6 +34,7 @@ Normal admin treasury actions are proposed before they execute:
 Public reads:
 
 ```bash
+curl -s https://api.mrwk.ltclab.site/api/v1/treasury/status
 curl -s https://api.mrwk.ltclab.site/api/v1/treasury/proposals
 curl -s https://api.mrwk.ltclab.site/api/v1/treasury/proposals/<proposal_id>
 ```
@@ -45,7 +46,10 @@ curl -X POST https://api.mrwk.ltclab.site/api/v1/treasury/proposals/<proposal_id
   -H "x-mergework-admin-token: $MERGEWORK_ADMIN_TOKEN"
 ```
 
-Bounty reserve execution is capped at `10,000 MRWK` per 24-hour epoch. GitHub
+Bounty reserve execution is capped at `10,000 MRWK` per 24-hour epoch. Check
+`/api/v1/treasury/status` or the `/admin` treasury panel before opening fresh
+rounds. It shows executed reserves in the rolling window, pending create-bounty
+reserve, remaining create capacity, and the next capacity release time. GitHub
 users with at least one accepted MRWK award can submit proposal challenges.
 Machine-checkable valid challenges block execution. Subjective challenges are
 public notes and do not block by themselves.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -17,6 +17,7 @@ Submit small, reviewable work and include evidence.
 - `GET /api/v1/ledger/{sequence}`
 - `GET /api/v1/activity`
 - `GET /api/v1/proofs/{hash}`
+- `GET /api/v1/treasury/status`
 - `GET /api/v1/treasury/proposals`
 - `GET /api/v1/treasury/proposals/{id}`
 - `POST /api/v1/wallets/register`
@@ -73,9 +74,14 @@ The `<bounty_id>` value is the internal MergeWork bounty id returned by
 Inspect treasury proposals:
 
 ```bash
+curl -s "$API_HOST/api/v1/treasury/status"
 curl -s "$API_HOST/api/v1/treasury/proposals"
 curl -s "$API_HOST/api/v1/treasury/proposals/<proposal_id>"
 ```
+
+Use `/api/v1/treasury/status` before proposing fresh bounty rounds. It reports
+the rolling 24-hour reserve cap, recent reserve usage, pending create-bounty
+reserve, remaining create capacity, and the next capacity release time.
 
 Proposal challenges require a GitHub-authenticated session and at least one
 accepted MRWK award. Use machine-checkable challenge types only when the rule is

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -90,9 +90,16 @@ stored when the proposal is created.
 Read proposals:
 
 ```bash
+curl -s "$API_HOST/api/v1/treasury/status"
 curl -s "$API_HOST/api/v1/treasury/proposals"
 curl -s "$API_HOST/api/v1/treasury/proposals/<proposal_id>"
 ```
+
+The treasury status endpoint reports the 24-hour create-bounty reserve cap,
+recent executed reserves, pending create-bounty proposal reserves, remaining
+create capacity, the next reserve capacity release time, and pending
+create-bounty proposals. Use it before drafting fresh bounty rounds so proposed
+issues do not sit around without a possible reserve proposal.
 
 Create or execute proposals with an admin token:
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -215,6 +215,8 @@ def test_admin_page_renders_safe_webhook_events_for_cookie_admin(
     assert unauthenticated.status_code == 302
     assert unauthenticated.headers["location"] == "/auth/github/login?next=/admin"
     assert all_events.status_code == 200
+    assert "Treasury reserve capacity" in all_events.text
+    assert "Available create reserve" in all_events.text
     assert "missing_submitter" in all_events.text
     assert "bounty_not_found" in all_events.text
     assert "exhausted_bounty" in all_events.text
@@ -222,7 +224,10 @@ def test_admin_page_renders_safe_webhook_events_for_cookie_admin(
         r"<code>missing_submitter</code>\s*</span>\s*<strong>2</strong>", all_events.text
     )
     summary_match = re.search(
-        r'<div class="bounty-list-summary"[^>]*>.*?</div>', all_events.text, flags=re.S
+        r'<div class="bounty-list-summary" aria-label="Webhook processed status summary">'
+        r".*?</div>",
+        all_events.text,
+        flags=re.S,
     )
     assert summary_match is not None
     summary_html = summary_match.group(0)

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -20,7 +20,7 @@ from app.ledger.service import (
     verify_supply_conservation,
 )
 from app.main import create_app
-from app.models import Bounty, Submission, TreasuryChallenge, TreasuryProposal, utc_now
+from app.models import Bounty, LedgerEntry, Submission, TreasuryChallenge, TreasuryProposal, utc_now
 from app.path_params import SQLITE_INTEGER_MAX
 
 ADMIN_HEADERS = {"x-mergework-admin-token": "admin-token-for-tests"}
@@ -117,6 +117,91 @@ def test_treasury_proposals_list_newest_first(
 
     assert listed.status_code == 200
     assert [proposal["id"] for proposal in listed.json()] == [second["id"], first["id"]]
+
+
+def test_treasury_status_reports_reserve_capacity_and_pending_create_proposals(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _client(sqlite_url, monkeypatch)
+    recent_time = utc_now() - timedelta(hours=2)
+    old_time = utc_now() - timedelta(hours=25)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=1,
+            issue_url="https://github.com/ramimbo/mergework/issues/1",
+            title="Recent reserve",
+            reward_mrwk="9000",
+            acceptance="Accepted work.",
+        )
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=2,
+            issue_url="https://github.com/ramimbo/mergework/issues/2",
+            title="Expired reserve",
+            reward_mrwk="500",
+            acceptance="Accepted work.",
+        )
+        recent_entry = session.scalar(
+            select(LedgerEntry).where(
+                LedgerEntry.entry_type == "bounty_reserve",
+                LedgerEntry.reference == "https://github.com/ramimbo/mergework/issues/1",
+            )
+        )
+        old_entry = session.scalar(
+            select(LedgerEntry).where(
+                LedgerEntry.entry_type == "bounty_reserve",
+                LedgerEntry.reference == "https://github.com/ramimbo/mergework/issues/2",
+            )
+        )
+        assert recent_entry is not None
+        assert old_entry is not None
+        recent_entry.created_at = recent_time
+        old_entry.created_at = old_time
+
+    proposal = client.post(
+        "/api/v1/bounties",
+        headers=ADMIN_HEADERS,
+        json={**_bounty_payload(issue_number=3, reward_mrwk="500"), "max_awards": 1},
+    )
+    response = client.get("/api/v1/treasury/status")
+
+    assert proposal.status_code == 200
+    assert response.status_code == 200
+    body = response.json()
+    assert body["reserve_cap_mrwk"] == "10000"
+    assert body["executed_reserve_24h_mrwk"] == "9000"
+    assert body["pending_create_reserve_mrwk"] == "500"
+    assert body["available_create_reserve_mrwk"] == "500"
+    assert (
+        body["next_capacity_release_at"]
+        == (recent_time.replace(tzinfo=None) + timedelta(hours=24)).isoformat()
+    )
+    assert body["pending_create_bounties"] == [
+        {
+            "proposal_id": proposal.json()["id"],
+            "issue_number": 3,
+            "issue_url": "https://github.com/ramimbo/mergework/issues/3",
+            "title": "Governance proposal test 3",
+            "reward_mrwk": "500",
+            "max_awards": 1,
+            "reserve_mrwk": "500",
+            "proposed_at": proposal.json()["proposed_at"],
+            "executes_after": proposal.json()["executes_after"],
+        }
+    ]
+    assert body["recent_reserves"] == [
+        {
+            "ledger_sequence": recent_entry.sequence,
+            "amount_mrwk": "9000",
+            "reference": "https://github.com/ramimbo/mergework/issues/1",
+            "created_at": recent_time.replace(tzinfo=None).isoformat(),
+            "expires_at": (recent_time.replace(tzinfo=None) + timedelta(hours=24)).isoformat(),
+        }
+    ]
 
 
 def test_direct_proposal_creation_requires_admin_token(


### PR DESCRIPTION
## Summary

Adds read-only treasury reserve capacity visibility for maintainers and agents:

- public `GET /api/v1/treasury/status`
- `/admin` treasury reserve capacity panel with pending create-bounty proposals
- docs for checking capacity before opening fresh rounds
- regression coverage for status output and admin rendering

This is a maintainer PR. I am not claiming or requesting a bounty for it.

## Why

Fresh bounty rounds are now proposal-gated and reserve-capped. Maintainers need to see the rolling 24h reserve cap, executed reserves, pending create-bounty reserve, remaining create capacity, and next release time before deciding whether to open or wait on new rounds.

## Validation

- `./.venv/bin/python -m pytest` (`483 passed`)
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m mypy app`
- `./.venv/bin/python scripts/docs_smoke.py`