### PR TITLE
Add public URLs to accepted-work API rows

### DIFF
--- a/app/serializers.py
+++ b/app/serializers.py
@@ -10,6 +10,7 @@ from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement
 
+from app.config import get_settings
 from app.ledger.reconciliation import AcceptedPayoutCheck
 from app.ledger.service import format_mrwk, get_balance
 from app.models import Bounty, LedgerEntry, Proof, TreasuryProposal, Wallet, WalletTransfer
@@ -356,6 +357,13 @@ def _bounty_detail_url(bounty_id: int | None) -> str | None:
     return f"/bounties/{bounty_id}" if bounty_id is not None else None
 
 
+def _public_page_url(path: str | None, public_base_url: str | None = None) -> str | None:
+    if path is None:
+        return None
+    base_url = public_base_url if public_base_url is not None else get_settings().public_base_url
+    return f"{base_url.rstrip('/')}{path}"
+
+
 def _proof_payload(proof: Proof) -> dict[str, Any] | None:
     try:
         data = json.loads(proof.public_json)
@@ -518,6 +526,7 @@ def account_accepted_summary(session: Session, account: str) -> dict[str, Any]:
         accepted.append(row)
 
     latest = accepted[0] if accepted else None
+    public_base_url = get_settings().public_base_url if latest else None
     return {
         "accepted_awards": len(accepted),
         "accepted_mrwk": format_mrwk(total_microunits),
@@ -525,6 +534,9 @@ def account_accepted_summary(session: Session, account: str) -> dict[str, Any]:
         "latest_submission_url": latest["submission_url"] if latest else None,
         "latest_proof_hash": latest["proof_hash"] if latest else None,
         "latest_proof_url": latest["proof_url"] if latest else None,
+        "latest_proof_public_url": (
+            _public_page_url(str(latest["proof_url"]), public_base_url) if latest else None
+        ),
     }
 
 
