### PR TITLE
Filter treasury proposals by recipient

### DIFF
--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from sqlalchemy import select
 
+from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import LedgerError
 from app.models import TreasuryProposal
@@ -12,6 +13,7 @@ from app.path_params import SQLITE_INTEGER_MAX
 from app.treasury import (
     challenge_to_dict,
     create_treasury_challenge,
+    proposal_payload,
     proposal_to_dict,
     propose_treasury_action,
     treasury_status,
@@ -36,6 +38,31 @@ def _proposal_error(exc: LedgerError) -> HTTPException:
     return HTTPException(status_code=400, detail=detail)
 
 
+def _proposal_payload_matches(
+    proposal: TreasuryProposal,
+    *,
+    to_account: str | None,
+) -> bool:
+    if to_account is None:
+        return True
+    payload = proposal_payload(proposal)
+    return payload.get("to_account") == to_account
+
+
+def _clean_to_account_filter(to_account: str | None) -> str | None:
+    if to_account is None:
+        return None
+    if contains_control_character(to_account):
+        raise HTTPException(
+            status_code=400,
+            detail="to_account must not contain control characters",
+        )
+    clean_to_account = to_account.strip()
+    if not clean_to_account:
+        raise HTTPException(status_code=400, detail="to_account must not be blank")
+    return clean_to_account
+
+
 def register_treasury_routes(
     app: FastAPI,
     *,
@@ -49,12 +76,31 @@ def register_treasury_routes(
     @app.get("/api/v1/treasury/proposals")
     def api_treasury_proposals(
         limit: Annotated[int, Query(ge=1, le=200)] = 100,
+        status: Annotated[str | None, Query(max_length=32)] = None,
+        action: Annotated[str | None, Query(max_length=32)] = None,
+        to_account: Annotated[str | None, Query(max_length=128)] = None,
     ) -> list[dict[str, Any]]:
+        to_account_filter = _clean_to_account_filter(to_account)
         with session_scope(db_url) as session:
-            proposals = session.scalars(
-                select(TreasuryProposal).order_by(TreasuryProposal.id.desc()).limit(limit)
-            ).all()
-            return [proposal_to_dict(proposal) for proposal in proposals]
+            stmt = select(TreasuryProposal).order_by(TreasuryProposal.id.desc())
+            if status is not None:
+                stmt = stmt.where(TreasuryProposal.status == status)
+            if action is not None:
+                stmt = stmt.where(TreasuryProposal.action == action)
+            if to_account_filter is None:
+                stmt = stmt.limit(limit)
+
+            proposals: list[dict[str, Any]] = []
+            for proposal in session.scalars(stmt):
+                if not _proposal_payload_matches(
+                    proposal,
+                    to_account=to_account_filter,
+                ):
+                    continue
+                proposals.append(proposal_to_dict(proposal))
+                if len(proposals) >= limit:
+                    break
+            return proposals
 
     @app.get("/api/v1/treasury/status")
     def api_treasury_status() -> dict[str, Any]:

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -44,8 +44,12 @@ Public reads:
 ```bash
 curl -s https://api.mrwk.online/api/v1/treasury/status
 curl -s https://api.mrwk.online/api/v1/treasury/proposals
+curl -s "https://api.mrwk.online/api/v1/treasury/proposals?status=pending&action=pay_bounty&to_account=github%3Aalice"
 curl -s https://api.mrwk.online/api/v1/treasury/proposals/<proposal_id>
 ```
+
+Use the filtered proposal list to reconcile pending payouts for one recipient
+without mixing unrelated `pay_bounty` proposals from busy review rounds.
 
 Legacy-compatible admin API reads remain available at
 `https://api.mrwk.ltclab.site` for existing scripts, but new examples should use

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -79,8 +79,12 @@ Inspect treasury proposals:
 ```bash
 curl -s "$API_HOST/api/v1/treasury/status"
 curl -s "$API_HOST/api/v1/treasury/proposals"
+curl -s "$API_HOST/api/v1/treasury/proposals?status=pending&action=pay_bounty&to_account=github%3Aalice"
 curl -s "$API_HOST/api/v1/treasury/proposals/<proposal_id>"
 ```
+
+Use `to_account` with `status=pending` and `action=pay_bounty` when reconciling
+which delayed payout proposals target one GitHub account or MRWK wallet.
 
 Use `/api/v1/treasury/status` before proposing fresh bounty rounds. It reports
 the rolling 24-hour reserve cap, recent reserve usage, pending create-bounty

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -417,6 +417,83 @@ def test_treasury_proposals_list_honors_limit(
     assert too_large.status_code == 422
 
 
+def test_treasury_proposals_list_filters_by_recipient_before_limit(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _client(sqlite_url, monkeypatch)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=74,
+            issue_url="https://github.com/ramimbo/mergework/issues/74",
+            title="Recipient filter proposal",
+            reward_mrwk="5",
+            max_awards=2,
+            acceptance="Contributor comments with proof.",
+        )
+        bounty_id = bounty.id
+
+    alice = client.post(
+        f"/api/v1/bounties/{bounty_id}/pay",
+        headers=ADMIN_HEADERS,
+        json={
+            "to_account": "github:alice",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/7401",
+            "accepted_by": "maintainer",
+        },
+    )
+    bob = client.post(
+        f"/api/v1/bounties/{bounty_id}/pay",
+        headers=ADMIN_HEADERS,
+        json={
+            "to_account": "github:bob",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/7402",
+            "accepted_by": "maintainer",
+        },
+    )
+
+    filtered = client.get(
+        "/api/v1/treasury/proposals"
+        "?status=pending&action=pay_bounty&to_account=github%3Aalice&limit=1"
+    )
+    bob_filtered = client.get(
+        "/api/v1/treasury/proposals"
+        "?status=pending&action=pay_bounty&to_account=github%3Abob&limit=1"
+    )
+
+    assert alice.status_code == 200
+    assert bob.status_code == 200
+    assert filtered.status_code == 200
+    assert [proposal["id"] for proposal in filtered.json()] == [alice.json()["id"]]
+    assert filtered.json()[0]["payload"]["to_account"] == "github:alice"
+    assert bob_filtered.status_code == 200
+    assert [proposal["id"] for proposal in bob_filtered.json()] == [bob.json()["id"]]
+
+
+@pytest.mark.parametrize(
+    ("query", "detail"),
+    [
+        ("to_account=%20%20", "to_account must not be blank"),
+        (
+            "to_account=github%3Aalice%0Abad",
+            "to_account must not contain control characters",
+        ),
+    ],
+)
+def test_treasury_proposals_list_rejects_invalid_recipient_filter(
+    sqlite_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+    query: str,
+    detail: str,
+) -> None:
+    response = _client(sqlite_url, monkeypatch).get(f"/api/v1/treasury/proposals?{query}")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == detail
+
+
 def test_direct_proposal_creation_requires_admin_token(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Bounty #647

Source issue: https://github.com/ramimbo/mergework/issues/680

## Summary
- add `to_account` filtering to `GET /api/v1/treasury/proposals`
- keep `status` and `action` filters composable with the recipient filter
- apply `limit` after recipient payload filtering so older matching payouts are not hidden by newer unrelated proposals
- stream filtered candidates instead of materializing an unbounded `.all()` result when `to_account` is present
- reject blank or control-character `to_account` query values
- document the recipient-filtered treasury proposal lookup for agents/admins

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_treasury_proposals.py -k "recipient or treasury_proposals_list_honors_limit"`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_treasury_proposals.py`
- `python -m ruff check app/treasury_routes.py tests/test_treasury_proposals.py`
- `python -m ruff format app/treasury_routes.py tests/test_treasury_proposals.py`
- `python scripts/docs_smoke.py`
- `git diff --check`

## Notes
This is intentionally scoped to the recipient filter requested by the source issue. It does not expand treasury proposal mutation behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended the treasury proposals API with query filters for status, action, and to_account so recipients can list proposals targeting their account.
  * Added input validation to reject invalid recipient filter values and return a clear error.

* **Documentation**
  * Updated admin and agent guides with examples showing how to filter proposals by recipient to reconcile pending payouts.

* **Tests**
  * Added tests covering recipient filtering, limit behavior, and rejection of invalid recipient filter values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->