### PR TITLE
Add treasury runway capacity projection

### DIFF
--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -73,6 +73,30 @@
     </tbody>
   </table>
   {% endif %}
+  {% if treasury_status.projected_capacity_events %}
+  <h3>Projected capacity events</h3>
+  <p>Pending create executions do not free capacity immediately. Capacity returns after the executed reserve leaves the 24h window.</p>
+  <table class="webhook-table">
+    <thead>
+      <tr>
+        <th>Time</th>
+        <th>Event</th>
+        <th>Amount</th>
+        <th>Available after</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for event in treasury_status.projected_capacity_events %}
+      <tr>
+        <td data-label="Time">{{ event.at }}</td>
+        <td data-label="Event">{{ event.note }}</td>
+        <td data-label="Amount">{{ event.amount_mrwk }} MRWK</td>
+        <td data-label="Available after">{{ event.available_create_reserve_mrwk }} MRWK</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
 </section>
 
 <section class="detail">

--- a/app/treasury.py
+++ b/app/treasury.py
@@ -468,14 +468,87 @@ def _recent_bounty_reserve_entries(session: Session, now: datetime) -> list[Ledg
     )
 
 
+def _projected_capacity_events(
+    *,
+    now: datetime,
+    executed_reserve: int,
+    pending_create_reserve: int,
+    recent_reserves: list[LedgerEntry],
+    pending_creates: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    event_rows: list[tuple[datetime, int, str, int, str]] = []
+    for entry in recent_reserves:
+        releases_at = _db_utc(entry.created_at) + TREASURY_EPOCH_WINDOW
+        if releases_at > now:
+            event_rows.append(
+                (
+                    releases_at,
+                    0,
+                    "recent_reserve_releases",
+                    int(entry.amount_microunits),
+                    "Executed reserve leaves the 24h cap window.",
+                )
+            )
+    for pending in pending_creates:
+        executes_after = pending["executes_after_dt"]
+        reserve = int(pending["reserve_microunits"])
+        event_rows.append(
+            (
+                executes_after,
+                1,
+                "pending_create_executes",
+                reserve,
+                "Pending create reserve becomes executed reserve; capacity does not increase.",
+            )
+        )
+        event_rows.append(
+            (
+                executes_after + TREASURY_EPOCH_WINDOW,
+                2,
+                "pending_create_releases",
+                reserve,
+                "Executed reserve from this pending create leaves the 24h cap window.",
+            )
+        )
+
+    projected_executed = executed_reserve
+    projected_pending = pending_create_reserve
+    events: list[dict[str, Any]] = []
+    for at, _, event_type, amount, note in sorted(event_rows, key=lambda item: (item[0], item[1])):
+        if event_type == "recent_reserve_releases":
+            projected_executed = max(projected_executed - amount, 0)
+        elif event_type == "pending_create_executes":
+            projected_pending = max(projected_pending - amount, 0)
+            projected_executed += amount
+        elif event_type == "pending_create_releases":
+            projected_executed = max(projected_executed - amount, 0)
+        available = max(
+            TREASURY_EPOCH_RESERVE_CAP_MICRO - projected_executed - projected_pending,
+            0,
+        )
+        events.append(
+            {
+                "at": at.isoformat(),
+                "event_type": event_type,
+                "amount_mrwk": format_mrwk(amount),
+                "available_create_reserve_mrwk": format_mrwk(available),
+                "note": note,
+            }
+        )
+    return events
+
+
 def treasury_status(session: Session) -> dict[str, Any]:
     now = _db_now()
     recent_reserves = _recent_bounty_reserve_entries(session, now)
     executed_reserve = sum(entry.amount_microunits for entry in recent_reserves)
     pending_create_bounties: list[dict[str, Any]] = []
+    pending_create_projection: list[dict[str, Any]] = []
     pending_create_reserve = 0
     for proposal, payload in _pending_action_payloads(session, "create_bounty"):
         reserve = parse_mrwk_amount(str(payload["reward_mrwk"])) * int(payload["max_awards"])
+        executes_after = _db_utc(proposal.executes_after)
+        capacity_releases_at = executes_after + TREASURY_EPOCH_WINDOW
         pending_create_reserve += reserve
         pending_create_bounties.append(
             {
@@ -487,7 +560,14 @@ def treasury_status(session: Session) -> dict[str, Any]:
                 "max_awards": int(payload["max_awards"]),
                 "reserve_mrwk": format_mrwk(reserve),
                 "proposed_at": _db_utc(proposal.proposed_at).isoformat(),
-                "executes_after": _db_utc(proposal.executes_after).isoformat(),
+                "executes_after": executes_after.isoformat(),
+                "capacity_releases_at": capacity_releases_at.isoformat(),
+            }
+        )
+        pending_create_projection.append(
+            {
+                "executes_after_dt": executes_after,
+                "reserve_microunits": reserve,
             }
         )
     available = max(TREASURY_EPOCH_RESERVE_CAP_MICRO - executed_reserve - pending_create_reserve, 0)
@@ -497,6 +577,18 @@ def treasury_status(session: Session) -> dict[str, Any]:
         if _db_utc(entry.created_at) + TREASURY_EPOCH_WINDOW > now
     ]
     next_capacity_release_at = min(release_times).isoformat() if release_times else None
