### PR TITLE
Flag stale current-head reviews in queue health

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -269,7 +269,10 @@ Live mode requires an authenticated GitHub CLI with access to the repository.
 The command only reads PRs and issues; it does not close PRs, label issues, or
 post comments. It reports missing bounty references, closed or exhausted bounty
 references, dirty or unknown merge state, `mrwk:needs-info`, and likely duplicate
-PR scope within the same bounty issue.
+PR scope within the same bounty issue. It also flags PRs whose latest useful
+non-author human review was submitted on an older commit than the current PR
+head, so maintainers can request a fresh current-head review before merge or
+payout triage. Bot reviews are ignored for that human freshness signal.
 
 ### Claim Inventory
 

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -16,6 +16,8 @@ from scripts.bounty_refs import BOUNTY_REF_RE
 
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
 UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
+USEFUL_REVIEW_STATES = {"approved", "changes_requested", "commented"}
+KNOWN_BOT_LOGINS = {"coderabbitai", "github-actions", "dependabot[bot]"}
 GH_TIMEOUT_SECONDS = 30
 GH_PR_SAFETY_CAP = 201
 GH_ISSUE_SAFETY_CAP = 201
@@ -50,6 +52,93 @@ def _merge_state(raw: dict[str, Any]) -> str:
         if isinstance(value, str) and value:
             return value.lower()
     return "unknown"
+
+
+def _author_login(raw: Any) -> str | None:
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    if isinstance(raw, dict):
+        login = raw.get("login")
+        if isinstance(login, str) and login.strip():
+            return login.strip()
+    return None
+
+
+def _is_bot_author(raw: Any) -> bool:
+    if isinstance(raw, dict):
+        is_bot = raw.get("is_bot")
+        if isinstance(is_bot, bool):
+            return is_bot
+        type_name = raw.get("__typename") or raw.get("type")
+        if isinstance(type_name, str) and type_name.lower() == "bot":
+            return True
+    login = _author_login(raw)
+    return bool(login and (login.lower().endswith("[bot]") or login.lower() in KNOWN_BOT_LOGINS))
+
+
+def _commit_oid(raw: dict[str, Any]) -> str | None:
+    for key in ("commit_oid", "commitOid", "commit_id", "commitId"):
+        value = raw.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    commit = raw.get("commit")
+    if isinstance(commit, dict):
+        oid = commit.get("oid")
+        if isinstance(oid, str) and oid.strip():
+            return oid.strip()
+    return None
+
+
+def _latest_useful_human_review(pr: dict[str, Any]) -> dict[str, Any] | None:
+    pr_author = _author_login(pr.get("author"))
+    candidates: list[tuple[str, int, dict[str, Any]]] = []
+    for index, review in enumerate(pr.get("reviews", [])):
+        if not isinstance(review, dict):
+            continue
+        author = review.get("author")
+        reviewer = _author_login(author)
+        if reviewer is None:
+            continue
+        if pr_author and reviewer.lower() == pr_author.lower():
+            continue
+        if _is_bot_author(author):
+            continue
+        state = str(review.get("state") or "").lower()
+        if state not in USEFUL_REVIEW_STATES:
+            continue
+        candidates.append((str(review.get("submittedAt") or ""), index, review))
+    if not candidates:
+        return None
+    return max(candidates)[2]
+
+
+def _stale_review_issue(pr: dict[str, Any]) -> dict[str, Any] | None:
+    current_head = pr.get("headRefOid") or pr.get("head_ref_oid") or pr.get("head_oid")
+    if not isinstance(current_head, str) or not current_head.strip():
+        return None
+    review = _latest_useful_human_review(pr)
+    if review is None:
+        return None
+    review_commit = _commit_oid(review)
+    if not review_commit or review_commit == current_head:
+        return None
+    reviewer = _author_login(review.get("author")) or "unknown"
+    state = str(review.get("state") or "unknown")
+    item = _issue(
+        pr,
+        "stale_current_head_review",
+        f"Latest useful human review by {reviewer} is {state} on "
+        f"{review_commit[:12]}, current head is {current_head[:12]}",
+    )
+    item.update(
+        {
+            "reviewer": reviewer,
+            "review_state": state,
+            "current_head": current_head,
+            "latest_review_commit": review_commit,
+        }
+    )
+    return item
 
 
 def _scope_key(raw: dict[str, Any]) -> str:
