### PR TITLE
docs: clarify bounty reference linking

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,4 +20,4 @@
 
 ## MRWK
 
-Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties):
+Related bounty or issue (`Bounty #N` for MergeWork tracking, `Refs #N` for GitHub-linked issue visibility):

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -246,8 +246,10 @@ Tools:
 - Read `AGENTS.md` before starting.
 - Use focused branches and focused PRs.
 - Run tests, lint, and type checks before submitting.
-- Link bounty PRs with `Bounty #<issue>` or `Refs #<issue>` unless the bounty
-  asks for a closing reference.
+- Link bounty PRs with `Bounty #<issue>` for MergeWork bounty tracking. Use
+  `Refs #<issue>` when you also want GitHub or bot linked-issue checks to see
+  the issue reference. Use closing keywords only when the bounty asks for a
+  closing reference.
 - Do not put private security details in public issues, PRs, or ledger metadata.
 - Do not claim acceptance until a maintainer applies `mrwk:accepted`.
 
@@ -261,7 +263,8 @@ Use this checklist before opening a PR for `mrwk:bounty` issues:
 3. Write the claim-window scope before coding: exact bounty, intended files or
    surfaces, expected PR size, test plan, and what is out of scope.
 4. Keep changes small and directly tied to one bounty issue.
-5. Include `Bounty #<issue>` or `Refs #<issue>` in PR body.
+5. Include `Bounty #<issue>` in the PR body, or `Refs #<issue>` when GitHub
+   linked-issue visibility is also desired.
 6. Explain the exact user or maintainer pain point you fixed.
 7. Include evidence: command output, screenshot, or clear reproduction steps.
 8. Run the required checks from the issue text (for docs work, run
@@ -324,15 +327,18 @@ python scripts/submission_quality_gate.py --text-file pr-body.md --repo ramimbo/
 
 The gate is advisory. It does not reserve work, claim acceptance, make payments,
 or block maintainer decisions. It checks for a `Bounty #<issue>` or
-`Refs #<issue>` reference, whether the referenced bounty appears open, whether
-the bounty has recent maintainer activity, whether active attempt reservations
-already exist for the referenced bounty, whether the draft includes a concise
-summary and validation evidence, whether multiple bounty references are mixed
-into one draft, and whether a similar open PR already references the same
-bounty. The active-attempt lookup is read-only and uses the internal bounty id
-from `/api/v1/bounties`; if the attempts API is unavailable, the gate keeps
-other checks and reports an advisory warning instead of crashing or hiding
-payability results.
+`Refs #<issue>` reference, whether GitHub-linked-issue semantics are present,
+whether the referenced bounty appears open, whether the bounty has recent
+maintainer activity, whether active attempt reservations already exist for the
+referenced bounty, whether the draft includes a concise summary and validation
+evidence, whether multiple bounty references are mixed into one draft, and
+whether a similar open PR already references the same bounty. `Bounty #<issue>`
+is valid MergeWork bounty tracking even when GitHub or bot linked-issue checks
+stay skipped; use `Refs #<issue>` for non-closing GitHub issue visibility and
+closing keywords only when the bounty should close. The active-attempt lookup is
+read-only and uses the internal bounty id from `/api/v1/bounties`; if the
+attempts API is unavailable, the gate keeps other checks and reports an
+advisory warning instead of crashing or hiding payability results.
 
 Results:
 

--- a/docs/bounty-rules.md
+++ b/docs/bounty-rules.md
@@ -237,9 +237,10 @@ GitHub login. Otherwise, MRWK is held at `github:{login}` until the contributor
 links a wallet and signs a claim. Manual payouts can target a registered
 `mrwk1...` wallet or a `github:{login}` account.
 
-PR bounty submissions should link the bounty issue with `Bounty #<issue>` or
-`Refs #<issue>`. Use a closing reference only when the issue should close after
-that PR.
+PR bounty submissions should include a MergeWork bounty reference such as
+`Bounty #<issue>`. Use `Refs #<issue>` when you also want GitHub and bot
+linked-issue checks to see an issue reference. Use a closing reference only when
+the issue should close after that PR.
 
 For bounty PRs, include the claim-window packet in the PR body: exact bounty
 reference, intended files or surfaces, expected PR size, test plan, evidence,

--- a/scripts/bounty_refs.py
+++ b/scripts/bounty_refs.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 import re
 
 LINKED_BOUNTY_VERBS = r"bounty|claims?|close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?"
+GITHUB_LINKED_ISSUE_VERBS = r"close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?"
 BOUNTY_REF_RE = re.compile(
     rf"\b(?:{LINKED_BOUNTY_VERBS})\s*:?\s+`?#(\d+)`?(?![A-Za-z0-9_-])",
+    re.IGNORECASE,
+)
+GITHUB_LINKED_ISSUE_RE = re.compile(
+    rf"\b(?:{GITHUB_LINKED_ISSUE_VERBS})\s*:?\s+`?#(\d+)`?(?![A-Za-z0-9_-])",
     re.IGNORECASE,
 )
 LEADING_BOUNTY_REF_RE = re.compile(

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -15,7 +15,7 @@ from urllib.request import urlopen
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.bounty_refs import BOUNTY_REF_RE, LEADING_BOUNTY_REF_RE
+from scripts.bounty_refs import BOUNTY_REF_RE, GITHUB_LINKED_ISSUE_RE, LEADING_BOUNTY_REF_RE
 
 EVIDENCE_RE = re.compile(
     r"\b(pytest|ruff|mypy|validation|verified|test evidence|checks? passed)\b",
@@ -39,6 +39,23 @@ def _bounty_refs(text: str) -> list[int]:
     refs: list[int] = []
     seen: set[int] = set()
     for match in BOUNTY_REF_RE.findall(text):
+        try:
+            ref = int(match)
+        except ValueError:
+            continue
+        if ref > MAX_BOUNTY_REF:
+            continue
+        if ref in seen:
+            continue
+        seen.add(ref)
+        refs.append(ref)
+    return refs
+
+
+def _github_linked_issue_refs(text: str) -> list[int]:
+    refs: list[int] = []
+    seen: set[int] = set()
+    for match in GITHUB_LINKED_ISSUE_RE.findall(text):
         try:
             ref = int(match)
         except ValueError:
@@ -252,6 +269,24 @@ def evaluate_submission(data: dict[str, Any]) -> dict[str, Any]:
         )
     else:
         checks.append(_check("bounty_reference", "pass", f"found bounty reference #{bounty_ref}"))
+        if bounty_ref in _github_linked_issue_refs(text):
+            checks.append(
+                _check(
+                    "github_linked_issue",
+                    "pass",
+                    f"GitHub-linking reference found for bounty #{bounty_ref}",
+                )
+            )
+        else:
+            checks.append(
+                _check(
+                    "github_linked_issue",
+                    "warn",
+                    f"MergeWork bounty reference #{bounty_ref} is valid, but GitHub or bot "
+                    "linked-issue checks may stay skipped without `Refs #"
+                    f"{bounty_ref}`; use closing keywords only when the bounty should close",
+                )
+            )
         if len(refs) > 1:
             joined_refs = ", ".join(f"#{ref}" for ref in refs)
             checks.append(

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -35,10 +35,10 @@ def _check(name: str, status: str, message: str) -> dict[str, str]:
     return {"name": name, "status": status, "message": message}
 
 
-def _bounty_refs(text: str) -> list[int]:
+def _extract_issue_refs(text: str, pattern: re.Pattern[str]) -> list[int]:
     refs: list[int] = []
     seen: set[int] = set()
-    for match in BOUNTY_REF_RE.findall(text):
+    for match in pattern.findall(text):
         try:
             ref = int(match)
         except ValueError:
@@ -50,23 +50,14 @@ def _bounty_refs(text: str) -> list[int]:
         seen.add(ref)
         refs.append(ref)
     return refs
+
+
+def _bounty_refs(text: str) -> list[int]:
+    return _extract_issue_refs(text, BOUNTY_REF_RE)
 
 
 def _github_linked_issue_refs(text: str) -> list[int]:
-    refs: list[int] = []
-    seen: set[int] = set()
-    for match in GITHUB_LINKED_ISSUE_RE.findall(text):
-        try:
-            ref = int(match)
-        except ValueError:
-            continue
-        if ref > MAX_BOUNTY_REF:
-            continue
-        if ref in seen:
-            continue
-        seen.add(ref)
-        refs.append(ref)
-    return refs
+    return _extract_issue_refs(text, GITHUB_LINKED_ISSUE_RE)
 
 
 def _bounty_is_payable(raw: dict[str, Any]) -> bool:

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -38,6 +38,7 @@ def test_submission_quality_gate_passes_open_bounty_with_evidence(capsys, tmp_pa
     assert result["bounty_reference"] == 319
     assert {check["name"]: check["status"] for check in result["checks"]} == {
         "bounty_reference": "pass",
+        "github_linked_issue": "pass",
         "bounty_payable": "pass",
         "summary_present": "pass",
         "evidence_present": "pass",
@@ -80,12 +81,21 @@ def test_submission_quality_gate_accepts_claim_command_reference() -> None:
         }
     )
 
-    assert result["status"] == "pass"
+    assert result["status"] == "warn"
     assert result["bounty_reference"] == 319
     assert {
         "name": "bounty_reference",
         "status": "pass",
         "message": "found bounty reference #319",
+    } in result["checks"]
+    assert {
+        "name": "github_linked_issue",
+        "status": "warn",
+        "message": (
+            "MergeWork bounty reference #319 is valid, but GitHub or bot linked-issue "
+            "checks may stay skipped without `Refs #319`; use closing keywords only "
+            "when the bounty should close"
+        ),
     } in result["checks"]
 
 
@@ -112,11 +122,44 @@ def test_submission_quality_gate_ignores_oversized_numeric_bounty_refs() -> None
     } in result["checks"]
 
 
-def test_submission_quality_gate_accepts_github_linking_keywords() -> None:
+def test_submission_quality_gate_warns_for_mergework_only_bounty_keywords() -> None:
     references = (
         "Bounty #319",
         "Claim #319",
         "Claims #319",
+    )
+    for reference in references:
+        result = evaluate_submission(
+            {
+                "submission_text": f"""
+                Summary:
+                Harden the bounty reference parser.
+
+                {reference}
+
+                Validation:
+                - pytest passed.
+                """,
+                "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+                "pull_requests": [],
+            }
+        )
+
+        assert result["status"] == "warn", reference
+        assert result["bounty_reference"] == 319
+        assert {
+            "name": "github_linked_issue",
+            "status": "warn",
+            "message": (
+                "MergeWork bounty reference #319 is valid, but GitHub or bot linked-issue "
+                "checks may stay skipped without `Refs #319`; use closing keywords only "
+                "when the bounty should close"
+            ),
+        } in result["checks"]
+
+
+def test_submission_quality_gate_accepts_github_linking_keywords() -> None:
+    references = (
         "Ref #319",
         "Refs #319",
         "Reference #319",


### PR DESCRIPTION
Bounty #647
Source issue: #696

## Summary
- Adds a non-blocking submission quality-gate advisory that distinguishes MergeWork bounty references from GitHub linked-issue references.
- Keeps `Bounty #N` and `/claim #N` valid for MergeWork bounty tracking while reporting when GitHub/bot linked-issue checks may stay skipped without `Refs #N`.
- Updates the PR template, bounty rules, and agent guide to explain when to use `Bounty #N`, `Refs #N`, and closing keywords.

## Verification
- `.venv/bin/python -m pytest tests/test_submission_quality_gate.py -q` passed: 35 passed
- `.venv/bin/python scripts/docs_smoke.py` passed: docs smoke ok
- `.venv/bin/python -m ruff check scripts/bounty_refs.py scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` passed
- `.venv/bin/python -m ruff format --check scripts/bounty_refs.py scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` passed
- `git diff --check` passed

No payout, wallet, treasury, transfer, private data, off-ramp, exchange, or claimability behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified bounty PR submission guidance, specifying when to use MergeWork-style bounty references vs GitHub-visible references and updating the bounty submission checklist and quality gate explanations.
* **Improvements**
  * Submission-quality checks now warn when a bounty reference is present without a GitHub-visible reference, explaining potential skipped linked-issue checks.
* **Tests**
  * Added and updated tests to assert the new warning behavior for MergeWork-only bounty keywords and GitHub-linking cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->