### PR TITLE
Add live bounty preflight checks to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,10 @@
 
 - Confusion, missing step, stale example, or bug this addresses:
 - Bounty capacity and active attempts/open PRs checked:
+- [ ] Referenced issue has `mrwk:bounty`, a `Reserved on MergeWork` comment,
+      and an open public bounty row with capacity.
+- [ ] Payment wording is proof-backed: a pending `pay_bounty` proposal is not
+      described as paid before a public proof exists.
 - Intended files or surfaces:
 - Expected PR size:
 - Out of scope:


### PR DESCRIPTION
## Summary

- Add explicit PR-template checks for the three live-bounty signals:
  `mrwk:bounty`, `Reserved on MergeWork`, and an open public bounty row with
  capacity.
- Add a proof-backed wording check so pending `pay_bounty` proposals are not
  described as paid before a public proof exists.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: the PR template
  asked contributors to check capacity but did not enumerate the live-bounty
  signals or distinguish pending payout proposals from proof-backed payments.
- Bounty capacity and active attempts/open PRs checked: Bounty #646 is live;
  open PRs were checked for duplicate template scope.
- Intended files or surfaces: `.github/pull_request_template.md`
- Expected PR size: one focused template-only diff.
- Out of scope: no code behavior changes, broad docs rewrite, payout claim, or
  private operational detail.

## Test Evidence

- `python3 scripts/docs_smoke.py`
- `git diff --check`

## MRWK

Refs #646


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request checklist with enhanced requirements for bounty and issue references, including proper documentation markers and capacity validation
  * Added stricter payment verification guidelines ensuring payment status is only documented after corresponding proof becomes available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->