@@ -136,6 +225,9 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
                 "labels": _labels(pr),
                 "merge_state": _merge_state(pr),
                 "scope": _scope_key(pr),
+                "headRefOid": pr.get("headRefOid") or pr.get("head_ref_oid") or pr.get("head_oid"),
+                "author": pr.get("author"),
+                "reviews": pr.get("reviews", []),
             }
         )
 
@@ -144,6 +236,7 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
     missing_bounty_references: list[dict[str, Any]] = []
     dirty_or_unstable_merge_state: list[dict[str, Any]] = []
     needs_info: list[dict[str, Any]] = []
+    stale_current_head_reviews: list[dict[str, Any]] = []
     duplicate_groups: dict[tuple[int, str], list[int]] = defaultdict(list)
 
     for pr in normalized_prs:
@@ -191,6 +284,9 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
             )
         if any(label.lower() == "mrwk:needs-info" for label in pr["labels"]):
             needs_info.append(_issue(pr, "mrwk_needs_info", "PR has mrwk:needs-info label"))
+        stale_review = _stale_review_issue(pr)
+        if stale_review is not None:
+            stale_current_head_reviews.append(stale_review)
 
     duplicate_scope_groups = [
         {"bounty": bounty, "scope": scope, "pull_requests": sorted(numbers)}
@@ -218,6 +314,7 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
             "missing_bounty_references": len(missing_bounty_references),
             "dirty_or_unstable_merge_state": len(dirty_or_unstable_merge_state),
             "needs_info": len(needs_info),
+            "stale_current_head_reviews": len(stale_current_head_reviews),
             "duplicate_scope_groups": len(duplicate_scope_groups),
         },
         "closed_bounty_references": closed_bounty_references,
@@ -225,6 +322,7 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
         "missing_bounty_references": missing_bounty_references,
         "dirty_or_unstable_merge_state": dirty_or_unstable_merge_state,
         "needs_info": needs_info,
+        "stale_current_head_reviews": stale_current_head_reviews,
         "duplicate_scope_groups": duplicate_scope_groups,
     }
     return report
@@ -239,6 +337,7 @@ def has_queue_issues(report: dict[str, Any]) -> bool:
             "missing_bounty_references",
             "dirty_or_unstable_merge_state",
             "needs_info",
+            "stale_current_head_reviews",
             "duplicate_scope_groups",
         )
     )
@@ -258,6 +357,7 @@ def format_text_report(report: dict[str, Any]) -> str:
         ("Missing bounty references", "missing_bounty_references"),
         ("Dirty or unstable merge state", "dirty_or_unstable_merge_state"),
         ("Needs info", "needs_info"),
+        ("Stale current-head reviews", "stale_current_head_reviews"),
     ]
     for title, key in sections:
         if report[key]:
@@ -301,6 +401,7 @@ def format_markdown_report(report: dict[str, Any]) -> str:
         ("Missing bounty references", "missing_bounty_references"),
         ("Dirty or unstable merge state", "dirty_or_unstable_merge_state"),
         ("Needs info", "needs_info"),
+        ("Stale current-head reviews", "stale_current_head_reviews"),
     ]
     for title, key in sections:
         if report[key]:
@@ -354,7 +455,7 @@ def load_live_queue(repo: str) -> dict[str, Any]:
             "--limit",
             str(GH_PR_SAFETY_CAP),
             "--json",
-            "number,title,url,body,labels,mergeStateStatus",
+            "number,title,url,body,labels,mergeStateStatus,headRefOid,author,reviews",
         ]
     )
     if len(prs) >= GH_PR_SAFETY_CAP:

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -69,6 +69,7 @@ def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
         "missing_bounty_references": 1,
         "dirty_or_unstable_merge_state": 2,
         "needs_info": 1,
+        "stale_current_head_reviews": 0,
         "duplicate_scope_groups": 1,
     }
     assert report["closed_bounty_references"][0]["pull_request"] == 1
@@ -274,6 +275,119 @@ def test_pr_queue_health_keeps_legacy_fixture_open_bounty_compatibility() -> Non
     assert report["summary"]["live_bounties"] == 1
     assert report["summary"]["non_live_bounty_references"] == 0
     assert report["non_live_bounty_references"] == []
