### PR TITLE
Refs #576: Reject control chars in MCP integer args

### DIFF
--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -9,7 +9,13 @@ from app.accounts import normalized_account, normalized_wallet_address
 from app.bounty_attempts import list_bounty_attempts
 from app.bounty_sorting import normalize_bounty_sort, sort_bounties
 from app.db import session_scope
-from app.ledger.service import format_mrwk, get_balance, register_wallet, submit_wallet_transfer
+from app.ledger.service import (
+    CONTROL_CHAR_RE,
+    format_mrwk,
+    get_balance,
+    register_wallet,
+    submit_wallet_transfer,
+)
 from app.ledger_views import ledger_entry_to_dict
 from app.mcp_work_proof import (
     generic_work_proof_guidance_json,
@@ -34,6 +40,8 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
         if isinstance(value, int):
             parsed = value
         elif isinstance(value, str):
+            if CONTROL_CHAR_RE.search(value):
+                raise ValueError(f"{field} must not contain control characters")
             clean = value.strip()
             if clean and clean.lstrip("+-").isdigit():
                 try:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -72,3 +72,39 @@ def test_call_mcp_tool_preserves_argument_validation_errors(
 
     with pytest.raises(ValueError, match=message):
         call_mcp_tool(sqlite_url, tool_name, arguments)
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments", "message"),
+    [
+        ("get_bounty", {"id": "\t1"}, "id must not contain control characters"),
+        (
+            "list_bounty_attempts",
+            {"bounty_id": "1\n"},
+            "bounty_id must not contain control characters",
+        ),
+        (
+            "submit_work_proof",
+            {"issue_number": "\x7f390"},
+            "issue_number must not contain control characters",
+        ),
+    ],
+)
+def test_mcp_integer_arguments_reject_control_characters_before_trimming(
+    sqlite_url: str, tool_name: str, arguments: dict[str, object], message: str
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=390,
+            issue_url="https://github.com/ramimbo/mergework/issues/390",
+            title="Code health bounty",
+            reward_mrwk="200",
+            acceptance="Extract a coherent subsystem from app.main.",
+        )
+
+    with pytest.raises(ValueError, match=message):
+        call_mcp_tool(sqlite_url, tool_name, arguments)


### PR DESCRIPTION
Refs #576

## Summary

Reject raw control characters in MCP integer-like string arguments before trimming/parsing.

This keeps MCP tool calls from accepting tab/newline/DEL-padded numeric strings as if they were clean integers:

- `get_bounty` with `id="\t1"`
- `list_bounty_attempts` with `bounty_id="1\n"`
- `submit_work_proof` with `issue_number="\x7f390"`

## Distinctness

This is limited to MCP integer argument parsing in `app/mcp_tools.py`.

It does not overlap PR #612, which covers MCP optional clean-string filters, or PR #614, which covers HTTP JSON integer parsing. It also stays separate from the wallet/account/bounty filter, source URL, MRWK amount, webhook, treasury, and public search control-character fixes.

## Validation

- `uv run --extra dev python -m pytest tests/test_mcp_tools.py -q` -> 8 passed
- `uv run --extra dev python -m pytest tests/test_mcp_tools.py tests/test_api_mcp.py -q` -> 90 passed, 1 warning
- `uv run --extra dev python -m pytest -q` -> 497 passed, 1 warning
- `uv run --extra dev ruff check app/mcp_tools.py tests/test_mcp_tools.py` -> passed
- `uv run --extra dev ruff format --check app/mcp_tools.py tests/test_mcp_tools.py` -> 2 files already formatted
- `uv run --extra dev mypy app/mcp_tools.py` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean

## Safety

No private data, wallet material, tokens, signatures, admin access, production mutation, price/liquidity/exchange/bridge/off-ramp claims, private security details, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Code formatting improvements to import statements.

* **Tests**
  * Added validation tests ensuring control characters are properly rejected in tool arguments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->