### PR TITLE
Expose structured bounty submission requirements

### DIFF
--- a/app/mcp_work_proof.py
+++ b/app/mcp_work_proof.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any
 
 from sqlalchemy.orm import Session
 
 from app.models import Bounty
 from app.serializers import bounty_to_dict
-
-SubmissionAvailability = Literal["open", "full", "closed", "unknown"]
+from app.submission_requirements import (
+    SubmissionAvailability,
+    work_proof_submission_requirements,
+)
 
 
 def work_proof_guidance(bounty: Bounty, session: Session | None = None) -> str:
@@ -45,93 +47,6 @@ def work_proof_guidance(bounty: Bounty, session: Session | None = None) -> str:
             ),
         ]
     )
-
-
-def work_proof_submission_requirements(
-    *,
-    bounty_id: int | None,
-    issue_number: int | None,
-    availability: SubmissionAvailability,
-) -> dict[str, Any]:
-    issue_ref = str(issue_number) if issue_number is not None else "<issue_number>"
-    bounty_ref = str(bounty_id) if bounty_id is not None else "<bounty_id>"
-    if availability == "open":
-        first_action = {
-            "id": "confirm_award_slot",
-            "required": True,
-            "text": "Confirm this bounty is open and has at least one award slot remaining.",
-        }
-    elif availability == "full":
-        first_action = {
-            "id": "watch_for_award_slot",
-            "required": True,
-            "text": (
-                "This bounty is open but has no award slots remaining; check for new "
-                "capacity before submitting new work."
-            ),
-        }
-    elif availability == "closed":
-        first_action = {
-            "id": "choose_open_bounty",
-            "required": True,
-            "text": "Do not open or claim new work for this bounty unless a maintainer reopens it.",
-        }
-    else:
-        first_action = {
-            "id": "select_bounty",
-            "required": True,
-            "text": "Select a concrete open bounty before submitting work proof.",
-        }
-    return {
-        "reference_formats": [f"Bounty #{issue_ref}", f"Refs #{issue_ref}"],
-        "claim_command": "/claim",
-        "attempt_endpoint": f"/api/v1/bounties/{bounty_ref}/attempts",
-        "evidence_required": [
-            "focused PR, issue, report, or evidence URL",
-            "short verification summary",
-            "tests, command output, screenshots, or reproduction steps when relevant",
-        ],
-        "acceptance_trigger": "maintainer_mrwk_accepted_label_or_admin_payout",
-        "public_metadata_must_avoid": [
-            "private keys",
-            "seed material",
-            "secrets",
-            "deployment credentials",
-            "private vulnerability details",
-            "price claims",
-        ],
-        "next_actions": [
-            first_action,
-            {
-                "id": "check_duplicate_scope",
-                "required": True,
-                "text": "Confirm no active claim or duplicate PR already covers the same scope.",
-            },
-            {
-                "id": "keep_scope_focused",
-                "required": True,
-                "text": "Keep changes directly tied to one bounty issue.",
-            },
-            {
-                "id": "include_bounty_reference",
-                "required": True,
-                "text": f"Include Bounty #{issue_ref} or Refs #{issue_ref} in the submission.",
-            },
-            {
-                "id": "include_review_evidence",
-                "required": True,
-                "text": "Include reviewable validation evidence before claiming.",
-            },
-            {
-                "id": "wait_for_maintainer_acceptance",
-                "required": True,
-                "text": (
-                    "Payment requires mrwk:accepted or an admin payout; merge or CI "
-                    "alone is not acceptance."
-                ),
-            },
-        ],
-    }
 
 
 def _submission_availability(bounty_data: dict[str, Any]) -> SubmissionAvailability:
@@ -183,6 +98,8 @@ def work_proof_guidance_json(bounty: Bounty, session: Session | None = None) -> 
             bounty_id=bounty_data["id"],
             issue_number=bounty_data["issue_number"],
             availability=submission_availability,
