### PR TITLE
Clarify agent payment status language

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -271,6 +271,24 @@ Use this checklist before opening a PR for `mrwk:bounty` issues:
 Common rejection reasons: duplicate scope, style-only changes without user
 impact, missing evidence, or ignoring issue-specific acceptance criteria.
 
+## Payment Status Language
+
+Use precise status words in PRs, issue comments, agent logs, and summaries:
+
+- **Submitted** means a PR, review, report, or comment was posted for a live
+  bounty. It does not mean the work was accepted or paid.
+- **Accepted** means a maintainer explicitly accepted the work or applied the
+  relevant accepted label. It may still need a public `pay_bounty` proposal
+  before any ledger payment exists.
+- **Pending payout** means a `pay_bounty` proposal exists but has not executed.
+  Do not describe this as paid, settled, withdrawable, or received.
+- **Paid** means the proposal executed and a public proof or ledger entry exists
+  for that exact submission. Link the proof when mentioning paid work.
+
+Do not infer cash value, exchangeability, bridge availability, or off-ramp
+timing from any of these states. Treat the proof-backed ledger state as the
+only source of truth for whether an accepted item has been paid.
+
 ## Proposed Work Requests
 
 Proposed work requests are intake issues, not live bounties. They may describe a


### PR DESCRIPTION
Bounty #646

## Summary
- Add a focused agent-guide section that distinguishes submitted, accepted, pending payout, and paid states.
- Clarify that `pay_bounty` proposals are not paid work until execution creates a public proof or ledger entry.
- Tell agents to link proof-backed ledger evidence when describing paid work and avoid cash-value/off-ramp inferences.

## Why
Agents currently have lifecycle docs, but the agent-facing workflow can still blur "submitted", "accepted", "pending payout", and "paid" in summaries and comments. This wording gives agents a short status-language rule to reduce overstated payment claims and confusion around pending payment proposals.

## Validation
- `.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.

No private data, credentials, wallet material, production mutation, price/exchange/bridge/off-ramp claims, or fabricated payout claims used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified payment status language with precise definitions for Submitted, Accepted, Pending payout, and Paid states. Added guidance on interpreting payment information and emphasizing ledger data as the authoritative source for payment verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->