### PR TITLE
Add non-live bounty reference correction template

### DIFF
--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -189,6 +189,24 @@ Maintainer decision this supports:
 Non-goals:
 ```
 
+Non-live or stale bounty reference correction:
+
+```text
+Referenced issue or PR:
+Claim text that needs correction:
+Missing live signal:
+- mrwk:bounty label:
+- Reserved on MergeWork comment:
+- Open public bounty row:
+Correct next action:
+```
+
+Use this correction template when a PR, issue comment, or agent summary treats
+proposed, pending, closed, exhausted, or unsupported work as claimable. Keep the
+comment factual: name the missing signal, link the current public evidence, and
+state whether the author should wait for proposal execution, retarget to a live
+bounty, update the PR body, or drop the MRWK claim.
+
 Do not describe work as accepted, merged, or paid until the public GitHub label,
 maintainer comment, or MRWK proof exists.
 

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -198,6 +198,7 @@ Missing live signal:
 - mrwk:bounty label:
 - Reserved on MergeWork comment:
 - Open public bounty row:
+Current public evidence link(s):
 Correct next action:
 ```
 

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -80,6 +80,7 @@ REQUIRED_PUBLIC_PHRASES = {
         "Review claim:",
         "Smoke-check or bug-report claim:",
         "Discussion or decision-support claim:",
+        "Non-live or stale bounty reference correction:",
         "Do not describe work as accepted, merged, or paid until the public GitHub label",
         "## Proposed Work Requests",
         "proposed issue -> maintainer review -> optional create_bounty proposal",

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -81,6 +81,7 @@ REQUIRED_PUBLIC_PHRASES = {
         "Smoke-check or bug-report claim:",
         "Discussion or decision-support claim:",
         "Non-live or stale bounty reference correction:",
+        "Current public evidence link(s):",
         "Do not describe work as accepted, merged, or paid until the public GitHub label",
         "## Proposed Work Requests",
         "proposed issue -> maintainer review -> optional create_bounty proposal",


### PR DESCRIPTION
Bounty #646

## Summary
- Add a focused submission-evidence template for correcting PRs, issue comments, or agent summaries that treat non-live bounty work as claimable.
- The template names the missing live signals: mrwk:bounty, Reserved on MergeWork, and an open public bounty row.
- Extend docs smoke coverage so the correction template remains present.

## Evidence
- Confusion, missing step, stale example, or bug this addresses: existing claim templates cover successful PR/review/smoke/discussion submissions, but they did not give maintainers or agents a reusable wording packet for correcting proposed, pending, closed, exhausted, or unsupported bounty references.
- Bounty capacity and active attempts/open PRs checked: issue #646 is live and claimable; existing open #646 PRs mostly cover PR-template live checks and payment-status language, while this change targets the public correction-comment template in docs/bounty-rules.md.
- Intended files or surfaces: docs/bounty-rules.md, scripts/docs_smoke.py.
- Expected PR size: focused docs plus smoke-check phrase.
- Out of scope: no code payout behavior, labels, acceptance, treasury mutation, price/exchange/cash-out claims, or private operational detail.

## Test Evidence
- python scripts/docs_smoke.py -> docs smoke ok
- python -m ruff check scripts/docs_smoke.py -> All checks passed
- python -m ruff format --check scripts/docs_smoke.py -> 1 file already formatted
- git diff --check -> no whitespace errors

## MRWK
Related bounty or issue: Bounty #646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Non-live or stale bounty reference correction" template with a checklist, required evidence fields (referenced issue/PR, incorrect claim text, missing live signal, current public evidence links), and guidance to keep corrections factual and state the next action (wait, retarget, update the claim text, or drop the claim).
* **Chores**
  * Updated documentation validation to require the new template phrases, causing automated checks to fail if missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->