### PR TITLE
Clarify README bounty claim states

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,17 @@ server or database bypass by an operator with production access.
 ## How Earning Works
 
 1. A maintainer posts a bounty linked to a GitHub issue.
-2. A contributor or agent submits useful work.
-3. Tests, review, and project rules confirm the work.
-4. A maintainer applies `mrwk:accepted`.
-5. MergeWork writes a public ledger entry and proof.
+2. The issue becomes claimable only after it has `mrwk:bounty`, a
+   `Reserved on MergeWork` comment, an open public bounty row, and award
+   capacity not already consumed by accepted or pending payout work.
+3. A contributor or agent submits useful work.
+4. Tests, review, and project rules confirm the work.
+5. A maintainer applies `mrwk:accepted`.
+6. MergeWork writes a public ledger entry and proof.
+
+Proposed-work issues and pending bounty proposals are intake signals, not live
+claimable work. Pending `pay_bounty` proposals mean a payout is queued for
+challenge review; the work is not paid until the public proof exists.
 
 Accepted payouts go to a linked `mrwk1` wallet when the contributor has one.
 Otherwise the payout is held at a native ledger account such as `github:alice`


### PR DESCRIPTION
Bounty #646

## Summary

- Clarify the README earning flow so the entry page names all live bounty signals, not just the existence of a GitHub bounty issue.
- Add the pending-vs-paid distinction directly beside the high-level earning flow: proposed-work and pending bounty proposals are intake signals, and pending `pay_bounty` proposals are not paid until public proof exists.

## Evidence

- Confusion this addresses: the README is the top-level project entry point, but the earning flow previously jumped from "maintainer posts a bounty" to "contributor submits useful work" without naming the `mrwk:bounty` label, `Reserved on MergeWork` comment, public bounty row, award capacity, or pending payout caveat.
- Bounty #646 is live with `mrwk:bounty` and `Reserved on MergeWork`.
- Duplicate/overlap check: current open #646 PRs target the PR template, agent guide, bounty rules correction template, CONTRIBUTING, and admin runbook. No open README-focused #646 PR was found.

## Validation

- `D:\codex\bounty-mergework\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check` -> passed

## Out of Scope

- No payout behavior changes.
- No automatic labels, claims, acceptance, or treasury mutation.
- No price, exchange, bridge, off-ramp, liquidity, cash-out, private security detail, or fabricated payout claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded "How Earning Works" section with detailed step-by-step process clarifying when bounties become claimable and required conditions.
  * Added clarification on the status of proposed work and pending proposals in the bounty workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->