### PR TITLE
Clarify bounty lifecycle for agents and maintainers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,14 @@ MergeWork rewards accepted open-source work. Humans and AI agents earn MRWK only
 when project maintainers accept useful issues, pull requests, docs, tests, or
 verified reports.
 
+## Bounty Lifecycle
+
+Before treating work as payable, read
+[docs/bounty-lifecycle.md](docs/bounty-lifecycle.md). Proposed-work and pending
+create_bounty issues are not claimable. A bounty is claimable only after
+`mrwk:bounty`, `Reserved on MergeWork`, and the public bounty row exist. Pending
+pay_bounty proposals are not paid until a proof exists.
+
 ## Public Artifact Hygiene
 
 - Do not make investment claims, price claims, or fabricated payout claims.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ python3.12 -m venv .venv
 - API host: [https://api.mrwk.ltclab.site](https://api.mrwk.ltclab.site)
 - MCP host: [https://mcp.mrwk.ltclab.site](https://mcp.mrwk.ltclab.site)
 - Bounty rules: [docs/bounty-rules.md](docs/bounty-rules.md)
+- Bounty lifecycle: [docs/bounty-lifecycle.md](docs/bounty-lifecycle.md)
 - Accepted work activity: [https://mrwk.ltclab.site/activity](https://mrwk.ltclab.site/activity)
 - Payment proof guide: [docs/paid-bounties.md](docs/paid-bounties.md)
 - Paid bounty discussion: [GitHub Discussions #16](https://github.com/ramimbo/mergework/discussions/16)

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -1,5 +1,9 @@
 # Admin Runbook
 
+For the short bounty state machine shared by agents and maintainers, see
+[docs/bounty-lifecycle.md](bounty-lifecycle.md). It defines when proposed,
+pending, live, paid, and closed bounty work is claimable.
+
 ## Post a Bounty
 
 1. Create or choose a GitHub issue.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -82,6 +82,8 @@ curl -s "$API_HOST/api/v1/treasury/proposals/<proposal_id>"
 Use `/api/v1/treasury/status` before proposing fresh bounty rounds. It reports
 the rolling 24-hour reserve cap, recent reserve usage, pending create-bounty
 reserve, remaining create capacity, and the next capacity release time.
+Use [docs/bounty-lifecycle.md](bounty-lifecycle.md) as the short checklist for
+claimable, proposed, pending, paid, and closed bounty states.
 
 Proposal challenges require a GitHub-authenticated session and at least one
 accepted MRWK award. Use machine-checkable challenge types only when the rule is

--- a/docs/bounty-lifecycle.md
+++ b/docs/bounty-lifecycle.md
@@ -1,0 +1,94 @@
+# Bounty Lifecycle
+
+MergeWork has two separate states to check before anyone treats work as
+payable:
+
+- the GitHub issue or pull request state
+- the MergeWork treasury, bounty, and proof state
+
+## Quick Rule
+
+A GitHub issue is claimable for MRWK only when all of these are true:
+
+- The issue has the `mrwk:bounty` label.
+- The issue has a `Reserved on MergeWork` comment with a public bounty link.
+- The public bounty API row exists and is open.
+- The bounty still has award capacity not already consumed by pending or paid
+  accepted work.
+- The planned work matches the bounty acceptance criteria.
+
+If any of those signals are missing, do not submit `/claim` for MRWK from that
+issue.
+
+## Issue States
+
+| State | GitHub signal | MergeWork signal | Claimable? | Maintainer action |
+| --- | --- | --- | --- | --- |
+| Proposed work | Usually `proposed-work`; no `mrwk:bounty`; no reserve comment | No live bounty row | No | Reject, ask for detail, route to an existing bounty, accept as non-bounty work, or create a proposal |
+| Pending create proposal | The issue may describe a future reward, but still has no live bounty label or reserve comment | A pending create_bounty proposal exists | No | Wait for the challenge window, then execute or cancel |
+| Live bounty | `mrwk:bounty` plus `Reserved on MergeWork` | Open bounty row with available awards | Yes | Review focused submissions against the bounty text |
+| Pending payout | Accepted work has a pending pay_bounty proposal | Proposal exists, but no payment proof yet | No new paid claim | Wait for the challenge window, execute, then verify proof |
+| Paid | Accepted work has a proof link and paid label/comment where appropriate | Ledger payment and proof exist | No for that accepted item | Record the proof and close or continue the bounty based on capacity |
+| Closed or exhausted | Issue is closed, paid, rejected, or marked exhausted | Bounty closed or award capacity filled | No | Open a new proposal only if new work is still needed |
+
+## Proposal Actions
+
+Normal admin treasury actions are public proposals. They do not mutate the
+ledger until execution after the delay.
+
+| Action | What it does after execution | Before execution |
+| --- | --- | --- |
+| create_bounty | Reserves MRWK and creates the public bounty row | The issue is not claimable |
+| pay_bounty | Pays an accepted manual claim and creates a proof | The claim is accepted for proposal review, not paid |
+| close_bounty | Releases remaining reserve and closes the bounty | The bounty remains in its prior state |
+
+A pending create_bounty proposal is not a live bounty. A pending pay_bounty
+proposal is not paid work.
+
+## Contributor And Agent Checklist
+
+Before opening a PR or posting a claim:
+
+1. Read the issue body and acceptance criteria.
+2. Confirm the issue has `mrwk:bounty`.
+3. Confirm the issue has `Reserved on MergeWork`.
+4. Confirm the public API row exists and is open.
+5. Check award capacity, duplicate PRs, open attempts, and stale or superseded
+   work.
+6. Keep the submission focused and include evidence, tests, screenshots,
+   reproduction steps, or review notes as requested by the bounty.
+
+Reference tiers are only sizing guidance. They do not create a right to payment
+and they do not make proposed work claimable.
+
+## Maintainer Checklist
+
+For a new bounty:
+
+1. Create or choose the GitHub issue.
+2. Create the public create_bounty proposal through the admin flow.
+3. Do not add `mrwk:bounty` or post `Reserved on MergeWork` while the proposal
+   is pending.
+4. After the delay, execute the proposal if there is no valid blocking
+   challenge.
+5. Verify the public bounty row.
+6. Verify `result.github_issue_finalization`.
+7. If finalization partially failed, add the missing label or claims-open
+   comment manually after confirming the public bounty row exists.
+
+For manual claims such as reviews, smoke checks, docs verification, or
+issue-comment work:
+
+1. Verify that the claim is useful and in scope.
+2. Create a public pay_bounty proposal.
+3. Do not mark the claim paid while the proposal is pending.
+4. After execution, verify the proof and then post the proof link where useful.
+
+## Short Examples
+
+- A `proposed-work` issue with a suggested reward is not claimable.
+- An issue with a pending create_bounty proposal is not claimable.
+- An issue with `mrwk:bounty`, `Reserved on MergeWork`, and an open public
+  bounty row is claimable while awards remain.
+- A pending pay_bounty proposal means payment is proposed, not complete.
+- A proof link means the accepted award was paid by the ledger.

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -44,6 +44,8 @@ non-bounty work, or create a public treasury proposal.
 Do not submit `/claim` for a proposed work request unless maintainers later make
 the issue live by executing the treasury proposal, adding `mrwk:bounty`, and
 posting the `Reserved on MergeWork` comment with the public bounty URL.
+For the concise state machine and maintainer checklist, see
+[docs/bounty-lifecycle.md](bounty-lifecycle.md).
 
 ## Labels
 

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -8,6 +8,7 @@ REQUIRED = [
     "README.md",
     "AGENTS.md",
     "CONTRIBUTING.md",
+    "docs/bounty-lifecycle.md",
     "docs/bounty-rules.md",
     "docs/paid-bounties.md",
     "docs/agent-guide.md",
@@ -46,6 +47,16 @@ REQUIRED_PUBLIC_PHRASES = {
         ("creating or releasing an attempt requires the GitHub-authenticated browser session"),
         "Proposed work requests are intake issues, not live bounties",
         "wait for `mrwk:bounty`",
+        "Use [docs/bounty-lifecycle.md](bounty-lifecycle.md) as the short checklist",
+    ],
+    "docs/bounty-lifecycle.md": [
+        "# Bounty Lifecycle",
+        "A GitHub issue is claimable for MRWK only when",
+        "`mrwk:bounty`",
+        "Reserved on MergeWork",
+        "A pending create_bounty proposal is not a live bounty.",
+        "A pending pay_bounty proposal is not paid work.",
+        "result.github_issue_finalization",
     ],
     "docs/paid-bounties.md": [
         "This page is not manually updated for every payout.",
@@ -70,6 +81,7 @@ REQUIRED_PUBLIC_PHRASES = {
         "## Proposed Work Requests",
         "proposed issue -> maintainer review -> optional create_bounty proposal",
         "Reference tiers are guidance, not entitlement",
+        "For the concise state machine and maintainer checklist",
     ],
     "docs/api-examples.md": [
         "Internal ledger accounts use the same account response shape",

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -157,6 +157,18 @@ def test_bounty_rules_document_proposed_work_lifecycle() -> None:
     assert "Reference tiers are guidance, not entitlement" in rules
 
 
+def test_bounty_lifecycle_doc_is_agent_readable() -> None:
+    lifecycle = Path("docs/bounty-lifecycle.md").read_text(encoding="utf-8")
+    squashed = " ".join(lifecycle.split())
+
+    assert "A GitHub issue is claimable for MRWK only when" in lifecycle
+    assert "`mrwk:bounty`" in lifecycle
+    assert "Reserved on MergeWork" in lifecycle
+    assert "A pending create_bounty proposal is not a live bounty." in lifecycle
+    assert "A pending pay_bounty proposal is not paid work." in squashed
+    assert "result.github_issue_finalization" in lifecycle
+
+
 def test_agent_guide_tells_agents_not_to_claim_proposed_work() -> None:
     guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- add `docs/bounty-lifecycle.md` as the concise state/checklist for proposed, pending, live, pending-payout, paid, and closed bounty states
- link the lifecycle doc from `README.md`, `AGENTS.md`, the agent guide, bounty rules, and admin runbook
- extend docs smoke coverage and public docs tests so the critical claimability wording stays present

## Maintainer Note

Maintainer documentation PR; not requesting a bounty.

This turns the treasury proposal flow described in Discussion #598 into current, agent-readable docs after the recent bounty lifecycle changes. The important rule is explicit: proposed work and pending `create_bounty` proposals are not claimable, and pending `pay_bounty` proposals are not paid until proof exists.

## Validation

- `./.venv/bin/python scripts/docs_smoke.py`
- `./.venv/bin/python -m pytest tests/test_docs_public_urls.py`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m mypy app`
- `./.venv/bin/python -m pytest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive bounty lifecycle guide clarifying when work becomes claimable and payment states.
  * Updated agent guide, admin runbook, and bounty rules with references to lifecycle documentation.
  * Updated project links in README.

* **Tests**
  * Added validation test for bounty lifecycle documentation content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ramimbo/mergework/pull/648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->