### PR TITLE
Reject C1 controls before input normalization

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -5,6 +5,7 @@ from typing import Any
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.control_chars import contains_control_character
 from app.models import WebhookEvent
 from app.treasury import propose_treasury_action, treasury_status
 
@@ -23,6 +24,8 @@ WEBHOOK_OUTCOME_SCAN_ORDER = {
 def normalize_webhook_status_filter(status: str | None) -> str | None:
     if status is None:
         return None
+    if contains_control_character(status):
+        raise ValueError("webhook_status must not contain control characters")
     normalized = status.strip().lower()
     return normalized or None
 

--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -58,13 +58,16 @@ def register_admin_routes(
                 return RedirectResponse("/auth/github/login?next=/admin", status_code=302)
             raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
         with session_scope(db_url) as session:
-            context = admin_page_context(
-                session,
-                login=login,
-                csrf_token=csrf_token("admin-bounty", login, settings.cookie_secret),
-                webhook_status=webhook_status,
-                webhook_limit=webhook_limit,
-            )
+            try:
+                context = admin_page_context(
+                    session,
+                    login=login,
+                    csrf_token=csrf_token("admin-bounty", login, settings.cookie_secret),
+                    webhook_status=webhook_status,
+                    webhook_limit=webhook_limit,
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
             context["proposal_id"] = proposal_id
         return templates.TemplateResponse(
             request,

--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from app.admin import list_webhook_events, webhook_events_to_dict
 from app.bounty_sorting import BOUNTY_SORT_ERROR, normalize_bounty_sort, sort_bounties
 from app.config import Settings
+from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.reconciliation import payout_reconciliation_summary, reconcile_accepted_payouts
 from app.ledger.service import (
@@ -104,10 +105,17 @@ def register_bounty_api_routes(
         try:
             normalized_sort = normalize_bounty_sort(sort)
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=BOUNTY_SORT_ERROR) from exc
+            detail = str(exc)
+            if "control characters" not in detail:
+                detail = BOUNTY_SORT_ERROR
+            raise HTTPException(status_code=400, detail=detail) from exc
         with session_scope(db_url) as session:
             query = select(Bounty)
             if status is not None:
+                if contains_control_character(status):
+                    raise HTTPException(
+                        status_code=400, detail="status must not contain control characters"
+                    )
                 normalized_status = status.strip().lower()
                 if normalized_status not in {"open", "paid", "closed"}:
                     raise HTTPException(
@@ -167,7 +175,10 @@ def register_bounty_api_routes(
     ) -> list[dict[str, Any]]:
         del admin_login
         with session_scope(db_url) as session:
-            return webhook_events_to_dict(list_webhook_events(session, status, limit))
+            try:
+                return webhook_events_to_dict(list_webhook_events(session, status, limit))
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     @app.post("/api/v1/bounties")
     async def api_create_bounty(

--- a/app/bounty_sorting.py
+++ b/app/bounty_sorting.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import Any
 
+from app.control_chars import contains_control_character
+
 BOUNTY_SORT_LABELS = {
     "newest": "Newest first",
     "reward": "Highest per-award reward",
@@ -16,7 +18,10 @@ BOUNTY_SORT_ERROR = f"sort must be one of: {', '.join(BOUNTY_SORT_OPTIONS)}"
 
 
 def normalize_bounty_sort(sort: str | None) -> str:
-    normalized_sort = (sort or "").strip().lower()
+    raw_sort = sort or ""
+    if contains_control_character(raw_sort):
+        raise ValueError("sort must not contain control characters")
+    normalized_sort = raw_sort.strip().lower()
     if not normalized_sort:
         return "newest"
     if normalized_sort not in BOUNTY_SORT_OPTIONS:

--- a/app/control_chars.py
+++ b/app/control_chars.py
@@ -1,0 +1,11 @@
+"""Shared raw control-character validation helpers."""
+
+from __future__ import annotations
+
+import re
+
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def contains_control_character(value: str) -> bool:
+    return CONTROL_CHAR_RE.search(value) is not None

--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ from app.bounty_attempts import (
     register_bounty_attempt_routes,
 )
 from app.config import get_settings
+from app.control_chars import contains_control_character
 from app.db import create_schema, session_scope
 from app.hub import is_ltc_lab_host, ltc_lab_context, mergework_hub_context
 from app.ledger.service import ensure_genesis, public_url_or_none
@@ -146,6 +147,10 @@ def _parse_int(value: Any, field: str) -> int:
     if isinstance(value, int):
         return value
     if isinstance(value, str):
+        if contains_control_character(value):
+            raise HTTPException(
+                status_code=400, detail=f"{field} must not contain control characters"
+            )
         clean = value.strip()
         if clean and clean.lstrip("+-").isdigit():
             try:

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -8,6 +8,7 @@ from sqlalchemy import func, or_, select
 from app.accounts import normalized_account, normalized_wallet_address
 from app.bounty_attempts import list_bounty_attempts
 from app.bounty_sorting import normalize_bounty_sort, sort_bounties
+from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import format_mrwk, get_balance, register_wallet, submit_wallet_transfer
 from app.ledger_views import ledger_entry_to_dict
@@ -34,6 +35,8 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
         if isinstance(value, int):
             parsed = value
         elif isinstance(value, str):
+            if contains_control_character(value):
+                raise ValueError(f"{field} must not contain control characters")
             clean = value.strip()
             if clean and clean.lstrip("+-").isdigit():
                 try:
@@ -76,6 +79,8 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             return None
         if not isinstance(value, str):
             raise ValueError(f"{field} must be a string")
+        if contains_control_character(value):
+            raise ValueError(f"{field} must not contain control characters")
         clean = value.strip()
         return clean or None
 

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -74,3 +74,20 @@ def test_admin_webhook_page_allows_api_limit_cap(
     assert response.text.count('data-label="Delivery"') == 120
     assert '<option value="200" selected>200</option>' in response.text
     assert too_large.status_code == 422
+
+
+def test_admin_webhook_page_rejects_c1_control_status_before_normalizing(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(
+        "/admin?webhook_status=%C2%85missing_submitter",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "webhook_status must not contain control characters"

--- a/tests/test_bounty_api.py
+++ b/tests/test_bounty_api.py
@@ -30,6 +30,16 @@ class TestBountyListRoutes:
         assert resp.status_code == 400
         assert "status must be one of" in resp.json()["detail"]
 
+    def test_list_bounties_rejects_c1_control_status_before_normalizing(self, client):
+        resp = client.get("/api/v1/bounties?status=%C2%85open")
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "status must not contain control characters"
+
+    def test_list_bounties_rejects_c1_control_sort_before_normalizing(self, client):
+        resp = client.get("/api/v1/bounties?sort=%C2%85reward")
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "sort must not contain control characters"
+
     def test_list_bounties_with_query(self, client):
         resp = client.get("/api/v1/bounties?q=test")
         assert resp.status_code == 200
@@ -87,6 +97,19 @@ class TestBountyPayRoute:
             },
         )
         assert resp.status_code == 401
+
+
+def test_admin_webhook_events_api_rejects_c1_control_status(monkeypatch):
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(create_app(webhook_secret="secret"))
+
+    resp = client.get(
+        "/api/v1/admin/webhook-events?status=%C2%85paid",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "webhook_status must not contain control characters"
 
 
 class TestBountyCloseRoute:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -72,3 +72,32 @@ def test_call_mcp_tool_preserves_argument_validation_errors(
 
     with pytest.raises(ValueError, match=message):
         call_mcp_tool(sqlite_url, tool_name, arguments)
+
+
+def test_call_mcp_tool_rejects_c1_status_before_normalizing(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    with pytest.raises(ValueError, match="status must not contain control characters"):
+        call_mcp_tool(sqlite_url, "list_bounties", {"status": "\u0085open"})
+
+
+def test_call_mcp_tool_rejects_c1_nonce_before_integer_parsing(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    with pytest.raises(ValueError, match="nonce must not contain control characters"):
+        call_mcp_tool(
+            sqlite_url,
+            "submit_wallet_transfer",
+            {
+                "from_address": "mrwk1" + ("a" * 40),
+                "to_address": "mrwk1" + ("b" * 40),
+                "amount_mrwk": "1",
+                "nonce": "\u00851",
+                "memo": "",
+                "signature_hex": "00" * 64,
+            },
+        )

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -206,6 +206,26 @@ def test_wallet_transfer_api_returns_validation_error(sqlite_url: str) -> None:
     assert response.json()["detail"] in {"invalid signature", "insufficient balance"}
 
 
+def test_wallet_transfer_api_rejects_c1_nonce_before_integer_parsing(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/api/v1/transfers",
+        json={
+            "from_address": "mrwk1" + ("a" * 40),
+            "to_address": "mrwk1" + ("b" * 40),
+            "amount_mrwk": "1",
+            "nonce": "\u00851",
+            "memo": "",
+            "signature_hex": "00" * 64,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "nonce must not contain control characters"
+
+
 def test_wallet_register_api_rejects_label_control_characters(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     _, public_hex, _ = _keypair()


### PR DESCRIPTION
Bounty #644

## Summary
- Add a shared raw control-character helper covering C0 controls, DEL, and C1 controls before normalization.
- Reject C1-padded bounty list status/sort filters, admin webhook status filters, MCP string/int arguments, and wallet-transfer nonce parsing before trimming/lowering/parsing.
- Preserve the existing valid-input behavior while returning explicit control-character validation errors.

## Why
The current code already rejects C1 controls in treasury/wallet helper paths, but several public/tooling paths normalize or parse raw input first. This closes the class called out in #644 without a broad validation rewrite.

## Validation
- `/Users/dom/bounty-work/mergework/.venv/bin/python -m pytest tests/test_bounty_api.py tests/test_admin_routes.py tests/test_mcp_tools.py tests/test_wallet_api.py -q` -> 67 passed, 1 warning.
- `/Users/dom/bounty-work/mergework/.venv/bin/python -m pytest -q` -> 551 passed, 1 warning.
- `/Users/dom/bounty-work/mergework/.venv/bin/ruff check app/control_chars.py app/bounty_sorting.py app/bounty_api.py app/admin.py app/admin_routes.py app/main.py app/mcp_tools.py tests/test_bounty_api.py tests/test_admin_routes.py tests/test_mcp_tools.py tests/test_wallet_api.py` -> passed.
- `/Users/dom/bounty-work/mergework/.venv/bin/ruff format --check app/control_chars.py app/bounty_sorting.py app/bounty_api.py app/admin.py app/admin_routes.py app/main.py app/mcp_tools.py tests/test_bounty_api.py tests/test_admin_routes.py tests/test_mcp_tools.py tests/test_wallet_api.py` -> 11 files already formatted.
- `/Users/dom/bounty-work/mergework/.venv/bin/python -m mypy app/control_chars.py app/bounty_sorting.py app/bounty_api.py app/admin.py app/admin_routes.py app/main.py app/mcp_tools.py` -> success.
- `git diff --check` -> clean.

No private data, credentials, wallet material, production mutation, price/exchange/bridge/off-ramp claims, or fabricated payout claims used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Query parameters and request arguments are now validated to reject values containing control characters.

* **Improvements**
  * API endpoints return HTTP 400 with descriptive error messages when control characters are detected in user input, providing clearer feedback on invalid requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->