### PR TITLE
Flag non-live bounty references in queue health

### DIFF
--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -20,6 +20,7 @@ GH_TIMEOUT_SECONDS = 30
 GH_PR_SAFETY_CAP = 201
 GH_ISSUE_SAFETY_CAP = 201
 MAX_BOUNTY_REF = 2**63 - 1
+CLAIMS_OPEN_RE = re.compile(r"\breserved on mergework\s*:", re.IGNORECASE)
 
 
 def _labels(raw: dict[str, Any]) -> list[str]:
@@ -31,6 +32,17 @@ def _labels(raw: dict[str, Any]) -> list[str]:
         elif isinstance(label, dict) and isinstance(label.get("name"), str):
             names.append(label["name"])
     return names
+
+
+def _comments(raw: dict[str, Any]) -> list[str]:
+    comments = raw.get("comments", [])
+    bodies: list[str] = []
+    for comment in comments:
+        if isinstance(comment, str):
+            bodies.append(comment)
+        elif isinstance(comment, dict) and isinstance(comment.get("body"), str):
+            bodies.append(comment["body"])
+    return bodies
 
 
 def _merge_state(raw: dict[str, Any]) -> str:
@@ -85,6 +97,32 @@ def _is_open_bounty(raw: dict[str, Any]) -> bool:
     return state == "open"
 
 
+def _bounty_liveness(raw: dict[str, Any]) -> tuple[bool, str]:
+    if not _is_open_bounty(raw):
+        return False, "closed or exhausted"
+
+    labels = _labels(raw)
+    comments = _comments(raw)
+    if "comments" not in raw:
+        return True, "open"
+    if not labels and not comments:
+        return True, "open"
+
+    has_bounty_label = any(label.lower() == "mrwk:bounty" for label in labels)
+    has_claims_open_comment = any(
+        CLAIMS_OPEN_RE.search(comment) is not None for comment in comments
+    )
+    if has_bounty_label and has_claims_open_comment:
+        return True, "live"
+
+    missing: list[str] = []
+    if not has_bounty_label:
+        missing.append("mrwk:bounty label")
+    if not has_claims_open_comment:
+        missing.append("Reserved on MergeWork comment")
+    return False, "missing " + " and ".join(missing)
+
+
 def _issue(pr: dict[str, Any], reason: str, detail: str) -> dict[str, Any]:
     return {
         "pull_request": pr["number"],
@@ -119,6 +157,7 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
         )
 
     closed_bounty_references: list[dict[str, Any]] = []
+    non_live_bounty_references: list[dict[str, Any]] = []
     missing_bounty_references: list[dict[str, Any]] = []
     dirty_or_unstable_merge_state: list[dict[str, Any]] = []
     needs_info: list[dict[str, Any]] = []
@@ -144,14 +183,24 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
                         f"Referenced bounty #{ref} was not in input",
                     )
                 )
