### PR TITLE
Add proposed-work queue fallback report

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -280,6 +280,19 @@ idea into a live bounty or #647-style focused implementation source:
 python scripts/proposed_work_queue.py --repo ramimbo/mergework --format markdown
 ```
 
+Use text for a quick terminal summary or JSON for scripts:
+
+```bash
+python scripts/proposed_work_queue.py --repo ramimbo/mergework --format text
+python scripts/proposed_work_queue.py --repo ramimbo/mergework --format json
+```
+
+For offline review using saved fixture data:
+
+```bash
+python scripts/proposed_work_queue.py --input proposed-work.json --format markdown
+```
+
 The report is read-only. It includes issues with the `proposed-work` label and
 also unlabeled issues whose title starts with `Proposed work:` and whose body
 contains the expected proposed-work sections. This fallback matters for CLI or

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -271,6 +271,21 @@ post comments. It reports missing bounty references, closed or exhausted bounty
 references, dirty or unknown merge state, `mrwk:needs-info`, and likely duplicate
 PR scope within the same bounty issue.
 
+### Proposed-Work Queue
+
+Use the proposed-work queue report when reviewing issue intake before turning an
+idea into a live bounty or #647-style focused implementation source:
+
+```bash
+python scripts/proposed_work_queue.py --repo ramimbo/mergework --format markdown
+```
+
+The report is read-only. It includes issues with the `proposed-work` label and
+also unlabeled issues whose title starts with `Proposed work:` and whose body
+contains the expected proposed-work sections. This fallback matters for CLI or
+API submissions from contributors who cannot attach labels. It does not label
+issues, create bounties, post comments, accept work, or trigger payouts.
+
 ### Claim Inventory
 
 Use the claim-inventory report when a busy bounty round needs a public,

--- a/scripts/proposed_work_queue.py
+++ b/scripts/proposed_work_queue.py
@@ -219,7 +219,7 @@ def _run_gh_json(args: list[str]) -> Any:
         if method not in READ_ONLY_API_METHODS:
             raise RuntimeError(f"refusing non-read-only gh api command: {' '.join(args)}")
     else:
-        raise RuntimeError(f"refusing non-read-only gh issue command: {' '.join(args)}")
+        raise RuntimeError(f"refusing unsupported gh command: {' '.join(args)}")
     try:
         completed = subprocess.run(
             args,
@@ -286,7 +286,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--format", choices=["json", "markdown", "text"], default="text")
     args = parser.parse_args(argv)
 
-    data = _load_input(args.input) if args.input else load_live_queue(args.repo)
+    data = _load_input(args.input) if args.input is not None else load_live_queue(args.repo)
     report = analyze_queue(data)
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/scripts/proposed_work_queue.py
+++ b/scripts/proposed_work_queue.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from typing import Any
+
+PROPOSED_WORK_LABEL = "proposed-work"
+GH_TIMEOUT_SECONDS = 30
+GH_ISSUE_SAFETY_CAP = 201
+PROPOSED_WORK_TITLE_RE = re.compile(r"^\s*proposed\s+work\s*:", re.IGNORECASE)
+
+REQUIRED_SECTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("problem", ("problem",)),
+    ("evidence", ("evidence",)),
+    ("proposed_work", ("proposed work",)),
+    ("expected_value", ("expected value",)),
+    ("acceptance_criteria", ("possible acceptance criteria", "acceptance criteria")),
+    ("tests", ("evidence or tests required", "tests required")),
+    ("duplicate_search", ("duplicate search",)),
+    ("out_of_scope", ("out of scope",)),
+)
+
+
+@dataclass(frozen=True)
+class ProposedWorkRow:
+    issue_number: int
+    title: str
+    url: str | None
+    author: str
+    detection: str
+    missing_sections: list[str]
+    warnings: list[str]
+
+
+def _label_names(raw: dict[str, Any]) -> list[str]:
+    labels = raw.get("labels", [])
+    names: list[str] = []
+    if not isinstance(labels, list):
+        return names
+    for label in labels:
+        if isinstance(label, str):
+            names.append(label)
+        elif isinstance(label, dict) and isinstance(label.get("name"), str):
+            names.append(label["name"])
+    return names
+
+
+def _author_login(raw: Any) -> str:
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, dict):
+        login = raw.get("login")
+        if isinstance(login, str) and login:
+            return login
+    return "unknown"
+
+
+def _normalize_heading(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+
+
+def _headings(body: str) -> set[str]:
+    headings: set[str] = set()
+    for match in re.finditer(r"^\s{0,3}#{1,6}\s+(.+?)\s*$", body or "", re.MULTILINE):
+        headings.add(_normalize_heading(match.group(1)))
+    return headings
+
+
+def _missing_sections(body: str) -> list[str]:
+    headings = _headings(body)
+    missing: list[str] = []
+    for key, aliases in REQUIRED_SECTION_GROUPS:
+        if not any(alias in headings for alias in aliases):
+            missing.append(key)
+    return missing
+
+
+def _is_labeled_proposed_work(issue: dict[str, Any]) -> bool:
+    return any(label.lower() == PROPOSED_WORK_LABEL for label in _label_names(issue))
+
+
+def _has_proposed_work_title(issue: dict[str, Any]) -> bool:
+    return bool(PROPOSED_WORK_TITLE_RE.search(str(issue.get("title") or "")))
+
+
+def _detect_issue(issue: dict[str, Any]) -> ProposedWorkRow | None:
+    number = issue.get("number")
+    if not isinstance(number, int):
+        return None
+    title = str(issue.get("title") or "")
+    body = str(issue.get("body") or "")
+    labeled = _is_labeled_proposed_work(issue)
+    title_matches = _has_proposed_work_title(issue)
+    missing_sections = _missing_sections(body)
+    body_matches_template = title_matches and not missing_sections
+    if not labeled and not body_matches_template:
+        return None
+
+    warnings: list[str] = []
+    if not labeled:
+        warnings.append("missing_proposed_work_label")
+    if missing_sections:
+        warnings.append("missing_required_sections")
+
+    if labeled and body_matches_template:
+        detection = "label_and_template"
+    elif labeled:
+        detection = "label"
+    else:
+        detection = "title_body_fallback"
+
+    return ProposedWorkRow(
+        issue_number=number,
+        title=title,
+        url=issue.get("url") if isinstance(issue.get("url"), str) else None,
+        author=_author_login(issue.get("author")),
+        detection=detection,
+        missing_sections=missing_sections,
+        warnings=warnings,
+    )
+
+
+def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
+    rows: list[ProposedWorkRow] = []
+    ignored_proposed_titles = 0
+    issues_seen = 0
+    for issue in data.get("issues", []):
+        if not isinstance(issue, dict):
+            continue
+        issues_seen += 1
+        row = _detect_issue(issue)
+        if row is None:
+            if _has_proposed_work_title(issue):
+                ignored_proposed_titles += 1
+            continue
+        rows.append(row)
+
+    rows.sort(key=lambda item: item.issue_number)
+    fallback_rows = [row for row in rows if row.detection == "title_body_fallback"]
+    missing_section_rows = [row for row in rows if row.missing_sections]
+    return {
+        "summary": {
+            "issues_seen": issues_seen,
+            "proposed_work": len(rows),
+            "labeled": len([row for row in rows if "label" in row.detection]),
+            "title_body_fallback": len(fallback_rows),
+            "missing_label": len(fallback_rows),
+            "missing_required_sections": len(missing_section_rows),
+            "ignored_proposed_titles": ignored_proposed_titles,
+        },
+        "required_sections": [key for key, _aliases in REQUIRED_SECTION_GROUPS],
+        "rows": [asdict(row) for row in rows],
+    }
+
+
+def _single_line(value: Any) -> str:
+    return " ".join(str(value or "").split())
+
+
+def format_text_report(report: dict[str, Any]) -> str:
+    lines = ["Proposed-work queue summary"]
+    for key, value in report["summary"].items():
+        lines.append(f"- {key.replace('_', ' ')}: {value}")
+    if not report["rows"]:
+        lines.append("")
+        lines.append("No proposed-work intake rows found.")
+        return "\n".join(lines)
+    lines.append("")
+    lines.append("Rows")
+    for row in report["rows"]:
+        warnings = ", ".join(row["warnings"]) if row["warnings"] else "none"
+        lines.append(
+            f"- Issue #{row['issue_number']}: {_single_line(row['title'])} "
+            f"({row['detection']}; warnings: {warnings})"
+        )
+    return "\n".join(lines)
+
+
+def format_markdown_report(report: dict[str, Any]) -> str:
+    lines = ["## Proposed-Work Queue", ""]
+    for key, value in report["summary"].items():
+        lines.append(f"- **{key.replace('_', ' ')}**: {value}")
+    lines.append("")
+    lines.append("| Issue | Detection | Author | Warnings | Missing sections |")
+    lines.append("| --- | --- | --- | --- | --- |")
+    for row in report["rows"]:
+        issue = f"#{row['issue_number']}"
+        if row.get("url"):
+            issue = f"[{issue}]({row['url']})"
+        warnings = ", ".join(row["warnings"]) if row["warnings"] else ""
+        missing = ", ".join(row["missing_sections"]) if row["missing_sections"] else ""
+        lines.append(
+            f"| {issue} | `{row['detection']}` | {row['author']} | {warnings} | {missing} |"
+        )
+    return "\n".join(lines)
+
+
+def _run_gh_json(args: list[str]) -> Any:
+    if args[:2] == ["gh", "api"]:
+        for flag in ("--method", "-X"):
+            if flag not in args:
+                continue
+            index = args.index(flag)
+            if index + 1 >= len(args) or args[index + 1].upper() not in {"GET", "HEAD"}:
+                raise RuntimeError(f"refusing non-read-only gh api command: {' '.join(args)}")
+    if any(arg == "issue" for arg in args) and any(
+        arg in {"comment", "edit", "close", "reopen"} for arg in args
+    ):
+        raise RuntimeError(f"refusing non-read-only gh issue command: {' '.join(args)}")
+    try:
+        completed = subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"gh command failed with exit {exc.returncode}: {' '.join(args)}\n{exc.stderr}"
+        ) from exc
+    return json.loads(completed.stdout)
+
+
+def load_live_queue(repo: str) -> dict[str, Any]:
+    issues = _run_gh_json(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(GH_ISSUE_SAFETY_CAP),
+            "--json",
+            "number,title,url,body,labels,author",
+        ]
+    )
+    if len(issues) >= GH_ISSUE_SAFETY_CAP:
+        raise RuntimeError(
+            f"gh issue list reached the {GH_ISSUE_SAFETY_CAP} item safety cap; "
+            "use an API-paginated collector before trusting this live report"
+        )
+    return {"issues": issues}
+
+
+def _load_input(path: str) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("proposed-work queue input must be a JSON object")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Summarize MergeWork proposed-work intake.")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--input", help="Read queue data from a JSON fixture file.")
+    source.add_argument(
+        "--repo",
+        help="Collect live proposed-work data with gh, for example ramimbo/mergework.",
+    )
+    parser.add_argument("--format", choices=["json", "markdown", "text"], default="text")
+    args = parser.parse_args(argv)
+
+    data = _load_input(args.input) if args.input else load_live_queue(args.repo)
+    report = analyze_queue(data)
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif args.format == "markdown":
+        print(format_markdown_report(report))
+    else:
+        print(format_text_report(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/proposed_work_queue.py
+++ b/scripts/proposed_work_queue.py
@@ -12,6 +12,8 @@ PROPOSED_WORK_LABEL = "proposed-work"
 GH_TIMEOUT_SECONDS = 30
 GH_ISSUE_SAFETY_CAP = 201
 PROPOSED_WORK_TITLE_RE = re.compile(r"^\s*proposed\s+work\s*:", re.IGNORECASE)
+READ_ONLY_ISSUE_COMMANDS = {"list", "view"}
+READ_ONLY_API_METHODS = {"GET", "HEAD"}
 
 REQUIRED_SECTION_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("problem", ("problem",)),
@@ -200,16 +202,23 @@ def format_markdown_report(report: dict[str, Any]) -> str:
 
 
 def _run_gh_json(args: list[str]) -> Any:
-    if args[:2] == ["gh", "api"]:
+    if len(args) < 2 or args[0] != "gh":
+        raise RuntimeError(f"refusing non-gh command: {' '.join(args)}")
+    if args[1] == "issue":
+        command = args[2] if len(args) > 2 else ""
+        if command not in READ_ONLY_ISSUE_COMMANDS:
+            raise RuntimeError(f"refusing non-read-only gh issue command: {' '.join(args)}")
+    elif args[1] == "api":
+        method = None
         for flag in ("--method", "-X"):
             if flag not in args:
                 continue
             index = args.index(flag)
-            if index + 1 >= len(args) or args[index + 1].upper() not in {"GET", "HEAD"}:
-                raise RuntimeError(f"refusing non-read-only gh api command: {' '.join(args)}")
-    if any(arg == "issue" for arg in args) and any(
-        arg in {"comment", "edit", "close", "reopen"} for arg in args
-    ):
+            method = args[index + 1].upper() if index + 1 < len(args) else ""
+            break
+        if method not in READ_ONLY_API_METHODS:
+            raise RuntimeError(f"refusing non-read-only gh api command: {' '.join(args)}")
+    else:
         raise RuntimeError(f"refusing non-read-only gh issue command: {' '.join(args)}")
     try:
         completed = subprocess.run(

--- a/scripts/proposed_work_queue.py
+++ b/scripts/proposed_work_queue.py
@@ -230,6 +230,10 @@ def _run_gh_json(args: list[str]) -> Any:
             errors="replace",
             timeout=GH_TIMEOUT_SECONDS,
         )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "gh executable not found; install GitHub CLI to use --repo mode"
+        ) from exc
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s") from exc
     except subprocess.CalledProcessError as exc:

--- a/tests/test_proposed_work_queue.py
+++ b/tests/test_proposed_work_queue.py
@@ -191,6 +191,32 @@ def test_proposed_work_queue_rejects_non_read_only_gh_command() -> None:
         )
 
 
+def test_proposed_work_queue_allows_explicit_read_only_gh_api_methods(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=json.dumps({"ok": True}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(proposed_work_queue.subprocess, "run", fake_run)
+
+    assert proposed_work_queue._run_gh_json(
+        ["gh", "api", "repos/ramimbo/mergework/issues", "--method", "GET"]
+    ) == {"ok": True}
+    assert proposed_work_queue._run_gh_json(
+        ["gh", "api", "repos/ramimbo/mergework/issues", "--method", "HEAD"]
+    ) == {"ok": True}
+    assert calls == [
+        ["gh", "api", "repos/ramimbo/mergework/issues", "--method", "GET"],
+        ["gh", "api", "repos/ramimbo/mergework/issues", "--method", "HEAD"],
+    ]
+
+
 def test_proposed_work_queue_rejects_when_safety_cap_reached(monkeypatch) -> None:
     def fake_run(args, **kwargs):
         issues = [

--- a/tests/test_proposed_work_queue.py
+++ b/tests/test_proposed_work_queue.py
@@ -189,6 +189,8 @@ def test_proposed_work_queue_rejects_non_read_only_gh_command() -> None:
         proposed_work_queue._run_gh_json(
             ["gh", "api", "repos/ramimbo/mergework/issues", "--method", "POST"]
         )
+    with pytest.raises(RuntimeError, match="refusing unsupported gh command"):
+        proposed_work_queue._run_gh_json(["gh", "pr", "list", "--repo", "ramimbo/mergework"])
 
 
 def test_proposed_work_queue_wraps_missing_gh_binary(monkeypatch) -> None:
@@ -269,3 +271,20 @@ def test_proposed_work_queue_main_reads_fixture(tmp_path, capsys) -> None:
     assert exit_code == 0
     output = json.loads(capsys.readouterr().out)
     assert output["summary"]["title_body_fallback"] == 1
+
+
+def test_proposed_work_queue_main_treats_empty_input_as_fixture_path(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_load_input(path: str) -> dict[str, object]:
+        calls.append(path)
+        return {"issues": []}
+
+    def fail_live_queue(repo: str) -> dict[str, object]:
+        raise AssertionError(f"unexpected live queue load for {repo}")
+
+    monkeypatch.setattr(proposed_work_queue, "_load_input", fake_load_input)
+    monkeypatch.setattr(proposed_work_queue, "load_live_queue", fail_live_queue)
+
+    assert main(["--input", ""]) == 0
+    assert calls == [""]

--- a/tests/test_proposed_work_queue.py
+++ b/tests/test_proposed_work_queue.py
@@ -191,6 +191,16 @@ def test_proposed_work_queue_rejects_non_read_only_gh_command() -> None:
         )
 
 
+def test_proposed_work_queue_wraps_missing_gh_binary(monkeypatch) -> None:
+    def fake_run(args, **kwargs):
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr(proposed_work_queue.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="gh executable not found"):
+        proposed_work_queue.load_live_queue("ramimbo/mergework")
+
+
 def test_proposed_work_queue_allows_explicit_read_only_gh_api_methods(monkeypatch) -> None:
     calls: list[list[str]] = []
 

--- a/tests/test_proposed_work_queue.py
+++ b/tests/test_proposed_work_queue.py
@@ -179,6 +179,35 @@ def test_proposed_work_queue_live_loader_uses_read_only_issue_list(monkeypatch) 
 def test_proposed_work_queue_rejects_non_read_only_gh_command() -> None:
     with pytest.raises(RuntimeError, match="refusing non-read-only gh issue command"):
         proposed_work_queue._run_gh_json(["gh", "issue", "edit", "2"])
+    with pytest.raises(RuntimeError, match="refusing non-read-only gh issue command"):
+        proposed_work_queue._run_gh_json(["gh", "issue", "create", "--title", "bad"])
+    with pytest.raises(RuntimeError, match="refusing non-read-only gh api command"):
+        proposed_work_queue._run_gh_json(
+            ["gh", "api", "repos/ramimbo/mergework/issues", "-f", "x=y"]
+        )
+    with pytest.raises(RuntimeError, match="refusing non-read-only gh api command"):
+        proposed_work_queue._run_gh_json(
+            ["gh", "api", "repos/ramimbo/mergework/issues", "--method", "POST"]
+        )
+
+
+def test_proposed_work_queue_rejects_when_safety_cap_reached(monkeypatch) -> None:
+    def fake_run(args, **kwargs):
+        issues = [
+            {"number": number, "title": "x", "body": "", "labels": []}
+            for number in range(proposed_work_queue.GH_ISSUE_SAFETY_CAP)
+        ]
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout=json.dumps(issues),
+            stderr="",
+        )
+
+    monkeypatch.setattr(proposed_work_queue.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="issue list reached the 201 item safety cap"):
+        proposed_work_queue.load_live_queue("ramimbo/mergework")
 
 
 def test_proposed_work_queue_main_reads_fixture(tmp_path, capsys) -> None:

--- a/tests/test_proposed_work_queue.py
+++ b/tests/test_proposed_work_queue.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts import proposed_work_queue
+from scripts.proposed_work_queue import analyze_queue, format_markdown_report, main
+
+ROOT = Path(__file__).resolve().parents[1]
+
+COMPLETE_PROPOSED_WORK_BODY = """
+## Problem
+CLI-created proposed-work issues may not get labels.
+
+## Evidence
+GitHub rejects non-maintainer label edits.
+
+## Proposed work
+Detect template-shaped issues without relying only on labels.
+
+## Expected value
+Maintainers can triage the full queue.
+
+## Possible acceptance criteria
+Unlabeled complete issues appear in the report.
+
+## Evidence or tests required
+Fixture tests cover labeled and unlabeled issues.
+
+## Duplicate search
+No matching focused implementation exists.
+
+## Out of scope
+No label mutation or payment behavior.
+"""
+
+
+def test_proposed_work_queue_includes_unlabeled_template_issues() -> None:
+    report = analyze_queue(
+        {
+            "issues": [
+                {
+                    "number": 1,
+                    "title": "Idea: missing sections but labeled",
+                    "url": "https://github.com/ramimbo/mergework/issues/1",
+                    "body": "## Problem\nOnly one section.",
+                    "labels": [{"name": "proposed-work"}],
+                    "author": {"login": "maintainer"},
+                },
+                {
+                    "number": 2,
+                    "title": "Proposed work: handle unlabeled CLI intake",
+                    "url": "https://github.com/ramimbo/mergework/issues/2",
+                    "body": COMPLETE_PROPOSED_WORK_BODY,
+                    "labels": [],
+                    "author": {"login": "cli-user"},
+                },
+                {
+                    "number": 3,
+                    "title": "Proposed work: vague title only",
+                    "body": "Please do the thing.",
+                    "labels": [],
+                    "author": {"login": "idea-user"},
+                },
+                {
+                    "number": 4,
+                    "title": "Bug: unrelated issue",
+                    "body": COMPLETE_PROPOSED_WORK_BODY,
+                    "labels": [],
+                    "author": {"login": "bug-user"},
+                },
+            ]
+        }
+    )
+
+    assert report["summary"] == {
+        "issues_seen": 4,
+        "proposed_work": 2,
+        "labeled": 1,
+        "title_body_fallback": 1,
+        "missing_label": 1,
+        "missing_required_sections": 1,
+        "ignored_proposed_titles": 1,
+    }
+    rows = {row["issue_number"]: row for row in report["rows"]}
+    assert rows[1]["detection"] == "label"
+    assert "missing_required_sections" in rows[1]["warnings"]
+    assert rows[2]["detection"] == "title_body_fallback"
+    assert rows[2]["warnings"] == ["missing_proposed_work_label"]
+    assert rows[2]["missing_sections"] == []
+    assert 3 not in rows
+    assert 4 not in rows
+
+
+def test_proposed_work_queue_markdown_report_is_pasteable() -> None:
+    report = analyze_queue(
+        {
+            "issues": [
+                {
+                    "number": 2,
+                    "title": "Proposed work: handle unlabeled CLI intake",
+                    "url": "https://github.com/ramimbo/mergework/issues/2",
+                    "body": COMPLETE_PROPOSED_WORK_BODY,
+                    "labels": [],
+                    "author": {"login": "cli-user"},
+                }
+            ]
+        }
+    )
+
+    markdown = format_markdown_report(report)
+
+    assert markdown.startswith("## Proposed-Work Queue")
+    assert "- **title body fallback**: 1" in markdown
+    assert "[#2](https://github.com/ramimbo/mergework/issues/2)" in markdown
+    assert "`title_body_fallback`" in markdown
+    assert "missing_proposed_work_label" in markdown
+
+
+def test_proposed_work_queue_script_entrypoint_loads_shared_parser() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/proposed_work_queue.py", "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout
+
+
+def test_proposed_work_queue_live_loader_uses_read_only_issue_list(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        stdout = json.dumps(
+            [
+                {
+                    "number": 2,
+                    "title": "Proposed work: handle unlabeled CLI intake",
+                    "url": "https://github.com/ramimbo/mergework/issues/2",
+                    "body": COMPLETE_PROPOSED_WORK_BODY,
+                    "labels": [],
+                    "author": {"login": "cli-user"},
+                }
+            ]
+        )
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(proposed_work_queue.subprocess, "run", fake_run)
+
+    data = proposed_work_queue.load_live_queue("ramimbo/mergework")
+    report = analyze_queue(data)
+
+    assert report["summary"]["title_body_fallback"] == 1
+    assert calls == [
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            "ramimbo/mergework",
+            "--state",
+            "open",
+            "--limit",
+            "201",
+            "--json",
+            "number,title,url,body,labels,author",
+        ]
+    ]
+
+
+def test_proposed_work_queue_rejects_non_read_only_gh_command() -> None:
+    with pytest.raises(RuntimeError, match="refusing non-read-only gh issue command"):
+        proposed_work_queue._run_gh_json(["gh", "issue", "edit", "2"])
+
+
+def test_proposed_work_queue_main_reads_fixture(tmp_path, capsys) -> None:
+    fixture_path = tmp_path / "proposed-work.json"
+    fixture_path.write_text(
+        json.dumps(
+            {
+                "issues": [
+                    {
+                        "number": 2,
+                        "title": "Proposed work: handle unlabeled CLI intake",
+                        "body": COMPLETE_PROPOSED_WORK_BODY,
+                        "labels": [],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(["--input", str(fixture_path), "--format", "json"])
+
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["summary"]["title_body_fallback"] == 1


### PR DESCRIPTION
## Summary

Bounty #647
Source issue: #684

This PR adds a read-only proposed-work intake report so maintainer triage can include CLI/API-created proposed-work issues that did not receive the `proposed-work` label.

- Adds `scripts/proposed_work_queue.py` with JSON, text, and Markdown output.
- Includes labeled `proposed-work` issues and unlabeled issues whose title starts with `Proposed work:` and whose body contains the expected proposed-work sections.
- Flags missing labels and missing required sections without mutating GitHub issues.
- Uses a fail-closed `gh` read guard: only `gh issue list/view` are allowed, and `gh api` requires explicit GET/HEAD.
- Tests both read-only `gh api --method GET/HEAD` allowlist paths and mutating-command rejection paths.
- Fails fast when live issue collection hits the safety cap instead of silently trusting a truncated report.
- Documents Markdown/text/JSON output and offline `--input` fixture usage in `docs/admin-runbook.md`.

## Verification

- `PATH=/Users/a30706/miniconda3/envs/dollar-hunt-mergework/bin:$PATH python -m pytest tests/test_proposed_work_queue.py tests/test_docs_public_urls.py -q` -> 40 passed
- `PATH=/Users/a30706/miniconda3/envs/dollar-hunt-mergework/bin:$PATH python -m ruff check scripts/proposed_work_queue.py tests/test_proposed_work_queue.py` -> All checks passed
- `PATH=/Users/a30706/miniconda3/envs/dollar-hunt-mergework/bin:$PATH python -m ruff format --check scripts/proposed_work_queue.py tests/test_proposed_work_queue.py` -> 2 files already formatted
- `PATH=/Users/a30706/miniconda3/envs/dollar-hunt-mergework/bin:$PATH python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> passed
- Hosted GitHub check `Quality, readiness, docs, and image checks` passed on previous head `b97f4e9199c0ac9209f72cc038be3feae9d098f8`; current head `5f108a17466721f5d7a15cfc5e06be6d7ad5ab9f` is rerunning checks.
- Live read-only smoke on the earlier head: `python scripts/proposed_work_queue.py --repo ramimbo/mergework --format json` detected #718 as `title_body_fallback` with `missing_proposed_work_label`, while #680/#684 remained `label_and_template`.

