### PR TITLE
Clarify live bounty signals in the bounty issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Do not add the live bounty label from this template. A GitHub issue is not claimable until the treasury proposal executes, the public bounty page exists, and maintainers post the reserved bounty comment.
+        Do not add the live bounty label from this template. A GitHub issue is not claimable until the treasury proposal executes, maintainers add `mrwk:bounty`, maintainers post the `Reserved on MergeWork` comment, the open public bounty row exists, and award capacity remains after accepted or pending payout work.
 
         Use the stable bounty shape from `docs/bounty-rules.md` so humans, GitHub search, API clients, and MCP agents can parse the reward, scope, evidence, and exclusions.
         Keep public MRWK wording work-based: no price, investment, exchange, liquidity, bridge, cash-out, or fabricated payout claims.

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -216,6 +216,11 @@ def main() -> int:
         for phrase in [
             "mrwk bounty: <amount> mrwk - <short scope>",
             "do not add the live bounty label from this template",
+            "treasury proposal executes",
+            "maintainers add `mrwk:bounty`",
+            "reserved on mergework",
+            "open public bounty row",
+            "award capacity remains after accepted or pending payout work",
             "id: evidence",
             "evidence or tests required",
             "id: out_of_scope",


### PR DESCRIPTION
Bounty #646

## Summary
- Tighten the MRWK bounty issue template first-screen warning so draft bounty issues list the full live-claimability signals.
- Require `mrwk:bounty`, `Reserved on MergeWork`, an open public bounty row, and remaining capacity after accepted or pending payout work before the issue is treated as claimable.
- Add docs smoke coverage so the issue template keeps those guardrails.

## Evidence
- Confusion, missing step, stale example, or bug this addresses: the bounty issue form only mentioned proposal execution, public bounty page, and reserved comment, but did not spell out the complete #646 live-claimability signals.
- Bounty capacity and active attempts/open PRs checked: issue #646 has `mrwk:bounty`, a `Reserved on MergeWork` comment, and maintainer comment says #646 remains live with 6 effective awards. Existing #646 PRs cover PR template, agent guide, bounty rules, CONTRIBUTING, admin runbook, README, and API examples; this PR is limited to the bounty issue template.
- Intended files or surfaces: `.github/ISSUE_TEMPLATE/bounty.yml`, `scripts/docs_smoke.py`.
- Expected PR size: 2 files, docs/template only.
- Out of scope: no code behavior changes, no broad docs rewrite, no price/exchange/bridge/off-ramp claims, no private data.

## Test Evidence
- [x] `F:\jiedan\mergework\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- [x] `F:\jiedan\mergework\.venv\Scripts\python.exe -m py_compile scripts\docs_smoke.py`
- [x] `uvx ruff check scripts\docs_smoke.py` -> All checks passed
- [x] `uvx ruff format --check scripts\docs_smoke.py` -> 1 file already formatted
- [x] `git diff --check` -> passed

## MRWK

Related bounty or issue: Bounty #646


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified bounty claimability requirements: treasury proposal execution, maintainer label and reservation comment, presence of an open public bounty row, and remaining award capacity after accepted or pending payouts.
* **Tests**
  * Added validation to enforce the updated bounty template language in documentation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->