@@ -541,6 +553,7 @@ def accepted_work_for_account(session: Session, account: str) -> list[dict[str, 
         .order_by(LedgerEntry.sequence.desc())
     ).all()
     accepted_work: list[dict[str, Any]] = []
+    public_base_url = get_settings().public_base_url if rows else None
     for proof, entry in rows:
         data = _proof_payload(proof)
         if data is None:
@@ -550,19 +563,25 @@ def accepted_work_for_account(session: Session, account: str) -> list[dict[str, 
         issue_url = None
         if isinstance(repo, str) and isinstance(issue_number, int):
             issue_url = f"https://github.com/{repo}/issues/{issue_number}"
+        ledger_url = f"/ledger/{entry.sequence}"
+        proof_url = f"/proofs/{proof.hash}"
+        bounty_url = _bounty_detail_url(proof.bounty_id)
         accepted_work.append(
             {
                 "ledger_sequence": entry.sequence,
-                "ledger_url": f"/ledger/{entry.sequence}",
+                "ledger_url": ledger_url,
+                "ledger_public_url": _public_page_url(ledger_url, public_base_url),
                 "proof_hash": proof.hash,
-                "proof_url": f"/proofs/{proof.hash}",
+                "proof_url": proof_url,
+                "proof_public_url": _public_page_url(proof_url, public_base_url),
                 "amount_mrwk": format_mrwk(entry.amount_microunits),
                 "submission_url": data.get("submission_url"),
                 "issue_url": issue_url,
                 "repo": repo,
                 "issue_number": issue_number,
                 "bounty_id": proof.bounty_id,
-                "bounty_url": _bounty_detail_url(proof.bounty_id),
+                "bounty_url": bounty_url,
+                "bounty_public_url": _public_page_url(bounty_url, public_base_url),
                 "accepted_by": data.get("accepted_by"),
                 "created_at": entry.created_at.isoformat(),
             }
@@ -579,6 +598,7 @@ def empty_accepted_summary() -> dict[str, Any]:
         "latest_submission_url": None,
         "latest_proof_hash": None,
         "latest_proof_url": None,
+        "latest_proof_public_url": None,
     }
 
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -372,7 +372,8 @@ move funds directly:
     "latest_ledger_sequence": 42,
     "latest_submission_url": "https://github.com/ramimbo/mergework/pull/183",
     "latest_proof_hash": "a29b9cf54f2ea4734d58e9371b20234f85936e95bd8c45687f0644ad6a9e6871",
-    "latest_proof_url": "/proofs/a29b9cf54f2ea4734d58e9371b20234f85936e95bd8c45687f0644ad6a9e6871"
+    "latest_proof_url": "/proofs/a29b9cf54f2ea4734d58e9371b20234f85936e95bd8c45687f0644ad6a9e6871",
+    "latest_proof_public_url": "https://mrwk.online/proofs/a29b9cf54f2ea4734d58e9371b20234f85936e95bd8c45687f0644ad6a9e6871"
   }
 }
 ```
@@ -403,7 +404,8 @@ curl -s "$API_HOST/api/v1/accounts/treasury:mrwk"
     "latest_ledger_sequence": null,
     "latest_submission_url": null,
     "latest_proof_hash": null,
-    "latest_proof_url": null
+    "latest_proof_url": null,
+    "latest_proof_public_url": null
   }
 }
 ```
@@ -423,6 +425,10 @@ by the public account page, so agents can inspect recent proof, ledger,
 submission, source issue, internal bounty id and public bounty URL, and
 maintainer acceptance details without scraping HTML:
 
+Relative URL fields are preserved for existing clients. The `*_public_url`
+companions use `https://mrwk.online` so proof-backed accepted-work evidence can
+be pasted directly into GitHub comments, reports, or reconciliation logs.
+
 ```json
 {
   "account": "github:carpedkm",
@@ -432,14 +438,17 @@ maintainer acceptance details without scraping HTML:
     "latest_ledger_sequence": 682,
     "latest_submission_url": "https://github.com/ramimbo/mergework/issues/407#issuecomment-4545035155",
     "latest_proof_hash": "cb7707861ca88447db67aa707d06ca51f4d6a1b382cbba33305b251f88fd1e80",
-    "latest_proof_url": "/proofs/cb7707861ca88447db67aa707d06ca51f4d6a1b382cbba33305b251f88fd1e80"
+    "latest_proof_url": "/proofs/cb7707861ca88447db67aa707d06ca51f4d6a1b382cbba33305b251f88fd1e80",
+    "latest_proof_public_url": "https://mrwk.online/proofs/cb7707861ca88447db67aa707d06ca51f4d6a1b382cbba33305b251f88fd1e80"
   },
   "accepted_work": [
     {
       "ledger_sequence": 682,
       "ledger_url": "/ledger/682",
+      "ledger_public_url": "https://mrwk.online/ledger/682",
       "proof_hash": "cb7707861ca88447db67aa707d06ca51f4d6a1b382cbba33305b251f88fd1e80",
       "proof_url": "/proofs/cb7707861ca88447db67aa707d06ca51f4d6a1b382cbba33305b251f88fd1e80",
+      "proof_public_url": "https://mrwk.online/proofs/cb7707861ca88447db67aa707d06ca51f4d6a1b382cbba33305b251f88fd1e80",
       "amount_mrwk": "50",
       "submission_url": "https://github.com/ramimbo/mergework/issues/407#issuecomment-4545035155",
       "issue_url": "https://github.com/ramimbo/mergework/issues/407",
@@ -447,6 +456,7 @@ maintainer acceptance details without scraping HTML:
       "issue_number": 407,
       "bounty_id": 67,
       "bounty_url": "/bounties/67",
+      "bounty_public_url": "https://mrwk.online/bounties/67",
       "accepted_by": "ramimbo",
       "created_at": "2026-05-26T15:30:01.346962"
     }

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1800,6 +1800,7 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
         "latest_submission_url": "https://github.com/ramimbo/mergework/pull/3",
         "latest_proof_hash": proof.hash,
         "latest_proof_url": f"/proofs/{proof.hash}",
+        "latest_proof_public_url": f"https://mrwk.online/proofs/{proof.hash}",
     }
     assert accepted_work_api["summary"] == account_api["accepted_work"]
     accepted_work = accepted_work_api["accepted_work"]
@@ -1808,8 +1809,10 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     assert accepted_work[0] | {"created_at": "<checked>"} == {
         "ledger_sequence": 3,
         "ledger_url": "/ledger/3",
+        "ledger_public_url": "https://mrwk.online/ledger/3",
         "proof_hash": proof.hash,
         "proof_url": f"/proofs/{proof.hash}",
+        "proof_public_url": f"https://mrwk.online/proofs/{proof.hash}",
         "amount_mrwk": "25",
         "submission_url": "https://github.com/ramimbo/mergework/pull/3",
         "issue_url": "https://github.com/ramimbo/mergework/issues/2",
@@ -1817,6 +1820,7 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
         "issue_number": 2,
         "bounty_id": bounty.id,
         "bounty_url": f"/bounties/{bounty.id}",
+        "bounty_public_url": f"https://mrwk.online/bounties/{bounty.id}",
         "accepted_by": "maintainer",
         "created_at": "<checked>",
     }
@@ -1879,6 +1883,7 @@ def test_account_api_keeps_schema_when_accepted_work_proof_is_malformed(
         "latest_submission_url": None,
         "latest_proof_hash": None,
         "latest_proof_url": None,
+        "latest_proof_public_url": None,
     }
 
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -441,4 +441,8 @@ def test_api_examples_document_accepted_work_bounty_context() -> None:
     assert "/api/v1/accounts/github:carpedkm/accepted-work" in examples
     assert '"bounty_id": 67' in examples
     assert '"bounty_url": "/bounties/67"' in examples
+    assert '"bounty_public_url": "https://mrwk.online/bounties/67"' in examples
+    assert '"latest_proof_public_url": "https://mrwk.online/proofs/' in examples
+    assert '"ledger_public_url": "https://mrwk.online/ledger/682"' in examples
     assert "internal bounty id and public bounty URL" in examples
+    assert "Relative URL fields are preserved for existing clients" in examples

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -246,8 +246,12 @@ def test_account_and_wallet_serializers_preserve_public_shapes(sqlite_url: str) 
     assert summary["accepted_awards"] == 1
     assert summary["accepted_mrwk"] == "40"
     assert summary["latest_submission_url"] == "https://github.com/ramimbo/mergework/pull/320"
+    assert summary["latest_proof_public_url"].startswith("https://mrwk.online/proofs/")
     assert accepted_work[0]["issue_url"] == "https://github.com/ramimbo/mergework/issues/320"
     assert accepted_work[0]["amount_mrwk"] == "40"
+    assert accepted_work[0]["ledger_public_url"].startswith("https://mrwk.online/ledger/")
+    assert accepted_work[0]["proof_public_url"].startswith("https://mrwk.online/proofs/")
+    assert accepted_work[0]["bounty_public_url"].startswith("https://mrwk.online/bounties/")
     assert wallet_data["label"] == "Serializer wallet"
     assert wallet_data["balance_mrwk"] == "0"
     assert wallet_data["next_nonce"] == 1


### PR DESCRIPTION
Maintainer accepted live-lane reroute: this merged work is evaluated under live bounty #777 because it matches that acceptance scope; the original closed/exhausted round reference was issue 647.

Bounty #777
Source issue: #687

## Summary
- Add absolute public URL companions to account accepted-work summary and row serializers.
- Preserve existing relative `latest_proof_url`, `ledger_url`, `proof_url`, and `bounty_url` fields for backward compatibility.
- Document the new `*_public_url` fields in the account API examples.

## Scope
This is a focused implementation of accepted proposed-work #687 for the live focused-fixes Bounty #777. It only changes proof-backed account accepted-work API serialization and docs. It does not change ledger entries, payout rules, proof payloads, treasury execution, wallet behavior, or pending payout semantics.

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q` -> 560 passed
- `python -m ruff format .`
- `python -m ruff check .`
- `git diff --check`

## Known validation gap
- `python -m mypy app` is blocked in this local environment by PySide6 stub `disable_error_code` errors and existing FastAPI `Request` generic type errors in modules outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added companion public (shareable) URL fields for accepted work: proof, ledger, bounty, and latest proof, alongside existing relative URLs.

* **Documentation**
  * API examples updated to show the new public URL fields and note that relative URLs remain for existing clients.

* **Tests**
  * Updated/added tests to assert presence and expected formats of the new public URL fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->