### PR TITLE
Expose public deployment metadata

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -74,6 +74,10 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "not": {"required": ["bounty_id", "issue_number"]},
         },
     },
+    {
+        "name": "server_info",
+        "description": "Get public MergeWork service and deployment metadata",
+    },
 ]
 
 

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -26,6 +26,7 @@ from app.serializers import (
     wallet_to_dict,
     wallet_transfer_to_dict,
 )
+from app.status import build_metadata
 
 
 def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | dict[str, Any]:
@@ -119,6 +120,9 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
         if not isinstance(value, bool):
             raise ValueError(f"{field} must be a boolean")
         return value
+
+    if name == "server_info":
+        return {"service": "mergework", "ticker": "MRWK", "build": build_metadata()}
 
     with session_scope(database_url) as session:
         if name == "list_bounties":

--- a/app/status.py
+++ b/app/status.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.control_chars import contains_control_character
 from app.ledger.service import (
     GENESIS_SUPPLY_MICRO,
     TREASURY_ACCOUNT,
@@ -26,6 +28,23 @@ FUTURE_PATH_BOUNDARY = (
     "Future public snapshots, bridges, and onchain claims require separate "
     "maintainer/contributor discussion before implementation."
 )
+BUILD_ENV_FIELDS = {
+    "git_sha": "MERGEWORK_GIT_SHA",
+    "build_id": "MERGEWORK_BUILD_ID",
+    "build_time": "MERGEWORK_BUILD_TIME",
+    "source_url": "MERGEWORK_SOURCE_URL",
+}
+
+
+def _public_env_value(name: str, *, max_length: int = 500) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value or len(value) > max_length or contains_control_character(value):
+        return "unknown"
+    return value
+
+
+def build_metadata() -> dict[str, str]:
+    return {field: _public_env_value(env_name) for field, env_name in BUILD_ENV_FIELDS.items()}
 
 
 def ledger_height(session: Session) -> int:
@@ -39,6 +58,7 @@ def health_status(session: Session) -> dict[str, Any]:
         "service": "mergework",
         "ticker": "MRWK",
         "ledger_height": ledger_height(session),
+        "build": build_metadata(),
     }
 
 
@@ -52,6 +72,7 @@ def system_status(session: Session) -> dict[str, Any]:
         "ticker": "MRWK",
         "genesis_supply_mrwk": format_mrwk(GENESIS_SUPPLY_MICRO),
         "ledger_height": ledger_height(session),
+        "build": build_metadata(),
         "active_bounties": int(active_bounties or 0),
         "treasury_balance_mrwk": format_mrwk(treasury_balance),
         "current_transfer_paths": list(CURRENT_TRANSFER_PATHS),

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -42,9 +42,15 @@ Legacy-compatible API reads remain available at
 List current system counts and recent bounties:
 
 ```bash
+curl -s "$API_HOST/health"
 curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
 ```
+
+`/health` and `/api/v1/status` include a public `build` object with safe
+deployment metadata. Use it to tell whether a live observation may be from an
+older deployment before filing duplicate proposed work. Unconfigured fields are
+reported as `"unknown"`.
 
 Get a lightweight counts-only bounty summary with optional status and search
 filters:
@@ -188,6 +194,14 @@ curl -s -X POST "$MCP_HOST/mcp" \
 
 ```json
 {"jsonrpc":"2.0","id":1,"method":"tools/list"}
+```
+
+Get public service and deployment metadata:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"server_info","arguments":{}}}'
 ```
 
 Get a balance:

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -15,6 +15,7 @@ The legacy-compatible hosts remain available for existing clients:
 Check service status and list bounties:
 
 ```bash
+curl -s "$API_HOST/health"
 curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
 curl -s "$API_HOST/api/v1/bounties?status=open"
@@ -22,6 +23,12 @@ curl -s "$API_HOST/api/v1/bounties?status=open&sort=available&limit=5"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open&q=proof"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open&sort=awards&limit=5"
 ```
+
+Status responses include a public `build` object with `git_sha`, `build_id`,
+`build_time`, and `source_url`. Deployments populate those fields from
+`MERGEWORK_GIT_SHA`, `MERGEWORK_BUILD_ID`, `MERGEWORK_BUILD_TIME`, and
+`MERGEWORK_SOURCE_URL`; unconfigured or unsafe values are reported as
+`"unknown"`.
 
 The bounties list returns public bounty rows. `status` can be omitted or set to
 `open`, `paid`, or `closed`:
@@ -557,6 +564,14 @@ List MCP tools:
 curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+Call `server_info` for service and public build metadata without scraping HTML:
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"server_info","arguments":{}}}'
 ```
 
 Call `get_balance`:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -50,6 +50,27 @@ def test_ledger_api_rejects_out_of_range_limits(sqlite_url: str, limit: str) -> 
     assert response.status_code == 422
 
 
