### PR TITLE
fix: reject C1 controls in account identifiers

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -9,7 +9,7 @@ from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
 from app.db import session_scope
-from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
+from app.ledger.service import CONTROL_CHAR_RE, TREASURY_ACCOUNT, format_mrwk, get_balance
 from app.ledger_views import account_ledger_transactions
 from app.models import Account
 from app.path_params import SQLITE_INTEGER_MAX
@@ -46,7 +46,7 @@ def normalized_wallet_address(address: str) -> str:
 def normalized_account(account: str) -> str:
     if not account or not account.strip():
         raise HTTPException(status_code=400, detail="account must not be empty")
-    if re.search(r"[\x00-\x1f\x7f]", account):
+    if CONTROL_CHAR_RE.search(account):
         raise HTTPException(status_code=400, detail="account must not contain control characters")
     clean = account.strip()
     lower = clean.lower()

--- a/tests/test_account_identifier_controls.py
+++ b/tests/test_account_identifier_controls.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+
+def test_account_api_rejects_c1_control_character_in_identifier(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/api/v1/accounts/foo%C2%85bar")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "account must not contain control characters"
+
+
+def test_account_page_rejects_c1_control_character_in_identifier(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/accounts/foo%C2%85bar")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "account must not contain control characters"

--- a/tests/test_account_identifier_controls.py
+++ b/tests/test_account_identifier_controls.py
@@ -1,23 +1,30 @@
 from __future__ import annotations
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.main import create_app
 
 
-def test_account_api_rejects_c1_control_character_in_identifier(sqlite_url: str) -> None:
+@pytest.mark.parametrize("encoded_control", ("%C2%80", "%C2%85", "%C2%9F"))
+def test_account_api_rejects_c1_control_character_in_identifier(
+    sqlite_url: str, encoded_control: str
+) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
-    response = client.get("/api/v1/accounts/foo%C2%85bar")
+    response = client.get(f"/api/v1/accounts/foo{encoded_control}bar")
 
     assert response.status_code == 400
     assert response.json()["detail"] == "account must not contain control characters"
 
 
-def test_account_page_rejects_c1_control_character_in_identifier(sqlite_url: str) -> None:
+@pytest.mark.parametrize("encoded_control", ("%C2%80", "%C2%85", "%C2%9F"))
+def test_account_page_rejects_c1_control_character_in_identifier(
+    sqlite_url: str, encoded_control: str
+) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
-    response = client.get("/accounts/foo%C2%85bar")
+    response = client.get(f"/accounts/foo{encoded_control}bar")
 
     assert response.status_code == 400
     assert response.json()["detail"] == "account must not contain control characters"


### PR DESCRIPTION
## Summary
- Reject C1 control characters (`\x80-\x9f`) in public account path identifiers.
- Reuse the existing ledger `CONTROL_CHAR_RE` so account routes match the broader project control-character hygiene.
- Add regression coverage for the C1 range boundaries (`U+0080`, `U+0085`, `U+009F`) on both JSON API and HTML account pages.

## Evidence
Before this change, `/api/v1/accounts/foo%C2%85bar` and `/accounts/foo%C2%85bar` accepted `foo\x85bar`, while C0/DEL controls were already rejected. Ledger-side validation already treats C1 controls as control characters.

## Test plan
- `./.venv/bin/python -m pytest tests/test_account_identifier_controls.py -q`
- `./.venv/bin/python -m pytest -q`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m mypy app`

Refs #576.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to reject account identifiers containing C1 control characters, returning consistent 400 responses across API and web endpoints.

* **Tests**
  * Added tests to verify account identifier rejection for C1 control characters and confirm consistent error responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->