### PR TITLE
Clarify security bounty proof status

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,3 +8,12 @@ report bodies in public issues, pull requests, comments, or ledger fields.
 Accepted private security work can receive MRWK with a redacted public proof that
 records the bounty, recipient account, amount, verifier result, and ledger hash
 without publishing sensitive details.
+
+For private security bounties, keep the payment status wording separate from the
+report content:
+
+- A pending `pay_bounty` proposal means the security work was accepted for
+  payout review, not paid.
+- A security bounty is paid only after a public proof or ledger entry exists.
+- Public comments should link the redacted proof and avoid vulnerability
+  mechanics unless maintainers approve disclosure.

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -104,6 +104,14 @@ REQUIRED_PUBLIC_PHRASES = {
         "Accepted claims queued as pending `pay_bounty` proposals",
         'Do not write "paid", "settled", "received", or "withdrawable"',
     ],
+    "SECURITY.md": [
+        (
+            "A pending `pay_bounty` proposal means the security work was "
+            "accepted for payout review, not paid."
+        ),
+        "A security bounty is paid only after a public proof or ledger entry exists.",
+        "Public comments should link the redacted proof",
+    ],
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"


### PR DESCRIPTION
Bounty #646

## Summary
- Clarify `SECURITY.md` payment-status wording for private security bounty work.
- State that a pending `pay_bounty` proposal is accepted for payout review, not paid.
- State that security bounty work is paid only after a public proof or ledger entry exists.
- Add docs smoke coverage so this private-security proof boundary stays present.

## Evidence
- Confusion, missing step, stale example, or bug this addresses: security reports need especially careful public wording, but `SECURITY.md` only described redacted proofs and did not distinguish pending payout proposals from proof-backed paid work.
- Bounty capacity and active attempts/open PRs checked: issue #646 has `mrwk:bounty` and the maintainer `Reserved on MergeWork` claims-open comment. Maintainer update says #646 remains live with 6 effective awards after the paid batch. Existing #646 work covered PR template, agent guide, bounty rules, CONTRIBUTING, admin runbook, README, API examples, and bounty issue template. This PR is limited to `SECURITY.md` plus docs-smoke coverage.
- Intended files or surfaces: `SECURITY.md`, `scripts/docs_smoke.py`.
- Expected PR size: 2 files, docs/security wording only.
- Out of scope: no private vulnerability details, no ledger or payout behavior changes, no labels, no accepted/paid status changes, no price/exchange/bridge/off-ramp claims.

## Validation
- `python scripts/docs_smoke.py` -> docs smoke ok
- `python -m py_compile scripts/docs_smoke.py` -> ok
- `uvx ruff check scripts/docs_smoke.py` -> All checks passed
- `uvx ruff format --check scripts/docs_smoke.py` -> 1 file already formatted
- `python -m pytest tests\test_docs_public_urls.py -q` -> 32 passed
- `git diff --check` -> passed

## MRWK

Related bounty or issue: Bounty #646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced security guidelines with clarifications on bounty payment status terminology and the meaning of pending payout proposals.
  * Added procedures for private security bounty submissions with guidance on separating payment information from vulnerability report details.
  * Updated recommendations for public disclosures, including best practices for linking proofs while protecting sensitive vulnerability information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->