### PR TITLE
Add docs-agent bounty claimability guardrails

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,5 +4,13 @@ Write docs for humans first. Keep language concise, concrete, and easy to act on
 
 - Do not make investment claims or imply a fixed MRWK fiat value.
 - Explain workflows plainly with commands, endpoints, labels, and expected states.
+- Before documenting a bounty as claimable, confirm `mrwk:bounty`,
+  `Reserved on MergeWork`, an open public bounty row, and remaining effective
+  award capacity.
+- Do not submit or encourage `/claim` for proposed-work issues, pending
+  `create_bounty` proposals, closed rounds, exhausted rounds, or duplicate
+  scopes.
+- Treat pending `pay_bounty` proposals as accepted-for-review, not proof-backed
+  paid work.
 - Keep public security wording careful: no private exploit details or unreleased report bodies.
 - Update examples when API, label, or ledger behavior changes.

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -17,6 +17,7 @@ REQUIRED = [
     "docs/admin-runbook.md",
     "SECURITY.md",
     "CODE_OF_CONDUCT.md",
+    "docs/AGENTS.md",
 ]
 BANNED_PUBLIC_PHRASES = [
     "guaranteed market value",
@@ -122,6 +123,12 @@ REQUIRED_PUBLIC_PHRASES = {
         ),
         "A security bounty is paid only after a public proof or ledger entry exists.",
         "Public comments should link the redacted proof",
+    ],
+    "docs/AGENTS.md": [
+        "Before documenting a bounty as claimable, confirm `mrwk:bounty`",
+        "remaining effective award capacity",
+        "Do not submit or encourage `/claim`",
+        "pending `pay_bounty` proposals as accepted-for-review",
     ],
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")


### PR DESCRIPTION
Bounty #646

Summary:
- Added docs-agent guardrails in docs/AGENTS.md for live bounty claimability signals.
- Clarified that proposed-work, pending create_bounty, closed/exhausted rounds, duplicate scopes, and pending pay_bounty proposals should not be documented as claimable or paid.
- Added docs smoke coverage so the docs-agent guardrails remain present.

Validation:
- ./.venv/bin/python scripts/docs_smoke.py -> docs smoke ok
- env PYTHONPYCACHEPREFIX=/tmp/mergework-pycache ./.venv/bin/python -m py_compile scripts/docs_smoke.py -> passed
- git diff --check -> passed

Duplicate check:
- Existing #646 PRs covered PR template, agent guide, bounty rules, CONTRIBUTING, admin runbook, README, API examples, bounty issue template, and SECURITY.md surfaces.
- This PR is limited to docs/AGENTS.md plus docs smoke coverage for that docs-agent surface.

No private data, credentials, wallet material, production mutation, price/exchange/bridge/off-ramp claims, or fabricated payout claims used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated bounty documentation with clearer guidance on claiming workflows, including a validation checklist for confirming claimability and clarified conditions for when to use the claim functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->