### PR TITLE
Require source context for proposed work

### DIFF
--- a/.github/ISSUE_TEMPLATE/proposed-work.yml
+++ b/.github/ISSUE_TEMPLATE/proposed-work.yml
@@ -10,6 +10,17 @@ body:
 
         Do not submit `/claim` for this issue unless maintainers later post a live reserved bounty comment and the public bounty page exists.
   - type: textarea
+    id: related_bounty_or_source
+    attributes:
+      label: Related bounty or source issue
+      description: Link the intake bounty, source issue, PR, discussion, API route, docs page, or observed workflow that prompted this proposal.
+      placeholder: |
+        Bounty #649
+        Source issue: #123
+        Route: GET /api/v1/bounties
+    validations:
+      required: true
+  - type: textarea
     id: problem
     attributes:
       label: Problem

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -41,6 +41,10 @@ suggest a tier to help maintainers size the work, but maintainers decide whether
 to reject, ask for more information, point to an existing live bounty, accept
 non-bounty work, or create a public treasury proposal.
 
+When opening a proposed work request, fill the related bounty or source issue
+field with the intake bounty, issue, PR, discussion, route, or docs page that
+prompted the proposal.
+
 Do not submit `/claim` for a proposed work request unless maintainers later make
 the issue live by executing the treasury proposal, adding `mrwk:bounty`, and
 posting the `Reserved on MergeWork` comment with the public bounty URL.

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -266,11 +266,17 @@ def main() -> int:
             'labels: ["proposed-work"]',
             "not a live mrwk bounty",
             "do not submit `/claim`",
+            "id: related_bounty_or_source",
+            "related bounty or source issue",
+            "link the intake bounty, source issue, pr, discussion, api route, docs page",
             "id: duplicate_search",
         ]:
             if phrase not in proposed_template:
                 print(f"proposed work issue template missing required phrase: {phrase}")
                 ok = False
+        if not _template_field_is_required(proposed_template, "related_bounty_or_source"):
+            print("proposed work issue template related_bounty_or_source field must be required")
+            ok = False
         if "mrwk:bounty" in proposed_template:
             print("proposed work issue template must not mention or apply mrwk:bounty")
             ok = False


### PR DESCRIPTION
Bounty #647
Source issue: #708

## Summary
- Adds a required `related_bounty_or_source` field to the proposed-work issue template.
- Documents that proposed-work authors should provide the intake bounty, issue, PR, discussion, route, or docs source that prompted the proposal.
- Extends docs smoke coverage so the source-context field remains present and required.

## Verification
- `python scripts/docs_smoke.py` -> docs smoke ok
- `python -m ruff check scripts/docs_smoke.py` -> All checks passed
- `python -m ruff format --check scripts/docs_smoke.py` -> 1 file already formatted
- `python -m py_compile scripts/docs_smoke.py` -> passed
- `git diff --check` -> passed

## Scope
This is the focused #708 template/docs-smoke slice only. It does not change bounty claimability, labels, payouts, proofs, treasury behavior, wallets, balances, exchange, bridge, cash-out, or price behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a required field to the proposed work issue template for linking the related bounty, source issue, PR, discussion, route, or docs page that prompted the proposal.

* **Documentation**
  * Updated proposed work request guidelines to clarify the requirement for submitting the bounty or source issue reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->