### PR TITLE
Clarify MRWK claim-window checks in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,3 +21,11 @@
 ## MRWK
 
 Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties):
+
+Claim-window check for MRWK bounty work:
+
+- [ ] GitHub issue has the `mrwk:bounty` label.
+- [ ] GitHub issue has the `Reserved on MergeWork` claims-open comment.
+- [ ] Public bounty API row is `open`.
+- [ ] Awards remain after checking accepted, pending, or paid work.
+- [ ] Active attempts and open PRs do not already cover this exact scope.

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -200,9 +200,20 @@ def main() -> int:
     if not pr_template.exists():
         print(f"missing pull request template: {PR_TEMPLATE}")
         ok = False
-    elif "expected pr size:" not in pr_template.read_text(encoding="utf-8").lower():
-        print("pull request template must ask for expected PR size")
-        ok = False
+    else:
+        pr_template_text = pr_template.read_text(encoding="utf-8").lower()
+        if "expected pr size:" not in pr_template_text:
+            print("pull request template must ask for expected PR size")
+            ok = False
+        for phrase in [
+            "claim-window check for mrwk bounty work",
+            "github issue has the `mrwk:bounty` label",
+            "public bounty api row is `open`",
+            "active attempts and open prs do not already cover this exact scope",
+        ]:
+            if phrase not in pr_template_text:
+                print(f"pull request template missing claim-window phrase: {phrase}")
+                ok = False
     bounty_issue_template = ROOT / ".github/ISSUE_TEMPLATE/bounty.yml"
     if not bounty_issue_template.exists():
         print("missing bounty issue template: .github/ISSUE_TEMPLATE/bounty.yml")


### PR DESCRIPTION
## Summary

- Adds a claim-window checklist to the pull request template so MRWK bounty PRs explicitly confirm live issue, reserve comment, API status, award capacity, and duplicate-scope checks before review.
- Extends `scripts/docs_smoke.py` to keep the PR-template claim-window prompts covered by docs smoke.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: PR authors could enter `Bounty #N` without explicitly showing the issue is live and claimable.
- Bounty capacity and active attempts/open PRs checked: Bounty #646 has `mrwk:bounty`, `Reserved on MergeWork`, API status `open`, 10 awards remaining, no active attempts; current open PRs checked for overlapping scope.
- Intended files or surfaces: `.github/pull_request_template.md`, `scripts/docs_smoke.py`.
- Expected PR size: small template/docs smoke change.
- Out of scope: code payout behavior, labels, accepted/paid status, treasury mutation, price/exchange/cash-out claims.

## Test Evidence

- [ ] `ruff format --check .`
- [ ] `ruff check .`
- [ ] `mypy app`
- [ ] `pytest`
- [x] `python scripts/docs_smoke.py` (docs, template, example, or onboarding changes)
- [x] `uvx ruff format --check scripts/docs_smoke.py`
- [x] `uvx ruff check scripts/docs_smoke.py`
- [x] `git diff --check`

## MRWK

Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties): Bounty #646

Claim-window check for MRWK bounty work:

- [x] GitHub issue has the `mrwk:bounty` label.
- [x] GitHub issue has the `Reserved on MergeWork` claims-open comment.
- [x] Public bounty API row is `open`.
- [x] Awards remain after checking accepted, pending, or paid work.
- [x] Active attempts and open PRs do not already cover this exact scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR template with MRWK bounty claim-window verification checklist, including checks for issue labels, bounty API status, award availability, and scope coverage.

* **Chores**
  * Enhanced validation to ensure PR template contains required bounty guidance phrases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->