-            elif not _is_open_bounty(bounty):
-                closed_bounty_references.append(
-                    _issue(
-                        pr,
-                        "closed_or_exhausted_bounty",
-                        f"Referenced bounty #{ref} is not payable",
+            else:
+                is_live, liveness_reason = _bounty_liveness(bounty)
+                if not is_live and liveness_reason == "closed or exhausted":
+                    closed_bounty_references.append(
+                        _issue(
+                            pr,
+                            "closed_or_exhausted_bounty",
+                            f"Referenced bounty #{ref} is not payable",
+                        )
                     )
-                )
+                elif not is_live:
+                    non_live_bounty_references.append(
+                        _issue(
+                            pr,
+                            "non_live_bounty_reference",
+                            f"Referenced bounty #{ref} is not claimable: {liveness_reason}",
+                        )
+                    )
             duplicate_groups[(ref, pr["scope"])].append(pr["number"])
         if pr["merge_state"] in UNSTABLE_MERGE_STATES:
             dirty_or_unstable_merge_state.append(
@@ -165,21 +214,32 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
         for (bounty, scope), numbers in sorted(duplicate_groups.items())
         if len(numbers) > 1 and scope
     ]
-    closed_or_exhausted_count = sum(
-        1 for bounty in bounties.values() if not _is_open_bounty(bounty)
-    )
+    closed_or_exhausted_count = 0
+    non_live_bounty_count = 0
+    for bounty in bounties.values():
+        is_live, liveness_reason = _bounty_liveness(bounty)
+        if is_live:
+            continue
+        if liveness_reason == "closed or exhausted":
+            closed_or_exhausted_count += 1
+        else:
+            non_live_bounty_count += 1
     report = {
         "summary": {
             "pull_requests": len(normalized_prs),
             "open_bounties": len(bounties) - closed_or_exhausted_count,
+            "live_bounties": (len(bounties) - closed_or_exhausted_count - non_live_bounty_count),
+            "non_live_bounties": non_live_bounty_count,
             "closed_or_exhausted_bounties": closed_or_exhausted_count,
             "closed_bounty_references": len(closed_bounty_references),
+            "non_live_bounty_references": len(non_live_bounty_references),
             "missing_bounty_references": len(missing_bounty_references),
             "dirty_or_unstable_merge_state": len(dirty_or_unstable_merge_state),
             "needs_info": len(needs_info),
             "duplicate_scope_groups": len(duplicate_scope_groups),
         },
         "closed_bounty_references": closed_bounty_references,
+        "non_live_bounty_references": non_live_bounty_references,
         "missing_bounty_references": missing_bounty_references,
         "dirty_or_unstable_merge_state": dirty_or_unstable_merge_state,
         "needs_info": needs_info,
@@ -193,6 +253,7 @@ def has_queue_issues(report: dict[str, Any]) -> bool:
         report[key]
         for key in (
             "closed_bounty_references",
+            "non_live_bounty_references",
             "missing_bounty_references",
             "dirty_or_unstable_merge_state",
             "needs_info",
@@ -211,6 +272,7 @@ def format_text_report(report: dict[str, Any]) -> str:
         return "\n".join(lines)
     sections = [
         ("Closed or exhausted bounty references", "closed_bounty_references"),
+        ("Non-live bounty references", "non_live_bounty_references"),
         ("Missing bounty references", "missing_bounty_references"),
         ("Dirty or unstable merge state", "dirty_or_unstable_merge_state"),
         ("Needs info", "needs_info"),
@@ -253,6 +315,7 @@ def format_markdown_report(report: dict[str, Any]) -> str:
 
     sections = [
         ("Closed or exhausted bounty references", "closed_bounty_references"),
+        ("Non-live bounty references", "non_live_bounty_references"),
         ("Missing bounty references", "missing_bounty_references"),
         ("Dirty or unstable merge state", "dirty_or_unstable_merge_state"),
         ("Needs info", "needs_info"),
@@ -296,6 +359,16 @@ def _run_gh_json(args: list[str]) -> Any:
     return json.loads(completed.stdout)
 
 
+def _gh_bounty_issue(raw: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "number": raw["number"],
+        "title": raw.get("title"),
+        "state": raw.get("state"),
+        "labels": raw.get("labels", []),
+        "awards_remaining": 1 if raw.get("state") == "OPEN" else 0,
+    }
+
+
 def load_live_queue(repo: str) -> dict[str, Any]:
     prs = _run_gh_json(
         [
@@ -317,6 +390,7 @@ def load_live_queue(repo: str) -> dict[str, Any]:
             f"gh pr list reached the {GH_PR_SAFETY_CAP} item safety cap; "
             "use an API-paginated collector before trusting this live report"
         )
+    referenced_bounties = {ref for pr in prs if isinstance(pr, dict) for ref in _bounty_refs(pr)}
     issues = _run_gh_json(
         [
             "gh",
@@ -337,17 +411,34 @@ def load_live_queue(repo: str) -> dict[str, Any]:
             f"gh issue list reached the {GH_ISSUE_SAFETY_CAP} item safety cap; "
             "use an API-paginated collector before trusting this live report"
         )
-    bounty_issues = [
-        {
-            "number": issue["number"],
-            "title": issue.get("title"),
-            "state": issue.get("state"),
-            "awards_remaining": 1 if issue.get("state") == "OPEN" else 0,
-        }
+    bounty_issues = {
+        int(issue["number"]): _gh_bounty_issue(issue)
         for issue in issues
-        if "bounty" in str(issue.get("title", "")).lower()
-    ]
-    return {"pull_requests": prs, "bounties": bounty_issues}
+        if isinstance(issue, dict)
+        and isinstance(issue.get("number"), int)
+        and "bounty" in str(issue.get("title", "")).lower()
+    }
+    for ref in referenced_bounties:
+        try:
+            issue = _run_gh_json(
+                [
+                    "gh",
+                    "issue",
+                    "view",
+                    str(ref),
+                    "--repo",
+                    repo,
+                    "--json",
+                    "number,title,state,labels,comments",
+                ]
+            )
+        except RuntimeError:
+            continue
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int):
+            bounty_issue = _gh_bounty_issue(issue)
+            bounty_issue["comments"] = issue.get("comments", [])
+            bounty_issues[int(issue["number"])] = bounty_issue
+    return {"pull_requests": prs, "bounties": list(bounty_issues.values())}
 
 
 def _load_input(path: str) -> dict[str, Any]:

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -61,8 +61,11 @@ def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
     assert report["summary"] == {
         "pull_requests": 4,
         "open_bounties": 2,
+        "live_bounties": 2,
+        "non_live_bounties": 0,
         "closed_or_exhausted_bounties": 1,
         "closed_bounty_references": 1,
+        "non_live_bounty_references": 0,
         "missing_bounty_references": 1,
         "dirty_or_unstable_merge_state": 2,
         "needs_info": 1,
@@ -183,6 +186,100 @@ def test_pr_queue_health_accepts_github_linking_keywords() -> None:
 
     assert report["summary"]["missing_bounty_references"] == 0
     assert report["missing_bounty_references"] == []
+
+
+def test_pr_queue_health_flags_non_live_bounty_references() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [
+                {
+                    "number": 597,
+                    "state": "OPEN",
+                    "awards_remaining": 8,
+                    "labels": [{"name": "mrwk:bounty"}],
+                    "comments": [
+                        {"body": "Reserved on MergeWork: https://mrwk.online/bounties/88"}
+                    ],
+                },
+                {
+                    "number": 645,
+                    "state": "OPEN",
+                    "awards_remaining": 1,
+                    "labels": [],
+                    "comments": [
+                        {
+                            "body": (
+                                "Status: pending create_bounty proposal. "
+                                "Maintainers will post the `Reserved on MergeWork` "
+                                "claims-open comment after execution. "
+                                "Please do not submit /claim work yet."
+                            )
+                        }
+                    ],
+                },
+            ],
+            "pull_requests": [
+                {
+                    "number": 10,
+                    "title": "Live bounty docs improvement",
+                    "body": "Bounty #597",
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+                {
+                    "number": 11,
+                    "title": "Premature guard implementation",
+                    "body": "Refs: #645",
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+            ],
+        }
+    )
+
+    assert report["summary"]["live_bounties"] == 1
+    assert report["summary"]["non_live_bounties"] == 1
+    assert report["summary"]["non_live_bounty_references"] == 1
+    assert report["non_live_bounty_references"][0]["pull_request"] == 11
+    assert (
+        report["non_live_bounty_references"][0]["detail"]
+        == "Referenced bounty #645 is not claimable: "
+        "missing mrwk:bounty label and Reserved on MergeWork comment"
+    )
+    markdown = format_markdown_report(report)
+    assert "### Non-live bounty references" in markdown
+    assert "Referenced bounty #645 is not claimable" in markdown
+
+
+def test_pr_queue_health_flags_missing_claims_open_comment() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [
+                {
+                    "number": 646,
+                    "state": "OPEN",
+                    "awards_remaining": 10,
+                    "labels": [{"name": "mrwk:bounty"}],
+                    "comments": [{"body": "Treasury proposal created, awaiting execution."}],
+                }
+            ],
+            "pull_requests": [
+                {
+                    "number": 12,
+                    "title": "Docs cleanup for proposed bounty flow",
+                    "body": "/claim #646",
+                    "merge_state": "clean",
+                    "labels": [],
+                }
+            ],
+        }
+    )
+
+    assert report["summary"]["non_live_bounty_references"] == 1
+    assert (
+        report["non_live_bounty_references"][0]["detail"]
+        == "Referenced bounty #646 is not claimable: missing Reserved on MergeWork comment"
+    )
 
 
 @pytest.mark.parametrize("reference", ("Fixes #310abc", "Fixes #310_abc", "Fixes #310-abc"))
@@ -363,6 +460,63 @@ def test_pr_queue_health_fails_fast_when_issue_fetch_hits_cap(monkeypatch) -> No
 
     with pytest.raises(RuntimeError, match="issue list reached the 201 item safety cap"):
         pr_queue_health.load_live_queue("ramimbo/mergework")
+
+
+def test_pr_queue_health_live_loader_fetches_reference_comments(monkeypatch) -> None:
+    def fake_run(args, **kwargs):
+        if args[:3] == ["gh", "pr", "list"]:
+            stdout = json.dumps(
+                [
+                    {
+                        "number": 657,
+                        "title": "Premature non-live bounty PR",
+                        "body": "Refs #645",
+                        "labels": [],
+                        "mergeStateStatus": "clean",
+                    }
+                ]
+            )
+        elif args[:3] == ["gh", "issue", "list"]:
+            assert args[-1] == "number,title,state,labels"
+            stdout = json.dumps(
+                [
+                    {
+                        "number": 645,
+                        "title": "MRWK bounty: proposed work",
+                        "state": "OPEN",
+                        "labels": [],
+                    }
+                ]
+            )
+        elif args[:3] == ["gh", "issue", "view"]:
+            assert args[3] == "645"
+            stdout = json.dumps(
+                {
+                    "number": 645,
+                    "title": "MRWK bounty: proposed work",
+                    "state": "OPEN",
+                    "labels": [],
+                    "comments": [
+                        {
+                            "body": (
+                                "Status: not claimable yet. Maintainers will post "
+                                "`Reserved on MergeWork` after execution."
+                            )
+                        }
+                    ],
+                }
+            )
+        else:
+            raise AssertionError(args)
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(pr_queue_health.subprocess, "run", fake_run)
+
+    data = pr_queue_health.load_live_queue("ramimbo/mergework")
+    report = analyze_queue(data)
+
+    assert report["summary"]["non_live_bounty_references"] == 1
+    assert report["non_live_bounty_references"][0]["pull_request"] == 657
 
 
 def test_pr_queue_health_fails_fast_when_pr_fetch_hits_cap(monkeypatch) -> None:


### PR DESCRIPTION
Bounty #645

## Summary
- Teach `scripts/pr_queue_health.py` to distinguish live bounty references from non-live proposed/pending bounty issues.
- Require referenced live bounty issues to have both the `mrwk:bounty` label and an actual `Reserved on MergeWork:` claims-open comment when live GitHub metadata is available.
- Report non-live bounty references in text/markdown/JSON queue-health output without auto-labeling, auto-closing, or making payment decisions.
- Keep fixture compatibility for older/offline inputs without comment metadata, and avoid fetching all issue comments in bulk by loading comments only for issue numbers referenced by open PRs.

## Why
Proposed-only issues can look like open bounty work before they are actually claimable. This guard gives maintainers a repo-native way to spot PRs that cite pending, proposed-only, closed, exhausted, missing, or unsupported bounty references before those PRs muddy the queue.

## Validation
- `.venv/bin/python -m pytest tests/test_pr_queue_health.py -q` -> 18 passed.
- `.venv/bin/ruff check scripts/pr_queue_health.py tests/test_pr_queue_health.py` -> passed.
- `.venv/bin/ruff format --check scripts/pr_queue_health.py tests/test_pr_queue_health.py` -> 2 files already formatted.
- `.venv/bin/python -m mypy scripts/pr_queue_health.py` -> success.
- `git diff --check` -> clean.
- `.venv/bin/python scripts/pr_queue_health.py --repo ramimbo/mergework --format markdown` -> live queue report completed and identified the existing dirty/needs-info PR #639 without non-live bounty false positives.

No private data, credentials, wallet material, production mutation, price/exchange/bridge/off-ramp claims, or fabricated payout claims used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bounty liveness detection now incorporates multiple signals to accurately determine claimability status
  * Queue reports distinguish between closed, live, and non-live bounties with separate tracking and reporting
  * Enhanced queue analysis with improved bounty categorization, detailed state counts, and better report clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->