### PR TITLE
Show effective bounty availability for pending proposals

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -24,6 +24,7 @@ from app.models import Bounty, Proof, Submission
 from app.path_params import issue_number_search_value, positive_bounty_id
 from app.serializers import (
     bounty_awards_to_dict,
+    bounty_effective_availability,
     bounty_list_summary,
     bounty_to_dict,
     payout_reconciliation_to_dict,
@@ -135,7 +136,11 @@ def register_bounty_api_routes(
                     query = query.where(text_filter)
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             sorted_bounties = sort_bounties(
-                [bounty_to_dict(bounty) for bounty in bounties], normalized_sort
+                [
+                    bounty_to_dict(bounty, bounty_effective_availability(session, bounty))
+                    for bounty in bounties
+                ],
+                normalized_sort,
             )
             if limit is not None:
                 return sorted_bounties[:limit]
@@ -203,7 +208,7 @@ def register_bounty_api_routes(
             bounty = session.get(Bounty, bounty_id)
             if bounty is None:
                 raise HTTPException(status_code=404, detail="bounty not found")
-            result = bounty_to_dict(bounty)
+            result = bounty_to_dict(bounty, bounty_effective_availability(session, bounty))
             result["accepted_awards"] = bounty_awards_to_dict(session, bounty.id)
             return result
 

--- a/app/bounty_sorting.py
+++ b/app/bounty_sorting.py
@@ -37,11 +37,17 @@ def sort_bounties(bounties: list[dict[str, Any]], sort: str | None) -> list[dict
     if normalized_sort == "available":
         return sorted(
             bounties,
-            key=lambda bounty: (Decimal(str(bounty["available_mrwk"])), int(bounty["id"])),
+            key=lambda bounty: (
+                Decimal(str(bounty.get("effective_available_mrwk", bounty["available_mrwk"]))),
+                int(bounty["id"]),
+            ),
             reverse=True,
         )
     return sorted(
         bounties,
-        key=lambda bounty: (int(bounty["awards_remaining"]), int(bounty["id"])),
+        key=lambda bounty: (
+            int(bounty.get("effective_awards_remaining", bounty["awards_remaining"])),
+            int(bounty["id"]),
+        ),
         reverse=True,
     )

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -20,6 +20,7 @@ from app.models import Bounty, Proof, Wallet
 from app.path_params import SQLITE_INTEGER_MAX, issue_number_search_value, proof_hash_from_path
 from app.serializers import (
     bounty_awards_to_dict,
+    bounty_effective_availability,
     bounty_to_dict,
     wallet_to_dict,
     wallet_transfer_to_dict,
@@ -142,15 +143,26 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 newest_bounties = session.scalars(
                     query.order_by(Bounty.id.desc()).limit(limit)
                 ).all()
-                return json.dumps([bounty_to_dict(bounty) for bounty in newest_bounties])
+                return json.dumps(
+                    [
+                        bounty_to_dict(bounty, bounty_effective_availability(session, bounty))
+                        for bounty in newest_bounties
+                    ]
+                )
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
-            sorted_bounties = sort_bounties([bounty_to_dict(bounty) for bounty in bounties], sort)
+            sorted_bounties = sort_bounties(
+                [
+                    bounty_to_dict(bounty, bounty_effective_availability(session, bounty))
+                    for bounty in bounties
+                ],
+                sort,
+            )
             return json.dumps(sorted_bounties[:limit])
         if name == "get_bounty":
             bounty = session.get(Bounty, positive_int_arg("id"))
             if bounty is None:
                 return "bounty not found"
-            bounty_data = bounty_to_dict(bounty)
+            bounty_data = bounty_to_dict(bounty, bounty_effective_availability(session, bounty))
             if optional_bool_arg("include_awards"):
                 bounty_data["awards"] = bounty_awards_to_dict(session, bounty.id)
             return json.dumps(bounty_data)

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -10,16 +10,104 @@ from sqlalchemy.orm import Session
 
 from app.ledger.reconciliation import AcceptedPayoutCheck
 from app.ledger.service import format_mrwk, get_balance
-from app.models import Bounty, LedgerEntry, Proof, Wallet, WalletTransfer
+from app.models import Bounty, LedgerEntry, Proof, TreasuryProposal, Wallet, WalletTransfer
 
 
-def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
-    """Serialize a bounty row for public API and page consumers."""
+def _bounty_awards_remaining(bounty: Bounty) -> int:
     awards_remaining = max(0, bounty.max_awards - bounty.awards_paid)
+    return awards_remaining if bounty.status == "open" else 0
+
+
+def _treasury_proposal_payload(proposal: TreasuryProposal) -> dict[str, Any] | None:
+    try:
+        data = json.loads(proposal.payload_json)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _payload_bounty_id(payload: dict[str, Any]) -> int | None:
+    try:
+        return int(payload.get("bounty_id") or 0)
+    except (TypeError, ValueError):
+        return None
+
+
+def bounty_effective_availability(session: Session, bounty: Bounty) -> dict[str, Any]:
+    """Return public availability after pending payout and close proposals."""
+    awards_remaining = _bounty_awards_remaining(bounty)
+    pending_payout_proposal_ids: list[int] = []
+    pending_close_proposal_id: int | None = None
+    if bounty.status == "open":
+        proposals = session.scalars(
+            select(TreasuryProposal)
+            .where(
+                TreasuryProposal.status == "pending",
+                TreasuryProposal.action.in_(("pay_bounty", "close_bounty")),
+            )
+            .order_by(TreasuryProposal.id.asc())
+        ).all()
+        for proposal in proposals:
+            payload = _treasury_proposal_payload(proposal)
+            if payload is None or _payload_bounty_id(payload) != bounty.id:
+                continue
+            if proposal.action == "pay_bounty":
+                pending_payout_proposal_ids.append(proposal.id)
+            elif proposal.action == "close_bounty" and pending_close_proposal_id is None:
+                pending_close_proposal_id = proposal.id
+
+    pending_awards = len(pending_payout_proposal_ids)
     if bounty.status != "open":
-        awards_remaining = 0
-    available_microunits = bounty.reward_microunits * awards_remaining
+        effective_awards_remaining = 0
+        availability_status = bounty.status
+        availability_note = f"Bounty is {bounty.status}; new work is not currently payable."
+    elif pending_close_proposal_id is not None:
+        effective_awards_remaining = 0
+        availability_status = "pending_close"
+        availability_note = (
+            "A pending close proposal makes this bounty unavailable until maintainers "
+            "resolve the proposal."
+        )
+    elif pending_awards:
+        effective_awards_remaining = max(0, awards_remaining - pending_awards)
+        availability_status = (
+            "pending_payouts" if effective_awards_remaining else "pending_payouts_full"
+        )
+        proposal_word = "proposal" if pending_awards == 1 else "proposals"
+        capacity_verb = "consumes" if pending_awards == 1 else "consume"
+        availability_note = (
+            f"{pending_awards} pending payout {proposal_word} "
+            f"{capacity_verb} practical award capacity."
+        )
+    else:
+        effective_awards_remaining = awards_remaining
+        availability_status = "open" if awards_remaining else "full"
+        availability_note = (
+            "Open awards are currently available."
+            if awards_remaining
+            else "No award slots remain for new accepted work."
+        )
     return {
+        "pending_awards": pending_awards,
+        "pending_payout_proposal_ids": pending_payout_proposal_ids,
+        "pending_close": pending_close_proposal_id is not None,
+        "pending_close_proposal_id": pending_close_proposal_id,
+        "effective_awards_remaining": effective_awards_remaining,
+        "effective_available_mrwk": format_mrwk(
+            bounty.reward_microunits * effective_awards_remaining
+        ),
+        "availability_status": availability_status,
+        "availability_note": availability_note,
+    }
+
+
+def bounty_to_dict(
+    bounty: Bounty, effective_availability: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Serialize a bounty row for public API and page consumers."""
+    awards_remaining = _bounty_awards_remaining(bounty)
+    available_microunits = bounty.reward_microunits * awards_remaining
+    result: dict[str, Any] = {
         "id": bounty.id,
         "repo": bounty.repo,
         "issue_number": bounty.issue_number,
@@ -35,6 +123,9 @@ def bounty_to_dict(bounty: Bounty) -> dict[str, Any]:
         "acceptance": bounty.acceptance,
         "created_at": bounty.created_at.isoformat(),
     }
+    if effective_availability is not None:
+        result.update(effective_availability)
+    return result
 
 
 def bounty_awards_to_dict(session: Session, bounty_id: int) -> list[dict[str, Any]]:
@@ -68,10 +159,13 @@ def bounty_awards_to_dict(session: Session, bounty_id: int) -> list[dict[str, An
 
 def bounty_list_summary(bounties: list[dict[str, Any]]) -> dict[str, Any]:
     """Aggregate visible bounty rows into capacity totals."""
-    open_awards = sum(int(bounty["awards_remaining"]) for bounty in bounties)
+    open_awards = sum(
+        int(bounty.get("effective_awards_remaining", bounty["awards_remaining"]))
+        for bounty in bounties
+    )
     open_pool_microunits = sum(
         int(Decimal(str(bounty["reward_mrwk"])) * Decimal(1_000_000))
-        * int(bounty["awards_remaining"])
+        * int(bounty.get("effective_awards_remaining", bounty["awards_remaining"]))
         for bounty in bounties
     )
     return {

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -426,6 +426,15 @@ button { cursor: pointer; color: white; background: var(--accent); border-color:
 .bounty-card-meta strong {
   color: var(--accent);
 }
+.availability-note {
+  border-left: 3px solid #f59e0b;
+  color: var(--muted);
+  margin-top: 8px;
+  padding-left: 10px;
+}
+.availability-note--detail {
+  margin: -16px 0 24px;
+}
 @media (prefers-color-scheme: dark) {
   .status-open {
     border-color: #166534;

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -48,6 +48,8 @@
 </p>
 <div class="list">
   {% for bounty in bounties %}
+  {% set effective_awards = bounty.effective_awards_remaining | default(bounty.awards_remaining) %}
+  {% set effective_available = bounty.effective_available_mrwk | default(bounty.available_mrwk) %}
   <article class="bounty-card bounty-card--{{ bounty.status }}">
     <div class="bounty-card-head">
       <h2><a href="/bounties/{{ bounty.id }}">{{ bounty.title }}</a></h2>
@@ -61,9 +63,17 @@
       {{ bounty.repo }} #{{ bounty.issue_number }} ·
       {% endif %}
       <strong>{{ bounty.reward_mrwk }} MRWK</strong> per award ·
+      {% if effective_awards == bounty.awards_remaining and not bounty.pending_awards and not bounty.pending_close %}
       {{ bounty.available_mrwk }} MRWK still available ·
       {{ bounty.awards_remaining }}/{{ bounty.max_awards }} awards open
+      {% else %}
+      {{ effective_available }} MRWK effectively available ·
+      {{ effective_awards }}/{{ bounty.max_awards }} awards effectively open
+      {% endif %}
     </p>
+    {% if bounty.pending_awards or bounty.pending_close %}
+    <p class="availability-note">{{ bounty.availability_note }}</p>
+    {% endif %}
     <p>{{ bounty.acceptance }}</p>
   </article>
   {% else %}

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -5,6 +5,9 @@
   <a href="/bounties">&larr; Back to bounties</a>
 </nav>
 <section class="detail">
+  {% set effective_awards = bounty.effective_awards_remaining | default(bounty.awards_remaining) %}
+  {% set effective_available = bounty.effective_available_mrwk | default(bounty.available_mrwk) %}
+  {% set has_pending_availability = bounty.pending_awards or bounty.pending_close %}
   <p class="eyebrow">Bounty #{{ bounty.id }}</p>
   <h1>{{ bounty.title }}</h1>
   <p class="lead">Review the reward, status, source issue, and acceptance criteria before starting.</p>
@@ -32,6 +35,14 @@
       <strong>{{ bounty.available_mrwk }} MRWK</strong>
     </article>
     <article>
+      <span>Effectively remaining</span>
+      <strong>{{ effective_awards }}</strong>
+    </article>
+    <article>
+      <span>Effectively available</span>
+      <strong>{{ effective_available }} MRWK</strong>
+    </article>
+    <article>
       <span>Issue</span>
       <strong>
         {% if issue_url %}
@@ -42,6 +53,9 @@
       </strong>
     </article>
   </div>
+  {% if bounty.pending_awards or bounty.pending_close %}
+  <p class="availability-note availability-note--detail">{{ bounty.availability_note }}</p>
+  {% endif %}
 
   <section class="acceptance-card" aria-labelledby="acceptance-heading">
     <p class="eyebrow">Acceptance</p>
@@ -56,10 +70,18 @@
       <li>Confirm the source issue is still open and your change is not already covered by another PR.</li>
       <li>Keep the PR focused, link the source issue as <strong>Bounty #{{ bounty.issue_number }}</strong>, and include test or smoke-check evidence.</li>
       <li>
-        {% if bounty.awards_remaining %}
-          {{ bounty.awards_remaining }} award{% if bounty.awards_remaining != 1 %}s{% endif %} still open for distinct accepted work.
+        {% if effective_awards %}
+          {% if has_pending_availability %}
+            {{ effective_awards }} award{% if effective_awards != 1 %}s{% endif %} effectively open for distinct accepted work.
+          {% else %}
+            {{ bounty.awards_remaining }} award{% if bounty.awards_remaining != 1 %}s{% endif %} still open for distinct accepted work.
+          {% endif %}
         {% else %}
-          No awards remain; treat new work as unpaid unless maintainers reopen the bounty.
+          {% if has_pending_availability %}
+            No effective awards remain; treat new work as unpaid unless maintainers reopen or clear pending proposals.
+          {% else %}
+            No awards remain; treat new work as unpaid unless maintainers reopen the bounty.
+          {% endif %}
         {% endif %}
       </li>
     </ol>
@@ -73,7 +95,7 @@
 <section>
   <div class="section-head">
     <h2>Accepted work</h2>
-    <p>{{ bounty.awards_paid }}/{{ bounty.max_awards }} awards paid{% if bounty.awards_remaining %}; {{ bounty.awards_remaining }} still open{% endif %}.</p>
+    <p>{{ bounty.awards_paid }}/{{ bounty.max_awards }} awards paid{% if effective_awards %}; {% if has_pending_availability %}{{ effective_awards }} effectively open{% else %}{{ bounty.awards_remaining }} still open{% endif %}{% endif %}.</p>
   </div>
   {% if bounty.accepted_awards %}
   <div class="ledger-list">

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -55,6 +55,11 @@ curl -s "$API_HOST/api/v1/bounties/summary?status=open"
 curl -s "$API_HOST/api/v1/bounties/summary?q=docs"
 ```
 
+Use `effective_awards_remaining`, `effective_available_mrwk`, `pending_awards`,
+and `pending_close` from bounty rows when deciding whether new work is
+practically claimable. `awards_remaining` is the raw ledger slot count and may
+not reflect pending payout or close proposals yet.
+
 Inspect one bounty, accepted-work activity, a ledger page, and a proof:
 
 ```bash
@@ -256,8 +261,8 @@ Tools:
 Use this checklist before opening a PR for `mrwk:bounty` issues:
 
 1. Confirm no active claim or duplicate PR already covers the same scope.
-2. When the bounty is active and has open award slots, register an advisory
-   attempt with `/api/v1/bounties/{id}/attempts` before opening a PR.
+2. When the bounty is active and has effective open award slots, register an
+   advisory attempt with `/api/v1/bounties/{id}/attempts` before opening a PR.
 3. Write the claim-window scope before coding: exact bounty, intended files or
    surfaces, expected PR size, test plan, and what is out of scope.
 4. Keep changes small and directly tied to one bounty issue.

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -39,6 +39,14 @@ The bounties list returns public bounty rows. `status` can be omitted or set to
   "max_awards": 5,
   "awards_paid": 4,
   "awards_remaining": 1,
+  "pending_awards": 1,
+  "pending_payout_proposal_ids": [91],
+  "pending_close": false,
+  "pending_close_proposal_id": null,
+  "effective_awards_remaining": 0,
+  "effective_available_mrwk": "0",
+  "availability_status": "pending_payouts_full",
+  "availability_note": "1 pending payout proposal consumes practical award capacity.",
   "status": "open",
   "acceptance": "Focused public-facing enhancements that help contributors find bounties, inspect accepted work, or understand proof/account activity, with tests. Duplicate, marketing-only, docs-only, broad redesign, or unrelated changes do not qualify.",
   "created_at": "2026-05-24T20:44:00.015953"
@@ -46,14 +54,18 @@ The bounties list returns public bounty rows. `status` can be omitted or set to
 ```
 
 Use `id` for the single-bounty API path. Use `issue_number` and `issue_url` when
-linking back to the source GitHub issue. Award counters can change as accepted
-work is paid; refresh concrete examples against the live API before relying on
-available slot counts.
+linking back to the source GitHub issue. `awards_remaining` is the ledger slot
+count before pending treasury proposals execute. For starting new work, prefer
+`effective_awards_remaining`, `effective_available_mrwk`, `pending_awards`, and
+`pending_close`; those fields account for pending payouts and pending close
+proposals that can consume practical capacity before the ledger mutates.
+Award counters can change as accepted work is paid; refresh concrete examples
+against the live API before relying on available slot counts.
 
 Use `sort` to choose the bounty order: `newest` is the default, `reward` sorts
-by per-award reward, `available` sorts by the remaining MRWK pool, and `awards`
-sorts by remaining award slots. Use `limit` from `1` to `200` to cap returned
-rows after filtering and sorting.
+by per-award reward, `available` sorts by the effective remaining MRWK pool, and
+`awards` sorts by effective remaining award slots. Use `limit` from `1` to `200`
+to cap returned rows after filtering and sorting.
 
 Use `/api/v1/bounties/summary` with the same optional `status`, `q`, `sort`, and
 `limit` filters when an agent only needs capacity totals instead of full bounty
@@ -771,7 +783,7 @@ curl -s "$API_HOST/api/v1/bounties/summary?status=open"
 curl -s "$API_HOST/api/v1/bounties/<bounty_id>"
 ```
 
-The single-bounty response includes `max_awards`, `awards_paid`, and `awards_remaining`:
+The single-bounty response includes raw and effective capacity:
 
 ```json
 {
@@ -781,11 +793,17 @@ The single-bounty response includes `max_awards`, `awards_paid`, and `awards_rem
   "max_awards": 5,
   "awards_paid": 4,
   "awards_remaining": 1,
+  "pending_awards": 1,
+  "pending_close": false,
+  "effective_awards_remaining": 0,
+  "effective_available_mrwk": "0",
+  "availability_status": "pending_payouts_full",
   "status": "open"
 }
 ```
 
-Do not open a PR if `awards_remaining` is zero, or if the bounty `status` is `paid` or `closed`.
+Do not open a PR if `effective_awards_remaining` is zero, `pending_close` is
+true, or the bounty `status` is `paid` or `closed`.
 
 ### Check Active Attempts
 
@@ -838,7 +856,7 @@ Filter by PR body references (`Bounty #N` or `Refs #N`) to find scope-alike PRs 
 
 Before opening work on a bounty round:
 
-1. **Check the live bounty API** — if `status` is not `"open"` or `awards_remaining` is zero, the round is exhausted or closed and no new work will be accepted.
+1. **Check the live bounty API** — if `status` is not `"open"`, `effective_awards_remaining` is zero, or `pending_close` is true, the round is exhausted, practically consumed by pending proposals, or closing.
 2. **Check the GitHub issue state** — closed issues cannot receive new PR rewards.
 3. **Check for recent maintainer comments** — if a maintainer has marked the bounty as superseded or redirected work elsewhere, that is authoritative.
 4. **Verify stale rounds** — a round is stale when the bounty text, latest maintainer comment, or open PR queue suggests the requested work is already handled, no longer needed, or no longer being reviewed. Do not target stale rounds unless a maintainer explicitly redirects the work.

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
+from app.treasury import propose_treasury_action
 
 
 def test_bounty_api_reports_multi_award_capacity(sqlite_url: str) -> None:
@@ -32,6 +33,112 @@ def test_bounty_api_reports_multi_award_capacity(sqlite_url: str) -> None:
     assert bounty["max_awards"] == 4
     assert bounty["awards_paid"] == 0
     assert bounty["awards_remaining"] == 4
+
+
+def test_bounty_api_reports_effective_capacity_after_pending_payouts(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=12,
+            issue_url="https://github.com/ramimbo/mergework/issues/12",
+            title="Pending payout availability",
+            reward_mrwk="25",
+            max_awards=3,
+            acceptance="Pending payouts should reduce practical capacity.",
+        )
+        bounty_id = bounty.id
+        first = propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": bounty_id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/12",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+        second = propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": bounty_id,
+                "to_account": "github:bob",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/13",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    body = client.get(f"/api/v1/bounties/{bounty_id}").json()
+    summary = client.get("/api/v1/bounties/summary?status=open").json()
+
+    assert body["awards_remaining"] == 3
+    assert body["available_mrwk"] == "75"
+    assert body["pending_awards"] == 2
+    assert body["pending_payout_proposal_ids"] == [first.id, second.id]
+    assert body["pending_close"] is False
+    assert body["effective_awards_remaining"] == 1
+    assert body["effective_available_mrwk"] == "25"
+    assert body["availability_status"] == "pending_payouts"
+    assert "pending payout proposals consume practical award capacity" in body["availability_note"]
+    assert summary == {
+        "bounties_shown": 1,
+        "open_awards": 1,
+        "open_pool_mrwk": "25",
+    }
+
+
+def test_bounty_api_reports_pending_close_as_effectively_unavailable(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=13,
+            issue_url="https://github.com/ramimbo/mergework/issues/13",
+            title="Pending close availability",
+            reward_mrwk="10",
+            max_awards=4,
+            acceptance="Pending close should hide practical capacity.",
+        )
+        bounty_id = bounty.id
+        close_proposal = propose_treasury_action(
+            session,
+            action="close_bounty",
+            payload={"bounty_id": bounty_id, "closed_by": "maintainer"},
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    body = client.get(f"/api/v1/bounties/{bounty_id}").json()
+    summary = client.get("/api/v1/bounties/summary?status=open").json()
+
+    assert body["awards_remaining"] == 4
+    assert body["available_mrwk"] == "40"
+    assert body["pending_awards"] == 0
+    assert body["pending_close"] is True
+    assert body["pending_close_proposal_id"] == close_proposal.id
+    assert body["effective_awards_remaining"] == 0
+    assert body["effective_available_mrwk"] == "0"
+    assert body["availability_status"] == "pending_close"
+    assert "pending close proposal" in body["availability_note"]
+    assert summary == {
+        "bounties_shown": 1,
+        "open_awards": 0,
+        "open_pool_mrwk": "0",
+    }
 
 
 def test_bounty_api_reports_paid_multi_award_as_exhausted(sqlite_url: str) -> None:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -8,6 +8,7 @@ from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
 from app.models import LedgerEntry, Proof
+from app.treasury import propose_treasury_action
 
 
 def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
@@ -76,6 +77,67 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert "Paid public bounty" in paid_rows_uppercase.text
     assert "Open public bounty" not in paid_rows_uppercase.text
     assert 'href="/bounties?status=paid" aria-current="page"' in paid_rows_uppercase.text
+
+
+def test_bounties_page_shows_effective_availability_for_pending_proposals(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        payout_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=52,
+            issue_url="https://github.com/ramimbo/mergework/issues/52",
+            title="Pending payout public bounty",
+            reward_mrwk="25",
+            max_awards=2,
+            acceptance="Pending payouts should be visible on public pages.",
+        )
+        close_bounty_row = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=53,
+            issue_url="https://github.com/ramimbo/mergework/issues/53",
+            title="Pending close public bounty",
+            reward_mrwk="40",
+            max_awards=3,
+            acceptance="Pending close should be visible on public pages.",
+        )
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": payout_bounty.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/52",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+        propose_treasury_action(
+            session,
+            action="close_bounty",
+            payload={"bounty_id": close_bounty_row.id, "closed_by": "maintainer"},
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    list_page = client.get("/bounties")
+    detail_page = client.get(f"/bounties/{close_bounty_row.id}")
+
+    assert list_page.status_code == 200
+    assert "25 MRWK effectively available" in list_page.text
+    assert "1/2 awards effectively open" in list_page.text
+    assert "0 MRWK effectively available" in list_page.text
+    assert "0/3 awards effectively open" in list_page.text
+    assert "pending payout proposal consumes practical award capacity" in list_page.text
+    assert "pending close proposal makes this bounty unavailable" in list_page.text
+    assert detail_page.status_code == 200
+    assert "Effectively remaining" in detail_page.text
+    assert "No effective awards remain" in detail_page.text
 
 
 def test_bounties_summary_api_matches_public_list_filters(sqlite_url: str) -> None:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -214,8 +214,8 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert "status` can be omitted or set to" in examples
     assert "`newest` is the default" in examples
     assert "by per-award reward" in examples
-    assert "`available` sorts by the remaining MRWK pool" in examples
-    assert "remaining award slots" in examples
+    assert "`available` sorts by the effective remaining MRWK pool" in examples
+    assert "effective remaining award slots" in examples
     assert "Use `limit` from `1` to `200`" in examples
     assert '"id": 36' in examples
     assert '"repo": "ramimbo/mergework"' in examples
@@ -225,6 +225,9 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert '"reserved_mrwk": "500"' in examples
     assert '"awards_paid": 4' in examples
     assert '"awards_remaining": 1' in examples
+    assert '"effective_awards_remaining": 0' in examples
+    assert '"effective_available_mrwk": "0"' in examples
+    assert '"pending_close": false' in examples
     assert '"bounties_shown": 1' in examples
     assert '"open_awards": 2' in examples
     assert '"open_pool_mrwk": "50"' in examples


### PR DESCRIPTION
## Summary
- Add effective availability fields to public bounty API and MCP bounty responses that subtract pending payout proposals and zero capacity for pending close proposals.
- Use effective availability in bounty summaries, sorting, and public list/detail copy so contributors can see when raw awards_remaining is practically consumed.
- Document the effective fields and add regression tests for pending payout, pending close, and normal public page behavior.

Refs #641
Bounty #641

## Tests
- ./.venv/bin/python -m pytest
- ./.venv/bin/python -m ruff format --check .
- ./.venv/bin/python -m ruff check .
- ./.venv/bin/python -m mypy app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bounties now display "effective availability" that accounts for pending treasury proposals, showing contributors the true remaining award capacity before starting new work.
  * Bounty lists and detail pages conditionally show effective remaining awards and available slots when pending proposals exist.
  * Bounty sorting prioritizes effective capacity metrics.

* **Documentation**
  * Updated contributor guidance to reference effective availability fields when assessing bounty capacity.
  * API documentation now includes pending proposal and effective availability fields in bounty responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->