+    projected_capacity_events = _projected_capacity_events(
+        now=now,
+        executed_reserve=executed_reserve,
+        pending_create_reserve=pending_create_reserve,
+        recent_reserves=recent_reserves,
+        pending_creates=pending_create_projection,
+    )
+    projected_release_events = [
+        event["at"]
+        for event in projected_capacity_events
+        if event["event_type"] in {"recent_reserve_releases", "pending_create_releases"}
+    ]
     return {
         "type": "treasury_status",
         "epoch_window_hours": int(TREASURY_EPOCH_WINDOW.total_seconds() // 3600),
@@ -505,7 +597,11 @@ def treasury_status(session: Session) -> dict[str, Any]:
         "pending_create_reserve_mrwk": format_mrwk(pending_create_reserve),
         "available_create_reserve_mrwk": format_mrwk(available),
         "next_capacity_release_at": next_capacity_release_at,
+        "next_projected_capacity_release_at": (
+            min(projected_release_events) if projected_release_events else None
+        ),
         "pending_create_bounties": pending_create_bounties,
+        "projected_capacity_events": projected_capacity_events,
         "recent_reserves": [
             {
                 "ledger_sequence": entry.sequence,

--- a/app/treasury.py
+++ b/app/treasury.py
@@ -491,6 +491,8 @@ def _projected_capacity_events(
             )
     for pending in pending_creates:
         executes_after = pending["executes_after_dt"]
+        if executes_after < now:
+            executes_after = now
         reserve = int(pending["reserve_microunits"])
         event_rows.append(
             (
@@ -548,7 +550,8 @@ def treasury_status(session: Session) -> dict[str, Any]:
     for proposal, payload in _pending_action_payloads(session, "create_bounty"):
         reserve = parse_mrwk_amount(str(payload["reward_mrwk"])) * int(payload["max_awards"])
         executes_after = _db_utc(proposal.executes_after)
-        capacity_releases_at = executes_after + TREASURY_EPOCH_WINDOW
+        projected_executes_after = max(executes_after, now)
+        capacity_releases_at = projected_executes_after + TREASURY_EPOCH_WINDOW
         pending_create_reserve += reserve
         pending_create_bounties.append(
             {
@@ -566,7 +569,7 @@ def treasury_status(session: Session) -> dict[str, Any]:
         )
         pending_create_projection.append(
             {
-                "executes_after_dt": executes_after,
+                "executes_after_dt": projected_executes_after,
                 "reserve_microunits": reserve,
             }
         )

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -79,6 +79,11 @@ users with at least one accepted MRWK award can submit proposal challenges.
 Machine-checkable valid challenges block execution. Subjective challenges are
 public notes and do not block by themselves.
 
+The admin treasury panel also shows projected capacity events. Use that table
+to plan the next runway before current rounds empty: a pending create execution
+does not free capacity immediately, because its reserve stays counted until it
+leaves the rolling 24-hour execution window.
+
 Proposal creation rejects known impossible or conflicting actions before they
 enter the public queue, including mismatched GitHub issue URLs, missing or
 non-open bounties, duplicate pending proposals, and pending reserve-cap

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -287,6 +287,8 @@ def test_admin_page_calls_out_pending_create_proposals_when_they_limit_capacity(
     assert "Pending create-bounty proposals are using current create-bounty capacity." in (
         response.text
     )
+    assert "Pending create executions do not free capacity immediately." in response.text
+    assert "Projected capacity events" in response.text
     assert "No recent reserve entries are currently limiting create-bounty capacity." not in (
         response.text
     )

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import cast
 
 import pytest
@@ -216,6 +216,9 @@ def test_treasury_status_reports_reserve_capacity_and_pending_create_proposals(
             "reserve_mrwk": "500",
             "proposed_at": proposal.json()["proposed_at"],
             "executes_after": proposal.json()["executes_after"],
+            "capacity_releases_at": (
+                datetime.fromisoformat(proposal.json()["executes_after"]) + timedelta(hours=24)
+            ).isoformat(),
         }
     ]
     assert body["recent_reserves"] == [
@@ -271,6 +274,77 @@ def test_treasury_status_includes_reserve_at_exact_24h_boundary(
         }
     ]
     assert body["next_capacity_release_at"] is None
+
+
+def test_treasury_status_projects_pending_create_capacity_events(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixed_now = utc_now().replace(microsecond=0)
+    monkeypatch.setattr("app.treasury.utc_now", lambda: fixed_now)
+    client = _client(sqlite_url, monkeypatch)
+    recent_time = fixed_now - timedelta(hours=1)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=201,
+            issue_url="https://github.com/ramimbo/mergework/issues/201",
+            title="Recent reserve",
+            reward_mrwk="8000",
+            acceptance="Accepted work.",
+        )
+        recent_entry = session.scalar(
+            select(LedgerEntry).where(
+                LedgerEntry.entry_type == "bounty_reserve",
+                LedgerEntry.reference == "https://github.com/ramimbo/mergework/issues/201",
+            )
+        )
+        assert recent_entry is not None
+        recent_entry.created_at = recent_time
+
+    proposal = client.post(
+        "/api/v1/bounties",
+        headers=ADMIN_HEADERS,
+        json={**_bounty_payload(issue_number=202, reward_mrwk="1000"), "max_awards": 1},
+    )
+    response = client.get("/api/v1/treasury/status")
+
+    assert proposal.status_code == 200
+    assert response.status_code == 200
+    body = response.json()
+    pending_release_at = fixed_now.replace(tzinfo=None) + timedelta(hours=48)
+    assert body["available_create_reserve_mrwk"] == "1000"
+    assert body["pending_create_bounties"][0]["capacity_releases_at"] == (
+        pending_release_at.isoformat()
+    )
+    assert body["projected_capacity_events"] == [
+        {
+            "at": (recent_time.replace(tzinfo=None) + timedelta(hours=24)).isoformat(),
+            "event_type": "recent_reserve_releases",
+            "amount_mrwk": "8000",
+            "available_create_reserve_mrwk": "9000",
+            "note": "Executed reserve leaves the 24h cap window.",
+        },
+        {
+            "at": (fixed_now.replace(tzinfo=None) + timedelta(hours=24)).isoformat(),
+            "event_type": "pending_create_executes",
+            "amount_mrwk": "1000",
+            "available_create_reserve_mrwk": "9000",
+            "note": "Pending create reserve becomes executed reserve; capacity does not increase.",
+        },
+        {
+            "at": pending_release_at.isoformat(),
+            "event_type": "pending_create_releases",
+            "amount_mrwk": "1000",
+            "available_create_reserve_mrwk": "10000",
+            "note": "Executed reserve from this pending create leaves the 24h cap window.",
+        },
+    ]
+    assert (
+        body["next_projected_capacity_release_at"]
+        == (recent_time.replace(tzinfo=None) + timedelta(hours=24)).isoformat()
+    )
 
 
 def test_treasury_proposals_list_honors_limit(

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -347,6 +347,54 @@ def test_treasury_status_projects_pending_create_capacity_events(
     )
 
 
+def test_treasury_status_clamps_overdue_pending_create_projection_to_now(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixed_now = utc_now().replace(microsecond=0)
+    monkeypatch.setattr("app.treasury.utc_now", lambda: fixed_now)
+    client = _client(sqlite_url, monkeypatch)
+    proposal = client.post(
+        "/api/v1/bounties",
+        headers=ADMIN_HEADERS,
+        json={**_bounty_payload(issue_number=203, reward_mrwk="1000"), "max_awards": 1},
+    )
+    assert proposal.status_code == 200
+    with session_scope(sqlite_url) as session:
+        stored = session.get(TreasuryProposal, proposal.json()["id"])
+        assert stored is not None
+        stored.executes_after = fixed_now - timedelta(hours=2)
+
+    response = client.get("/api/v1/treasury/status")
+
+    assert response.status_code == 200
+    body = response.json()
+    pending_release_at = fixed_now.replace(tzinfo=None) + timedelta(hours=24)
+    assert (
+        body["pending_create_bounties"][0]["executes_after"]
+        == (fixed_now.replace(tzinfo=None) - timedelta(hours=2)).isoformat()
+    )
+    assert body["pending_create_bounties"][0]["capacity_releases_at"] == (
+        pending_release_at.isoformat()
+    )
+    assert body["projected_capacity_events"] == [
+        {
+            "at": fixed_now.replace(tzinfo=None).isoformat(),
+            "event_type": "pending_create_executes",
+            "amount_mrwk": "1000",
+            "available_create_reserve_mrwk": "9000",
+            "note": "Pending create reserve becomes executed reserve; capacity does not increase.",
+        },
+        {
+            "at": pending_release_at.isoformat(),
+            "event_type": "pending_create_releases",
+            "amount_mrwk": "1000",
+            "available_create_reserve_mrwk": "10000",
+            "note": "Executed reserve from this pending create leaves the 24h cap window.",
+        },
+    ]
+    assert body["next_projected_capacity_release_at"] == pending_release_at.isoformat()
+
+
 def test_treasury_proposals_list_honors_limit(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Add projected reserve-cap events to `/api/v1/treasury/status`.
- Show projected capacity events in the admin treasury panel so maintainers can see when reserve room actually returns.
- Document the operational rule in the admin runbook: pending create-bounty execution does not free reserve capacity immediately; capacity returns after the executed reserve leaves the rolling 24h window.

This is maintainer infrastructure work and is not submitted for a bounty.

## Why

The current status panel shows pending creates and recent executed reserves, but it does not make the next-day runway obvious. That made it too easy to wait for proposals to execute and assume capacity would open today, when execution only converts pending reserve into executed reserve.

## Validation

- `./.venv/bin/python scripts/check_agents.py`
- `./.venv/bin/python -m pytest` (`540 passed`)
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m mypy app`
- `./.venv/bin/python scripts/docs_smoke.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin treasury panel now shows "Projected capacity events" with future event timestamps and projected available create reserve.
  * Treasury status API returns forward-looking capacity projections including next projected release time and event timeline.

* **Documentation**
  * Admin runbook updated to explain projected capacity events and that pending executions don’t immediately free capacity.

* **Tests**
  * Added tests validating projected capacity timelines, clamping of overdue events, and admin UI callouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->