### PR TITLE
Add treasury proposal filters and links

### DIFF
--- a/app/treasury.py
+++ b/app/treasury.py
@@ -365,6 +365,7 @@ def challenge_to_dict(challenge: TreasuryChallenge) -> dict[str, Any]:
     return {
         "id": challenge.id,
         "proposal_id": challenge.proposal_id,
+        "proposal_url": f"/api/v1/treasury/proposals/{challenge.proposal_id}",
         "challenger_account": challenge.challenger_account,
         "challenge_type": challenge.challenge_type,
         "status": challenge.status,
@@ -374,9 +375,11 @@ def challenge_to_dict(challenge: TreasuryChallenge) -> dict[str, Any]:
 
 
 def proposal_to_dict(proposal: TreasuryProposal) -> dict[str, Any]:
+    executed_ledger_sequence = proposal.executed_ledger_sequence
     return {
         "id": proposal.id,
         "type": "treasury_proposal",
+        "proposal_url": f"/api/v1/treasury/proposals/{proposal.id}",
         "action": proposal.action,
         "status": proposal.status,
         "payload_hash": proposal.payload_hash,
@@ -386,7 +389,10 @@ def proposal_to_dict(proposal: TreasuryProposal) -> dict[str, Any]:
         "proposed_at": proposal.proposed_at.isoformat(),
         "executes_after": proposal.executes_after.isoformat(),
         "executed_at": proposal.executed_at.isoformat() if proposal.executed_at else None,
-        "executed_ledger_sequence": proposal.executed_ledger_sequence,
+        "executed_ledger_sequence": executed_ledger_sequence,
+        "executed_ledger_url": (
+            f"/ledger/{executed_ledger_sequence}" if executed_ledger_sequence else None
+        ),
         "result": proposal_result(proposal),
         "challenges": [challenge_to_dict(challenge) for challenge in proposal.challenges],
     }

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -6,7 +6,7 @@ from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from sqlalchemy import select
 
 from app.db import session_scope
-from app.ledger.service import LedgerError
+from app.ledger.service import CONTROL_CHAR_RE, LedgerError
 from app.models import TreasuryProposal
 from app.path_params import SQLITE_INTEGER_MAX
 from app.treasury import (
@@ -41,6 +41,8 @@ def _proposal_error(exc: LedgerError) -> HTTPException:
 def _normalized_filter(value: str | None, field: str, allowed: set[str]) -> str | None:
     if value is None:
         return None
+    if CONTROL_CHAR_RE.search(value):
+        raise HTTPException(status_code=400, detail=f"{field} must not contain control characters")
     normalized = value.strip().lower()
     if not normalized:
         return None

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -10,12 +10,15 @@ from app.ledger.service import LedgerError
 from app.models import TreasuryProposal
 from app.path_params import SQLITE_INTEGER_MAX
 from app.treasury import (
+    TREASURY_ACTIONS,
     challenge_to_dict,
     create_treasury_challenge,
     execute_treasury_proposal,
     proposal_to_dict,
     propose_treasury_action,
 )
+
+TREASURY_PROPOSAL_STATUSES = {"pending", "executed", "blocked"}
 
 
 def _positive_proposal_id(proposal_id: int) -> int:
@@ -35,6 +38,18 @@ def _proposal_error(exc: LedgerError) -> HTTPException:
     return HTTPException(status_code=400, detail=detail)
 
 
+def _normalized_filter(value: str | None, field: str, allowed: set[str]) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized not in allowed:
+        allowed_values = ", ".join(sorted(allowed))
+        raise HTTPException(status_code=400, detail=f"{field} must be one of: {allowed_values}")
+    return normalized
+
+
 def register_treasury_routes(
     app: FastAPI,
     *,
@@ -45,11 +60,20 @@ def register_treasury_routes(
 ) -> None:
     @app.get("/api/v1/treasury/proposals")
     def api_treasury_proposals(
+        status: str | None = Query(None),
+        action: str | None = Query(None),
         limit: Annotated[int, Query(ge=1, le=200)] = 100,
     ) -> list[dict[str, Any]]:
+        normalized_status = _normalized_filter(status, "status", TREASURY_PROPOSAL_STATUSES)
+        normalized_action = _normalized_filter(action, "action", TREASURY_ACTIONS)
         with session_scope(db_url) as session:
+            query = select(TreasuryProposal)
+            if normalized_status is not None:
+                query = query.where(TreasuryProposal.status == normalized_status)
+            if normalized_action is not None:
+                query = query.where(TreasuryProposal.action == normalized_action)
             proposals = session.scalars(
-                select(TreasuryProposal).order_by(TreasuryProposal.id.desc()).limit(limit)
+                query.order_by(TreasuryProposal.id.desc()).limit(limit)
             ).all()
             return [proposal_to_dict(proposal) for proposal in proposals]
 

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -35,8 +35,15 @@ Public reads:
 
 ```bash
 curl -s https://api.mrwk.ltclab.site/api/v1/treasury/proposals
+curl -s 'https://api.mrwk.ltclab.site/api/v1/treasury/proposals?status=pending'
+curl -s 'https://api.mrwk.ltclab.site/api/v1/treasury/proposals?action=pay_bounty&limit=10'
 curl -s https://api.mrwk.ltclab.site/api/v1/treasury/proposals/<proposal_id>
 ```
+
+Use `status` filters (`pending`, `executed`, `blocked`) and `action` filters
+(`create_bounty`, `pay_bounty`, `close_bounty`) when checking a proposal queue.
+Each row includes its detail `proposal_url` and, after execution, an
+`executed_ledger_url`.
 
 Execution requires an admin token and only works after the 24-hour delay:
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -74,6 +74,8 @@ Inspect treasury proposals:
 
 ```bash
 curl -s "$API_HOST/api/v1/treasury/proposals"
+curl -s "$API_HOST/api/v1/treasury/proposals?status=pending"
+curl -s "$API_HOST/api/v1/treasury/proposals?action=create_bounty&limit=10"
 curl -s "$API_HOST/api/v1/treasury/proposals/<proposal_id>"
 ```
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -91,8 +91,15 @@ Read proposals:
 
 ```bash
 curl -s "$API_HOST/api/v1/treasury/proposals"
+curl -s "$API_HOST/api/v1/treasury/proposals?status=pending"
+curl -s "$API_HOST/api/v1/treasury/proposals?action=pay_bounty&limit=10"
 curl -s "$API_HOST/api/v1/treasury/proposals/<proposal_id>"
 ```
+
+The proposal list accepts `status` values `pending`, `executed`, and `blocked`,
+plus `action` values `create_bounty`, `pay_bounty`, and `close_bounty`. Proposal
+rows include `proposal_url` for detail reads and `executed_ledger_url` once an
+executed proposal creates a ledger entry.
 
 Create or execute proposals with an admin token:
 

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -215,6 +215,24 @@ def test_treasury_proposals_list_filters_status_and_action(
     )
 
 
+@pytest.mark.parametrize(
+    ("query", "expected_detail"),
+    [
+        ("status=%09pending", "status must not contain control characters"),
+        ("action=%C2%85create_bounty", "action must not contain control characters"),
+    ],
+)
+def test_treasury_proposals_filters_reject_raw_control_characters(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch, query: str, expected_detail: str
+) -> None:
+    client = _client(sqlite_url, monkeypatch)
+
+    response = client.get(f"/api/v1/treasury/proposals?{query}")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == expected_detail
+
+
 def test_direct_proposal_creation_requires_admin_token(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -84,8 +84,10 @@ def test_admin_bounty_creation_creates_public_delayed_proposal(
     assert response.status_code == 200
     body = response.json()
     assert body["type"] == "treasury_proposal"
+    assert body["proposal_url"] == f"/api/v1/treasury/proposals/{body['id']}"
     assert body["action"] == "create_bounty"
     assert body["status"] == "pending"
+    assert body["executed_ledger_url"] is None
     assert body["payload"]["repo"] == "ramimbo/mergework"
     assert body["payload"]["reward_mrwk"] == "25"
     assert body["executes_after"] > body["proposed_at"]
@@ -153,6 +155,64 @@ def test_treasury_proposals_list_honors_limit(
     assert first["id"] not in [proposal["id"] for proposal in limited.json()]
     assert too_small.status_code == 422
     assert too_large.status_code == 422
+
+
+def test_treasury_proposals_list_filters_status_and_action(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _client(sqlite_url, monkeypatch)
+    create_proposal = client.post(
+        "/api/v1/bounties",
+        headers=ADMIN_HEADERS,
+        json=_bounty_payload(issue_number=74),
+    ).json()
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=75,
+            issue_url="https://github.com/ramimbo/mergework/issues/75",
+            title="Proposal filter payout",
+            reward_mrwk="5",
+            acceptance="Accepted proof.",
+        )
+        bounty_id = bounty.id
+    pay_proposal = client.post(
+        f"/api/v1/bounties/{bounty_id}/pay",
+        headers=ADMIN_HEADERS,
+        json={
+            "to_account": "github:bob",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/75",
+            "accepted_by": "maintainer",
+        },
+    ).json()
+    _make_executable(sqlite_url, create_proposal["id"])
+
+    executed = client.post(
+        f"/api/v1/treasury/proposals/{create_proposal['id']}/execute",
+        headers=ADMIN_HEADERS,
+    )
+    pending = client.get("/api/v1/treasury/proposals?status=pending")
+    executed_list = client.get("/api/v1/treasury/proposals?status=executed")
+    payout_actions = client.get("/api/v1/treasury/proposals?action=pay_bounty")
+    combined = client.get("/api/v1/treasury/proposals?status=pending&action=pay_bounty")
+    invalid_status = client.get("/api/v1/treasury/proposals?status=reviewing")
+    invalid_action = client.get("/api/v1/treasury/proposals?action=delete_bounty")
+
+    assert executed.status_code == 200
+    assert pending.status_code == 200
+    assert [proposal["id"] for proposal in pending.json()] == [pay_proposal["id"]]
+    assert [proposal["id"] for proposal in executed_list.json()] == [create_proposal["id"]]
+    assert [proposal["id"] for proposal in payout_actions.json()] == [pay_proposal["id"]]
+    assert [proposal["id"] for proposal in combined.json()] == [pay_proposal["id"]]
+    assert invalid_status.status_code == 400
+    assert invalid_status.json()["detail"] == "status must be one of: blocked, executed, pending"
+    assert invalid_action.status_code == 400
+    assert (
+        invalid_action.json()["detail"]
+        == "action must be one of: close_bounty, create_bounty, pay_bounty"
+    )
 
 
 def test_direct_proposal_creation_requires_admin_token(
@@ -232,6 +292,9 @@ def test_proposal_execution_requires_admin_delay_and_is_idempotent(
     assert executed.status_code == 200
     assert executed.json()["status"] == "executed"
     assert executed.json()["result"]["bounty"]["issue_number"] == 77
+    assert executed.json()["executed_ledger_url"] == (
+        f"/ledger/{executed.json()['executed_ledger_sequence']}"
+    )
     assert duplicate.status_code == 409
     assert duplicate.json()["detail"] == "proposal already executed"
 
@@ -665,6 +728,7 @@ def test_challenges_require_accepted_work_and_can_block_invalid_proposals(
     assert unearned.status_code == 403
     assert unearned.json()["detail"] == "accepted MRWK work required to challenge proposals"
     assert subjective.status_code == 200
+    assert subjective.json()["proposal_url"] == f"/api/v1/treasury/proposals/{proposal['id']}"
     assert subjective.json()["status"] == "noted"
     assert blocking.status_code == 200
     assert blocking.json()["status"] == "accepted_blocking"


### PR DESCRIPTION
## Summary
- add `proposal_url` and `executed_ledger_url` to treasury proposal responses, plus `proposal_url` on challenge responses
- support bounded `status` and `action` filters on `GET /api/v1/treasury/proposals`
- document the filters and link fields for admins and agents

Refs #597
/claim #597

## Tests
- `./.venv/bin/ruff check app/treasury.py app/treasury_routes.py tests/test_treasury_proposals.py`
- `./.venv/bin/python -m pytest tests/test_treasury_proposals.py`
- `./.venv/bin/python scripts/docs_smoke.py`
- `./.venv/bin/python -m pytest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Treasury proposals now include proposal_url and executed_ledger_url; list endpoint supports status and action filters with validation and clear 400 errors for invalid values.
* **Documentation**
  * API and admin docs updated with examples for filtering proposals and noting the new URL fields.
* **Tests**
  * Added tests validating filter behavior (including control-character rejection) and presence of the new URL fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->