### PR TITLE
Add effective availability filter to bounty discovery

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -11,6 +11,11 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from app.admin import list_webhook_events, webhook_events_to_dict
+from app.bounty_availability import (
+    BOUNTY_AVAILABILITY_ERROR,
+    filter_bounties_by_availability,
+    normalize_bounty_availability_filter,
+)
 from app.bounty_sorting import BOUNTY_SORT_ERROR, normalize_bounty_sort, sort_bounties
 from app.config import Settings
 from app.control_chars import contains_control_character
@@ -102,12 +107,19 @@ def register_bounty_api_routes(
         query_text: str | None = None,
         sort: str | None = None,
         limit: int | None = None,
+        availability: str | None = None,
     ) -> list[dict[str, Any]]:
         try:
             normalized_sort = normalize_bounty_sort(sort)
+            normalized_availability = normalize_bounty_availability_filter(availability)
         except ValueError as exc:
             detail = str(exc)
-            if "control characters" not in detail:
+            if detail not in {
+                BOUNTY_SORT_ERROR,
+                BOUNTY_AVAILABILITY_ERROR,
+                "sort must not contain control characters",
+                "availability must not contain control characters",
+            }:
                 detail = BOUNTY_SORT_ERROR
             raise HTTPException(status_code=400, detail=detail) from exc
         with session_scope(db_url) as session:
