### PR TITLE
docs: clarify pending payout intake updates

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -209,6 +209,29 @@ Manual payout checklist:
 Do not apply `mrwk:accepted` to maintainer-authored bounty issues for payment;
 those issues require the manual payout path.
 
+When posting a claim-intake update before proposal execution, use pending
+payout language and include enough data for contributors to distinguish queued
+work from paid proof-backed work:
+
+```text
+Accepted claims queued as pending `pay_bounty` proposals. These are not paid
+until proposal execution creates proof links.
+
+| Source | Recipient | Proposal | Executes after |
+| --- | --- | --- | --- |
+| <submission URL> | `<github:user-or-mrwk1...>` | <proposal URL> | <timestamp> |
+
+Skipped in this pass:
+
+| Source | Reason |
+| --- | --- |
+| <submission URL> | <duplicate, stale, out-of-scope, or needs-info reason> |
+```
+
+Do not write "paid", "settled", "received", or "withdrawable" in intake
+updates. Reserve those words for the follow-up comment after a proposal executes
+and the public proof or ledger entry exists.
+
 ### Webhook Outcome Inspection
 
 Use the admin-token webhook events API to inspect recent delivery outcomes before

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -99,6 +99,8 @@ REQUIRED_PUBLIC_PHRASES = {
         "uses the production `.env`",
         "docker compose logs -f treasury-executor",
         "Verify `result.github_issue_finalization`",
+        "Accepted claims queued as pending `pay_bounty` proposals",
+        'Do not write "paid", "settled", "received", or "withdrawable"',
     ],
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")


### PR DESCRIPTION
## Summary

- Add a maintainer-facing claim-intake update template for pending manual payout proposals.
- Make the runbook explicitly avoid calling queued `pay_bounty` proposals paid, settled, received, or withdrawable before proof execution.
- Add docs smoke coverage for the new wording.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: #646 asks for docs/runbook wording that reduces confusion between submitted, accepted, pending payout, and proof-backed paid work.
- Bounty capacity and active attempts/open PRs checked: #646 has `mrwk:bounty` and a maintainer `Reserved on MergeWork` comment; open PRs checked were #662, #664, #667, and #669. This PR targets `docs/admin-runbook.md`, which those PRs do not cover.
- Intended files or surfaces: `docs/admin-runbook.md`, `scripts/docs_smoke.py`.
- Expected PR size: small docs + smoke guard.
- Out of scope: no payout logic, token value/cash-out claims, admin API changes, or broad docs rewrite.

## Test Evidence

- [x] `python3 scripts/docs_smoke.py` -> docs smoke ok
- [x] `uvx ruff check scripts/docs_smoke.py` -> All checks passed
- [x] `uvx ruff format --check scripts/docs_smoke.py` -> 1 file already formatted
- [x] `git diff --check` -> passed

## MRWK

Bounty #646


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added administrator guidance on writing claim-intake updates, clarifying when accepted claims are pending versus paid and specifying which payout terminology to reserve for post-execution communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->