### PR TITLE
docs: clarify non-PR bounty submissions

### DIFF
--- a/docs/bounty-lifecycle.md
+++ b/docs/bounty-lifecycle.md
@@ -55,7 +55,10 @@ Before opening a PR or posting a claim:
 4. Confirm the public API row exists and is open.
 5. Check award capacity, duplicate PRs, open attempts, and stale or superseded
    work.
-6. Keep the submission focused and include evidence, tests, screenshots,
+6. Confirm the requested submission artifact: PR, review, issue comment,
+   smoke-check report, or proposed-work issue. Do not force a PR-shaped claim
+   onto a bounty that explicitly asks for another artifact.
+7. Keep the submission focused and include evidence, tests, screenshots,
    reproduction steps, or review notes as requested by the bounty.
 
 Reference tiers are only sizing guidance. They do not create a right to payment

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -56,6 +56,7 @@ REQUIRED_PUBLIC_PHRASES = {
         "Reserved on MergeWork",
         "A pending create_bounty proposal is not a live bounty.",
         "A pending pay_bounty proposal is not paid work.",
+        "Confirm the requested submission artifact: PR, review, issue comment,",
         "result.github_issue_finalization",
     ],
     "docs/paid-bounties.md": [


### PR DESCRIPTION
## Summary
- Clarifies that bounty preflight should confirm the requested submission artifact before submitting work.
- Adds examples for PR, review, issue comment, smoke-check report, and proposed-work issue submissions.
- Guards the lifecycle wording in the docs smoke check.

Bounty #646
/claim #646

## Test Plan
- `python3 scripts/docs_smoke.py`
- `git diff --check`

## Notes
- Scope is limited to `docs/bounty-lifecycle.md` plus docs smoke coverage.