+
+
+def test_pr_queue_health_accepts_current_head_human_review() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [
+                {
+                    "number": 8,
+                    "title": "Queue freshness signal",
+                    "body": "Bounty #310",
+                    "merge_state": "clean",
+                    "labels": [],
+                    "author": {"login": "contributor", "is_bot": False},
+                    "headRefOid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "reviews": [
+                        {
+                            "author": {"login": "reviewer", "is_bot": False},
+                            "state": "APPROVED",
+                            "submittedAt": "2026-05-31T10:00:00Z",
+                            "commit": {"oid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert report["summary"]["stale_current_head_reviews"] == 0
+    assert report["stale_current_head_reviews"] == []
+
+
+def test_pr_queue_health_flags_stale_human_review_commit() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [
+                {
+                    "number": 8,
+                    "title": "Queue freshness signal",
+                    "url": "https://github.com/ramimbo/mergework/pull/8",
+                    "body": "Bounty #310",
+                    "merge_state": "clean",
+                    "labels": [],
+                    "author": {"login": "contributor", "is_bot": False},
+                    "headRefOid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    "reviews": [
+                        {
+                            "author": {"login": "reviewer", "is_bot": False},
+                            "state": "APPROVED",
+                            "submittedAt": "2026-05-31T10:00:00Z",
+                            "commit": {"oid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert report["summary"]["stale_current_head_reviews"] == 1
+    assert report["stale_current_head_reviews"] == [
+        {
+            "pull_request": 8,
+            "title": "Queue freshness signal",
+            "url": "https://github.com/ramimbo/mergework/pull/8",
+            "reason": "stale_current_head_review",
+            "detail": (
+                "Latest useful human review by reviewer is APPROVED on aaaaaaaaaaaa, "
+                "current head is bbbbbbbbbbbb"
+            ),
+            "reviewer": "reviewer",
+            "review_state": "APPROVED",
+            "current_head": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "latest_review_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        }
+    ]
+
+
+def test_pr_queue_health_current_head_bot_review_does_not_mask_stale_human_review() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [
+                {
+                    "number": 8,
+                    "title": "Queue freshness signal",
+                    "body": "Bounty #310",
+                    "merge_state": "clean",
+                    "labels": [],
+                    "author": {"login": "contributor", "is_bot": False},
+                    "headRefOid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    "reviews": [
+                        {
+                            "author": {"login": "reviewer", "is_bot": False},
+                            "state": "APPROVED",
+                            "submittedAt": "2026-05-31T10:00:00Z",
+                            "commit": {"oid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+                        },
+                        {
+                            "author": {"login": "coderabbitai"},
+                            "state": "COMMENTED",
+                            "submittedAt": "2026-05-31T11:00:00Z",
+                            "commit": {"oid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+                        },
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert report["summary"]["stale_current_head_reviews"] == 1
+    assert report["stale_current_head_reviews"][0]["reviewer"] == "reviewer"
+    assert "current head is bbbbbbbbbbbb" in report["stale_current_head_reviews"][0]["detail"]
 
 
 @pytest.mark.parametrize("reference", ("Fixes #310abc", "Fixes #310_abc", "Fixes #310-abc"))


### PR DESCRIPTION
Bounty #647
Source issue: #679

Summary:
- add a read-only stale_current_head_reviews queue-health category for latest useful non-author human reviews whose review commit differs from the current PR head;
- keep bot reviews from satisfying the human current-head freshness signal, including CodeRabbit login-only review authors;
- include reviewer, review state, current head, latest review commit, and reason in JSON/text/Markdown reports;
- document the advisory signal in the admin runbook.

Verification:
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_pr_queue_health.py -q
- python -m ruff check scripts/pr_queue_health.py tests/test_pr_queue_health.py
- python -m ruff format --check scripts/pr_queue_health.py tests/test_pr_queue_health.py
- python scripts/docs_smoke.py
- python -m py_compile scripts/pr_queue_health.py
- git diff --check
- python scripts/pr_queue_health.py --repo ramimbo/mergework --format json

No auto-labeling, auto-closing, payout, treasury, wallet, ledger, proof, private data, price, bridge, exchange, or cash-out behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for human reviews based on outdated PR commits, flagging them as needing renewal against the current version.

* **Documentation**
  * Clarified PR queue health rules: how bot reviews are handled and when human reviews are considered fresh relative to the current PR state.

* **Tests**
  * Added comprehensive test coverage for stale review detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->