### PR TITLE
Expose active attempt summaries on bounty rows

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -70,7 +70,7 @@ def _active_attempt_conditions(bounty_id: int, now: datetime) -> tuple[Any, ...]
     )
 
 
-def bounty_attempt_warnings(session: Session, bounty: Bounty, now: datetime) -> list[str]:
+def _bounty_attempt_warnings_for_count(bounty: Bounty, active_count: int) -> list[str]:
     warnings: list[str] = []
     awards_remaining = max(0, bounty.max_awards - bounty.awards_paid)
     if bounty.status != "open":
@@ -78,17 +78,61 @@ def bounty_attempt_warnings(session: Session, bounty: Bounty, now: datetime) -> 
         awards_remaining = 0
     if awards_remaining <= 0:
         warnings.append("bounty has no award slots remaining")
-    active_count = session.scalar(
-        select(func.count())
-        .select_from(BountyAttempt)
-        .where(*_active_attempt_conditions(bounty.id, now))
-    )
     if active_count and (
         active_count > 1 or (awards_remaining > 0 and active_count >= awards_remaining)
     ):
         attempt_label = "attempt" if active_count == 1 else "attempts"
         warnings.append(f"bounty has {active_count} active {attempt_label}")
     return warnings
+
+
+def active_bounty_attempt_count(session: Session, bounty_id: int, now: datetime) -> int:
+    active_count = session.scalar(
+        select(func.count())
+        .select_from(BountyAttempt)
+        .where(*_active_attempt_conditions(bounty_id, now))
+    )
+    return int(active_count or 0)
+
+
+def active_bounty_attempt_counts(
+    session: Session, bounty_ids: Sequence[int], now: datetime
+) -> dict[int, int]:
+    if not bounty_ids:
+        return {}
+    rows = session.execute(
+        select(BountyAttempt.bounty_id, func.count())
+        .where(
+            BountyAttempt.bounty_id.in_(bounty_ids),
+            BountyAttempt.status == "active",
+            BountyAttempt.expires_at > now,
+        )
+        .group_by(BountyAttempt.bounty_id)
+    ).all()
+    return {int(bounty_id): int(active_count or 0) for bounty_id, active_count in rows}
+
+
+def bounty_attempt_warnings(session: Session, bounty: Bounty, now: datetime) -> list[str]:
+    return _bounty_attempt_warnings_for_count(
+        bounty, active_bounty_attempt_count(session, bounty.id, now)
+    )
+
+
+def bounty_attempt_summary_from_count(bounty: Bounty, active_count: int) -> dict[str, Any]:
+    return {
+        "active_attempt_count": active_count,
+        "active_attempt_warnings": _bounty_attempt_warnings_for_count(bounty, active_count),
+        "attempt_endpoint": f"/api/v1/bounties/{bounty.id}/attempts",
+    }
+
+
+def bounty_attempt_summary(
+    session: Session, bounty: Bounty, now: datetime | None = None
+) -> dict[str, Any]:
+    now = _as_utc(now or _utc_now())
+    return bounty_attempt_summary_from_count(
+        bounty, active_bounty_attempt_count(session, bounty.id, now)
+    )
 
 
 def list_bounty_attempts(

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -10,6 +10,11 @@ from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement
 
+from app.bounty_attempts import (
+    active_bounty_attempt_counts,
+    bounty_attempt_summary,
+    bounty_attempt_summary_from_count,
+)
 from app.ledger.reconciliation import AcceptedPayoutCheck
 from app.ledger.service import format_mrwk, get_balance
 from app.models import Bounty, LedgerEntry, Proof, TreasuryProposal, Wallet, WalletTransfer
@@ -21,6 +26,7 @@ def bounty_to_dict(
     bounty: Bounty,
     session: Session | None = None,
     pending_proposals: PendingBountyProposals | None = None,
+    attempt_summary: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Serialize a bounty row for public API and page consumers."""
     awards_remaining = max(0, bounty.max_awards - bounty.awards_paid)
@@ -44,7 +50,9 @@ def bounty_to_dict(
         pending_payouts=pending_payouts,
         pending_close=pending_close,
     )
-    return {
+    if attempt_summary is None and session is not None:
+        attempt_summary = bounty_attempt_summary(session, bounty)
+    payload = {
         "id": bounty.id,
         "repo": bounty.repo,
         "issue_number": bounty.issue_number,
@@ -73,6 +81,9 @@ def bounty_to_dict(
         "acceptance": bounty.acceptance,
         "created_at": bounty.created_at.isoformat(),
     }
+    if attempt_summary is not None:
+        payload.update(attempt_summary)
+    return payload
 
 
 def bounties_to_dict(
@@ -83,10 +94,16 @@ def bounties_to_dict(
         return [bounty_to_dict(bounty) for bounty in bounties]
 
     pending_by_bounty = _pending_bounty_proposals_by_bounty_id(session)
+    attempt_counts = active_bounty_attempt_counts(
+        session, [bounty.id for bounty in bounties], datetime.now(UTC)
+    )
     return [
         bounty_to_dict(
             bounty,
             pending_proposals=pending_by_bounty.get(bounty.id, ([], None)),
+            attempt_summary=bounty_attempt_summary_from_count(
+                bounty, attempt_counts.get(bounty.id, 0)
+            ),
         )
         for bounty in bounties
     ]

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -44,6 +44,9 @@ The bounties list returns public bounty rows. `status` can be omitted or set to
   "pending_payout_awards": 0,
   "availability_state": "open",
   "availability_note": "1 award effectively available.",
+  "active_attempt_count": 0,
+  "active_attempt_warnings": [],
+  "attempt_endpoint": "/api/v1/bounties/36/attempts",
   "status": "open",
   "acceptance": "Focused public-facing enhancements that help contributors find bounties, inspect accepted work, or understand proof/account activity, with tests. Duplicate, marketing-only, docs-only, broad redesign, or unrelated changes do not qualify.",
   "created_at": "2026-05-24T20:44:00.015953"
@@ -60,6 +63,10 @@ when deciding whether a bounty still has practical capacity; do not describe
 pending payout proposals as proof-backed paid work until a proof exists. Award counters can change
 as accepted work is paid; refresh concrete examples against the live API before
 relying on available slot counts.
+
+The `active_attempt_count` and `active_attempt_warnings` fields are advisory
+overlap signals. When a warning is present, inspect `attempt_endpoint` before
+opening a PR so you can avoid duplicating another active attempt's scope.
 
 Use `sort` to choose the bounty order: `newest` is the default, `reward` sorts
 by per-award reward, `available` sorts by the remaining MRWK pool, and `awards`

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -272,6 +272,62 @@ def test_multi_award_bounty_still_warns_for_multiple_active_attempts(sqlite_url:
         assert bounty_attempt_warnings(session, bounty, now) == ["bounty has 2 active attempts"]
 
 
+def test_bounty_api_rows_include_active_attempt_summary(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    now = datetime.now(UTC)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=329,
+            issue_url="https://github.com/ramimbo/mergework/issues/329",
+            title="Attempt summary on bounty rows",
+            reward_mrwk="50",
+            max_awards=2,
+            acceptance="Expose active-attempt summary on public bounty rows.",
+        )
+        for submitter, status, expires_at in (
+            ("github:alice", "active", now + timedelta(hours=1)),
+            ("github:bob", "active", now + timedelta(hours=1)),
+            ("github:carol", "active", now - timedelta(minutes=1)),
+            ("github:dana", "released", now + timedelta(hours=1)),
+        ):
+            session.add(
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account=submitter,
+                    status=status,
+                    expires_at=expires_at,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        session.flush()
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    detail = client.get(f"/api/v1/bounties/{bounty_id}")
+    assert detail.status_code == 200
+    detail_body = detail.json()
+    assert detail_body["active_attempt_count"] == 2
+    assert detail_body["active_attempt_warnings"] == ["bounty has 2 active attempts"]
+    assert detail_body["attempt_endpoint"] == f"/api/v1/bounties/{bounty_id}/attempts"
+
+    listed = client.get("/api/v1/bounties").json()
+    row = next(item for item in listed if item["id"] == bounty_id)
+    assert row["active_attempt_count"] == 2
+    assert row["active_attempt_warnings"] == ["bounty has 2 active attempts"]
+    assert row["attempt_endpoint"] == f"/api/v1/bounties/{bounty_id}/attempts"
+
+    attempts = client.get(f"/api/v1/bounties/{bounty_id}/attempts").json()
+    assert [attempt["submitter_account"] for attempt in attempts["attempts"]] == [
+        "github:bob",
+        "github:alice",
+    ]
+
+
 def test_expired_bounty_attempt_is_visible_but_no_longer_blocks_submitter(
     sqlite_url: str,
     monkeypatch,

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -225,6 +225,10 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert '"reserved_mrwk": "500"' in examples
     assert '"awards_paid": 4' in examples
     assert '"awards_remaining": 1' in examples
+    assert '"active_attempt_count": 0' in examples
+    assert '"active_attempt_warnings": []' in examples
+    assert '"attempt_endpoint": "/api/v1/bounties/36/attempts"' in examples
+    assert "overlap signals" in examples
     assert '"bounties_shown": 1' in examples
     assert '"open_awards": 2' in examples
     assert '"open_pool_mrwk": "50"' in examples


### PR DESCRIPTION
Maintainer accepted live-lane reroute: this merged work is evaluated under live bounty #777 because it matches that acceptance scope; the original closed/exhausted round reference was issue 647.

## Summary

Bounty #777
Source issue: #677

This PR exposes a bounded active-attempt summary on public bounty rows so agents can notice overlap without doing an immediate N+1 attempts lookup for every bounty.

- Adds active attempt count helpers that ignore expired and released attempts.
- Adds `active_attempt_count`, `active_attempt_warnings`, and `attempt_endpoint` to bounty detail and list serializers when session context is available.
- Preloads active attempt counts for bounty list serialization.
- Documents the new fields in the public API examples.
- Keeps the detailed `/api/v1/bounties/{id}/attempts` endpoint unchanged for full reservation rows.

## Verification

- `/private/tmp/mergework-venv-312/bin/python -m pytest tests/test_bounty_attempts.py tests/test_serializers.py tests/test_docs_public_urls.py -q` -> 49 passed, 1 existing FastAPI/Starlette deprecation warning
- `/private/tmp/mergework-venv-312/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `/private/tmp/mergework-venv-312/bin/python -m pytest -q` -> 561 passed, 1 existing FastAPI/Starlette deprecation warning
- `/private/tmp/mergework-venv-312/bin/python -m ruff format --check .` -> 96 files already formatted
- `/private/tmp/mergework-venv-312/bin/python -m ruff check .` -> All checks passed
- `git diff --check` -> passed

## Duplicate Check

- `gh pr list --repo ramimbo/mergework --state open --search "677"` returned no open PRs.
- `https://api.mrwk.online/api/v1/bounties/95/attempts` returned no active attempts.
- Related open work covers proposed-work triage, availability, and accepted-work links; this PR is limited to active-attempt summaries on bounty rows.

## Out of Scope

- No treasury execution, balances, proofs, payout rules, award capacity, or acceptance behavior changes.
- No automatic blocking when another attempt exists; attempts remain advisory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API bounty endpoints now include active attempt count, advisory warnings, and an attempt endpoint; list views include per-bounty attempt summaries for consistent, efficient responses.

* **Documentation**
  * Updated API examples to document new bounty fields and guidance about overlap signals and using the attempt endpoint.

* **Tests**
  * Added API tests validating active attempt summaries, warnings, and attempt-list behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->