### PR TITLE
Show effective bounty availability for pending proposals

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -135,7 +135,8 @@ def register_bounty_api_routes(
                     query = query.where(text_filter)
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             sorted_bounties = sort_bounties(
-                [bounty_to_dict(bounty) for bounty in bounties], normalized_sort
+                [bounty_to_dict(bounty, session=session) for bounty in bounties],
+                normalized_sort,
             )
             if limit is not None:
                 return sorted_bounties[:limit]
@@ -203,7 +204,7 @@ def register_bounty_api_routes(
             bounty = session.get(Bounty, bounty_id)
             if bounty is None:
                 raise HTTPException(status_code=404, detail="bounty not found")
-            result = bounty_to_dict(bounty)
+            result = bounty_to_dict(bounty, session=session)
             result["accepted_awards"] = bounty_awards_to_dict(session, bounty.id)
             return result
 

--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -23,6 +23,7 @@ from app.ledger.service import (
 from app.models import Bounty, Proof, Submission
 from app.path_params import issue_number_search_value, positive_bounty_id
 from app.serializers import (
+    bounties_to_dict,
     bounty_awards_to_dict,
     bounty_list_summary,
     bounty_to_dict,
@@ -135,7 +136,7 @@ def register_bounty_api_routes(
                     query = query.where(text_filter)
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             sorted_bounties = sort_bounties(
-                [bounty_to_dict(bounty, session=session) for bounty in bounties],
+                bounties_to_dict(bounties, session=session),
                 normalized_sort,
             )
             if limit is not None:

--- a/app/bounty_sorting.py
+++ b/app/bounty_sorting.py
@@ -37,11 +37,17 @@ def sort_bounties(bounties: list[dict[str, Any]], sort: str | None) -> list[dict
     if normalized_sort == "available":
         return sorted(
             bounties,
-            key=lambda bounty: (Decimal(str(bounty["available_mrwk"])), int(bounty["id"])),
+            key=lambda bounty: (
+                Decimal(str(bounty.get("effective_available_mrwk", bounty["available_mrwk"]))),
+                int(bounty["id"]),
+            ),
             reverse=True,
         )
     return sorted(
         bounties,
-        key=lambda bounty: (int(bounty["awards_remaining"]), int(bounty["id"])),
+        key=lambda bounty: (
+            int(bounty.get("effective_awards_remaining", bounty["awards_remaining"])),
+            int(bounty["id"]),
+        ),
         reverse=True,
     )

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -19,6 +19,7 @@ from app.mcp_work_proof import (
 from app.models import Bounty, Proof, Wallet
 from app.path_params import SQLITE_INTEGER_MAX, issue_number_search_value, proof_hash_from_path
 from app.serializers import (
+    bounties_to_dict,
     bounty_awards_to_dict,
     bounty_to_dict,
     wallet_to_dict,
@@ -142,13 +143,9 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 newest_bounties = session.scalars(
                     query.order_by(Bounty.id.desc()).limit(limit)
                 ).all()
-                return json.dumps(
-                    [bounty_to_dict(bounty, session=session) for bounty in newest_bounties]
-                )
+                return json.dumps(bounties_to_dict(newest_bounties, session=session))
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
-            sorted_bounties = sort_bounties(
-                [bounty_to_dict(bounty, session=session) for bounty in bounties], sort
-            )
+            sorted_bounties = sort_bounties(bounties_to_dict(bounties, session=session), sort)
             return json.dumps(sorted_bounties[:limit])
         if name == "get_bounty":
             bounty = session.get(Bounty, positive_int_arg("id"))

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -142,15 +142,19 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 newest_bounties = session.scalars(
                     query.order_by(Bounty.id.desc()).limit(limit)
                 ).all()
-                return json.dumps([bounty_to_dict(bounty) for bounty in newest_bounties])
+                return json.dumps(
+                    [bounty_to_dict(bounty, session=session) for bounty in newest_bounties]
+                )
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
-            sorted_bounties = sort_bounties([bounty_to_dict(bounty) for bounty in bounties], sort)
+            sorted_bounties = sort_bounties(
+                [bounty_to_dict(bounty, session=session) for bounty in bounties], sort
+            )
             return json.dumps(sorted_bounties[:limit])
         if name == "get_bounty":
             bounty = session.get(Bounty, positive_int_arg("id"))
             if bounty is None:
                 return "bounty not found"
-            bounty_data = bounty_to_dict(bounty)
+            bounty_data = bounty_to_dict(bounty, session=session)
             if optional_bool_arg("include_awards"):
                 bounty_data["awards"] = bounty_awards_to_dict(session, bounty.id)
             return json.dumps(bounty_data)
@@ -238,9 +242,9 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 if bounty is None:
                     return "bounty not found"
                 return (
-                    work_proof_guidance_json(bounty)
+                    work_proof_guidance_json(bounty, session=session)
                     if output_format == "json"
-                    else work_proof_guidance(bounty)
+                    else work_proof_guidance(bounty, session=session)
                 )
             if has_issue_number:
                 issue_query = select(Bounty).where(
@@ -254,9 +258,9 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 if len(bounties) > 1:
                     raise ValueError("issue_number matches multiple bounties")
                 return (
-                    work_proof_guidance_json(bounties[0])
+                    work_proof_guidance_json(bounties[0], session=session)
                     if output_format == "json"
-                    else work_proof_guidance(bounties[0])
+                    else work_proof_guidance(bounties[0], session=session)
                 )
             if output_format == "json":
                 return generic_work_proof_guidance_json()

--- a/app/mcp_work_proof.py
+++ b/app/mcp_work_proof.py
@@ -2,17 +2,22 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
+from sqlalchemy.orm import Session
+
 from app.models import Bounty
 from app.serializers import bounty_to_dict
 
 SubmissionAvailability = Literal["open", "full", "closed", "unknown"]
 
 
-def work_proof_guidance(bounty: Bounty) -> str:
-    bounty_data = bounty_to_dict(bounty)
+def work_proof_guidance(bounty: Bounty, session: Session | None = None) -> str:
+    bounty_data = bounty_to_dict(bounty, session=session)
+    remaining_awards = int(
+        bounty_data.get("effective_awards_remaining", bounty_data["awards_remaining"])
+    )
     availability = (
         "open for submissions"
-        if bounty_data["status"] == "open" and bounty_data["awards_remaining"] > 0
+        if bounty_data["status"] == "open" and remaining_awards > 0
         else "not currently open for new submissions"
     )
     return "\n".join(
@@ -24,8 +29,9 @@ def work_proof_guidance(bounty: Bounty) -> str:
             (
                 f"Status: {bounty_data['status']} ({availability}); "
                 f"awards remaining: {bounty_data['awards_remaining']} "
-                f"of {bounty_data['max_awards']}"
+                f"of {bounty_data['max_awards']}; effectively remaining: {remaining_awards}"
             ),
+            f"Availability note: {bounty_data['availability_note']}",
             f"Reward: {bounty_data['reward_mrwk']} MRWK per accepted award",
             f"Acceptance: {bounty_data['acceptance']}",
             (
@@ -129,20 +135,25 @@ def work_proof_submission_requirements(
 
 
 def _submission_availability(bounty_data: dict[str, Any]) -> SubmissionAvailability:
+    awards_remaining = int(
+        bounty_data.get("effective_awards_remaining", bounty_data["awards_remaining"])
+    )
     if bounty_data["status"] == "open":
-        return "open" if bounty_data["awards_remaining"] > 0 else "full"
+        return "open" if awards_remaining > 0 else "full"
     return "closed"
 
 
-def work_proof_guidance_json(bounty: Bounty) -> dict[str, Any]:
-    bounty_data = bounty_to_dict(bounty)
+def work_proof_guidance_json(bounty: Bounty, session: Session | None = None) -> dict[str, Any]:
+    bounty_data = bounty_to_dict(bounty, session=session)
     submission_availability = _submission_availability(bounty_data)
     can_submit = submission_availability == "open"
     availability_warnings = []
     if bounty_data["status"] != "open":
         availability_warnings.append(f"bounty is {bounty_data['status']}")
-    if bounty_data["awards_remaining"] <= 0:
+    if bounty_data["effective_awards_remaining"] <= 0:
         availability_warnings.append("bounty has no award slots remaining")
+    if bounty_data["availability_state"] not in {"open", "full", bounty_data["status"]}:
+        availability_warnings.append(bounty_data["availability_note"])
     return {
         "bounty_id": bounty_data["id"],
         "issue_number": bounty_data["issue_number"],
@@ -151,10 +162,14 @@ def work_proof_guidance_json(bounty: Bounty) -> dict[str, Any]:
         "can_submit": can_submit,
         "availability_warnings": availability_warnings,
         "awards_remaining": bounty_data["awards_remaining"],
+        "effective_awards_remaining": bounty_data["effective_awards_remaining"],
         "max_awards": bounty_data["max_awards"],
         "awards_paid": bounty_data["awards_paid"],
         "reward_mrwk": bounty_data["reward_mrwk"],
         "available_mrwk": bounty_data["available_mrwk"],
+        "effective_available_mrwk": bounty_data["effective_available_mrwk"],
+        "availability_state": bounty_data["availability_state"],
+        "availability_note": bounty_data["availability_note"],
         "repository": bounty_data["repo"],
         "issue_url": bounty_data["issue_url"],
         "title": bounty_data["title"],

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -10,15 +10,30 @@ from sqlalchemy.orm import Session
 
 from app.ledger.reconciliation import AcceptedPayoutCheck
 from app.ledger.service import format_mrwk, get_balance
-from app.models import Bounty, LedgerEntry, Proof, Wallet, WalletTransfer
+from app.models import Bounty, LedgerEntry, Proof, TreasuryProposal, Wallet, WalletTransfer
 
 
-def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
+def bounty_to_dict(bounty: Bounty, session: Session | None = None) -> dict[str, Any]:
     """Serialize a bounty row for public API and page consumers."""
     awards_remaining = max(0, bounty.max_awards - bounty.awards_paid)
     if bounty.status != "open":
         awards_remaining = 0
     available_microunits = bounty.reward_microunits * awards_remaining
+    pending_payouts: list[dict[str, Any]] = []
+    pending_close: dict[str, Any] | None = None
+    if session is not None:
+        pending_payouts, pending_close = _pending_bounty_proposals(session, bounty.id)
+    effective_awards_remaining = _effective_awards_remaining(
+        awards_remaining, pending_payouts, pending_close
+    )
+    effective_available_microunits = bounty.reward_microunits * effective_awards_remaining
+    availability_state = _availability_state(
+        status=bounty.status,
+        awards_remaining=awards_remaining,
+        effective_awards_remaining=effective_awards_remaining,
+        pending_payouts=pending_payouts,
+        pending_close=pending_close,
+    )
     return {
         "id": bounty.id,
         "repo": bounty.repo,
@@ -31,6 +46,19 @@ def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
         "max_awards": bounty.max_awards,
         "awards_paid": bounty.awards_paid,
         "awards_remaining": awards_remaining,
+        "effective_available_mrwk": format_mrwk(effective_available_microunits),
+        "effective_awards_remaining": effective_awards_remaining,
+        "pending_payout_awards": len(pending_payouts),
+        "pending_payout_proposals": pending_payouts,
+        "pending_close_proposal": pending_close,
+        "availability_state": availability_state,
+        "availability_note": _availability_note(
+            status=bounty.status,
+            awards_remaining=awards_remaining,
+            effective_awards_remaining=effective_awards_remaining,
+            pending_payouts=pending_payouts,
+            pending_close=pending_close,
+        ),
         "status": bounty.status,
         "acceptance": bounty.acceptance,
         "created_at": bounty.created_at.isoformat(),
@@ -74,11 +102,139 @@ def bounty_list_summary(bounties: list[dict[str, Any]]) -> dict[str, Any]:
         * int(bounty["awards_remaining"])
         for bounty in bounties
     )
+    effective_open_awards = sum(
+        int(bounty.get("effective_awards_remaining", bounty["awards_remaining"]))
+        for bounty in bounties
+    )
+    effective_open_pool_microunits = sum(
+        int(Decimal(str(bounty["reward_mrwk"])) * Decimal(1_000_000))
+        * int(bounty.get("effective_awards_remaining", bounty["awards_remaining"]))
+        for bounty in bounties
+    )
     return {
         "bounties_shown": len(bounties),
         "open_awards": open_awards,
         "open_pool_mrwk": format_mrwk(open_pool_microunits),
+        "effective_open_awards": effective_open_awards,
+        "effective_open_pool_mrwk": format_mrwk(effective_open_pool_microunits),
     }
+
+
+def _proposal_payload(proposal: TreasuryProposal) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(proposal.payload_json)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _proposal_bounty_id(payload: dict[str, Any]) -> int | None:
+    try:
+        return int(payload["bounty_id"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _proposal_summary(
+    proposal: TreasuryProposal, payload: dict[str, Any], fields: tuple[str, ...]
+) -> dict[str, Any]:
+    summary = {
+        "proposal_id": proposal.id,
+        "proposed_by": proposal.proposed_by,
+        "proposed_at": proposal.proposed_at.isoformat(),
+        "executes_after": proposal.executes_after.isoformat(),
+    }
+    for field in fields:
+        value = payload.get(field)
+        summary[field] = str(value) if value is not None else None
+    return summary
+
+
+def _pending_bounty_proposals(
+    session: Session, bounty_id: int
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    proposals = session.scalars(
+        select(TreasuryProposal)
+        .where(
+            TreasuryProposal.status == "pending",
+            TreasuryProposal.action.in_(("pay_bounty", "close_bounty")),
+        )
+        .order_by(TreasuryProposal.id.asc())
+    ).all()
+    pending_payouts: list[dict[str, Any]] = []
+    pending_close: dict[str, Any] | None = None
+    for proposal in proposals:
+        payload = _proposal_payload(proposal)
+        if payload is None or _proposal_bounty_id(payload) != bounty_id:
+            continue
+        if proposal.action == "pay_bounty":
+            pending_payouts.append(
+                _proposal_summary(
+                    proposal,
+                    payload,
+                    ("to_account", "submission_url", "accepted_by"),
+                )
+            )
+        elif proposal.action == "close_bounty" and pending_close is None:
+            pending_close = _proposal_summary(proposal, payload, ("closed_by", "reference"))
+    return pending_payouts, pending_close
+
+
+def _effective_awards_remaining(
+    awards_remaining: int,
+    pending_payouts: list[dict[str, Any]],
+    pending_close: dict[str, Any] | None,
+) -> int:
+    if pending_close is not None:
+        return 0
+    return max(0, awards_remaining - len(pending_payouts))
+
+
+def _availability_state(
+    *,
+    status: str,
+    awards_remaining: int,
+    effective_awards_remaining: int,
+    pending_payouts: list[dict[str, Any]],
+    pending_close: dict[str, Any] | None,
+) -> str:
+    if status != "open":
+        return status
+    if pending_close is not None:
+        return "pending_close"
+    if not pending_payouts:
+        return "open" if effective_awards_remaining > 0 else "full"
+    if awards_remaining > 0 and effective_awards_remaining <= 0:
+        return "pending_payouts_full"
+    return "pending_payouts_partial"
+
+
+def _plural_awards(count: int) -> str:
+    return f"{count} award{'s' if count != 1 else ''}"
+
+
+def _availability_note(
+    *,
+    status: str,
+    awards_remaining: int,
+    effective_awards_remaining: int,
+    pending_payouts: list[dict[str, Any]],
+    pending_close: dict[str, Any] | None,
+) -> str:
+    if status != "open":
+        return f"This bounty is {status}; no awards are available for new submissions."
+    if pending_close is not None:
+        return "A pending close proposal would make this bounty unavailable if executed."
+    if pending_payouts:
+        pending_count = len(pending_payouts)
+        return (
+            f"{_plural_awards(pending_count)} covered by pending payout "
+            f"proposal{'s' if pending_count != 1 else ''}; "
+            f"{_plural_awards(effective_awards_remaining)} effectively available."
+        )
+    if awards_remaining <= 0:
+        return "No awards remain available for new submissions."
+    return f"{_plural_awards(effective_awards_remaining)} effectively available."
 
 
 def payout_reconciliation_to_dict(check: AcceptedPayoutCheck) -> dict[str, Any]:

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
@@ -12,8 +13,14 @@ from app.ledger.reconciliation import AcceptedPayoutCheck
 from app.ledger.service import format_mrwk, get_balance
 from app.models import Bounty, LedgerEntry, Proof, TreasuryProposal, Wallet, WalletTransfer
 
+PendingBountyProposals = tuple[list[dict[str, Any]], dict[str, Any] | None]
 
-def bounty_to_dict(bounty: Bounty, session: Session | None = None) -> dict[str, Any]:
+
+def bounty_to_dict(
+    bounty: Bounty,
+    session: Session | None = None,
+    pending_proposals: PendingBountyProposals | None = None,
+) -> dict[str, Any]:
     """Serialize a bounty row for public API and page consumers."""
     awards_remaining = max(0, bounty.max_awards - bounty.awards_paid)
     if bounty.status != "open":
@@ -21,7 +28,9 @@ def bounty_to_dict(bounty: Bounty, session: Session | None = None) -> dict[str, 
     available_microunits = bounty.reward_microunits * awards_remaining
     pending_payouts: list[dict[str, Any]] = []
     pending_close: dict[str, Any] | None = None
-    if session is not None:
+    if pending_proposals is not None:
+        pending_payouts, pending_close = pending_proposals
+    elif session is not None:
         pending_payouts, pending_close = _pending_bounty_proposals(session, bounty.id)
     effective_awards_remaining = _effective_awards_remaining(
         awards_remaining, pending_payouts, pending_close
@@ -63,6 +72,23 @@ def bounty_to_dict(bounty: Bounty, session: Session | None = None) -> dict[str, 
         "acceptance": bounty.acceptance,
         "created_at": bounty.created_at.isoformat(),
     }
+
+
+def bounties_to_dict(
+    bounties: Sequence[Bounty], session: Session | None = None
+) -> list[dict[str, Any]]:
+    """Serialize bounty rows, preloading pending proposals once for list views."""
+    if session is None or not bounties:
+        return [bounty_to_dict(bounty) for bounty in bounties]
+
+    pending_by_bounty = _pending_bounty_proposals_by_bounty_id(session)
+    return [
+        bounty_to_dict(
+            bounty,
+            pending_proposals=pending_by_bounty.get(bounty.id, ([], None)),
+        )
+        for bounty in bounties
+    ]
 
 
 def bounty_awards_to_dict(session: Session, bounty_id: int) -> list[dict[str, Any]]:
@@ -153,6 +179,12 @@ def _proposal_summary(
 def _pending_bounty_proposals(
     session: Session, bounty_id: int
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    return _pending_bounty_proposals_by_bounty_id(session).get(bounty_id, ([], None))
+
+
+def _pending_bounty_proposals_by_bounty_id(
+    session: Session,
+) -> dict[int, PendingBountyProposals]:
     proposals = session.scalars(
         select(TreasuryProposal)
         .where(
@@ -161,12 +193,15 @@ def _pending_bounty_proposals(
         )
         .order_by(TreasuryProposal.id.asc())
     ).all()
-    pending_payouts: list[dict[str, Any]] = []
-    pending_close: dict[str, Any] | None = None
+    pending_by_bounty: dict[int, PendingBountyProposals] = {}
     for proposal in proposals:
         payload = _proposal_payload(proposal)
-        if payload is None or _proposal_bounty_id(payload) != bounty_id:
+        if payload is None:
             continue
+        bounty_id = _proposal_bounty_id(payload)
+        if bounty_id is None:
+            continue
+        pending_payouts, pending_close = pending_by_bounty.setdefault(bounty_id, ([], None))
         if proposal.action == "pay_bounty":
             pending_payouts.append(
                 _proposal_summary(
@@ -176,8 +211,11 @@ def _pending_bounty_proposals(
                 )
             )
         elif proposal.action == "close_bounty" and pending_close is None:
-            pending_close = _proposal_summary(proposal, payload, ("closed_by", "reference"))
-    return pending_payouts, pending_close
+            pending_by_bounty[bounty_id] = (
+                pending_payouts,
+                _proposal_summary(proposal, payload, ("closed_by", "reference")),
+            )
+    return pending_by_bounty
 
 
 def _effective_awards_remaining(

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -6,8 +6,9 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
+from sqlalchemy.sql.elements import ColumnElement
 
 from app.ledger.reconciliation import AcceptedPayoutCheck
 from app.ledger.service import format_mrwk, get_balance
@@ -179,7 +180,41 @@ def _proposal_summary(
 def _pending_bounty_proposals(
     session: Session, bounty_id: int
 ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
-    return _pending_bounty_proposals_by_bounty_id(session).get(bounty_id, ([], None))
+    proposals = session.scalars(
+        select(TreasuryProposal)
+        .where(
+            TreasuryProposal.status == "pending",
+            TreasuryProposal.action.in_(("pay_bounty", "close_bounty")),
+            _payload_bounty_id_filter(bounty_id),
+        )
+        .order_by(TreasuryProposal.id.asc())
+    ).all()
+    pending_payouts: list[dict[str, Any]] = []
+    pending_close: dict[str, Any] | None = None
+    for proposal in proposals:
+        payload = _proposal_payload(proposal)
+        if payload is None or _proposal_bounty_id(payload) != bounty_id:
+            continue
+        if proposal.action == "pay_bounty":
+            pending_payouts.append(
+                _proposal_summary(
+                    proposal,
+                    payload,
+                    ("to_account", "submission_url", "accepted_by"),
+                )
+            )
+        elif proposal.action == "close_bounty" and pending_close is None:
+            pending_close = _proposal_summary(proposal, payload, ("closed_by", "reference"))
+    return pending_payouts, pending_close
+
+
+def _payload_bounty_id_filter(bounty_id: int) -> ColumnElement[bool]:
+    """Narrow pending-proposal scans for canonical JSON payloads."""
+    marker = f'"bounty_id":{bounty_id}'
+    return or_(
+        TreasuryProposal.payload_json.contains(f"{marker},"),
+        TreasuryProposal.payload_json.contains(f"{marker}}}"),
+    )
 
 
 def _pending_bounty_proposals_by_bounty_id(

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -42,6 +42,14 @@
     <span>Open reward pool</span>
     <strong>{{ summary.open_pool_mrwk }} MRWK</strong>
   </article>
+  <article>
+    <span>Effectively open</span>
+    <strong>{{ summary.effective_open_awards }}</strong>
+  </article>
+  <article>
+    <span>Effectively available</span>
+    <strong>{{ summary.effective_open_pool_mrwk }} MRWK</strong>
+  </article>
 </section>
 <p class="notice">
   <a href="{{ api_results_url }}">View JSON results</a>
@@ -61,9 +69,14 @@
       {{ bounty.repo }} #{{ bounty.issue_number }} ·
       {% endif %}
       <strong>{{ bounty.reward_mrwk }} MRWK</strong> per award ·
-      {{ bounty.available_mrwk }} MRWK still available ·
-      {{ bounty.awards_remaining }}/{{ bounty.max_awards }} awards open
+      {{ bounty.available_mrwk }} MRWK still available before pending proposals ·
+      {{ bounty.awards_remaining }}/{{ bounty.max_awards }} awards visibly open ·
+      {{ bounty.effective_available_mrwk }} MRWK effectively available ·
+      {{ bounty.effective_awards_remaining }}/{{ bounty.max_awards }} awards effectively open
     </p>
+    {% if bounty.availability_state != "open" or bounty.effective_awards_remaining != bounty.awards_remaining %}
+    <p class="notice">{{ bounty.availability_note }}</p>
+    {% endif %}
     <p>{{ bounty.acceptance }}</p>
   </article>
   {% else %}

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -32,6 +32,14 @@
       <strong>{{ bounty.available_mrwk }} MRWK</strong>
     </article>
     <article>
+      <span>Effective remaining</span>
+      <strong>{{ bounty.effective_awards_remaining }}</strong>
+    </article>
+    <article>
+      <span>Effective available</span>
+      <strong>{{ bounty.effective_available_mrwk }} MRWK</strong>
+    </article>
+    <article>
       <span>Issue</span>
       <strong>
         {% if issue_url %}
@@ -42,6 +50,14 @@
       </strong>
     </article>
   </div>
+  {% if bounty.availability_state != "open" or bounty.effective_awards_remaining != bounty.awards_remaining %}
+  <p class="notice">
+    {{ bounty.availability_note }}
+    {% if bounty.effective_awards_remaining != bounty.awards_remaining %}
+    Visible capacity before pending proposals: {{ bounty.awards_remaining }} award{% if bounty.awards_remaining != 1 %}s{% endif %}, {{ bounty.available_mrwk }} MRWK.
+    {% endif %}
+  </p>
+  {% endif %}
 
   <section class="acceptance-card" aria-labelledby="acceptance-heading">
     <p class="eyebrow">Acceptance</p>
@@ -56,10 +72,16 @@
       <li>Confirm the source issue is still open and your change is not already covered by another PR.</li>
       <li>Keep the PR focused, link the source issue as <strong>Bounty #{{ bounty.issue_number }}</strong>, and include test or smoke-check evidence.</li>
       <li>
-        {% if bounty.awards_remaining %}
-          {{ bounty.awards_remaining }} award{% if bounty.awards_remaining != 1 %}s{% endif %} still open for distinct accepted work.
-        {% else %}
+        {% if bounty.effective_awards_remaining %}
+          {% if bounty.effective_awards_remaining == bounty.awards_remaining %}
+          {{ bounty.effective_awards_remaining }} award{% if bounty.effective_awards_remaining != 1 %}s{% endif %} still open for distinct accepted work.
+          {% else %}
+          {{ bounty.effective_awards_remaining }} award{% if bounty.effective_awards_remaining != 1 %}s{% endif %} still open for distinct accepted work after pending treasury proposals.
+          {% endif %}
+        {% elif bounty.effective_awards_remaining == bounty.awards_remaining %}
           No awards remain; treat new work as unpaid unless maintainers reopen the bounty.
+        {% else %}
+          No awards remain after pending treasury proposals; treat new work as unpaid unless maintainers reopen or free capacity.
         {% endif %}
       </li>
     </ol>
@@ -73,7 +95,7 @@
 <section>
   <div class="section-head">
     <h2>Accepted work</h2>
-    <p>{{ bounty.awards_paid }}/{{ bounty.max_awards }} awards paid{% if bounty.awards_remaining %}; {{ bounty.awards_remaining }} still open{% endif %}.</p>
+    <p>{{ bounty.awards_paid }}/{{ bounty.max_awards }} awards paid{% if bounty.effective_awards_remaining %}; {{ bounty.effective_awards_remaining }} still open{% elif bounty.awards_remaining %}; {{ bounty.awards_remaining }} visibly open before pending proposals{% endif %}.</p>
   </div>
   {% if bounty.accepted_awards %}
   <div class="ledger-list">

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
+from app.treasury import propose_treasury_action
 
 
 def test_bounty_api_reports_multi_award_capacity(sqlite_url: str) -> None:
@@ -32,6 +33,100 @@ def test_bounty_api_reports_multi_award_capacity(sqlite_url: str) -> None:
     assert bounty["max_awards"] == 4
     assert bounty["awards_paid"] == 0
     assert bounty["awards_remaining"] == 4
+    assert bounty["effective_available_mrwk"] == "100"
+    assert bounty["effective_awards_remaining"] == 4
+    assert bounty["pending_payout_awards"] == 0
+    assert bounty["pending_close_proposal"] is None
+    assert bounty["availability_state"] == "open"
+
+
+def test_bounty_api_reports_pending_payout_effective_capacity(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=12,
+            issue_url="https://github.com/ramimbo/mergework/issues/12",
+            title="Pending payout capacity",
+            reward_mrwk="40",
+            max_awards=2,
+            acceptance="Pending payouts should reduce effective public capacity.",
+        )
+        bounty_id = bounty.id
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": bounty_id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/12",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    body = client.get(f"/api/v1/bounties/{bounty_id}").json()
+    summary = client.get("/api/v1/bounties/summary?status=open").json()
+
+    assert body["awards_remaining"] == 2
+    assert body["available_mrwk"] == "80"
+    assert body["effective_awards_remaining"] == 1
+    assert body["effective_available_mrwk"] == "40"
+    assert body["pending_payout_awards"] == 1
+    assert body["pending_payout_proposals"][0]["submission_url"] == (
+        "https://github.com/ramimbo/mergework/pull/12"
+    )
+    assert body["availability_state"] == "pending_payouts_partial"
+    assert "1 award covered by pending payout proposal" in body["availability_note"]
+    assert summary["open_awards"] == 2
+    assert summary["open_pool_mrwk"] == "80"
+    assert summary["effective_open_awards"] == 1
+    assert summary["effective_open_pool_mrwk"] == "40"
+
+
+def test_bounty_api_reports_pending_close_as_effectively_unavailable(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=13,
+            issue_url="https://github.com/ramimbo/mergework/issues/13",
+            title="Pending close capacity",
+            reward_mrwk="15",
+            max_awards=3,
+            acceptance="Pending close proposals should make public capacity unavailable.",
+        )
+        bounty_id = bounty.id
+        proposal = propose_treasury_action(
+            session,
+            action="close_bounty",
+            payload={
+                "bounty_id": bounty_id,
+                "closed_by": "maintainer",
+                "reference": "https://github.com/ramimbo/mergework/issues/13#close",
+            },
+            proposed_by="maintainer",
+        )
+        proposal_id = proposal.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    body = client.get(f"/api/v1/bounties/{bounty_id}").json()
+
+    assert body["status"] == "open"
+    assert body["awards_remaining"] == 3
+    assert body["available_mrwk"] == "45"
+    assert body["effective_awards_remaining"] == 0
+    assert body["effective_available_mrwk"] == "0"
+    assert body["pending_close_proposal"]["proposal_id"] == proposal_id
+    assert body["availability_state"] == "pending_close"
+    assert "pending close proposal" in body["availability_note"]
 
 
 def test_bounty_api_reports_paid_multi_award_as_exhausted(sqlite_url: str) -> None:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -185,6 +185,51 @@ def test_bounties_page_shows_effective_capacity_after_pending_payout(
     )
 
 
+def test_bounties_page_shows_effective_capacity_after_pending_close(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=68,
+            issue_url="https://github.com/ramimbo/mergework/issues/68",
+            title="Pending close public capacity",
+            reward_mrwk="30",
+            max_awards=3,
+            acceptance="Public pages should show no effective capacity after pending close.",
+        )
+        bounty_id = bounty.id
+        propose_treasury_action(
+            session,
+            action="close_bounty",
+            payload={
+                "bounty_id": bounty_id,
+                "closed_by": "maintainer",
+                "reference": "https://github.com/ramimbo/mergework/issues/68#close",
+            },
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    page = client.get("/bounties")
+    detail = client.get(f"/bounties/{bounty_id}")
+
+    assert page.status_code == 200
+    assert "90 MRWK still available before pending proposals" in page.text
+    assert "0 MRWK effectively available" in page.text
+    assert "A pending close proposal would make this bounty unavailable if executed." in page.text
+    assert detail.status_code == 200
+    assert "Visible capacity before pending proposals: 3 awards, 90 MRWK." in detail.text
+    assert (
+        "No awards remain after pending treasury proposals; treat new work as unpaid unless "
+        "maintainers reopen or free capacity."
+    ) in detail.text
+
+
 def test_bounties_page_honors_limit_filter(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -8,6 +8,7 @@ from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
 from app.models import LedgerEntry, Proof
+from app.treasury import propose_treasury_action
 
 
 def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
@@ -117,6 +118,8 @@ def test_bounties_summary_api_matches_public_list_filters(sqlite_url: str) -> No
         "bounties_shown": 1,
         "open_awards": 2,
         "open_pool_mrwk": "50",
+        "effective_open_awards": 2,
+        "effective_open_pool_mrwk": "50",
     }
 
     paid_summary = client.get("/api/v1/bounties/summary?status=paid&q=discovery").json()
@@ -124,11 +127,62 @@ def test_bounties_summary_api_matches_public_list_filters(sqlite_url: str) -> No
         "bounties_shown": 0,
         "open_awards": 0,
         "open_pool_mrwk": "0",
+        "effective_open_awards": 0,
+        "effective_open_pool_mrwk": "0",
     }
 
     invalid = client.get("/api/v1/bounties/summary?status=bogus")
     assert invalid.status_code == 400
     assert invalid.json()["detail"] == "status must be one of: open, paid, closed"
+
+
+def test_bounties_page_shows_effective_capacity_after_pending_payout(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=67,
+            issue_url="https://github.com/ramimbo/mergework/issues/67",
+            title="Pending payout public capacity",
+            reward_mrwk="25",
+            max_awards=2,
+            acceptance="Public pages should show effective capacity after pending payouts.",
+        )
+        bounty_id = bounty.id
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": bounty_id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/67",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    page = client.get("/bounties")
+    detail = client.get(f"/bounties/{bounty_id}")
+
+    assert page.status_code == 200
+    assert "Effectively open" in page.text
+    assert "Effectively available" in page.text
+    assert "50 MRWK still available before pending proposals" in page.text
+    assert "25 MRWK effectively available" in page.text
+    assert "1 award covered by pending payout proposal" in page.text
+    assert detail.status_code == 200
+    assert "<span>Effective remaining</span>" in detail.text
+    assert "<span>Effective available</span>" in detail.text
+    assert "Visible capacity before pending proposals: 2 awards, 50 MRWK." in detail.text
+    assert "1 award still open for distinct accepted work after pending treasury proposals." in (
+        detail.text
+    )
 
 
 def test_bounties_page_honors_limit_filter(sqlite_url: str) -> None:

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -24,6 +24,8 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
             "bounties_shown": 1,
             "open_awards": 2,
             "open_pool_mrwk": "50",
+            "effective_open_awards": 2,
+            "effective_open_pool_mrwk": "50",
         },
         "selected_status": "open",
         "query_text": "proof",

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta, timezone
 
+from sqlalchemy import event
+
 from app.db import create_schema, session_scope
 from app.ledger.service import create_bounty, ensure_genesis, pay_bounty, register_wallet
 from app.models import Bounty, Proof, WalletTransfer
@@ -9,6 +11,7 @@ from app.serializers import (
     accepted_work_for_account,
     account_accepted_summary,
     activity_to_dict,
+    bounties_to_dict,
     bounty_awards_to_dict,
     bounty_list_summary,
     bounty_to_dict,
@@ -18,6 +21,7 @@ from app.serializers import (
     wallet_to_dict,
     wallet_transfer_to_dict,
 )
+from app.treasury import propose_treasury_action
 
 
 class BrokenSession:
@@ -53,6 +57,93 @@ def test_bounty_serializers_preserve_public_capacity_fields(sqlite_url: str) -> 
         "effective_open_awards": 4,
         "effective_open_pool_mrwk": "100",
     }
+
+
+def test_bounties_to_dict_preloads_pending_proposals_once(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        payout_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=321,
+            issue_url="https://github.com/ramimbo/mergework/issues/321",
+            title="Pending payout serializer",
+            reward_mrwk="25",
+            max_awards=2,
+            acceptance="Pending payout should reduce effective capacity.",
+        )
+        close_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=322,
+            issue_url="https://github.com/ramimbo/mergework/issues/322",
+            title="Pending close serializer",
+            reward_mrwk="30",
+            max_awards=3,
+            acceptance="Pending close should hide effective capacity.",
+        )
+        plain_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=323,
+            issue_url="https://github.com/ramimbo/mergework/issues/323",
+            title="Plain serializer",
+            reward_mrwk="10",
+            acceptance="Plain bounty should remain open.",
+        )
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": payout_bounty.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/321",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+        propose_treasury_action(
+            session,
+            action="close_bounty",
+            payload={
+                "bounty_id": close_bounty.id,
+                "closed_by": "maintainer",
+                "reference": "https://github.com/ramimbo/mergework/issues/322#close",
+            },
+            proposed_by="maintainer",
+        )
+
+        treasury_selects: list[str] = []
+
+        def count_treasury_selects(
+            conn,
+            cursor,
+            statement,
+            parameters,
+            context,
+            executemany,
+        ) -> None:
+            del conn, cursor, parameters, context, executemany
+            if "treasury_proposals" in statement.lower() and statement.lstrip().upper().startswith(
+                "SELECT"
+            ):
+                treasury_selects.append(statement)
+
+        bind = session.get_bind()
+        event.listen(bind, "before_cursor_execute", count_treasury_selects)
+        try:
+            serialized = bounties_to_dict(
+                [payout_bounty, close_bounty, plain_bounty], session=session
+            )
+        finally:
+            event.remove(bind, "before_cursor_execute", count_treasury_selects)
+
+    by_title = {bounty["title"]: bounty for bounty in serialized}
+    assert by_title["Pending payout serializer"]["effective_awards_remaining"] == 1
+    assert by_title["Pending close serializer"]["availability_state"] == "pending_close"
+    assert by_title["Plain serializer"]["availability_state"] == "open"
+    assert len(treasury_selects) == 1
 
 
 def test_account_and_wallet_serializers_preserve_public_shapes(sqlite_url: str) -> None:

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -146,6 +146,73 @@ def test_bounties_to_dict_preloads_pending_proposals_once(sqlite_url: str) -> No
     assert len(treasury_selects) == 1
 
 
+def test_bounty_to_dict_narrows_single_pending_proposal_lookup(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        target_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=331,
+            issue_url="https://github.com/ramimbo/mergework/issues/331",
+            title="Single bounty serializer",
+            reward_mrwk="1",
+            acceptance="Single serialization should only inspect matching proposals.",
+        )
+        other_bounty = target_bounty
+        for issue_number in range(332, 341):
+            other_bounty = create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=issue_number,
+                issue_url=f"https://github.com/ramimbo/mergework/issues/{issue_number}",
+                title=f"Other serializer {issue_number}",
+                reward_mrwk="1",
+                acceptance="Used to guard against bounty_id prefix matches.",
+            )
+        assert other_bounty.id != target_bounty.id
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": other_bounty.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/340",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+        treasury_selects: list[str] = []
+
+        def count_treasury_selects(
+            conn,
+            cursor,
+            statement,
+            parameters,
+            context,
+            executemany,
+        ) -> None:
+            del conn, cursor, parameters, context, executemany
+            if "treasury_proposals" in statement.lower() and statement.lstrip().upper().startswith(
+                "SELECT"
+            ):
+                treasury_selects.append(statement)
+
+        bind = session.get_bind()
+        event.listen(bind, "before_cursor_execute", count_treasury_selects)
+        try:
+            serialized = bounty_to_dict(target_bounty, session=session)
+        finally:
+            event.remove(bind, "before_cursor_execute", count_treasury_selects)
+
+    assert serialized["availability_state"] == "open"
+    assert serialized["pending_payout_awards"] == 0
+    assert serialized["effective_awards_remaining"] == 1
+    assert len(treasury_selects) == 1
+    assert "payload_json" in treasury_selects[0].lower()
+
+
 def test_account_and_wallet_serializers_preserve_public_shapes(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -50,6 +50,8 @@ def test_bounty_serializers_preserve_public_capacity_fields(sqlite_url: str) -> 
         "bounties_shown": 1,
         "open_awards": 4,
         "open_pool_mrwk": "100",
+        "effective_open_awards": 4,
+        "effective_open_pool_mrwk": "100",
     }
 
 


### PR DESCRIPTION
/claim #641

## Summary

- Add effective bounty availability fields that account for pending `pay_bounty` and `close_bounty` treasury proposals without changing payout or proposal rules.
- Surface the distinction between visible capacity and effective capacity in the public bounties API, list page, detail page, sort behavior, and MCP bounty guidance.
- Include pending proposal summaries so contributors and agents can tell when visible awards are already practically consumed or the bounty is pending closure.

## How this handles the pending-proposal confusion

For #576/#578/#569-style cases, `awards_remaining` and `available_mrwk` still report the current persisted bounty state, but new `effective_awards_remaining`, `effective_available_mrwk`, `availability_state`, and `availability_note` fields show whether pending payouts or a pending close make that capacity no longer freely claimable. The UI now labels the pre-pending capacity as visible capacity and displays the effective availability next to it.

## Tests

- `.venv/bin/python -m pytest -q` (`548 passed`)
- `.venv/bin/python -m ruff check app tests`
- `.venv/bin/python -m ruff format --check app tests`
- `.venv/bin/python -m mypy app`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounties now surface “effective” availability (effective awards, effective MRWK, availability state and human-readable notes) in list and detail pages, API JSON, and work-submission guidance.

* **Other**
  * Listing, sorting, and summaries now prefer effective availability values where applicable; availability warnings expanded to account for pending proposals.

* **Tests**
  * Updated and added tests for effective availability, pending payout/close scenarios, UI/API rendering, and serializer preload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->