+def test_status_routes_include_configured_build_metadata(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_GIT_SHA", "abc123")
+    monkeypatch.setenv("MERGEWORK_BUILD_ID", "deploy-42")
+    monkeypatch.setenv("MERGEWORK_BUILD_TIME", "2026-05-31T18:26:42Z")
+    monkeypatch.setenv("MERGEWORK_SOURCE_URL", "https://github.com/ramimbo/mergework")
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    expected_build = {
+        "git_sha": "abc123",
+        "build_id": "deploy-42",
+        "build_time": "2026-05-31T18:26:42Z",
+        "source_url": "https://github.com/ramimbo/mergework",
+    }
+
+    assert client.get("/health").json()["build"] == expected_build
+    assert client.get("/api/v1/status").json()["build"] == expected_build
+
+
 def test_head_requests_match_get_routes_without_body(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -213,6 +234,28 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
         tool for tool in tools["result"]["tools"] if tool["name"] == "list_bounty_attempts"
     )
     assert "active-attempt reservations" in attempt_tool["description"]
+    server_info_tool = next(
+        tool for tool in tools["result"]["tools"] if tool["name"] == "server_info"
+    )
+    assert "deployment metadata" in server_info_tool["description"]
+
+    server_info = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "server_info", "arguments": {}},
+        },
+    ).json()
+    assert server_info["result"]["structuredContent"]["service"] == "mergework"
+    assert server_info["result"]["structuredContent"]["ticker"] == "MRWK"
+    assert server_info["result"]["structuredContent"]["build"] == {
+        "git_sha": "unknown",
+        "build_id": "unknown",
+        "build_time": "unknown",
+        "source_url": "unknown",
+    }
 
     balance = client.post(
         "/mcp",

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -12,7 +12,45 @@ from app.ledger.service import (
     pay_bounty,
 )
 from app.models import LedgerEntry
-from app.status import health_status, system_status
+from app.status import build_metadata, health_status, system_status
+
+
+def test_build_metadata_defaults_to_unknown(monkeypatch) -> None:
+    for name in (
+        "MERGEWORK_GIT_SHA",
+        "MERGEWORK_BUILD_ID",
+        "MERGEWORK_BUILD_TIME",
+        "MERGEWORK_SOURCE_URL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    assert build_metadata() == {
+        "git_sha": "unknown",
+        "build_id": "unknown",
+        "build_time": "unknown",
+        "source_url": "unknown",
+    }
+
+
+def test_build_metadata_reports_only_safe_public_env_values(monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_GIT_SHA", " abc123 ")
+    monkeypatch.setenv("MERGEWORK_BUILD_ID", "deploy-42")
+    monkeypatch.setenv("MERGEWORK_BUILD_TIME", "2026-05-31T18:26:42Z")
+    monkeypatch.setenv("MERGEWORK_SOURCE_URL", "https://github.com/ramimbo/mergework")
+
+    assert build_metadata() == {
+        "git_sha": "abc123",
+        "build_id": "deploy-42",
+        "build_time": "2026-05-31T18:26:42Z",
+        "source_url": "https://github.com/ramimbo/mergework",
+    }
+
+    monkeypatch.setenv("MERGEWORK_GIT_SHA", "abc\n123")
+    monkeypatch.setenv("MERGEWORK_BUILD_ID", "x" * 501)
+
+    metadata = build_metadata()
+    assert metadata["git_sha"] == "unknown"
+    assert metadata["build_id"] == "unknown"
 
 
 def test_health_status_reports_current_ledger_height(sqlite_url: str) -> None:
@@ -23,6 +61,12 @@ def test_health_status_reports_current_ledger_height(sqlite_url: str) -> None:
             "service": "mergework",
             "ticker": "MRWK",
             "ledger_height": 0,
+            "build": {
+                "git_sha": "unknown",
+                "build_id": "unknown",
+                "build_time": "unknown",
+                "source_url": "unknown",
+            },
         }
 
         ensure_genesis(session)
@@ -70,6 +114,12 @@ def test_system_status_counts_only_open_bounties(sqlite_url: str) -> None:
     assert status["ticker"] == "MRWK"
     assert status["genesis_supply_mrwk"] == "100000000"
     assert status["ledger_height"] == expected_height
+    assert status["build"] == {
+        "git_sha": "unknown",
+        "build_id": "unknown",
+        "build_time": "unknown",
+        "source_url": "unknown",
+    }
     assert status["active_bounties"] == 1
     assert status["treasury_balance_mrwk"] == expected_treasury_balance
     assert status["current_transfer_paths"] == [


### PR DESCRIPTION
Bounty #647

Source issue: https://github.com/ramimbo/mergework/issues/718

## Summary
- add safe public build metadata to `/health` and `/api/v1/status`
- read only explicit env vars: `MERGEWORK_GIT_SHA`, `MERGEWORK_BUILD_ID`, `MERGEWORK_BUILD_TIME`, and `MERGEWORK_SOURCE_URL`
- return `unknown` for missing, blank, control-character, or overlong metadata values
- add MCP `server_info` so MCP clients can retrieve service/build metadata without scraping HTML
- document the diagnostic-only metadata in agent/API examples

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_status.py tests/test_api_mcp.py -q`
- `python -m ruff check app/status.py app/mcp.py app/mcp_tools.py tests/test_status.py tests/test_api_mcp.py`
- `python -m ruff format app/status.py app/mcp.py app/mcp_tools.py tests/test_status.py tests/test_api_mcp.py`
- `python scripts/docs_smoke.py`
- `git diff --check`

## Notes
This is read-only diagnostic metadata only. It does not change ledger, bounty, treasury proposal, payout, wallet, proof, balance, exchange, bridge, cash-out, deployment orchestration, or private configuration behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build and deployment metadata (git SHA, build ID, build time, and source URL) now included in health and status endpoint responses.
  * New service metadata tool available for retrieving public service information and current build details.

* **Documentation**
  * API examples and agent guide updated with usage examples for accessing new metadata endpoints and service information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->