### PR TITLE
Clarify live bounty checks in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,8 @@
 ## Evidence
 
 - Confusion, missing step, stale example, or bug this addresses:
-- Bounty capacity and active attempts/open PRs checked:
+- Live bounty signals checked (`mrwk:bounty`, `Reserved on MergeWork`, open public API row):
+- Bounty capacity, active attempts, and overlapping open PRs checked:
 - Intended files or surfaces:
 - Expected PR size:
 - Out of scope:


### PR DESCRIPTION
Bounty #646

## Summary
- Clarifies the PR template's evidence prompt so contributors explicitly confirm the live bounty signals before treating work as claimable.
- Separates live-bounty proof (`mrwk:bounty`, `Reserved on MergeWork`, open public API row) from capacity/attempt/overlap checks.
- Keeps the change limited to the contributor-facing PR template.

## Evidence
- Confusion, missing step, stale example, or bug this addresses: the prior prompt combined bounty capacity and active-attempt checks, but did not explicitly ask PR authors to record the three live-bounty signals that distinguish proposed/pending work from claimable bounty work.
- Live bounty signals checked: issue #646 has `mrwk:bounty`, a `Reserved on MergeWork: https://mrwk.online/bounties/94` comment, and public API row 94 is `open`.
- Bounty capacity, active attempts, and overlapping open PRs checked: API row 94 reported 10 awards remaining; `/api/v1/bounties/94/attempts` returned no attempts; GitHub open PR search for issue 646 returned no overlapping PRs during preparation.
- Intended files or surfaces: `.github/pull_request_template.md` only.
- Expected PR size: one focused template wording change.
- Out of scope: code behavior changes, payment/account changes, bounty acceptance or payout claims.

## Test Evidence
- [ ] `ruff format --check .` (not run; docs-template-only wording change)
- [ ] `ruff check .` (not run; docs-template-only wording change)
- [ ] `mypy app` (not run; docs-template-only wording change)
- [ ] `pytest` (not run; docs-template-only wording change)
- [x] `python3 scripts/docs_smoke.py` — passed (`docs smoke ok`)
- [x] `git diff --check` — passed

## MRWK
Related bounty or issue: Bounty #646


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request template to enhance the bounty verification checklist with explicit steps for confirming live bounty signals and expanded validation criteria for bounty capacity and related open pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->