### PR TITLE
Add effective bounty availability filter

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -11,6 +11,10 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from app.admin import list_webhook_events, webhook_events_to_dict
+from app.bounty_filters import (
+    filter_bounties_by_availability,
+    normalize_bounty_availability_filter,
+)
 from app.bounty_sorting import BOUNTY_SORT_ERROR, normalize_bounty_sort, sort_bounties
 from app.config import Settings
 from app.control_chars import contains_control_character
@@ -102,12 +106,14 @@ def register_bounty_api_routes(
         query_text: str | None = None,
         sort: str | None = None,
         limit: int | None = None,
+        availability: str | None = None,
     ) -> list[dict[str, Any]]:
         try:
             normalized_sort = normalize_bounty_sort(sort)
+            normalized_availability = normalize_bounty_availability_filter(availability)
         except ValueError as exc:
             detail = str(exc)
-            if "control characters" not in detail:
+            if "control characters" not in detail and not detail.startswith("availability"):
                 detail = BOUNTY_SORT_ERROR
             raise HTTPException(status_code=400, detail=detail) from exc
         with session_scope(db_url) as session:
@@ -144,7 +150,10 @@ def register_bounty_api_routes(
                     query = query.where(text_filter)
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             sorted_bounties = sort_bounties(
-                bounties_to_dict(bounties, session=session),
+                filter_bounties_by_availability(
+                    bounties_to_dict(bounties, session=session),
+                    normalized_availability,
+                ),
                 normalized_sort,
             )
             if limit is not None:
@@ -157,8 +166,11 @@ def register_bounty_api_routes(
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
         sort: str | None = Query(None),
+        availability: str | None = Query(None),
     ) -> list[dict[str, Any]]:
-        return _list_bounties_by_status(status, q, sort=sort, limit=limit)
+        return _list_bounties_by_status(
+            status, q, sort=sort, limit=limit, availability=availability
+        )
 
     @app.get("/api/v1/bounties/summary")
     def api_bounties_summary(
@@ -166,8 +178,11 @@ def register_bounty_api_routes(
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
         sort: str | None = Query(None),
+        availability: str | None = Query(None),
     ) -> dict[str, Any]:
-        return bounty_list_summary(_list_bounties_by_status(status, q, sort=sort, limit=limit))
+        return bounty_list_summary(
+            _list_bounties_by_status(status, q, sort=sort, limit=limit, availability=availability)
+        )
 
     @app.get("/api/v1/admin/webhook-events")
     def api_admin_webhook_events(

--- a/app/bounty_filters.py
+++ b/app/bounty_filters.py
@@ -1,0 +1,41 @@
+"""Shared bounty list filtering helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.control_chars import contains_control_character
+
+BOUNTY_AVAILABILITY_FILTER_LABELS = {
+    "all": "All availability",
+    "effectively_open": "Effectively open",
+}
+BOUNTY_AVAILABILITY_FILTER_OPTIONS = tuple(BOUNTY_AVAILABILITY_FILTER_LABELS)
+BOUNTY_AVAILABILITY_FILTER_ERROR = (
+    f"availability must be one of: {', '.join(BOUNTY_AVAILABILITY_FILTER_OPTIONS)}"
+)
+
+
+def normalize_bounty_availability_filter(availability: str | None) -> str:
+    raw_availability = availability or ""
+    if contains_control_character(raw_availability):
+        raise ValueError("availability must not contain control characters")
+    normalized_availability = raw_availability.strip().lower()
+    if not normalized_availability:
+        return "all"
+    if normalized_availability not in BOUNTY_AVAILABILITY_FILTER_OPTIONS:
+        raise ValueError(BOUNTY_AVAILABILITY_FILTER_ERROR)
+    return normalized_availability
+
+
+def filter_bounties_by_availability(
+    bounties: list[dict[str, Any]], availability: str | None
+) -> list[dict[str, Any]]:
+    normalized_availability = normalize_bounty_availability_filter(availability)
+    if normalized_availability == "all":
+        return bounties
+    return [
+        bounty
+        for bounty in bounties
+        if int(bounty.get("effective_awards_remaining", bounty["awards_remaining"])) > 0
+    ]

--- a/app/mcp.py
+++ b/app/mcp.py
@@ -14,7 +14,9 @@ MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
-        "description": "List MRWK bounties with optional status, q, sort, and limit filters",
+        "description": (
+            "List MRWK bounties with optional status, q, sort, availability, and limit filters"
+        ),
     },
     {
         "name": "get_bounty",

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -7,6 +7,7 @@ from sqlalchemy import func, or_, select
 
 from app.accounts import normalized_account, normalized_wallet_address
 from app.bounty_attempts import list_bounty_attempts
+from app.bounty_filters import filter_bounties_by_availability, normalize_bounty_availability_filter
 from app.bounty_sorting import normalize_bounty_sort, sort_bounties
 from app.control_chars import contains_control_character
 from app.db import session_scope
@@ -127,6 +128,9 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             if normalized_status not in {"open", "paid", "closed"}:
                 raise ValueError("status must be one of: open, paid, closed")
             query = select(Bounty).where(Bounty.status == normalized_status)
+            availability = normalize_bounty_availability_filter(
+                optional_clean_str_arg("availability")
+            )
             query_text = optional_clean_str_arg("q")
             if query_text:
                 escaped_query = (
@@ -144,13 +148,19 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 query = query.where(text_filter)
             sort = normalize_bounty_sort(optional_clean_str_arg("sort"))
             limit = list_limit_arg()
-            if sort == "newest":
+            if sort == "newest" and availability == "all":
                 newest_bounties = session.scalars(
                     query.order_by(Bounty.id.desc()).limit(limit)
                 ).all()
                 return json.dumps(bounties_to_dict(newest_bounties, session=session))
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
-            sorted_bounties = sort_bounties(bounties_to_dict(bounties, session=session), sort)
+            sorted_bounties = sort_bounties(
+                filter_bounties_by_availability(
+                    bounties_to_dict(bounties, session=session),
+                    availability,
+                ),
+                sort,
+            )
             return json.dumps(sorted_bounties[:limit])
         if name == "get_bounty":
             bounty = session.get(Bounty, positive_int_arg("id"))

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -11,6 +11,10 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from app.accounts import normalized_wallet_address
+from app.bounty_filters import (
+    BOUNTY_AVAILABILITY_FILTER_LABELS,
+    normalize_bounty_availability_filter,
+)
 from app.bounty_sorting import BOUNTY_SORT_LABELS, normalize_bounty_sort
 from app.db import session_scope
 from app.ledger_views import account_ledger_transaction_types, account_ledger_transactions
@@ -25,7 +29,11 @@ from app.status import (
 
 
 def _bounties_api_url(
-    status: str | None, query_text: str, selected_sort: str, limit: int | None
+    status: str | None,
+    query_text: str,
+    selected_sort: str,
+    limit: int | None,
+    selected_availability: str,
 ) -> str:
     params: list[tuple[str, str]] = []
     if status:
@@ -34,9 +42,29 @@ def _bounties_api_url(
         params.append(("q", query_text))
     if selected_sort != "newest":
         params.append(("sort", selected_sort))
+    if selected_availability != "all":
+        params.append(("availability", selected_availability))
     if limit is not None:
         params.append(("limit", str(limit)))
     return f"/api/v1/bounties?{urlencode(params)}" if params else "/api/v1/bounties"
+
+
+def _bounties_page_url(
+    *,
+    status: str | None,
+    query_text: str,
+    selected_sort: str,
+    limit: int | None,
+    selected_availability: str,
+) -> str:
+    api_path = _bounties_api_url(
+        status,
+        query_text,
+        selected_sort,
+        limit,
+        selected_availability,
+    )
+    return api_path.replace("/api/v1/bounties", "/bounties", 1)
 
 
 def public_bounties_context(
@@ -45,13 +73,25 @@ def public_bounties_context(
     q: str | None,
     sort: str | None = None,
     limit: int | None = None,
+    availability: str | None = None,
 ) -> dict[str, Any]:
     selected_status = status.strip().lower() if status is not None else None
     query_text = q.strip() if q is not None else ""
     selected_sort = normalize_bounty_sort(sort)
+    selected_availability = normalize_bounty_availability_filter(availability)
     limit_options: tuple[int, ...] = (10, 25, 50, 100, 200)
     if limit is not None and limit not in limit_options:
         limit_options = tuple(sorted((*limit_options, limit)))
+    status_filter_urls = {
+        status_value or "all": _bounties_page_url(
+            status=status_value,
+            query_text=query_text,
+            selected_sort=selected_sort,
+            limit=limit,
+            selected_availability=selected_availability,
+        )
+        for status_value in (None, "open", "paid", "closed")
+    }
     return {
         "bounties": bounties,
         "summary": bounty_list_summary(bounties),
@@ -59,9 +99,25 @@ def public_bounties_context(
         "query_text": query_text,
         "selected_sort": selected_sort,
         "sort_options": BOUNTY_SORT_LABELS,
+        "selected_availability": selected_availability,
+        "availability_options": BOUNTY_AVAILABILITY_FILTER_LABELS,
         "selected_limit": limit,
         "limit_options": limit_options,
-        "api_results_url": _bounties_api_url(selected_status, query_text, selected_sort, limit),
+        "status_filter_urls": status_filter_urls,
+        "clear_search_url": _bounties_page_url(
+            status=selected_status,
+            query_text="",
+            selected_sort=selected_sort,
+            limit=limit,
+            selected_availability=selected_availability,
+        ),
+        "api_results_url": _bounties_api_url(
+            selected_status,
+            query_text,
+            selected_sort,
+            limit,
+            selected_availability,
+        ),
     }
 
 
@@ -130,7 +186,7 @@ def register_public_routes(
     db_url: str,
     templates: Jinja2Templates,
     list_bounties_by_status: Callable[
-        [str | None, str | None, str | None, int | None], list[dict[str, Any]]
+        [str | None, str | None, str | None, int | None, str | None], list[dict[str, Any]]
     ],
     api_bounty: Callable[[int], dict[str, Any]],
     api_ledger: Callable[[], list[dict[str, Any]]],
@@ -144,12 +200,13 @@ def register_public_routes(
         q: str | None = Query(None),
         sort: str | None = Query(None),
         limit: int | None = Query(None, ge=1, le=200),
+        availability: str | None = Query(None),
     ) -> HTMLResponse:
-        bounties = list_bounties_by_status(status, q, sort, limit)
+        bounties = list_bounties_by_status(status, q, sort, limit, availability)
         return templates.TemplateResponse(
             request,
             "bounties.html",
-            public_bounties_context(bounties, status, q, sort, limit),
+            public_bounties_context(bounties, status, q, sort, limit, availability),
         )
 
     @app.get("/bounties/{bounty_id}", response_class=HTMLResponse)

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -19,14 +19,20 @@
     <option value="{{ limit_option }}"{% if selected_limit == limit_option %} selected{% endif %}>{{ limit_option }}</option>
     {% endfor %}
   </select>
+  <label for="bounty-availability">Availability</label>
+  <select id="bounty-availability" name="availability">
+    {% for availability_value, availability_label in availability_options.items() %}
+    <option value="{{ availability_value }}"{% if selected_availability == availability_value %} selected{% endif %}>{{ availability_label }}</option>
+    {% endfor %}
+  </select>
   <button type="submit">Search</button>
-  {% if query_text %}<a href="/bounties{% if selected_status or selected_sort != "newest" or selected_limit %}?{% if selected_status %}status={{ selected_status }}{% endif %}{% if selected_status and (selected_sort != "newest" or selected_limit) %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% if selected_sort != "newest" and selected_limit %}&{% endif %}{% if selected_limit %}limit={{ selected_limit }}{% endif %}{% endif %}">Clear search</a>{% endif %}
+  {% if query_text %}<a href="{{ clear_search_url }}">Clear search</a>{% endif %}
 </form>
 <nav aria-label="Bounty status filters">
-  <a href="/bounties{% if query_text or selected_sort != "newest" or selected_limit %}?{% if query_text %}q={{ query_text | urlencode }}{% endif %}{% if query_text and (selected_sort != "newest" or selected_limit) %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% if selected_sort != "newest" and selected_limit %}&{% endif %}{% if selected_limit %}limit={{ selected_limit }}{% endif %}{% endif %}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
-  <a href="/bounties?status=open{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
-  <a href="/bounties?status=paid{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
-  <a href="/bounties?status=closed{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
+  <a href="{{ status_filter_urls.all }}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
+  <a href="{{ status_filter_urls.open }}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
+  <a href="{{ status_filter_urls.paid }}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
+  <a href="{{ status_filter_urls.closed }}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
 </nav>
 {% if query_text %}<p>Showing matches for “{{ query_text }}”.</p>{% endif %}
 <section class="bounty-list-summary" aria-label="Bounty list summary">
@@ -80,7 +86,7 @@
     <p>{{ bounty.acceptance }}</p>
   </article>
   {% else %}
-  {% if query_text or selected_status %}
+  {% if query_text or selected_status or selected_availability != "all" %}
   <p>No bounties match these filters.</p>
   <p><a href="/bounties">Clear filters</a></p>
   {% else %}

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -44,6 +44,7 @@ List current system counts and recent bounties:
 ```bash
 curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
+curl -s "$API_HOST/api/v1/bounties?status=open&availability=effectively_open"
 ```
 
 Get a lightweight counts-only bounty summary with optional status and search
@@ -52,8 +53,12 @@ filters:
 ```bash
 curl -s "$API_HOST/api/v1/bounties/summary"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open"
+curl -s "$API_HOST/api/v1/bounties/summary?status=open&availability=effectively_open"
 curl -s "$API_HOST/api/v1/bounties/summary?q=docs"
 ```
+
+Use `availability=effectively_open` when scouting only for bounties with at
+least one effective award slot remaining.
 
 Inspect one bounty, accepted-work activity, a ledger page, and a proof:
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -18,8 +18,10 @@ Check service status and list bounties:
 curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
 curl -s "$API_HOST/api/v1/bounties?status=open"
+curl -s "$API_HOST/api/v1/bounties?status=open&availability=effectively_open"
 curl -s "$API_HOST/api/v1/bounties?status=open&sort=available&limit=5"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open&q=proof"
+curl -s "$API_HOST/api/v1/bounties/summary?status=open&availability=effectively_open"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open&sort=awards&limit=5"
 ```
 
@@ -60,6 +62,11 @@ when deciding whether a bounty still has practical capacity; do not describe
 pending payout proposals as proof-backed paid work until a proof exists. Award counters can change
 as accepted work is paid; refresh concrete examples against the live API before
 relying on available slot counts.
+
+Use `availability=effectively_open` when discovery clients should only return
+rows whose `effective_awards_remaining` is greater than zero. Omit it, or use
+`availability=all`, when raw ledger status should remain the only availability
+filter.
 
 Use `sort` to choose the bounty order: `newest` is the default, `reward` sorts
 by per-award reward, `available` sorts by the remaining MRWK pool, and `awards`
@@ -777,9 +784,11 @@ and has effectively available awards:
 ```bash
 # List all open bounties with their capacity
 curl -s "$API_HOST/api/v1/bounties?status=open"
+curl -s "$API_HOST/api/v1/bounties?status=open&availability=effectively_open"
 
 # Quick capacity summary
 curl -s "$API_HOST/api/v1/bounties/summary?status=open"
+curl -s "$API_HOST/api/v1/bounties/summary?status=open&availability=effectively_open"
 
 # Inspect one bounty by its internal id (from /api/v1/bounties)
 curl -s "$API_HOST/api/v1/bounties/<bounty_id>"

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -10,6 +10,7 @@ from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
 from app.models import BountyAttempt, Proof
+from app.treasury import propose_treasury_action
 
 
 def test_health_status_and_bounty_api(sqlite_url: str) -> None:
@@ -194,7 +195,10 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
 
     tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()
     assert tools["result"]["tools"][0]["name"] == "list_bounties"
-    assert "status, q, sort, and limit filters" in tools["result"]["tools"][0]["description"]
+    assert (
+        "status, q, sort, availability, and limit filters"
+        in (tools["result"]["tools"][0]["description"])
+    )
     submit_tool = next(
         tool for tool in tools["result"]["tools"] if tool["name"] == "submit_work_proof"
     )
@@ -479,6 +483,63 @@ def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> No
     assert digit_limit_payload == []
 
 
+def test_mcp_list_bounties_filters_effective_availability(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        effectively_open = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=291,
+            issue_url="https://github.com/ramimbo/mergework/issues/291",
+            title="Effectively open MCP bounty",
+            reward_mrwk="100",
+            acceptance="MCP should keep this bounty visible.",
+        )
+        effectively_full = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=292,
+            issue_url="https://github.com/ramimbo/mergework/issues/292",
+            title="Effectively full MCP bounty",
+            reward_mrwk="100",
+            acceptance="Pending payout should hide this bounty from effective filtering.",
+        )
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": effectively_full.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/292",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounties",
+                "arguments": {
+                    "status": "open",
+                    "availability": "effectively_open",
+                    "sort": "newest",
+                },
+            },
+        },
+    ).json()
+
+    payload = json.loads(result["result"]["content"][0]["text"])
+    assert [item["id"] for item in payload] == [effectively_open.id]
+
+
 def test_mcp_list_bounties_honors_sort_argument(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -538,6 +599,7 @@ def test_mcp_list_bounties_honors_sort_argument(sqlite_url: str) -> None:
         ({"limit": 0}, 34),
         ({"limit": 101}, 35),
         ({"sort": "invalid"}, 36),
+        ({"availability": "invalid"}, 37),
     ],
 )
 def test_mcp_list_bounties_rejects_invalid_filters(

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -88,6 +88,59 @@ def test_bounty_api_reports_pending_payout_effective_capacity(sqlite_url: str) -
     assert summary["effective_open_pool_mrwk"] == "40"
 
 
+def test_bounty_api_filters_effectively_open_rows(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        effectively_open = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=121,
+            issue_url="https://github.com/ramimbo/mergework/issues/121",
+            title="Effectively open bounty",
+            reward_mrwk="30",
+            max_awards=2,
+            acceptance="This bounty still has effective capacity.",
+        )
+        effectively_full = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=122,
+            issue_url="https://github.com/ramimbo/mergework/issues/122",
+            title="Effectively full bounty",
+            reward_mrwk="40",
+            acceptance="Pending payout covers the only visible award.",
+        )
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": effectively_full.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/122",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    raw_open = client.get("/api/v1/bounties?status=open").json()
+    filtered = client.get("/api/v1/bounties?status=open&availability=effectively_open").json()
+    summary = client.get(
+        "/api/v1/bounties/summary?status=open&availability=effectively_open"
+    ).json()
+    invalid = client.get("/api/v1/bounties?availability=bogus")
+
+    assert [item["id"] for item in raw_open] == [effectively_full.id, effectively_open.id]
+    assert [item["id"] for item in filtered] == [effectively_open.id]
+    assert summary["bounties_shown"] == 1
+    assert summary["open_awards"] == 2
+    assert summary["effective_open_awards"] == 2
+    assert invalid.status_code == 400
+    assert invalid.json()["detail"] == "availability must be one of: all, effectively_open"
+
+
 def test_bounty_api_reports_pending_close_as_effectively_unavailable(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -271,7 +271,7 @@ def test_bounties_page_honors_limit_filter(sqlite_url: str) -> None:
     assert "<strong>2</strong>" in limited_page.text
     assert '<option value="2" selected>2</option>' in limited_page.text
     assert '<option value=""' in limited_page.text
-    assert 'href="/bounties?status=open&limit=2"' in limited_page.text
+    assert 'href="/bounties?status=open&amp;limit=2"' in limited_page.text
 
     filtered_limited_page = client.get("/bounties?q=public&sort=reward&limit=2")
     assert filtered_limited_page.status_code == 200
@@ -279,7 +279,9 @@ def test_bounties_page_honors_limit_filter(sqlite_url: str) -> None:
         '<option value="reward" selected>Highest per-award reward</option>'
         in filtered_limited_page.text
     )
-    assert 'href="/bounties?sort=reward&limit=2">Clear search</a>' in filtered_limited_page.text
+    assert 'href="/bounties?sort=reward&amp;limit=2">Clear search</a>' in (
+        filtered_limited_page.text
+    )
     assert (
         'href="/api/v1/bounties?q=public&amp;sort=reward&amp;limit=2">View JSON results</a>'
         in filtered_limited_page.text
@@ -293,6 +295,55 @@ def test_bounties_page_honors_limit_filter(sqlite_url: str) -> None:
 
     too_large_limit = client.get("/bounties?limit=201")
     assert too_large_limit.status_code == 422
+
+
+def test_bounties_page_filters_effective_availability(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        visible = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=76,
+            issue_url="https://github.com/ramimbo/mergework/issues/76",
+            title="Visible effective bounty",
+            reward_mrwk="25",
+            acceptance="This bounty should remain visible.",
+        )
+        hidden = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=77,
+            issue_url="https://github.com/ramimbo/mergework/issues/77",
+            title="Hidden effective bounty",
+            reward_mrwk="25",
+            acceptance="Pending payout should hide this row from effective filtering.",
+        )
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": hidden.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/77",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    page = client.get("/bounties?status=open&availability=effectively_open")
+
+    assert page.status_code == 200
+    assert visible.title in page.text
+    assert hidden.title not in page.text
+    assert '<option value="effectively_open" selected>Effectively open</option>' in page.text
+    assert 'href="/bounties?availability=effectively_open"' in page.text
+    assert (
+        'href="/api/v1/bounties?status=open&amp;availability=effectively_open">'
+        "View JSON results</a>"
+    ) in page.text
 
 
 def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) -> None:
@@ -335,7 +386,7 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     assert "Showing matches for “proof inspection”." in text_search.text
     assert "Improve public bounty discovery" in text_search.text
     assert "Internal admin cleanup" not in text_search.text
-    assert 'href="/bounties?status=open&q=proof%20inspection"' in text_search.text
+    assert 'href="/bounties?status=open&amp;q=proof+inspection"' in text_search.text
 
     issue_search = client.get("/api/v1/bounties?q=65")
     assert issue_search.status_code == 200
@@ -444,7 +495,7 @@ def test_bounties_page_and_api_sort_public_rows(sqlite_url: str) -> None:
     )
     assert 'name="sort"' in available_page.text
     assert '<option value="available" selected>Most MRWK available</option>' in available_page.text
-    assert 'href="/bounties?status=open&sort=available"' in available_page.text
+    assert 'href="/bounties?status=open&amp;sort=available"' in available_page.text
 
     whitespace_sort_page = client.get("/bounties", params={"sort": "   "})
     assert whitespace_sort_page.status_code == 200

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -208,8 +208,10 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 
     assert "/api/v1/bounties?status=open" in examples
+    assert "/api/v1/bounties?status=open&availability=effectively_open" in examples
     assert "/api/v1/bounties?status=open&sort=available&limit=5" in examples
     assert "/api/v1/bounties/summary?status=open&q=proof" in examples
+    assert "/api/v1/bounties/summary?status=open&availability=effectively_open" in examples
     assert "/api/v1/bounties/summary?status=open&sort=awards&limit=5" in examples
     assert "status` can be omitted or set to" in examples
     assert "`newest` is the default" in examples

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -16,7 +16,13 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
         }
     ]
 
-    context = public_bounties_context(bounties, status=" OPEN ", q=" proof ", sort=" Reward ")
+    context = public_bounties_context(
+        bounties,
+        status=" OPEN ",
+        q=" proof ",
+        sort=" Reward ",
+        availability=" effectively_open ",
+    )
 
     assert context == {
         "bounties": bounties,
@@ -36,9 +42,23 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
             "available": "Most MRWK available",
             "awards": "Most award slots",
         },
+        "selected_availability": "effectively_open",
+        "availability_options": {
+            "all": "All availability",
+            "effectively_open": "Effectively open",
+        },
         "selected_limit": None,
         "limit_options": (10, 25, 50, 100, 200),
-        "api_results_url": "/api/v1/bounties?status=open&q=proof&sort=reward",
+        "status_filter_urls": {
+            "all": "/bounties?q=proof&sort=reward&availability=effectively_open",
+            "open": "/bounties?status=open&q=proof&sort=reward&availability=effectively_open",
+            "paid": "/bounties?status=paid&q=proof&sort=reward&availability=effectively_open",
+            "closed": ("/bounties?status=closed&q=proof&sort=reward&availability=effectively_open"),
+        },
+        "clear_search_url": "/bounties?status=open&sort=reward&availability=effectively_open",
+        "api_results_url": (
+            "/api/v1/bounties?status=open&q=proof&sort=reward&availability=effectively_open"
+        ),
     }
 
 


### PR DESCRIPTION
## Summary

Bounty #647
Source issue: #683

This PR adds a read-only `availability=effectively_open` discovery filter for bounties whose effective award capacity is still greater than zero.

- Adds shared availability filter normalization and row filtering in `app/bounty_filters.py`.
- Supports `availability=effectively_open` on `/api/v1/bounties` and `/api/v1/bounties/summary`.
- Preserves default/raw `status=open` behavior when availability is omitted or `all`.
- Wires the same filter through the public `/bounties` page and its JSON-results/status links.
- Wires MCP `list_bounties` to the same filter while keeping the newest/limit fast path for default availability.
- Documents the filter in the API examples and agent guide.

## Verification

- `/private/tmp/mergework-venv-312/bin/python -m pytest tests/test_bounty_api_routes.py tests/test_api_mcp.py tests/test_public_routes.py tests/test_bounty_pages.py tests/test_docs_public_urls.py tests/test_mcp_tools.py -q` -> 155 passed, 1 existing FastAPI/Starlette deprecation warning
- `/private/tmp/mergework-venv-312/bin/python -m pytest -q` -> 564 passed, 1 existing FastAPI/Starlette deprecation warning
- `/private/tmp/mergework-venv-312/bin/python -m ruff format --check .` -> 97 files already formatted
- `/private/tmp/mergework-venv-312/bin/python -m ruff check .` -> All checks passed
- `/private/tmp/mergework-venv-312/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> passed

## Duplicate Check

- `gh pr list --repo ramimbo/mergework --state open --search "683"` returned no open PRs.
- `https://api.mrwk.online/api/v1/bounties/95/attempts` returned no active attempts.
- Related open work covers summary breakdowns, submission requirements, row-level attempt summaries, OpenAPI schemas, public proof URLs, and submission-gate effective availability; this PR is limited to an explicit discovery filter over existing effective capacity fields.

## Out of Scope

- No ledger status, payout execution, treasury mutation, proof generation, wallet, balance, reserve accounting, bridge, exchange, cash-out, price, or acceptance rule changes.
- Raw `status=open` rows remain visible unless callers opt into `availability=effectively_open`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added availability filter to bounty API endpoints (`/api/v1/bounties` and `/api/v1/bounties/summary`) to display only bounties with effective award capacity.
  * Added availability filter control to the public bounties page.
  * MCP list_bounties tool now supports availability filtering.

* **Documentation**
  * Updated API documentation with examples demonstrating the availability filter parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->