## Review follow-up

Addressed CodeRabbit's actionable comments:

- documented text/JSON output and offline `--input` fixture mode;
- hardened `_run_gh_json()` so future changes cannot accidentally run mutating `gh issue` or implicit-POST `gh api -f/-F` commands;
- added positive allowlist coverage for explicit `gh api --method GET/HEAD`;
- added a safety-cap boundary test for live issue collection.

## Duplicate Check

- Open #647 PRs checked before submission; visible source issues covered #676/#677/#678/#681/#682/#683/#687/#688/#698, but not #684.
- #672 proposes a broader proposed-work intake report; #684 is the accepted narrower fallback for unlabeled CLI/API-created proposed-work intake.
- This PR implements the narrow #684 slice only.

## Out of Scope

- No GitHub label mutation, issue edits, comments, bounty creation, claim acceptance, treasury execution, payout proposals, proof generation, ledger, wallet, balance, bridge, exchange, cash-out, or price behavior changes.
- No private data, credentials, admin token, production mutation, or private deployment reads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a proposed-work intake reviewer that analyzes queues (fixture or live) and emits text, markdown, or JSON reports showing detected items, missing required sections, and summary metrics.

* **Documentation**
  * Added runbook guidance on using the proposed-work queue report and its read-only semantics.

* **Tests**
  * Added end-to-end and safety tests for detection, report formatting, live-loading safeguards, CLI help/smoke, and error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->