### PR TITLE
Flag non-live bounty references in queue health

### DIFF
--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -33,6 +33,17 @@ def _labels(raw: dict[str, Any]) -> list[str]:
     return names
 
 
+def _comments(raw: dict[str, Any]) -> list[str]:
+    comments = raw.get("comments", [])
+    bodies: list[str] = []
+    for comment in comments:
+        if isinstance(comment, str):
+            bodies.append(comment)
+        elif isinstance(comment, dict) and isinstance(comment.get("body"), str):
+            bodies.append(comment["body"])
+    return bodies
+
+
 def _merge_state(raw: dict[str, Any]) -> str:
     for key in ("merge_state", "mergeStateStatus", "mergeable", "mergeable_state"):
         value = raw.get(key)
@@ -85,6 +96,16 @@ def _is_open_bounty(raw: dict[str, Any]) -> bool:
     return state == "open"
 
 
+def _bounty_liveness(raw: dict[str, Any]) -> tuple[bool, str]:
+    if not _is_open_bounty(raw):
+        return False, "closed or exhausted"
+    if "labels" in raw and not any(label.lower() == "mrwk:bounty" for label in _labels(raw)):
+        return False, "missing mrwk:bounty label"
+    if "comments" in raw and not any("Reserved on MergeWork:" in body for body in _comments(raw)):
+        return False, "missing Reserved on MergeWork claims-open comment"
+    return True, "live"
+
+
 def _issue(pr: dict[str, Any], reason: str, detail: str) -> dict[str, Any]:
     return {
         "pull_request": pr["number"],
@@ -119,6 +140,7 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
         )
 
     closed_bounty_references: list[dict[str, Any]] = []
+    non_live_bounty_references: list[dict[str, Any]] = []
     missing_bounty_references: list[dict[str, Any]] = []
     dirty_or_unstable_merge_state: list[dict[str, Any]] = []
     needs_info: list[dict[str, Any]] = []
@@ -152,6 +174,16 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
                         f"Referenced bounty #{ref} is not payable",
                     )
                 )
