### PR TITLE
Respect effective capacity for attempts

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from app.db import session_scope
 from app.ledger.service import CONTROL_CHAR_RE, LedgerError, validate_public_url
 from app.models import Bounty, BountyAttempt
+from app.serializers import bounty_to_dict
 
 DEFAULT_ATTEMPT_TTL_SECONDS = 24 * 60 * 60
 MIN_ATTEMPT_TTL_SECONDS = 60
@@ -72,12 +73,14 @@ def _active_attempt_conditions(bounty_id: int, now: datetime) -> tuple[Any, ...]
 
 def bounty_attempt_warnings(session: Session, bounty: Bounty, now: datetime) -> list[str]:
     warnings: list[str] = []
-    awards_remaining = max(0, bounty.max_awards - bounty.awards_paid)
-    if bounty.status != "open":
+    bounty_data = bounty_to_dict(bounty, session=session)
+    awards_remaining = int(bounty_data["effective_awards_remaining"])
+    if bounty_data["status"] != "open":
         warnings.append(f"bounty is {bounty.status}")
-        awards_remaining = 0
     if awards_remaining <= 0:
         warnings.append("bounty has no award slots remaining")
+    if bounty_data["availability_state"] not in {"open", "full", bounty_data["status"]}:
+        warnings.append(bounty_data["availability_note"])
     active_count = session.scalar(
         select(func.count())
         .select_from(BountyAttempt)
@@ -198,7 +201,8 @@ def register_bounty_attempt_routes(
             if bounty is None:
                 raise HTTPException(status_code=404, detail="bounty not found")
             expire_stale_bounty_attempts(session, bounty_id, now, submitter_account)
-            awards_remaining = max(0, bounty.max_awards - bounty.awards_paid)
+            bounty_data = bounty_to_dict(bounty, session=session)
+            awards_remaining = int(bounty_data["effective_awards_remaining"])
             if bounty.status != "open" or awards_remaining <= 0:
                 return JSONResponse(
                     status_code=409,

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -10,6 +10,7 @@ from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import _signed_value, create_app
 from app.models import BountyAttempt, LedgerEntry
+from app.treasury import propose_treasury_action
 
 COOKIE_SECRET = "test-cookie-secret"
 
@@ -270,6 +271,133 @@ def test_multi_award_bounty_still_warns_for_multiple_active_attempts(sqlite_url:
         session.flush()
 
         assert bounty_attempt_warnings(session, bounty, now) == ["bounty has 2 active attempts"]
+
+
+def test_bounty_attempt_warnings_respect_full_pending_payout_capacity(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    now = datetime.now(UTC)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=329,
+            issue_url="https://github.com/ramimbo/mergework/issues/329",
+            title="Full pending payout attempt warning",
+            reward_mrwk="50",
+            max_awards=2,
+            acceptance="Effective capacity should block attempts.",
+        )
+        for pull_number, submitter in ((329, "github:alice"), (330, "github:bob")):
+            propose_treasury_action(
+                session,
+                action="pay_bounty",
+                payload={
+                    "bounty_id": bounty.id,
+                    "to_account": submitter,
+                    "submission_url": f"https://github.com/ramimbo/mergework/pull/{pull_number}",
+                    "accepted_by": "maintainer",
+                },
+                proposed_by="maintainer",
+            )
+
+        assert bounty_attempt_warnings(session, bounty, now) == [
+            "bounty has no award slots remaining",
+            "2 awards covered by pending payout proposals; 0 awards effectively available.",
+        ]
+
+
+def test_bounty_attempt_registration_blocks_full_pending_payout_capacity(
+    sqlite_url: str, monkeypatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", COOKIE_SECRET)
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=330,
+            issue_url="https://github.com/ramimbo/mergework/issues/330",
+            title="Full pending payout attempt creation",
+            reward_mrwk="50",
+            acceptance="Attempt creation should use effective capacity.",
+        )
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": bounty.id,
+                "to_account": "github:winner",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/330",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _set_login(client, "alice")
+
+    response = client.post(
+        f"/api/v1/bounties/{bounty.id}/attempts",
+        json={"submitter_account": "github:alice", "ttl_seconds": 3600},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "status": "not_available",
+        "bounty_id": bounty.id,
+        "warnings": [
+            "bounty has no award slots remaining",
+            "1 award covered by pending payout proposal; 0 awards effectively available.",
+        ],
+    }
+
+
+def test_bounty_attempt_registration_allows_partial_pending_payout_capacity(
+    sqlite_url: str, monkeypatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", COOKIE_SECRET)
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=331,
+            issue_url="https://github.com/ramimbo/mergework/issues/331",
+            title="Partial pending payout attempt creation",
+            reward_mrwk="50",
+            max_awards=2,
+            acceptance="Positive effective capacity should remain startable.",
+        )
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": bounty.id,
+                "to_account": "github:winner",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/331",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _set_login(client, "alice")
+
+    response = client.post(
+        f"/api/v1/bounties/{bounty.id}/attempts",
+        json={"submitter_account": "github:alice", "ttl_seconds": 3600},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["warnings"] == [
+        "1 award covered by pending payout proposal; 1 award effectively available.",
+        "bounty has 1 active attempt",
+    ]
 
 
 def test_expired_bounty_attempt_is_visible_but_no_longer_blocks_submitter(


### PR DESCRIPTION
Bounty #647
Source issue: #715

## Summary
- Makes active-attempt warnings use the same effective availability calculation as public bounty rows.
- Adds pending-payout availability notes to attempt warnings when pending proposals reduce or exhaust capacity.
- Blocks new attempt registrations when effective capacity is zero, even if raw award slots remain.
- Preserves partial pending-payout capacity: attempts remain startable when effective awards are still positive.

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests\test_bounty_attempts.py -q` -> 11 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py -k "list_bounty_attempts" -q` -> 2 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests\test_bounty_attempts.py tests\test_api_mcp.py -k "bounty_attempt or list_bounty_attempts" -q` -> 13 passed
- `.\.venv\Scripts\python.exe -m ruff check app\bounty_attempts.py tests\test_bounty_attempts.py` -> All checks passed
- `.\.venv\Scripts\python.exe -m ruff format --check app\bounty_attempts.py tests\test_bounty_attempts.py` -> 2 files already formatted
- `git diff --check` -> passed

## Duplicate Check
- Open PRs checked for source issue #715 returned no existing PR.
- Related open #647 PRs target #709, #697, #718, #708, #680, #684, #698, #683, #682, #676, #677, #681, #687, and #688; this PR is limited to #715.
- Bounty API row #95 is open with 9 effective awards remaining at submission time.

## Scope
No payout execution, proof generation, ledger mutation, treasury execution, wallet behavior, balance, exchange, bridge, cash-out, price, private data, or production mutation behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bounty award availability calculations to properly account for pending payout proposals, preventing over-allocation of awards during attempt registration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->