### PR TITLE
Clarify live bounty claim checks in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,15 @@ small, verifiable, and easy for maintainers to review.
 ## Claiming Work
 
 1. Choose an issue labeled `mrwk:bounty`.
-2. Comment that you are working on it if nobody has an active attempt.
-3. Keep the pull request focused on the issue.
-4. Include test evidence, screenshots, or reproduction steps when relevant.
-5. Wait for maintainer review. Payment happens only after `mrwk:accepted`.
+2. Confirm the issue also has a `Reserved on MergeWork` comment and an open
+   public bounty row with available capacity.
+3. Do not claim proposed-work issues, pending `create_bounty` proposals, closed
+   rounds, exhausted rounds, or work already covered by another useful PR.
+4. Comment that you are working on it if nobody has an active attempt.
+5. Keep the pull request focused on the issue.
+6. Include test evidence, screenshots, or reproduction steps when relevant.
+7. Wait for maintainer review. Payment happens only after `mrwk:accepted`; a
+   pending `pay_bounty` proposal is not paid work until a public proof exists.
 
 ## Quality Expectations
 

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -32,6 +32,11 @@ REQUIRED_PUBLIC_PHRASES = {
         ),
         "require separate maintainer/contributor discussion before implementation",
     ],
+    "CONTRIBUTING.md": [
+        "Confirm the issue also has a `Reserved on MergeWork` comment",
+        "pending `create_bounty` proposals",
+        "a pending `pay_bounty` proposal is not paid work until a public proof exists",
+    ],
     "docs/ledger.md": [
         "## Current Transfer Paths",
         "`github:*` balance claims into a linked wallet.",


### PR DESCRIPTION
Bounty #646

## Summary

- Tighten `CONTRIBUTING.md` so the first contributor-facing claiming steps require the live bounty signals, not only the `mrwk:bounty` label.
- Clarify that proposed-work issues, pending `create_bounty` proposals, closed/exhausted rounds, and already-covered scopes should not be claimed.
- Clarify that pending `pay_bounty` proposals are not paid work until a public proof exists.
- Add docs smoke coverage for the new contributing guidance.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: the contributor guide previously said to choose an issue labeled `mrwk:bounty`, but did not mention the `Reserved on MergeWork` comment, public bounty row, capacity check, or pending payout vs proof-backed paid distinction.
- Bounty #646 is live: issue has `mrwk:bounty`, maintainer posted `Reserved on MergeWork: https://mrwk.online/bounties/94`, and the public API row is `open` with 10 awards remaining.
- Duplicate/overlap check: current open #646 PRs cover the PR template, `docs/agent-guide.md`, and `docs/bounty-rules.md`; this PR stays on `CONTRIBUTING.md` plus the existing docs smoke script.

## Validation

- `./.venv/bin/python scripts/docs_smoke.py` -> `docs smoke ok`
- `./.venv/bin/python -m ruff format --check scripts/docs_smoke.py` -> `1 file already formatted`
- `./.venv/bin/python -m ruff check scripts/docs_smoke.py` -> `All checks passed!`
- `git diff --check` -> passed

## Out of Scope

- No payout behavior changes.
- No automatic labels, claims, acceptance, or treasury mutation.
- No price, exchange, bridge, off-ramp, liquidity, cash-out, private security detail, or fabricated payout claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced contribution guidelines with a detailed checklist for claiming bounty work items
  * Clarified eligibility requirements and states that exclude work from consideration
  * Added guidance on commenting, maintaining focused pull requests, and providing relevant test evidence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->