@@ -144,7 +156,10 @@ def register_bounty_api_routes(
                     query = query.where(text_filter)
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             sorted_bounties = sort_bounties(
-                bounties_to_dict(bounties, session=session),
+                filter_bounties_by_availability(
+                    bounties_to_dict(bounties, session=session),
+                    normalized_availability,
+                ),
                 normalized_sort,
             )
             if limit is not None:
@@ -157,8 +172,11 @@ def register_bounty_api_routes(
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
         sort: str | None = Query(None),
+        availability: str | None = Query(None),
     ) -> list[dict[str, Any]]:
-        return _list_bounties_by_status(status, q, sort=sort, limit=limit)
+        return _list_bounties_by_status(
+            status, q, sort=sort, limit=limit, availability=availability
+        )
 
     @app.get("/api/v1/bounties/summary")
     def api_bounties_summary(
@@ -166,8 +184,11 @@ def register_bounty_api_routes(
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
         sort: str | None = Query(None),
+        availability: str | None = Query(None),
     ) -> dict[str, Any]:
-        return bounty_list_summary(_list_bounties_by_status(status, q, sort=sort, limit=limit))
+        return bounty_list_summary(
+            _list_bounties_by_status(status, q, sort=sort, limit=limit, availability=availability)
+        )
 
     @app.get("/api/v1/admin/webhook-events")
     def api_admin_webhook_events(

--- a/app/bounty_availability.py
+++ b/app/bounty_availability.py
@@ -1,0 +1,35 @@
+"""Shared effective-availability filtering for bounty discovery surfaces."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.control_chars import contains_control_character
+
+BOUNTY_AVAILABILITY_FILTERS = {"all", "effectively_open"}
+BOUNTY_AVAILABILITY_ERROR = "availability must be one of: all, effectively_open"
+
+
+def normalize_bounty_availability_filter(availability: str | None) -> str:
+    raw_availability = availability or ""
+    if contains_control_character(raw_availability):
+        raise ValueError("availability must not contain control characters")
+    normalized = raw_availability.strip().lower()
+    if not normalized:
+        return "all"
+    if normalized not in BOUNTY_AVAILABILITY_FILTERS:
+        raise ValueError(BOUNTY_AVAILABILITY_ERROR)
+    return normalized
+
+
+def filter_bounties_by_availability(
+    bounties: list[dict[str, Any]], availability: str | None
+) -> list[dict[str, Any]]:
+    normalized = normalize_bounty_availability_filter(availability)
+    if normalized == "all":
+        return bounties
+    return [
+        bounty
+        for bounty in bounties
+        if int(bounty.get("effective_awards_remaining", bounty["awards_remaining"])) > 0
+    ]

--- a/app/mcp.py
+++ b/app/mcp.py
@@ -14,7 +14,9 @@ MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
-        "description": "List MRWK bounties with optional status, q, sort, and limit filters",
+        "description": (
+            "List MRWK bounties with optional status, q, sort, limit, and availability filters"
+        ),
     },
     {
         "name": "get_bounty",

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -7,6 +7,10 @@ from sqlalchemy import func, or_, select
 
 from app.accounts import normalized_account, normalized_wallet_address
 from app.bounty_attempts import list_bounty_attempts
+from app.bounty_availability import (
+    filter_bounties_by_availability,
+    normalize_bounty_availability_filter,
+)
 from app.bounty_sorting import normalize_bounty_sort, sort_bounties
 from app.control_chars import contains_control_character
 from app.db import session_scope
@@ -143,14 +147,23 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                     text_filter = or_(text_filter, Bounty.issue_number == issue_number)
                 query = query.where(text_filter)
             sort = normalize_bounty_sort(optional_clean_str_arg("sort"))
+            availability = normalize_bounty_availability_filter(
+                optional_clean_str_arg("availability")
+            )
             limit = list_limit_arg()
-            if sort == "newest":
+            if sort == "newest" and availability == "all":
                 newest_bounties = session.scalars(
                     query.order_by(Bounty.id.desc()).limit(limit)
                 ).all()
                 return json.dumps(bounties_to_dict(newest_bounties, session=session))
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
-            sorted_bounties = sort_bounties(bounties_to_dict(bounties, session=session), sort)
+            sorted_bounties = sort_bounties(
+                filter_bounties_by_availability(
+                    bounties_to_dict(bounties, session=session),
+                    availability,
+                ),
+                sort,
+            )
             return json.dumps(sorted_bounties[:limit])
         if name == "get_bounty":
             bounty = session.get(Bounty, positive_int_arg("id"))

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -11,6 +11,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from app.accounts import normalized_wallet_address
+from app.bounty_availability import normalize_bounty_availability_filter
 from app.bounty_sorting import BOUNTY_SORT_LABELS, normalize_bounty_sort
 from app.db import session_scope
 from app.ledger_views import account_ledger_transaction_types, account_ledger_transactions
@@ -25,7 +26,11 @@ from app.status import (
 
 
 def _bounties_api_url(
-    status: str | None, query_text: str, selected_sort: str, limit: int | None
+    status: str | None,
+    query_text: str,
+    selected_sort: str,
+    limit: int | None,
+    selected_availability: str,
 ) -> str:
     params: list[tuple[str, str]] = []
     if status:
@@ -36,6 +41,8 @@ def _bounties_api_url(
         params.append(("sort", selected_sort))
     if limit is not None:
         params.append(("limit", str(limit)))
+    if selected_availability != "all":
+        params.append(("availability", selected_availability))
     return f"/api/v1/bounties?{urlencode(params)}" if params else "/api/v1/bounties"
 
 
@@ -45,10 +52,12 @@ def public_bounties_context(
     q: str | None,
     sort: str | None = None,
     limit: int | None = None,
+    availability: str | None = None,
 ) -> dict[str, Any]:
     selected_status = status.strip().lower() if status is not None else None
     query_text = q.strip() if q is not None else ""
     selected_sort = normalize_bounty_sort(sort)
+    selected_availability = normalize_bounty_availability_filter(availability)
     limit_options: tuple[int, ...] = (10, 25, 50, 100, 200)
     if limit is not None and limit not in limit_options:
         limit_options = tuple(sorted((*limit_options, limit)))
@@ -60,8 +69,11 @@ def public_bounties_context(
         "selected_sort": selected_sort,
         "sort_options": BOUNTY_SORT_LABELS,
         "selected_limit": limit,
+        "selected_availability": selected_availability,
         "limit_options": limit_options,
-        "api_results_url": _bounties_api_url(selected_status, query_text, selected_sort, limit),
+        "api_results_url": _bounties_api_url(
+            selected_status, query_text, selected_sort, limit, selected_availability
+        ),
     }
 
 
@@ -130,7 +142,7 @@ def register_public_routes(
     db_url: str,
     templates: Jinja2Templates,
     list_bounties_by_status: Callable[
-        [str | None, str | None, str | None, int | None], list[dict[str, Any]]
+        [str | None, str | None, str | None, int | None, str | None], list[dict[str, Any]]
     ],
     api_bounty: Callable[[int], dict[str, Any]],
     api_ledger: Callable[[], list[dict[str, Any]]],
@@ -144,12 +156,13 @@ def register_public_routes(
         q: str | None = Query(None),
         sort: str | None = Query(None),
         limit: int | None = Query(None, ge=1, le=200),
+        availability: str | None = Query(None),
     ) -> HTMLResponse:
-        bounties = list_bounties_by_status(status, q, sort, limit)
+        bounties = list_bounties_by_status(status, q, sort, limit, availability)
         return templates.TemplateResponse(
             request,
             "bounties.html",
-            public_bounties_context(bounties, status, q, sort, limit),
+            public_bounties_context(bounties, status, q, sort, limit, availability),
         )
 
     @app.get("/bounties/{bounty_id}", response_class=HTMLResponse)

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -19,6 +19,11 @@
     <option value="{{ limit_option }}"{% if selected_limit == limit_option %} selected{% endif %}>{{ limit_option }}</option>
     {% endfor %}
   </select>
+  <label for="bounty-availability">Availability</label>
+  <select id="bounty-availability" name="availability">
+    <option value="all"{% if selected_availability == "all" %} selected{% endif %}>All visible rows</option>
+    <option value="effectively_open"{% if selected_availability == "effectively_open" %} selected{% endif %}>Effectively open</option>
+  </select>
   <button type="submit">Search</button>
   {% if query_text %}<a href="/bounties{% if selected_status or selected_sort != "newest" or selected_limit %}?{% if selected_status %}status={{ selected_status }}{% endif %}{% if selected_status and (selected_sort != "newest" or selected_limit) %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% if selected_sort != "newest" and selected_limit %}&{% endif %}{% if selected_limit %}limit={{ selected_limit }}{% endif %}{% endif %}">Clear search</a>{% endif %}
 </form>

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -25,13 +25,13 @@
     <option value="effectively_open"{% if selected_availability == "effectively_open" %} selected{% endif %}>Effectively open</option>
   </select>
   <button type="submit">Search</button>
-  {% if query_text %}<a href="/bounties{% if selected_status or selected_sort != "newest" or selected_limit %}?{% if selected_status %}status={{ selected_status }}{% endif %}{% if selected_status and (selected_sort != "newest" or selected_limit) %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% if selected_sort != "newest" and selected_limit %}&{% endif %}{% if selected_limit %}limit={{ selected_limit }}{% endif %}{% endif %}">Clear search</a>{% endif %}
+  {% if query_text %}<a href="/bounties{% if selected_status or selected_sort != "newest" or selected_limit or selected_availability != "all" %}?{% if selected_status %}status={{ selected_status }}{% endif %}{% if selected_status and (selected_sort != "newest" or selected_limit or selected_availability != "all") %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% if selected_sort != "newest" and (selected_limit or selected_availability != "all") %}&{% endif %}{% if selected_limit %}limit={{ selected_limit }}{% endif %}{% if selected_limit and selected_availability != "all" %}&{% endif %}{% if selected_availability != "all" %}availability={{ selected_availability }}{% endif %}{% endif %}">Clear search</a>{% endif %}
 </form>
 <nav aria-label="Bounty status filters">
-  <a href="/bounties{% if query_text or selected_sort != "newest" or selected_limit %}?{% if query_text %}q={{ query_text | urlencode }}{% endif %}{% if query_text and (selected_sort != "newest" or selected_limit) %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% if selected_sort != "newest" and selected_limit %}&{% endif %}{% if selected_limit %}limit={{ selected_limit }}{% endif %}{% endif %}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
-  <a href="/bounties?status=open{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
-  <a href="/bounties?status=paid{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
-  <a href="/bounties?status=closed{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
+  <a href="/bounties{% if query_text or selected_sort != "newest" or selected_limit or selected_availability != "all" %}?{% if query_text %}q={{ query_text | urlencode }}{% endif %}{% if query_text and (selected_sort != "newest" or selected_limit or selected_availability != "all") %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% if selected_sort != "newest" and (selected_limit or selected_availability != "all") %}&{% endif %}{% if selected_limit %}limit={{ selected_limit }}{% endif %}{% if selected_limit and selected_availability != "all" %}&{% endif %}{% if selected_availability != "all" %}availability={{ selected_availability }}{% endif %}{% endif %}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
+  <a href="/bounties?status=open{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}{% if selected_availability != "all" %}&availability={{ selected_availability }}{% endif %}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
+  <a href="/bounties?status=paid{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}{% if selected_availability != "all" %}&availability={{ selected_availability }}{% endif %}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
+  <a href="/bounties?status=closed{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}{% if selected_availability != "all" %}&availability={{ selected_availability }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
 </nav>
 {% if query_text %}<p>Showing matches for “{{ query_text }}”.</p>{% endif %}
 <section class="bounty-list-summary" aria-label="Bounty list summary">
@@ -85,7 +85,7 @@
     <p>{{ bounty.acceptance }}</p>
   </article>
   {% else %}
-  {% if query_text or selected_status %}
+  {% if query_text or selected_status or selected_availability != "all" %}
   <p>No bounties match these filters.</p>
   <p><a href="/bounties">Clear filters</a></p>
   {% else %}

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -210,6 +210,10 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_bounties","arguments":{}}}'
 ```
 
+Use `{"availability":"effectively_open"}` with `list_bounties` when you only want
+raw-open bounties that still have positive effective award capacity after
+pending payout or close proposals are considered.
+
 Inspect active attempt reservations for a bounty before opening overlapping
 work:
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -66,9 +66,13 @@ by per-award reward, `available` sorts by the remaining MRWK pool, and `awards`
 sorts by remaining award slots. Use `limit` from `1` to `200` to cap returned
 rows after filtering and sorting.
 
-Use `/api/v1/bounties/summary` with the same optional `status`, `q`, `sort`, and
-`limit` filters when an agent only needs capacity totals instead of full bounty
-rows:
+Use `availability=effectively_open` when discovery should hide raw-open rows
+whose remaining awards are fully covered by pending payout or close proposals.
+The default `availability=all` keeps the existing raw list behavior.
+
+Use `/api/v1/bounties/summary` with the same optional `status`, `q`, `sort`,
+`limit`, and `availability` filters when an agent only needs capacity totals
+instead of full bounty rows:
 
 ```json
 {
@@ -574,6 +578,9 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_bounties","arguments":{}}}'
 ```
+
+Pass `{"availability":"effectively_open"}` to `list_bounties` when an agent only
+wants bounty rows with positive effective award capacity.
 
 Call `get_bounty` with the internal bounty `id` returned by `list_bounties`,
 not the GitHub issue number:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -10,6 +10,7 @@ from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
 from app.models import BountyAttempt, Proof
+from app.treasury import propose_treasury_action
 
 
 def test_health_status_and_bounty_api(sqlite_url: str) -> None:
@@ -194,7 +195,10 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
 
     tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()
     assert tools["result"]["tools"][0]["name"] == "list_bounties"
-    assert "status, q, sort, and limit filters" in tools["result"]["tools"][0]["description"]
+    assert (
+        "status, q, sort, limit, and availability filters"
+        in tools["result"]["tools"][0]["description"]
+    )
     submit_tool = next(
         tool for tool in tools["result"]["tools"] if tool["name"] == "submit_work_proof"
     )
@@ -529,6 +533,58 @@ def test_mcp_list_bounties_honors_sort_argument(sqlite_url: str) -> None:
     assert [item["id"] for item in limited_payload] == [large_bounty.id]
 
 
+def test_mcp_list_bounties_filters_effective_availability(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        open_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=303,
+            issue_url="https://github.com/ramimbo/mergework/issues/303",
+            title="MCP visible open bounty",
+            reward_mrwk="100",
+            acceptance="This row should remain visible.",
+        )
+        full_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=304,
+            issue_url="https://github.com/ramimbo/mergework/issues/304",
+            title="MCP raw-open full bounty",
+            reward_mrwk="100",
+            acceptance="This row should be hidden by effective availability.",
+        )
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": full_bounty.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/304",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounties",
+                "arguments": {"availability": "effectively_open"},
+            },
+        },
+    ).json()
+
+    payload = json.loads(result["result"]["content"][0]["text"])
+    assert [item["id"] for item in payload] == [open_bounty.id]
+
+
 @pytest.mark.parametrize(
     ("arguments", "request_id"),
     [
@@ -538,6 +594,7 @@ def test_mcp_list_bounties_honors_sort_argument(sqlite_url: str) -> None:
         ({"limit": 0}, 34),
         ({"limit": 101}, 35),
         ({"sort": "invalid"}, 36),
+        ({"availability": "maybe"}, 37),
     ],
 )
 def test_mcp_list_bounties_rejects_invalid_filters(

--- a/tests/test_bounty_api.py
+++ b/tests/test_bounty_api.py
@@ -40,6 +40,16 @@ class TestBountyListRoutes:
         assert resp.status_code == 400
         assert resp.json()["detail"] == "sort must not contain control characters"
 
+    def test_list_bounties_rejects_invalid_availability_filter(self, client):
+        resp = client.get("/api/v1/bounties?availability=maybe")
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "availability must be one of: all, effectively_open"
+
+    def test_list_bounties_rejects_c1_control_availability_before_normalizing(self, client):
+        resp = client.get("/api/v1/bounties?availability=%C2%85effectively_open")
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "availability must not contain control characters"
+
     def test_list_bounties_with_query(self, client):
         resp = client.get("/api/v1/bounties?q=test")
         assert resp.status_code == 200

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -461,6 +461,85 @@ def test_bounties_page_and_api_sort_public_rows(sqlite_url: str) -> None:
     assert invalid_sort.json()["detail"] == "sort must be one of: newest, reward, available, awards"
 
 
+def test_bounties_page_api_and_summary_filter_effectively_open_rows(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        effectively_open = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=80,
+            issue_url="https://github.com/ramimbo/mergework/issues/80",
+            title="Fresh open bounty",
+            reward_mrwk="100",
+            acceptance="This bounty has no pending payout proposals.",
+        )
+        partially_open = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=81,
+            issue_url="https://github.com/ramimbo/mergework/issues/81",
+            title="Partially open bounty",
+            reward_mrwk="50",
+            max_awards=2,
+            acceptance="This bounty still has one effective award after a pending payout.",
+        )
+        effectively_full = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=82,
+            issue_url="https://github.com/ramimbo/mergework/issues/82",
+            title="Effectively full bounty",
+            reward_mrwk="75",
+            acceptance="This bounty is raw-open but covered by a pending payout.",
+        )
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": partially_open.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/81",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": effectively_full.id,
+                "to_account": "github:bob",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/82",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    default_rows = client.get("/api/v1/bounties?status=open")
+    assert default_rows.status_code == 200
+    assert [row["issue_number"] for row in default_rows.json()] == [82, 81, 80]
+
+    filtered_rows = client.get("/api/v1/bounties?status=open&availability=effectively_open")
+    assert filtered_rows.status_code == 200
+    assert [row["issue_number"] for row in filtered_rows.json()] == [81, 80]
+
+    summary = client.get("/api/v1/bounties/summary?status=open&availability=effectively_open")
+    assert summary.status_code == 200
+    assert summary.json()["bounties_shown"] == 2
+    assert summary.json()["open_awards"] == 3
+    assert summary.json()["effective_open_awards"] == 2
+
+    page = client.get("/bounties?status=open&availability=effectively_open")
+    assert page.status_code == 200
+    assert effectively_open.title in page.text
+    assert partially_open.title in page.text
+    assert effectively_full.title not in page.text
+    assert 'href="/api/v1/bounties?status=open&amp;availability=effectively_open">' in page.text
+
+
 def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -539,6 +539,22 @@ def test_bounties_page_api_and_summary_filter_effectively_open_rows(sqlite_url: 
     assert effectively_full.title not in page.text
     assert 'href="/api/v1/bounties?status=open&amp;availability=effectively_open">' in page.text
 
+    filtered_search_page = client.get("/bounties?status=open&q=Fresh&availability=effectively_open")
+    assert filtered_search_page.status_code == 200
+    assert (
+        'href="/bounties?status=open&availability=effectively_open">Clear search</a>'
+        in filtered_search_page.text
+    )
+    assert 'href="/bounties?q=Fresh&availability=effectively_open"' in filtered_search_page.text
+    assert (
+        'href="/bounties?status=paid&q=Fresh&availability=effectively_open"'
+        in filtered_search_page.text
+    )
+
+    empty_effective_page = client.get("/bounties?availability=effectively_open&q=missing")
+    assert empty_effective_page.status_code == 200
+    assert "No bounties match these filters." in empty_effective_page.text
+
 
 def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     create_schema(sqlite_url)

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -231,7 +231,9 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert "Award counters can change" in examples
     assert "capacity totals" in examples
     assert "full bounty" in examples
-    assert "same optional `status`, `q`, `sort`, and" in examples
+    assert "same optional `status`, `q`, `sort`," in examples
+    assert "`limit`, and `availability` filters" in examples
+    assert "availability=effectively_open" in examples
     assert "Use `id` for the single-bounty API path" in examples
 
 

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -37,6 +37,7 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
             "awards": "Most award slots",
         },
         "selected_limit": None,
+        "selected_availability": "all",
         "limit_options": (10, 25, 50, 100, 200),
         "api_results_url": "/api/v1/bounties?status=open&q=proof&sort=reward",
     }


### PR DESCRIPTION
Bounty #647
Source issue: #683

## Summary

This PR adds an additive effective-availability filter for bounty discovery so clients can keep the existing raw `status=open` behavior or explicitly ask for rows that still have positive effective award capacity.

- Adds shared `availability` normalization/filtering with `all` and `effectively_open` modes.
- Supports `availability=effectively_open` on `/api/v1/bounties` and `/api/v1/bounties/summary`.
- Carries the same selector through the public `/bounties` page and JSON results link.
- Supports the selector in MCP `list_bounties`.
- Documents the filter in API examples and the agent guide.

## Verification

- `uv run --extra dev python -m pytest tests/test_bounty_api.py tests/test_bounty_pages.py tests/test_api_mcp.py tests/test_docs_public_urls.py -q` -> 150 passed, 1 existing Starlette/httpx deprecation warning
- `uv run --extra dev python -m pytest -q` -> 565 passed, 1 existing Starlette/httpx deprecation warning
- `uv run --extra dev ruff format --check app/bounty_availability.py app/bounty_api.py app/public_routes.py app/mcp_tools.py app/mcp.py tests/test_bounty_api.py tests/test_bounty_pages.py tests/test_api_mcp.py tests/test_docs_public_urls.py` -> 9 files already formatted
- `uv run --extra dev ruff check app/bounty_availability.py app/bounty_api.py app/public_routes.py app/mcp_tools.py app/mcp.py tests/test_bounty_api.py tests/test_bounty_pages.py tests/test_api_mcp.py tests/test_docs_public_urls.py` -> All checks passed
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> passed

## Duplicate Check

- `gh pr list --repo ramimbo/mergework --state all --search "683"` returned no PRs.
- `https://api.mrwk.ltclab.site/api/v1/bounties/95/attempts` returned no active attempts.
- Related open PRs cover source issues #676, #677, #678, #681, #682, #687, and #688; this PR is limited to #683 discovery filtering.

## Out of Scope

- No ledger status changes, payout execution, proof generation, treasury mutation, wallet behavior, balances, reserves, bridge, exchange, cash-out, price, or bounty acceptance behavior changes.
- No change to default raw `status=open` listing behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Availability" filter (All vs. Effectively open) to bounty listings across APIs, public pages, and tooling; preserved filter in links/pagination and applied to summaries and MCP queries.

* **Bug Fixes**
  * Validates availability input (rejects control characters/invalid values) and returns proper error responses.

* **Documentation**
  * Updated API examples and agent guide to document the availability filter.

* **Tests**
  * Added/updated tests covering filtering, validation, UI behavior, and summary counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->