### PR TITLE
Refs #576: Reject control chars in login CSV config

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -35,11 +35,18 @@ DNS_LABEL_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
 IPV4_DOTTED_QUAD_RE = re.compile(r"(?:\d{1,3}\.){3}\d{1,3}")
 
 
+def _contains_control_character(value: str) -> bool:
+    return any(ord(char) < 32 or 127 <= ord(char) < 160 for char in value)
+
+
 def _csv_env(name: str, default: str = "") -> tuple[str, ...]:
     raw_value = os.environ.get(name, default)
     if not raw_value.strip():
         return ()
-    return tuple(item.strip().lower() for item in raw_value.split(","))
+    return tuple(
+        item.lower() if _contains_control_character(item) else item.strip().lower()
+        for item in raw_value.split(",")
+    )
 
 
 def _secret_errors(name: str, value: str) -> list[str]:

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -336,6 +336,27 @@ def test_deploy_readiness_rejects_empty_login_csv_entries(monkeypatch) -> None:
     )
 
 
+def test_deploy_readiness_rejects_control_character_login_csv_entries(monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_DATABASE_URL", "sqlite:////srv/mergework/data/app.sqlite3")
+    monkeypatch.setenv("MERGEWORK_PUBLIC_BASE_URL", "https://staging.mrwk.example.test")
+    monkeypatch.setenv(
+        "MERGEWORK_GITHUB_WEBHOOK_SECRET", "webhook-8efc3925bb8746b8a8fd3392c4c48e32"
+    )
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv(
+        "MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", "oauth-7818e79f9d3a4a1d82ff0e1b9f0b8e42"
+    )
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-14dcaab83bb245f2bfb5d5c21a9bb55b")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "cookie-27fd1c41324a4bdcb2e4014adc3a6108")
+    monkeypatch.setenv("MERGEWORK_ADMIN_LOGINS", "\talice")
+    monkeypatch.setenv("MERGEWORK_GITHUB_ACCEPTED_LABELERS", "alice\x85")
+
+    errors = validate_deploy_settings(get_settings())
+
+    assert "MERGEWORK_ADMIN_LOGINS must contain valid GitHub logins" in errors
+    assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS must contain valid GitHub logins" in errors
+
+
 def test_deploy_readiness_rejects_public_base_url_path_query_or_fragment() -> None:
     path_errors = validate_deploy_settings(
         _settings(public_base_url="https://mrwk.example.test/app")


### PR DESCRIPTION
Refs #576

## Summary

Reject raw control characters in deploy GitHub-login CSV entries before trimming them into clean admin or accepted-labeler logins.

This keeps values such as these from being accepted as `alice` during deploy readiness checks:

- `MERGEWORK_ADMIN_LOGINS=<tab>alice`
- `MERGEWORK_GITHUB_ACCEPTED_LABELERS=alice\x85`

Normal clean entries and ordinary comma-separated login behavior remain unchanged.

## Distinctness

This is limited to the admin/accepted-labeler GitHub-login CSV parsing path. It does not overlap the existing #576 slices for deploy secret/database/base URL C1 controls, webhook identities, wallet material, account/wallet filters, bounty filters, MCP arguments, JSON integers, MRWK amounts, or attempt source URLs.

## Validation

- focused CSV-login regression: 1 passed
- `tests/test_deploy_readiness.py`: 28 passed
- full test suite: 495 passed, 1 warning
- ruff check on changed files: passed
- ruff format-check on changed files: passed
- `mypy app/config.py`: success
- docs smoke: ok
- `git diff --check`: clean
- clean merge-tree against current `origin/main` and PR #623
- submission quality gate: PASS

## Safety

No private data, secrets, admin token values, wallet material, production mutation, price/liquidity/exchange/bridge/off-ramp claims, or fabricated payout claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of environment configuration values. The system now properly detects control characters in comma-separated configuration entries and applies appropriate handling rules to ensure stricter validation of login credentials and labeler settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->