### PR TITLE
docs: add bounty discovery links

### DIFF
--- a/app/templates/docs.html
+++ b/app/templates/docs.html
@@ -23,12 +23,15 @@
     <li><a href="/api/v1/status">API status</a></li>
     <li><a href="/api/docs">OpenAPI docs</a></li>
     <li><a href="/api/v1/bounties">Bounty API</a></li>
+    <li><a href="/api/v1/bounties/summary">Bounty summary API</a></li>
+    <li><a href="/api/v1/treasury/proposals">Treasury proposals API</a></li>
     <li><a href="/activity">Activity dashboard</a></li>
     <li><a href="/api/v1/activity">Activity API</a></li>
     <li><a href="/api/v1/ledger">Ledger API</a></li>
     <li><a href="/wallets">Wallets</a></li>
     <li><a href="/transfer">Transfer UI</a></li>
     <li><a href="https://github.com/ramimbo/mergework/discussions/16" rel="nofollow noopener">Paid bounty discussion</a></li>
+    <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/bounty-lifecycle.md" rel="nofollow noopener">Bounty lifecycle checklist</a></li>
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/bounty-rules.md" rel="nofollow noopener">Bounty rules</a></li>
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/paid-bounties.md" rel="nofollow noopener">Payment proof guide</a></li>
     <li><a href="https://github.com/ramimbo/mergework/blob/main/docs/agent-guide.md" rel="nofollow noopener">Agent usage</a></li>

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -63,6 +63,7 @@ def test_docs_page_marks_static_github_links_as_untrusted(sqlite_url: str) -> No
         "https://api.mrwk.ltclab.site",
         "https://mcp.mrwk.ltclab.site",
         "https://github.com/ramimbo/mergework/discussions/16",
+        "https://github.com/ramimbo/mergework/blob/main/docs/bounty-lifecycle.md",
         "https://github.com/ramimbo/mergework/blob/main/docs/bounty-rules.md",
         "https://github.com/ramimbo/mergework/blob/main/docs/paid-bounties.md",
         "https://github.com/ramimbo/mergework/blob/main/docs/agent-guide.md",
@@ -70,6 +71,11 @@ def test_docs_page_marks_static_github_links_as_untrusted(sqlite_url: str) -> No
         "https://github.com/ramimbo/mergework/blob/main/docs/ledger.md",
     ):
         assert f'href="{url}" rel="nofollow noopener"' in page.text
+    for url in (
+        "/api/v1/bounties/summary",
+        "/api/v1/treasury/proposals",
+    ):
+        assert f'href="{url}"' in page.text
 
 
 def test_ltc_lab_header_marks_github_nav_link_as_untrusted(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- Adds public `/docs` links for the bounty lifecycle checklist, bounty summary API, and treasury proposals API.
- Updates the public docs route test so these discovery links stay visible.
- Keeps the change read-only and docs/navigation scoped.

Bounty #647
Source issue: #709

## Verification
- `.venv/bin/python -m pytest tests/test_public_routes.py -q` passed: 6 passed, 1 warning
- `.venv/bin/python scripts/docs_smoke.py` passed: docs smoke ok
- `.venv/bin/python -m ruff check tests/test_public_routes.py` passed
- `.venv/bin/python -m ruff format --check tests/test_public_routes.py` passed
- `git diff --check` passed

No payout, wallet, treasury, transfer, private data, off-ramp, exchange, or claimability behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Bounty summary API" documentation link
  * Added "Treasury proposals API" documentation link

<!-- end of auto-generated comment: release notes by coderabbit.ai -->