+            title=bounty_data["title"],
+            acceptance=bounty_data["acceptance"],
         ),
         "safety_rules": [
             "Do not include private keys, seed material, secrets, deployment "

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -13,6 +13,10 @@ from sqlalchemy.sql.elements import ColumnElement
 from app.ledger.reconciliation import AcceptedPayoutCheck
 from app.ledger.service import format_mrwk, get_balance
 from app.models import Bounty, LedgerEntry, Proof, TreasuryProposal, Wallet, WalletTransfer
+from app.submission_requirements import (
+    SubmissionAvailability,
+    work_proof_submission_requirements,
+)
 
 PendingBountyProposals = tuple[list[dict[str, Any]], dict[str, Any] | None]
 
@@ -68,6 +72,16 @@ def bounty_to_dict(
             effective_awards_remaining=effective_awards_remaining,
             pending_payouts=pending_payouts,
             pending_close=pending_close,
+        ),
+        "submission_requirements": work_proof_submission_requirements(
+            bounty_id=bounty.id,
+            issue_number=bounty.issue_number,
+            availability=_submission_availability(
+                status=bounty.status,
+                effective_awards_remaining=effective_awards_remaining,
+            ),
+            title=bounty.title,
+            acceptance=bounty.acceptance,
         ),
         "status": bounty.status,
         "acceptance": bounty.acceptance,
@@ -308,6 +322,14 @@ def _availability_note(
     if awards_remaining <= 0:
         return "No awards remain available for new submissions."
     return f"{_plural_awards(effective_awards_remaining)} effectively available."
+
+
+def _submission_availability(
+    *, status: str, effective_awards_remaining: int
+) -> SubmissionAvailability:
+    if status == "open":
+        return "open" if effective_awards_remaining > 0 else "full"
+    return "closed"
 
 
 def payout_reconciliation_to_dict(check: AcceptedPayoutCheck) -> dict[str, Any]:

--- a/app/submission_requirements.py
+++ b/app/submission_requirements.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+SubmissionAvailability = Literal["open", "full", "closed", "unknown"]
+
+
+def work_proof_submission_requirements(
+    *,
+    bounty_id: int | None,
+    issue_number: int | None,
+    availability: SubmissionAvailability,
+    title: str | None = None,
+    acceptance: str | None = None,
+) -> dict[str, Any]:
+    issue_ref = str(issue_number) if issue_number is not None else "<issue_number>"
+    bounty_ref = str(bounty_id) if bounty_id is not None else "<bounty_id>"
+    if _is_issue_submission(title=title, acceptance=acceptance):
+        submission_mode = "issue"
+        submission_url_kind = "github_issue"
+        expected_artifact = "new proposed-work GitHub issue URL"
+        attempt_endpoint_applicability = "not_required_for_issue_submission"
+        reference_formats = [
+            f"Bounty #{issue_ref}",
+            f"Refs #{issue_ref}",
+            f"Linked bounty: #{issue_ref}",
+        ]
+        claim_command = f"/claim #{issue_ref}"
+        evidence_required = [
+            "new proposed-work GitHub issue URL",
+            "problem, evidence, proposed work, expected value, and acceptance notes",
+            "duplicate search and out-of-scope notes",
+        ]
+        mode_actions = [
+            {
+                "id": "open_proposed_work_issue",
+                "required": True,
+                "text": "Open a concrete proposed-work issue before claiming this bounty.",
+            },
+            {
+                "id": "link_bounty_issue",
+                "required": True,
+                "text": f"Link bounty #{issue_ref} from the proposed-work issue or bounty thread.",
+            },
+        ]
+    else:
+        submission_mode = "pr_or_evidence"
+        submission_url_kind = "github_pr_or_public_evidence_url"
+        expected_artifact = "focused PR, issue, report, or evidence URL"
+        attempt_endpoint_applicability = "recommended_before_submission"
+        reference_formats = [f"Bounty #{issue_ref}", f"Refs #{issue_ref}"]
+        claim_command = "/claim"
+        evidence_required = [
+            "focused PR, issue, report, or evidence URL",
+            "short verification summary",
+            "tests, command output, screenshots, or reproduction steps when relevant",
+        ]
+        mode_actions = [
+            {
+                "id": "keep_scope_focused",
+                "required": True,
+                "text": "Keep changes directly tied to one bounty issue.",
+            },
+            {
+                "id": "include_bounty_reference",
+                "required": True,
+                "text": f"Include Bounty #{issue_ref} or Refs #{issue_ref} in the submission.",
+            },
+        ]
+
+    if availability == "open":
+        first_action = {
+            "id": "confirm_award_slot",
+            "required": True,
+            "text": "Confirm this bounty is open and has at least one award slot remaining.",
+        }
+    elif availability == "full":
+        first_action = {
+            "id": "watch_for_award_slot",
+            "required": True,
+            "text": (
+                "This bounty is open but has no award slots remaining; check for new "
+                "capacity before submitting new work."
+            ),
+        }
+    elif availability == "closed":
+        first_action = {
+            "id": "choose_open_bounty",
+            "required": True,
+            "text": "Do not open or claim new work for this bounty unless a maintainer reopens it.",
+        }
+    else:
+        first_action = {
+            "id": "select_bounty",
+            "required": True,
+            "text": "Select a concrete open bounty before submitting work proof.",
+        }
+
+    return {
+        "submission_mode": submission_mode,
+        "submission_url_kind": submission_url_kind,
+        "expected_artifact": expected_artifact,
+        "attempt_endpoint_applicability": attempt_endpoint_applicability,
+        "reference_formats": reference_formats,
+        "claim_command": claim_command,
+        "attempt_endpoint": f"/api/v1/bounties/{bounty_ref}/attempts",
+        "evidence_required": evidence_required,
+        "acceptance_trigger": "maintainer_mrwk_accepted_label_or_admin_payout",
+        "public_metadata_must_avoid": [
+            "private keys",
+            "seed material",
+            "secrets",
+            "deployment credentials",
+            "private vulnerability details",
+            "price claims",
+        ],
+        "next_actions": [
+            first_action,
+            {
+                "id": "check_duplicate_scope",
+                "required": True,
+                "text": "Confirm no active claim or duplicate PR already covers the same scope.",
+            },
+            *mode_actions,
+            {
+                "id": "include_review_evidence",
+                "required": True,
+                "text": "Include reviewable validation evidence before claiming.",
+            },
+            {
+                "id": "wait_for_maintainer_acceptance",
+                "required": True,
+                "text": (
+                    "Payment requires mrwk:accepted or an admin payout; merge or CI "
+                    "alone is not acceptance."
+                ),
+            },
+        ],
+    }
+
+
+def _is_issue_submission(*, title: str | None, acceptance: str | None) -> bool:
+    text = f"{title or ''}\n{acceptance or ''}".casefold()
+    return (
+        "accepted work is a new proposed-work issue" in text
+        or "proposed-work issue url as submission_url" in text
+    )

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -44,6 +44,15 @@ The bounties list returns public bounty rows. `status` can be omitted or set to
   "pending_payout_awards": 0,
   "availability_state": "open",
   "availability_note": "1 award effectively available.",
+  "submission_requirements": {
+    "submission_mode": "pr_or_evidence",
+    "submission_url_kind": "github_pr_or_public_evidence_url",
+    "expected_artifact": "focused PR, issue, report, or evidence URL",
+    "attempt_endpoint_applicability": "recommended_before_submission",
+    "reference_formats": ["Bounty #164", "Refs #164"],
+    "claim_command": "/claim",
+    "attempt_endpoint": "/api/v1/bounties/36/attempts"
+  },
   "status": "open",
   "acceptance": "Focused public-facing enhancements that help contributors find bounties, inspect accepted work, or understand proof/account activity, with tests. Duplicate, marketing-only, docs-only, broad redesign, or unrelated changes do not qualify.",
   "created_at": "2026-05-24T20:44:00.015953"
@@ -60,6 +69,25 @@ when deciding whether a bounty still has practical capacity; do not describe
 pending payout proposals as proof-backed paid work until a proof exists. Award counters can change
 as accepted work is paid; refresh concrete examples against the live API before
 relying on available slot counts.
+
+`submission_requirements` gives agents the structured submission shape without
+parsing the human acceptance text. Most implementation bounties use
+`"submission_mode": "pr_or_evidence"`, while issue-shaped rounds can state the
+expected artifact directly:
+
+```json
+{
+  "submission_requirements": {
+    "submission_mode": "issue",
+    "submission_url_kind": "github_issue",
+    "expected_artifact": "new proposed-work GitHub issue URL",
+    "attempt_endpoint_applicability": "not_required_for_issue_submission",
+    "reference_formats": ["Bounty #649", "Refs #649", "Linked bounty: #649"],
+    "claim_command": "/claim #649",
+    "attempt_endpoint": "/api/v1/bounties/96/attempts"
+  }
+}
+```
 
 Use `sort` to choose the bounty order: `newest` is the default, `reward` sorts
 by per-award reward, `available` sorts by the remaining MRWK pool, and `awards`

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1400,6 +1400,10 @@ def test_mcp_submit_work_proof_returns_structured_generic_guidance(sqlite_url: s
             "evidence, and wait for a maintainer to apply mrwk:accepted."
         ),
         "submission_requirements": {
+            "submission_mode": "pr_or_evidence",
+            "submission_url_kind": "github_pr_or_public_evidence_url",
+            "expected_artifact": "focused PR, issue, report, or evidence URL",
+            "attempt_endpoint_applicability": "recommended_before_submission",
             "reference_formats": ["Bounty #<issue_number>", "Refs #<issue_number>"],
             "claim_command": "/claim",
             "attempt_endpoint": "/api/v1/bounties/<bounty_id>/attempts",

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -38,6 +38,41 @@ def test_bounty_api_reports_multi_award_capacity(sqlite_url: str) -> None:
     assert bounty["pending_payout_awards"] == 0
     assert bounty["pending_close_proposal"] is None
     assert bounty["availability_state"] == "open"
+    assert bounty["submission_requirements"]["submission_mode"] == "pr_or_evidence"
+    assert bounty["submission_requirements"]["expected_artifact"] == (
+        "focused PR, issue, report, or evidence URL"
+    )
+
+
+def test_bounty_api_reports_issue_submission_requirements(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=649,
+            issue_url="https://github.com/ramimbo/mergework/issues/649",
+            title="MRWK bounty: accepted proposed-work requests, round 1",
+            reward_mrwk="50",
+            max_awards=20,
+            acceptance=(
+                "Accepted work is a new proposed-work issue in ramimbo/mergework. "
+                "Payment review uses the proposed-work issue URL as submission_url."
+            ),
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    requirements = client.get(f"/api/v1/bounties/{bounty_id}").json()["submission_requirements"]
+
+    assert requirements["submission_mode"] == "issue"
+    assert requirements["submission_url_kind"] == "github_issue"
+    assert requirements["expected_artifact"] == "new proposed-work GitHub issue URL"
+    assert requirements["claim_command"] == "/claim #649"
+    assert requirements["attempt_endpoint"] == f"/api/v1/bounties/{bounty_id}/attempts"
+    assert requirements["attempt_endpoint_applicability"] == ("not_required_for_issue_submission")
 
 
 def test_bounty_api_reports_pending_payout_effective_capacity(sqlite_url: str) -> None:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -225,6 +225,9 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert '"reserved_mrwk": "500"' in examples
     assert '"awards_paid": 4' in examples
     assert '"awards_remaining": 1' in examples
+    assert '"submission_mode": "pr_or_evidence"' in examples
+    assert '"submission_mode": "issue"' in examples
+    assert "new proposed-work GitHub issue URL" in examples
     assert '"bounties_shown": 1' in examples
     assert '"open_awards": 2' in examples
     assert '"open_pool_mrwk": "50"' in examples

--- a/tests/test_mcp_work_proof.py
+++ b/tests/test_mcp_work_proof.py
@@ -46,6 +46,8 @@ def test_work_proof_submission_requirements_choose_open_bounty_for_closed_state(
     )
 
     assert requirements["reference_formats"] == ["Bounty #377", "Refs #377"]
+    assert requirements["submission_mode"] == "pr_or_evidence"
+    assert requirements["expected_artifact"] == "focused PR, issue, report, or evidence URL"
     assert requirements["attempt_endpoint"] == "/api/v1/bounties/7/attempts"
     assert _action(requirements, "choose_open_bounty") == {
         "id": "choose_open_bounty",
@@ -53,6 +55,33 @@ def test_work_proof_submission_requirements_choose_open_bounty_for_closed_state(
         "text": "Do not open or claim new work for this bounty unless a maintainer reopens it.",
     }
     assert "price claims" in requirements["public_metadata_must_avoid"]
+
+
+def test_work_proof_submission_requirements_marks_issue_mode() -> None:
+    requirements = work_proof_submission_requirements(
+        bounty_id=96,
+        issue_number=649,
+        availability="open",
+        title="MRWK bounty: accepted proposed-work requests, round 1",
+        acceptance=(
+            "Accepted work is a new proposed-work issue in ramimbo/mergework. "
+            "Payment review uses the proposed-work issue URL as submission_url."
+        ),
+    )
+
+    assert requirements["submission_mode"] == "issue"
+    assert requirements["submission_url_kind"] == "github_issue"
+    assert requirements["expected_artifact"] == "new proposed-work GitHub issue URL"
+    assert requirements["claim_command"] == "/claim #649"
+    assert requirements["attempt_endpoint"] == "/api/v1/bounties/96/attempts"
+    assert requirements["attempt_endpoint_applicability"] == ("not_required_for_issue_submission")
+    next_action_ids = [action["id"] for action in requirements["next_actions"]]
+    assert next_action_ids[:4] == [
+        "confirm_award_slot",
+        "check_duplicate_scope",
+        "open_proposed_work_issue",
+        "link_bounty_issue",
+    ]
 
 
 def test_work_proof_submission_requirements_distinguishes_full_bounty_state() -> None:
@@ -89,6 +118,23 @@ def test_work_proof_guidance_json_reports_open_bounty_state() -> None:
     assert guidance["available_mrwk"] == "1200"
     next_actions = guidance["submission_requirements"]["next_actions"]
     assert any(action["id"] == "confirm_award_slot" for action in next_actions)
+
+
+def test_work_proof_guidance_json_uses_issue_submission_mode() -> None:
+    guidance = work_proof_guidance_json(
+        _bounty(
+            issue_number=649,
+            title="MRWK bounty: accepted proposed-work requests, round 1",
+            acceptance=(
+                "Accepted work is a new proposed-work issue in ramimbo/mergework. "
+                "Payment review uses the proposed-work issue URL as submission_url."
+            ),
+        )
+    )
+
+    requirements = guidance["submission_requirements"]
+    assert requirements["submission_mode"] == "issue"
+    assert requirements["expected_artifact"] == "new proposed-work GitHub issue URL"
 
 
 def test_work_proof_guidance_json_reports_open_full_bounty_state() -> None:

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -50,6 +50,12 @@ def test_bounty_serializers_preserve_public_capacity_fields(sqlite_url: str) -> 
     assert bounty_data["available_mrwk"] == "100"
     assert bounty_data["reserved_mrwk"] == "100"
     assert bounty_data["awards_remaining"] == 4
+    requirements = bounty_data["submission_requirements"]
+    assert requirements["submission_mode"] == "pr_or_evidence"
+    assert requirements["submission_url_kind"] == "github_pr_or_public_evidence_url"
+    assert requirements["expected_artifact"] == "focused PR, issue, report, or evidence URL"
+    assert requirements["reference_formats"] == ["Bounty #320", "Refs #320"]
+    assert requirements["claim_command"] == "/claim"
     assert bounty_list_summary([bounty_data]) == {
         "bounties_shown": 1,
         "open_awards": 4,
@@ -57,6 +63,45 @@ def test_bounty_serializers_preserve_public_capacity_fields(sqlite_url: str) -> 
         "effective_open_awards": 4,
         "effective_open_pool_mrwk": "100",
     }
+
+
+def test_bounty_serializer_marks_proposed_work_issue_submission_mode(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=649,
+            issue_url="https://github.com/ramimbo/mergework/issues/649",
+            title="MRWK bounty: accepted proposed-work requests, round 1",
+            reward_mrwk="50",
+            max_awards=20,
+            acceptance=(
+                "Accepted work is a new proposed-work issue in ramimbo/mergework. "
+                "Payment review uses the proposed-work issue URL as submission_url "
+                "through pay_bounty after maintainer acceptance."
+            ),
+        )
+
+        requirements = bounty_to_dict(bounty)["submission_requirements"]
+
+    assert requirements["submission_mode"] == "issue"
+    assert requirements["submission_url_kind"] == "github_issue"
+    assert requirements["expected_artifact"] == "new proposed-work GitHub issue URL"
+    assert requirements["attempt_endpoint_applicability"] == ("not_required_for_issue_submission")
+    assert requirements["reference_formats"] == [
+        "Bounty #649",
+        "Refs #649",
+        "Linked bounty: #649",
+    ]
+    assert requirements["claim_command"] == "/claim #649"
+    assert "new proposed-work GitHub issue URL" in requirements["evidence_required"]
+    next_action_ids = [action["id"] for action in requirements["next_actions"]]
+    assert "open_proposed_work_issue" in next_action_ids
+    assert "link_bounty_issue" in next_action_ids
 
 
 def test_bounties_to_dict_preloads_pending_proposals_once(sqlite_url: str) -> None:


### PR DESCRIPTION
Maintainer accepted live-lane reroute: this merged work is evaluated under live bounty #777 because it matches that acceptance scope; the original closed/exhausted round reference was issue 647.

## Summary

Bounty #777
Source issue: #676

This PR exposes structured bounty submission requirements on public bounty rows and reuses the same shape for MCP work-proof guidance.

- Adds a shared `app/submission_requirements.py` helper for submission mode, expected artifact, URL kind, claim command, attempt endpoint applicability, evidence, and next actions.
- Adds `submission_requirements` to public bounty serialization so `/api/v1/bounties` and `/api/v1/bounties/{id}` can distinguish PR/evidence submissions from issue-shaped proposed-work rounds.
- Detects #649-style proposed-work bounty wording as `submission_mode: "issue"` with `expected_artifact: "new proposed-work GitHub issue URL"`.
- Keeps existing MCP guidance behavior while enriching the nested requirements shape.
- Documents the new public API fields and covers both default PR/evidence and issue submission modes.

## Verification

- `/private/tmp/mergework-venv-312/bin/python -m pytest tests/test_serializers.py tests/test_bounty_api_routes.py tests/test_mcp_work_proof.py tests/test_api_mcp.py tests/test_docs_public_urls.py -q` -> 141 passed, 1 existing FastAPI/Starlette deprecation warning
- `/private/tmp/mergework-venv-312/bin/python -m pytest -q` -> 564 passed, 1 existing FastAPI/Starlette deprecation warning
- `/private/tmp/mergework-venv-312/bin/python -m ruff format --check .` -> 97 files already formatted
- `/private/tmp/mergework-venv-312/bin/python -m ruff check .` -> All checks passed
- `/private/tmp/mergework-venv-312/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> passed

## Duplicate Check

- `gh pr list --repo ramimbo/mergework --state open --search "676"` returned no open PRs.
- `https://api.mrwk.online/api/v1/bounties/95/attempts` returned no active attempts.
- Related open work covers effective availability, pending payout inventory, public proof URLs, and OpenAPI schemas; this PR is limited to structured submission requirements for bounty rows and MCP guidance.

## Out of Scope

- No treasury execution, payout proposals, proof generation, balances, wallet behavior, ledger mutation, reserve accounting, exchange, bridge, cash-out, price, or acceptance behavior changes.
- No broad natural-language classifier for arbitrary bounty text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API now returns structured submission_requirements per bounty: submission mode (issue or PR/evidence), expected artifact types, claim/attempt guidance, and next actions.
  * Guidance adapts to bounty availability (open, full, closed, unknown) and bounty metadata (title/acceptance).

* **Documentation**
  * Examples and docs extended to show submission_requirements and recommend using them instead of parsing acceptance text.

* **Tests**
  * Added and updated tests to assert submission_requirements in API responses and guidance outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->