+            else:
+                is_live, reason = _bounty_liveness(bounty)
+                if not is_live:
+                    non_live_bounty_references.append(
+                        _issue(
+                            pr,
+                            "non_live_bounty_reference",
+                            f"Referenced bounty #{ref} is not live claimable: {reason}",
+                        )
+                    )
             duplicate_groups[(ref, pr["scope"])].append(pr["number"])
         if pr["merge_state"] in UNSTABLE_MERGE_STATES:
             dirty_or_unstable_merge_state.append(
@@ -168,18 +200,28 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
     closed_or_exhausted_count = sum(
         1 for bounty in bounties.values() if not _is_open_bounty(bounty)
     )
+    live_bounty_count = sum(1 for bounty in bounties.values() if _bounty_liveness(bounty)[0])
+    non_live_bounty_count = sum(
+        1
+        for bounty in bounties.values()
+        if _is_open_bounty(bounty) and not _bounty_liveness(bounty)[0]
+    )
     report = {
         "summary": {
             "pull_requests": len(normalized_prs),
             "open_bounties": len(bounties) - closed_or_exhausted_count,
+            "live_bounties": live_bounty_count,
+            "non_live_bounties": non_live_bounty_count,
             "closed_or_exhausted_bounties": closed_or_exhausted_count,
             "closed_bounty_references": len(closed_bounty_references),
+            "non_live_bounty_references": len(non_live_bounty_references),
             "missing_bounty_references": len(missing_bounty_references),
             "dirty_or_unstable_merge_state": len(dirty_or_unstable_merge_state),
             "needs_info": len(needs_info),
             "duplicate_scope_groups": len(duplicate_scope_groups),
         },
         "closed_bounty_references": closed_bounty_references,
+        "non_live_bounty_references": non_live_bounty_references,
         "missing_bounty_references": missing_bounty_references,
         "dirty_or_unstable_merge_state": dirty_or_unstable_merge_state,
         "needs_info": needs_info,
@@ -193,6 +235,7 @@ def has_queue_issues(report: dict[str, Any]) -> bool:
         report[key]
         for key in (
             "closed_bounty_references",
+            "non_live_bounty_references",
             "missing_bounty_references",
             "dirty_or_unstable_merge_state",
             "needs_info",
@@ -211,6 +254,7 @@ def format_text_report(report: dict[str, Any]) -> str:
         return "\n".join(lines)
     sections = [
         ("Closed or exhausted bounty references", "closed_bounty_references"),
+        ("Non-live bounty references", "non_live_bounty_references"),
         ("Missing bounty references", "missing_bounty_references"),
         ("Dirty or unstable merge state", "dirty_or_unstable_merge_state"),
         ("Needs info", "needs_info"),
@@ -253,6 +297,7 @@ def format_markdown_report(report: dict[str, Any]) -> str:
 
     sections = [
         ("Closed or exhausted bounty references", "closed_bounty_references"),
+        ("Non-live bounty references", "non_live_bounty_references"),
         ("Missing bounty references", "missing_bounty_references"),
         ("Dirty or unstable merge state", "dirty_or_unstable_merge_state"),
         ("Needs info", "needs_info"),
@@ -317,6 +362,9 @@ def load_live_queue(repo: str) -> dict[str, Any]:
             f"gh pr list reached the {GH_PR_SAFETY_CAP} item safety cap; "
             "use an API-paginated collector before trusting this live report"
         )
+    referenced_issues = sorted(
+        {ref for pr in prs if isinstance(pr, dict) for ref in _bounty_refs(pr)}
+    )
     issues = _run_gh_json(
         [
             "gh",
@@ -337,16 +385,51 @@ def load_live_queue(repo: str) -> dict[str, Any]:
             f"gh issue list reached the {GH_ISSUE_SAFETY_CAP} item safety cap; "
             "use an API-paginated collector before trusting this live report"
         )
-    bounty_issues = [
-        {
-            "number": issue["number"],
-            "title": issue.get("title"),
-            "state": issue.get("state"),
-            "awards_remaining": 1 if issue.get("state") == "OPEN" else 0,
-        }
+    issues_by_number = {
+        int(issue["number"]): issue
         for issue in issues
-        if "bounty" in str(issue.get("title", "")).lower()
-    ]
+        if isinstance(issue, dict) and isinstance(issue.get("number"), int)
+    }
+    bounty_numbers = {
+        int(issue["number"])
+        for issue in issues
+        if isinstance(issue, dict)
+        and isinstance(issue.get("number"), int)
+        and "bounty" in str(issue.get("title", "")).lower()
+    } | set(referenced_issues)
+    bounty_issues = []
+    for number in sorted(bounty_numbers):
+        issue = issues_by_number.get(number, {"number": number})
+        viewed_issue = issue
+        include_comments = number in referenced_issues
+        if include_comments:
+            try:
+                viewed_issue = _run_gh_json(
+                    [
+                        "gh",
+                        "issue",
+                        "view",
+                        str(number),
+                        "--repo",
+                        repo,
+                        "--comments",
+                        "--json",
+                        "number,title,state,labels,comments",
+                    ]
+                )
+            except RuntimeError:
+                if number not in issues_by_number:
+                    continue
+        bounty_issue = {
+            "number": int(viewed_issue["number"]),
+            "title": viewed_issue.get("title"),
+            "state": viewed_issue.get("state"),
+            "labels": viewed_issue.get("labels", []),
+            "awards_remaining": 1 if viewed_issue.get("state") == "OPEN" else 0,
+        }
+        if include_comments:
+            bounty_issue["comments"] = viewed_issue.get("comments", [])
+        bounty_issues.append(bounty_issue)
     return {"pull_requests": prs, "bounties": bounty_issues}
 
 

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -365,6 +365,7 @@ def load_live_queue(repo: str) -> dict[str, Any]:
     referenced_issues = sorted(
         {ref for pr in prs if isinstance(pr, dict) for ref in _bounty_refs(pr)}
     )
+    referenced_issue_numbers = set(referenced_issues)
     issues = _run_gh_json(
         [
             "gh",
@@ -396,12 +397,12 @@ def load_live_queue(repo: str) -> dict[str, Any]:
         if isinstance(issue, dict)
         and isinstance(issue.get("number"), int)
         and "bounty" in str(issue.get("title", "")).lower()
-    } | set(referenced_issues)
+    } | referenced_issue_numbers
     bounty_issues = []
     for number in sorted(bounty_numbers):
         issue = issues_by_number.get(number, {"number": number})
         viewed_issue = issue
-        include_comments = number in referenced_issues
+        include_comments = number in referenced_issue_numbers
         if include_comments:
             try:
                 viewed_issue = _run_gh_json(

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -61,8 +61,11 @@ def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
     assert report["summary"] == {
         "pull_requests": 4,
         "open_bounties": 2,
+        "live_bounties": 2,
+        "non_live_bounties": 0,
         "closed_or_exhausted_bounties": 1,
         "closed_bounty_references": 1,
+        "non_live_bounty_references": 0,
         "missing_bounty_references": 1,
         "dirty_or_unstable_merge_state": 2,
         "needs_info": 1,
@@ -185,6 +188,94 @@ def test_pr_queue_health_accepts_github_linking_keywords() -> None:
     assert report["missing_bounty_references"] == []
 
 
+def test_pr_queue_health_flags_open_issue_without_live_bounty_signals() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [
+                {
+                    "number": 310,
+                    "state": "OPEN",
+                    "awards_remaining": 1,
+                    "labels": [{"name": "mrwk:bounty"}],
+                    "comments": [
+                        {"body": "Reserved on MergeWork: https://mrwk.online/bounties/310"}
+                    ],
+                },
+                {
+                    "number": 311,
+                    "state": "OPEN",
+                    "awards_remaining": 1,
+                    "labels": [],
+                    "comments": [],
+                },
+                {
+                    "number": 312,
+                    "state": "OPEN",
+                    "awards_remaining": 1,
+                    "labels": [{"name": "mrwk:bounty"}],
+                    "comments": [],
+                },
+            ],
+            "pull_requests": [
+                {
+                    "number": 1,
+                    "title": "Live bounty work",
+                    "body": "Bounty #310",
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+                {
+                    "number": 2,
+                    "title": "Proposed-only bounty work",
+                    "body": "Bounty #311",
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+                {
+                    "number": 3,
+                    "title": "Label-only bounty work",
+                    "body": "Bounty #312",
+                    "merge_state": "clean",
+                    "labels": [],
+                },
+            ],
+        }
+    )
+
+    assert report["summary"]["live_bounties"] == 1
+    assert report["summary"]["non_live_bounties"] == 2
+    assert report["summary"]["non_live_bounty_references"] == 2
+    details = {
+        item["pull_request"]: item["detail"] for item in report["non_live_bounty_references"]
+    }
+    assert details[2] == "Referenced bounty #311 is not live claimable: missing mrwk:bounty label"
+    assert (
+        details[3] == "Referenced bounty #312 is not live claimable: "
+        "missing Reserved on MergeWork claims-open comment"
+    )
+
+
+def test_pr_queue_health_keeps_legacy_fixture_open_bounty_compatibility() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [
+                {
+                    "number": 8,
+                    "title": "Legacy fixture bounty work",
+                    "body": "Bounty #310",
+                    "merge_state": "clean",
+                    "labels": [],
+                }
+            ],
+        }
+    )
+
+    assert report["summary"]["live_bounties"] == 1
+    assert report["summary"]["non_live_bounty_references"] == 0
+    assert report["non_live_bounty_references"] == []
+
+
 @pytest.mark.parametrize("reference", ("Fixes #310abc", "Fixes #310_abc", "Fixes #310-abc"))
 def test_pr_queue_health_rejects_linking_keyword_issue_suffix(reference: str) -> None:
     report = analyze_queue(
@@ -280,6 +371,8 @@ def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
         "- [PR #1](https://github.com/ramimbo/mergework/pull/1): "
         "Add public bounty summary API (Referenced bounty #293 is not payable)"
     ) in markdown
+    assert "- **live bounties**: 1" in markdown
+    assert "- **non live bounty references**: 0" in markdown
     assert "### Missing bounty references" in markdown
     assert (
         "- [PR #2](https://github.com/ramimbo/mergework/pull/2): "
@@ -342,6 +435,58 @@ def test_pr_queue_health_wraps_gh_timeouts(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="gh command timed out"):
         pr_queue_health._run_gh_json(["gh", "pr", "list"])
+
+
+def test_pr_queue_health_live_loader_includes_referenced_issue_comments(monkeypatch) -> None:
+    def fake_run(args, **kwargs):
+        if args[:3] == ["gh", "pr", "list"]:
+            stdout = json.dumps(
+                [
+                    {
+                        "number": 8,
+                        "title": "Queue guard",
+                        "url": "https://github.com/ramimbo/mergework/pull/8",
+                        "body": "Bounty #310",
+                        "labels": [],
+                        "mergeStateStatus": "clean",
+                    }
+                ]
+            )
+        elif args[:3] == ["gh", "issue", "list"]:
+            stdout = json.dumps(
+                [
+                    {
+                        "number": 310,
+                        "title": "MRWK bounty: queue guard",
+                        "state": "OPEN",
+                        "labels": [{"name": "mrwk:bounty"}],
+                    }
+                ]
+            )
+        elif args[:3] == ["gh", "issue", "view"]:
+            stdout = json.dumps(
+                {
+                    "number": 310,
+                    "title": "MRWK bounty: queue guard",
+                    "state": "OPEN",
+                    "labels": [{"name": "mrwk:bounty"}],
+                    "comments": [
+                        {"body": "Reserved on MergeWork: https://mrwk.online/bounties/310"}
+                    ],
+                }
+            )
+        else:
+            raise AssertionError(args)
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(pr_queue_health.subprocess, "run", fake_run)
+
+    data = pr_queue_health.load_live_queue("ramimbo/mergework")
+    report = analyze_queue(data)
+
+    assert data["bounties"][0]["comments"]
+    assert report["summary"]["live_bounties"] == 1
+    assert report["summary"]["non_live_bounty_references"] == 0
 
 
 def test_pr_queue_health_fails_fast_when_issue_fetch_hits_cap(monkeypatch) -> None:

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -438,6 +438,8 @@ def test_pr_queue_health_wraps_gh_timeouts(monkeypatch) -> None:
 
 
 def test_pr_queue_health_live_loader_includes_referenced_issue_comments(monkeypatch) -> None:
+    viewed_numbers = []
+
     def fake_run(args, **kwargs):
         if args[:3] == ["gh", "pr", "list"]:
             stdout = json.dumps(
@@ -460,10 +462,17 @@ def test_pr_queue_health_live_loader_includes_referenced_issue_comments(monkeypa
                         "title": "MRWK bounty: queue guard",
                         "state": "OPEN",
                         "labels": [{"name": "mrwk:bounty"}],
-                    }
+                    },
+                    {
+                        "number": 311,
+                        "title": "MRWK bounty: unrelated docs",
+                        "state": "OPEN",
+                        "labels": [{"name": "mrwk:bounty"}],
+                    },
                 ]
             )
         elif args[:3] == ["gh", "issue", "view"]:
+            viewed_numbers.append(args[3])
             stdout = json.dumps(
                 {
                     "number": 310,
@@ -485,7 +494,9 @@ def test_pr_queue_health_live_loader_includes_referenced_issue_comments(monkeypa
     report = analyze_queue(data)
 
     assert data["bounties"][0]["comments"]
-    assert report["summary"]["live_bounties"] == 1
+    assert viewed_numbers == ["310"]
+    assert report["summary"]["live_bounties"] == 2
+    assert report["summary"]["non_live_bounties"] == 0
     assert report["summary"]["non_live_bounty_references"] == 0
 
 


### PR DESCRIPTION
Bounty #645

## Summary

- Add a `non_live_bounty_references` queue-health category for PRs that reference open issues missing live bounty signals.
- Require explicit metadata, when available, to show both `mrwk:bounty` and a `Reserved on MergeWork:` claims-open comment before a referenced bounty is treated as live claimable.
- Teach live queue collection to fetch comments for PR-referenced issues, so the repo-native queue-health path can verify the claims-open comment without broad rewrites.
- Preserve legacy fixture compatibility when old fixtures do not include label/comment metadata.

## Why this is useful

The guard now catches the non-live case where an open issue has empty `labels` and empty `comments`; that previously looked open/payable if the fixture only checked state and awards remaining. The output stays maintainer-facing and read-only: no labels, comments, acceptance, payout, or close actions are mutated.

## Validation

- `uv run --python 3.12 --with pytest pytest tests/test_pr_queue_health.py tests/test_submission_quality_gate.py -q` -> 52 passed
- `uv run --python 3.12 --with pytest pytest -q` -> 553 passed, 1 warning
- `uvx ruff check .` -> All checks passed
- `uvx ruff format --check .` -> 95 files already formatted
- `uv run --python 3.12 --extra dev mypy app scripts/pr_queue_health.py` -> Success: no issues found in 35 source files
- `python3 scripts/pr_queue_health.py --repo ramimbo/mergework --format markdown` -> ran successfully against the live queue; summary included 10 PRs, 9 live bounties, 3 non-live bounties, and 0 current non-live bounty references
- regression probe with an open bounty fixture using empty `labels` and `comments` now reports `non_live_bounty_references: 1`
- `git diff --check` -> clean

## Duplicate/overlap check

Existing open #645 work overlaps the queue-health area, but this PR specifically adds strict label/comment liveness classification and regression coverage for the empty-metadata non-live case.

No private data, credentials, wallet material, production mutation, price/exchange/bridge/off-ramp claims, or fabricated payout claims used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue health reports now classify bounties as live vs non-live and surface counts and non-live reference details in summaries and reports

* **Tests**
  * Expanded test coverage for live/non-live bounty classification, summary metrics, and report rendering, including integration-style validation of referenced-bounty comment fetching
<!-- end of auto-generated comment: release notes by coderabbit.ai -->