### PR TITLE
Refs #576: Reject control chars in payout notes

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -246,13 +246,14 @@ def register_bounty_api_routes(
             "accepted_by": accepted_by,
         }
         if data.get("note") is not None:
-            note = optional_str(data, "note").strip()
+            raw_note = optional_str(data, "note")
+            if CONTROL_CHAR_RE.search(raw_note):
+                raise HTTPException(
+                    status_code=400,
+                    detail="verifier_result.note must not contain control characters",
+                )
+            note = raw_note.strip()
             if note:
-                if CONTROL_CHAR_RE.search(note):
-                    raise HTTPException(
-                        status_code=400,
-                        detail="verifier_result.note must not contain control characters",
-                    )
                 verifier_result["note"] = note[:240]
         with session_scope(db_url) as session:
             existing_proof = _existing_payout_proof_for_submission(

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1032,8 +1032,9 @@ def test_bounty_payment_proof_rejects_control_character_metadata(sqlite_url: str
         assert get_balance(session, "github:bob") == 0
 
 
+@pytest.mark.parametrize("note", ("line1\nline2", "\tverified manually", "verified manually\x85"))
 def test_admin_payout_api_rejects_control_character_note(
-    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch, note: str
 ) -> None:
     create_schema(sqlite_url)
     monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
@@ -1061,7 +1062,7 @@ def test_admin_payout_api_rejects_control_character_note(
             "to_account": "github:alice",
             "submission_url": "https://github.com/ramimbo/mergework/pull/17",
             "accepted_by": "maintainer",
-            "note": "line1\nline2",
+            "note": note,
         },
     )
 


### PR DESCRIPTION
Refs #576

## Summary

Reject raw control characters in admin payout `note` values before trimming them into public verifier metadata.

This keeps values such as these from being accepted as clean notes during bounty payout proposal creation:

- `note="<tab>verified manually"`
- `note="verified manually\x85"`

Blank whitespace-only notes are still omitted, and ordinary space-padded notes are still trimmed before being stored.

## Distinctness

This is limited to the admin payout API `note` field before it becomes verifier/proposal metadata. It does not overlap the existing #576 slices for attempt `source_url`, MRWK amount strings, treasury proposal fields, webhook identities, wallet material, account/wallet/bounty filters, MCP arguments, JSON integers, forwarded proto headers, or deploy settings.

## Validation

- focused note-control regression: 3 passed
- note behavior slice including blank/trimmed notes: 5 passed
- `tests/test_security.py`: 57 passed, 1 warning
- full test suite: 496 passed, 1 warning
- ruff check on changed files: passed
- ruff format-check on changed files: passed
- `mypy app/bounty_api.py`: success
- docs smoke: ok
- `git diff --check`: clean
- clean merge-tree against current `origin/main`, PR #621, and PR #623
- submission quality gate: PASS

## Safety

No private data, secrets, admin token values, wallet material, production mutation, price/liquidity/exchange/bridge/off-ramp claims, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Control character validation for note fields now runs on raw input before whitespace processing.
  * Note content is truncated to a maximum of 240 characters when non-empty.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->