### PR TITLE
Add typed OpenAPI schemas for public read APIs

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -8,6 +8,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
+from app.api_schemas import AccountAcceptedWorkResponse, AccountResponse
 from app.db import session_scope
 from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
 from app.ledger_views import account_ledger_transactions
@@ -156,12 +157,20 @@ def account_page_context(
 
 
 def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
-    @app.get("/api/v1/accounts/{account}")
+    @app.get(
+        "/api/v1/accounts/{account}",
+        response_model=AccountResponse,
+        response_model_exclude_unset=True,
+    )
     def api_account(account: str) -> dict[str, Any]:
         with session_scope(db_url) as session:
             return account_api_context(session, account)
 
-    @app.get("/api/v1/accounts/{account}/accepted-work")
+    @app.get(
+        "/api/v1/accounts/{account}/accepted-work",
+        response_model=AccountAcceptedWorkResponse,
+        response_model_exclude_unset=True,
+    )
     def api_account_accepted_work(account: str) -> dict[str, Any]:
         with session_scope(db_url) as session:
             return account_accepted_work_context(session, account)

--- a/app/activity.py
+++ b/app/activity.py
@@ -7,6 +7,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
+from app.api_schemas import ActivityResponse
 from app.db import session_scope
 from app.serializers import activity_to_dict
 
@@ -16,7 +17,11 @@ def activity_context(session: Session, query: str | None = None) -> dict[str, An
 
 
 def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
-    @app.get("/api/v1/activity")
+    @app.get(
+        "/api/v1/activity",
+        response_model=ActivityResponse,
+        response_model_exclude_unset=True,
+    )
     def api_activity(q: str | None = Query(None)) -> dict[str, Any]:
         with session_scope(db_url) as session:
             return activity_context(session, q)

--- a/app/api_schemas.py
+++ b/app/api_schemas.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PublicApiModel(BaseModel):
+    """Allow additive public API fields while documenting the stable core."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class SystemStatusResponse(PublicApiModel):
+    name: str
+    ticker: str
+    genesis_supply_mrwk: str
+    ledger_height: int
+    active_bounties: int
+    treasury_balance_mrwk: str
+    current_transfer_paths: list[str]
+    unsupported_public_paths: list[str]
+    unsupported_public_paths_summary: str
+    future_path: str
+    future_path_boundary: str
+
+
+class TreasuryProposalSummary(PublicApiModel):
+    proposal_id: int
+    proposed_by: str
+    proposed_at: str
+    executes_after: str
+
+
+class PendingPayoutProposal(TreasuryProposalSummary):
+    to_account: str | None = None
+    submission_url: str | None = None
+    accepted_by: str | None = None
+
+
+class PendingCloseProposal(TreasuryProposalSummary):
+    closed_by: str | None = None
+    reference: str | None = None
+
+
+class AcceptedAwardResponse(PublicApiModel):
+    proof_hash: str
+    proof_url: str
+    ledger_sequence: int
+    ledger_url: str
+    account: str | None = None
+    amount_mrwk: str | None = None
+    submission_url: str | None = None
+    accepted_by: str | None = None
+    created_at: str
+
+
+class BountyResponse(PublicApiModel):
+    id: int
+    repo: str
+    issue_number: int
+    issue_url: str
+    title: str
+    reward_mrwk: str
+    available_mrwk: str
+    reserved_mrwk: str
+    max_awards: int
+    awards_paid: int
+    awards_remaining: int
+    effective_available_mrwk: str
+    effective_awards_remaining: int
+    pending_payout_awards: int
+    pending_payout_proposals: list[PendingPayoutProposal]
+    pending_close_proposal: PendingCloseProposal | None = None
+    availability_state: str
+    availability_note: str
+    status: str
+    acceptance: str
+    created_at: str
+    accepted_awards: list[AcceptedAwardResponse] | None = None
+
+
+class BountySummaryResponse(PublicApiModel):
+    bounties_shown: int
+    open_awards: int
+    open_pool_mrwk: str
+    effective_open_awards: int
+    effective_open_pool_mrwk: str
+
+
+class TreasuryChallengeResponse(PublicApiModel):
+    id: int
+    proposal_id: int
+    challenger_account: str
+    challenge_type: str
+    status: str
+    reason: str
+    created_at: str
+
+
+class TreasuryProposalResponse(PublicApiModel):
+    id: int
+    type: str
+    action: str
+    status: str
+    payload_hash: str
+    payload: dict[str, Any]
+    proposed_by: str
+    executed_by: str | None = None
+    proposed_at: str
+    executes_after: str
+    executed_at: str | None = None
+    executed_ledger_sequence: int | None = None
+    result: dict[str, Any]
+    challenges: list[TreasuryChallengeResponse]
+
+
+class ActivityTotalsResponse(PublicApiModel):
+    accepted_awards: int
+    accepted_mrwk: str
+    contributors: int
+
+
+class ActivityContributorResponse(PublicApiModel):
+    account: str
+    accepted_awards: int
+    accepted_mrwk: str
+    latest_submission_url: str | None = None
+    latest_bounty_repo: str | None = None
+    latest_bounty_issue_number: int | None = None
+    latest_bounty_issue_url: str | None = None
+    latest_proof_hash: str | None = None
+    latest_proof_url: str | None = None
+
+
+class ActivityRecentRowResponse(PublicApiModel):
+    ledger_sequence: int
+    account: str
+    amount_mrwk: str
+    submission_url: str
+    bounty_repo: str | None = None
+    bounty_issue_number: int | None = None
+    bounty_issue_url: str | None = None
+    proof_hash: str
+    proof_url: str
+    bounty_id: int | None = None
+    bounty_url: str | None = None
+    created_at: str
+
+
+class ActivityResponse(PublicApiModel):
+    totals: ActivityTotalsResponse
+    query: str
+    contributors: list[ActivityContributorResponse]
+    recent: list[ActivityRecentRowResponse]
+
+
+class AcceptedWorkSummaryResponse(PublicApiModel):
+    accepted_awards: int
+    accepted_mrwk: str
+    latest_ledger_sequence: int | None = None
+    latest_submission_url: str | None = None
+    latest_proof_hash: str | None = None
+    latest_proof_url: str | None = None
+
+
+class AccountResponse(PublicApiModel):
+    account: str
+    ledger_address: str
+    github_login: str | None = None
+    exists: bool
+    balance_mrwk: str
+    transfer_status: str
+    accepted_work: AcceptedWorkSummaryResponse
+
+
+class AcceptedWorkRowResponse(PublicApiModel):
+    ledger_sequence: int
+    ledger_url: str
+    proof_hash: str
+    proof_url: str
+    amount_mrwk: str
+    submission_url: str | None = None
+    issue_url: str | None = None
+    repo: str | None = None
+    issue_number: int | None = None
+    bounty_id: int | None = None
+    bounty_url: str | None = None
+    accepted_by: str | None = None
+    created_at: str
+
+
+class AccountAcceptedWorkResponse(PublicApiModel):
+    account: str
+    summary: AcceptedWorkSummaryResponse
+    accepted_work: list[AcceptedWorkRowResponse]
+
+
+class ProofResponse(PublicApiModel):
+    kind: str | None = None
+    bounty_id: int | None = None
+    repo: str | None = None
+    issue_number: int | None = None
+    submission_url: str | None = None
+    accepted_by: str | None = None
+    to_account: str | None = None
+    amount_mrwk: str | None = None
+    ledger_sequence: int | None = None
+    ledger_hash: str | None = None
+    verifier_result: dict[str, Any] | None = None

--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -11,6 +11,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from app.admin import list_webhook_events, webhook_events_to_dict
+from app.api_schemas import BountyResponse, BountySummaryResponse
 from app.bounty_sorting import BOUNTY_SORT_ERROR, normalize_bounty_sort, sort_bounties
 from app.config import Settings
 from app.control_chars import contains_control_character
@@ -151,7 +152,11 @@ def register_bounty_api_routes(
                 return sorted_bounties[:limit]
             return sorted_bounties
 
-    @app.get("/api/v1/bounties")
+    @app.get(
+        "/api/v1/bounties",
+        response_model=list[BountyResponse],
+        response_model_exclude_unset=True,
+    )
     def api_bounties(
         status: str | None = Query(None),
         q: str | None = Query(None),
@@ -160,7 +165,11 @@ def register_bounty_api_routes(
     ) -> list[dict[str, Any]]:
         return _list_bounties_by_status(status, q, sort=sort, limit=limit)
 
-    @app.get("/api/v1/bounties/summary")
+    @app.get(
+        "/api/v1/bounties/summary",
+        response_model=BountySummaryResponse,
+        response_model_exclude_unset=True,
+    )
     def api_bounties_summary(
         status: str | None = Query(None),
         q: str | None = Query(None),
@@ -209,7 +218,11 @@ def register_bounty_api_routes(
                 raise _ledger_http_error(exc) from exc
             return proposal_to_dict(proposal)
 
-    @app.get("/api/v1/bounties/{bounty_id}")
+    @app.get(
+        "/api/v1/bounties/{bounty_id}",
+        response_model=BountyResponse,
+        response_model_exclude_unset=True,
+    )
     def api_bounty(bounty_id: int) -> dict[str, Any]:
         bounty_id = positive_bounty_id(bounty_id)
         with session_scope(db_url) as session:

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from app import auth as auth_module
 from app.accounts import normalized_account, normalized_wallet_address, register_account_routes
 from app.activity import register_activity_routes
 from app.admin_routes import register_admin_routes
+from app.api_schemas import ProofResponse, SystemStatusResponse
 from app.bounty_api import register_bounty_api_routes
 from app.bounty_attempts import (
     register_bounty_attempt_routes,
@@ -245,7 +246,11 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         with session_scope(db_url) as session:
             return health_status(session)
 
-    @app.get("/api/v1/status")
+    @app.get(
+        "/api/v1/status",
+        response_model=SystemStatusResponse,
+        response_model_exclude_unset=True,
+    )
     def api_status() -> dict[str, Any]:
         with session_scope(db_url) as session:
             return system_status(session)
@@ -319,7 +324,11 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 raise HTTPException(status_code=404, detail="ledger entry not found")
             return entry
 
-    @app.get("/api/v1/proofs/{proof_hash}")
+    @app.get(
+        "/api/v1/proofs/{proof_hash}",
+        response_model=ProofResponse,
+        response_model_exclude_unset=True,
+    )
     def api_proof(proof_hash: str) -> dict[str, Any]:
         proof_hash = proof_hash_from_path(proof_hash)
         with session_scope(db_url) as session:

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from sqlalchemy import select
 
+from app.api_schemas import TreasuryProposalResponse
 from app.db import session_scope
 from app.ledger.service import LedgerError
 from app.models import TreasuryProposal
@@ -46,7 +47,11 @@ def register_treasury_routes(
     require_github_login: Any,
     json_object: Any,
 ) -> None:
-    @app.get("/api/v1/treasury/proposals")
+    @app.get(
+        "/api/v1/treasury/proposals",
+        response_model=list[TreasuryProposalResponse],
+        response_model_exclude_unset=True,
+    )
     def api_treasury_proposals(
         limit: Annotated[int, Query(ge=1, le=200)] = 100,
     ) -> list[dict[str, Any]]:
@@ -61,7 +66,11 @@ def register_treasury_routes(
         with session_scope(db_url) as session:
             return treasury_status(session)
 
-    @app.get("/api/v1/treasury/proposals/{proposal_id}")
+    @app.get(
+        "/api/v1/treasury/proposals/{proposal_id}",
+        response_model=TreasuryProposalResponse,
+        response_model_exclude_unset=True,
+    )
     def api_treasury_proposal(proposal_id: int) -> dict[str, Any]:
         proposal_id = _positive_proposal_id(proposal_id)
         with session_scope(db_url) as session:

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -276,13 +276,17 @@ def test_bounty_api_keeps_terminal_multi_awards_visible_but_inactive(sqlite_url:
     assert paid_detail["status"] == "paid"
     assert paid_detail["awards_paid"] == 2
     assert paid_detail["awards_remaining"] == 0
+    assert len(paid_detail["accepted_awards"]) == 2
     assert closed_detail["status"] == "closed"
     assert closed_detail["awards_paid"] == 1
     assert closed_detail["awards_remaining"] == 0
+    assert len(closed_detail["accepted_awards"]) == 1
     assert listed[paid_bounty_id]["status"] == "paid"
     assert listed[paid_bounty_id]["awards_remaining"] == 0
+    assert "accepted_awards" not in listed[paid_bounty_id]
     assert listed[closed_bounty_id]["status"] == "closed"
     assert listed[closed_bounty_id]["awards_remaining"] == 0
+    assert "accepted_awards" not in listed[closed_bounty_id]
     assert status["active_bounties"] == 0
 
 

--- a/tests/test_openapi_public_schemas.py
+++ b/tests/test_openapi_public_schemas.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from app.db import create_schema, session_scope
+from app.ledger.service import create_bounty, ensure_genesis, pay_bounty
+from app.main import create_app
+from app.treasury import propose_treasury_action
+
+
+def _schema_for(openapi: dict[str, Any], path: str) -> dict[str, Any]:
+    schema = openapi["paths"][path]["get"]["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]
+    assert isinstance(schema, dict)
+    return schema
+
+
+def _ref_name(ref: str) -> str:
+    return ref.removeprefix("#/components/schemas/")
+
+
+def _resolved(openapi: dict[str, Any], schema: dict[str, Any]) -> dict[str, Any]:
+    if "$ref" in schema:
+        return openapi["components"]["schemas"][_ref_name(str(schema["$ref"]))]
+    return schema
+
+
+def _array_item_schema(openapi: dict[str, Any], path: str) -> dict[str, Any]:
+    schema = _schema_for(openapi, path)
+    assert schema["type"] == "array"
+    item_schema = schema["items"]
+    assert "$ref" in item_schema
+    return _resolved(openapi, item_schema)
+
+
+def _properties(openapi: dict[str, Any], path: str) -> dict[str, Any]:
+    schema = _resolved(openapi, _schema_for(openapi, path))
+    properties = schema["properties"]
+    assert isinstance(properties, dict)
+    return properties
+
+
+def test_public_read_openapi_responses_expose_typed_fields(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    openapi = client.get("/openapi.json").json()
+
+    status_props = _properties(openapi, "/api/v1/status")
+    assert {
+        "current_transfer_paths",
+        "unsupported_public_paths",
+        "future_path_boundary",
+    } <= set(status_props)
+
+    bounty_item = _array_item_schema(openapi, "/api/v1/bounties")
+    bounty_props = bounty_item["properties"]
+    assert {
+        "effective_awards_remaining",
+        "effective_available_mrwk",
+        "pending_payout_awards",
+        "pending_payout_proposals",
+        "availability_state",
+        "availability_note",
+    } <= set(bounty_props)
+
+    bounty_detail_props = _properties(openapi, "/api/v1/bounties/{bounty_id}")
+    assert {"accepted_awards", "pending_close_proposal"} <= set(bounty_detail_props)
+
+    summary_props = _properties(openapi, "/api/v1/bounties/summary")
+    assert {"effective_open_awards", "effective_open_pool_mrwk"} <= set(summary_props)
+
+    proposal_item = _array_item_schema(openapi, "/api/v1/treasury/proposals")
+    proposal_props = proposal_item["properties"]
+    assert {"payload_hash", "payload", "result", "challenges"} <= set(proposal_props)
+
+    activity_props = _properties(openapi, "/api/v1/activity")
+    assert {"totals", "contributors", "recent"} <= set(activity_props)
+
+    accepted_work_props = _properties(openapi, "/api/v1/accounts/{account}/accepted-work")
+    assert {"summary", "accepted_work"} <= set(accepted_work_props)
+
+    proof_props = _properties(openapi, "/api/v1/proofs/{proof_hash}")
+    assert {
+        "kind",
+        "bounty_id",
+        "submission_url",
+        "amount_mrwk",
+        "ledger_sequence",
+        "verifier_result",
+    } <= set(proof_props)
+
+
+def test_public_read_response_models_accept_seeded_payloads(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=688,
+            issue_url="https://github.com/ramimbo/mergework/issues/688",
+            title="Typed public read APIs",
+            reward_mrwk="75",
+            max_awards=2,
+            acceptance="Public read endpoints should serialize typed payloads.",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/699",
+            accepted_by="maintainer",
+            verifier_result={"source": "test", "accepted_by": "maintainer"},
+        )
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": bounty.id,
+                "to_account": "github:bob",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/700",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+        bounty_id = bounty.id
+        proof_hash = proof.hash
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    assert client.get("/api/v1/status").status_code == 200
+
+    bounties_response = client.get("/api/v1/bounties")
+    assert bounties_response.status_code == 200
+    assert bounties_response.json()[0]["pending_payout_awards"] == 1
+
+    bounty_response = client.get(f"/api/v1/bounties/{bounty_id}")
+    assert bounty_response.status_code == 200
+    assert bounty_response.json()["accepted_awards"][0]["proof_hash"] == proof_hash
+
+    summary_response = client.get("/api/v1/bounties/summary")
+    assert summary_response.status_code == 200
+    assert summary_response.json()["effective_open_awards"] == 0
+
+    proposals_response = client.get("/api/v1/treasury/proposals")
+    assert proposals_response.status_code == 200
+    assert proposals_response.json()[0]["result"] == {}
+    assert proposals_response.json()[0]["challenges"] == []
+
+    activity_response = client.get("/api/v1/activity")
+    assert activity_response.status_code == 200
+    assert activity_response.json()["totals"]["accepted_awards"] == 1
+
+    account_response = client.get("/api/v1/accounts/github:alice/accepted-work")
+    assert account_response.status_code == 200
+    assert account_response.json()["summary"]["latest_proof_hash"] == proof_hash
+
+    proof_response = client.get(f"/api/v1/proofs/{proof_hash}")
+    assert proof_response.status_code == 200
+    assert proof_response.json()["bounty_id"] == bounty_id


### PR DESCRIPTION
## Related bounty or issue

Bounty: #647
Source issue: #688

## Summary

This PR adds typed OpenAPI response models for the public MRWK read APIs called out in #688, without changing payout, ledger, wallet, proof, treasury execution, or bounty acceptance behavior.

Covered public read surfaces:

- `GET /api/v1/status`
- `GET /api/v1/bounties`
- `GET /api/v1/bounties/{bounty_id}`
- `GET /api/v1/bounties/summary`
- `GET /api/v1/treasury/proposals`
- `GET /api/v1/activity`
- `GET /api/v1/accounts/{account}`
- `GET /api/v1/accounts/{account}/accepted-work`
- `GET /api/v1/proofs/{proof_hash}`

The models use `extra="allow"` and the routes use `response_model_exclude_unset=True` so additive public fields remain possible and list/detail JSON shapes are not padded with default-only fields.

## Verification

- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests\test_openapi_public_schemas.py -q` -> 2 passed
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q` -> 562 passed
- [x] `python -m ruff format .`
- [x] `python -m ruff check .`
- [x] `git diff --check`
- [x] Seeded route smoke test exercises the scoped public read routes and validates real response serialization, including a pre-execution treasury proposal path.
- [x] OpenAPI smoke check confirmed the scoped routes use component refs such as `BountyResponse`, `SystemStatusResponse`, `TreasuryProposalResponse`, `ActivityResponse`, `AccountAcceptedWorkResponse`, and `ProofResponse`.

## Not tested

- `python -m mypy app` is blocked in this local environment before this change can be isolated: PySide6 stubs report invalid `disable_error_code` values, and the existing codebase reports FastAPI `Request` generic type errors across multiple modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured response models applied to public read endpoints for consistent, typed JSON.
  * API responses now omit unset/unused fields for cleaner payloads.

* **Bug Fixes**
  * Terminal bounty detail responses retain accepted-awards data; bounty listing entries omit accepted-awards as expected.

* **Tests**
  * Added integration tests validating OpenAPI response schemas and endpoint payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->