### PR TITLE
Show pending payouts on account views

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -16,6 +16,8 @@ from app.path_params import SQLITE_INTEGER_MAX
 from app.serializers import (
     accepted_work_for_account,
     account_accepted_summary,
+    pending_payout_summary,
+    pending_payouts_for_account,
     safe_accepted_work_for_account,
     safe_account_accepted_summary,
 )
@@ -105,6 +107,7 @@ def account_transfer_status(account: str) -> str:
 def account_api_context(session: Session, account: str) -> dict[str, Any]:
     account = normalized_account(account)
     account_row = session.get(Account, account)
+    pending_payouts = pending_payouts_for_account(session, account)
     return {
         "account": account,
         "ledger_address": account,
@@ -113,15 +116,19 @@ def account_api_context(session: Session, account: str) -> dict[str, Any]:
         "balance_mrwk": format_mrwk(get_balance(session, account)),
         "transfer_status": account_transfer_status(account),
         "accepted_work": safe_account_accepted_summary(session, account),
+        "pending_payouts": pending_payout_summary(pending_payouts),
     }
 
 
 def account_accepted_work_context(session: Session, account: str) -> dict[str, Any]:
     account = normalized_account(account)
+    pending_payouts = pending_payouts_for_account(session, account)
     return {
         "account": account,
         "summary": account_accepted_summary(session, account),
         "accepted_work": accepted_work_for_account(session, account),
+        "pending_summary": pending_payout_summary(pending_payouts),
+        "pending_payouts": pending_payouts,
     }
 
 
@@ -143,10 +150,13 @@ def account_page_context(
 ) -> dict[str, Any]:
     account = normalized_account(account)
     selected_transaction_type, transaction_filter = _transaction_type_filter(transaction_type)
+    pending_payouts = pending_payouts_for_account(session, account)
     return {
         "account": account_api_context(session, account),
         "accepted_summary": safe_account_accepted_summary(session, account),
         "accepted_work": safe_accepted_work_for_account(session, account),
+        "pending_summary": pending_payout_summary(pending_payouts),
+        "pending_payouts": pending_payouts,
         "selected_transaction_type": selected_transaction_type,
         "transaction_type_options": ACCOUNT_TRANSACTION_TYPE_OPTIONS,
         "transactions": account_ledger_transactions(

--- a/app/accounts.py
+++ b/app/accounts.py
@@ -20,6 +20,7 @@ from app.serializers import (
     pending_payouts_for_account,
     safe_accepted_work_for_account,
     safe_account_accepted_summary,
+    safe_pending_payouts_for_account,
 )
 from app.wallets import WalletError, normalize_wallet_address
 
@@ -107,7 +108,7 @@ def account_transfer_status(account: str) -> str:
 def account_api_context(session: Session, account: str) -> dict[str, Any]:
     account = normalized_account(account)
     account_row = session.get(Account, account)
-    pending_payouts = pending_payouts_for_account(session, account)
+    pending_payouts = safe_pending_payouts_for_account(session, account)
     return {
         "account": account,
         "ledger_address": account,
@@ -116,7 +117,8 @@ def account_api_context(session: Session, account: str) -> dict[str, Any]:
         "balance_mrwk": format_mrwk(get_balance(session, account)),
         "transfer_status": account_transfer_status(account),
         "accepted_work": safe_account_accepted_summary(session, account),
-        "pending_payouts": pending_payout_summary(pending_payouts),
+        "pending_summary": pending_payout_summary(pending_payouts),
+        "pending_payouts": pending_payouts,
     }
 
 
@@ -150,7 +152,7 @@ def account_page_context(
 ) -> dict[str, Any]:
     account = normalized_account(account)
     selected_transaction_type, transaction_filter = _transaction_type_filter(transaction_type)
-    pending_payouts = pending_payouts_for_account(session, account)
+    pending_payouts = safe_pending_payouts_for_account(session, account)
     return {
         "account": account_api_context(session, account),
         "accepted_summary": safe_account_accepted_summary(session, account),

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -217,6 +217,16 @@ def _payload_bounty_id_filter(bounty_id: int) -> ColumnElement[bool]:
     )
 
 
+def _payload_account_filter(account: str) -> ColumnElement[bool]:
+    """Narrow pending-proposal scans for canonical JSON account fields."""
+    encoded_account = json.dumps(account, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    marker = f'"to_account":{encoded_account}'
+    return or_(
+        TreasuryProposal.payload_json.contains(f"{marker},"),
+        TreasuryProposal.payload_json.contains(f"{marker}}}"),
+    )
+
+
 def _pending_bounty_proposals_by_bounty_id(
     session: Session,
 ) -> dict[int, PendingBountyProposals]:
@@ -574,7 +584,11 @@ def pending_payouts_for_account(session: Session, account: str) -> list[dict[str
     """Return accepted-but-not-yet-executed payout proposals for one account."""
     proposals = session.scalars(
         select(TreasuryProposal)
-        .where(TreasuryProposal.status == "pending", TreasuryProposal.action == "pay_bounty")
+        .where(
+            TreasuryProposal.status == "pending",
+            TreasuryProposal.action == "pay_bounty",
+            _payload_account_filter(account),
+        )
         .order_by(TreasuryProposal.executes_after.asc(), TreasuryProposal.id.asc())
     ).all()
     pending: list[dict[str, Any]] = []
@@ -623,6 +637,15 @@ def pending_payout_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def empty_pending_payout_summary() -> dict[str, Any]:
+    """Return the stable empty shape for pending payout summaries."""
+    return {
+        "pending_awards": 0,
+        "pending_mrwk": "0",
+        "next_executes_after": None,
+    }
+
+
 def empty_accepted_summary() -> dict[str, Any]:
     """Return the stable empty shape for accepted-work summaries."""
     return {
@@ -647,6 +670,14 @@ def safe_accepted_work_for_account(session: Session, account: str) -> list[dict[
     """Return accepted-work rows, falling back to an empty list."""
     try:
         return accepted_work_for_account(session, account)
+    except Exception:
+        return []
+
+
+def safe_pending_payouts_for_account(session: Session, account: str) -> list[dict[str, Any]]:
+    """Return pending payout rows, falling back to an empty list."""
+    try:
+        return pending_payouts_for_account(session, account)
     except Exception:
         return []
 

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -570,6 +570,59 @@ def accepted_work_for_account(session: Session, account: str) -> list[dict[str, 
     return accepted_work
 
 
+def pending_payouts_for_account(session: Session, account: str) -> list[dict[str, Any]]:
+    """Return accepted-but-not-yet-executed payout proposals for one account."""
+    proposals = session.scalars(
+        select(TreasuryProposal)
+        .where(TreasuryProposal.status == "pending", TreasuryProposal.action == "pay_bounty")
+        .order_by(TreasuryProposal.executes_after.asc(), TreasuryProposal.id.asc())
+    ).all()
+    pending: list[dict[str, Any]] = []
+    for proposal in proposals:
+        payload = _proposal_payload(proposal)
+        if payload is None or payload.get("to_account") != account:
+            continue
+        bounty_id = _proposal_bounty_id(payload)
+        bounty = session.get(Bounty, bounty_id) if bounty_id is not None else None
+        pending.append(
+            {
+                "proposal_id": proposal.id,
+                "proposal_url": f"/api/v1/treasury/proposals/{proposal.id}",
+                "status": proposal.status,
+                "amount_mrwk": format_mrwk(bounty.reward_microunits) if bounty else None,
+                "bounty_id": bounty_id,
+                "bounty_url": _bounty_detail_url(bounty_id),
+                "repo": bounty.repo if bounty else None,
+                "issue_number": bounty.issue_number if bounty else None,
+                "issue_url": bounty.issue_url if bounty else None,
+                "submission_url": payload.get("submission_url"),
+                "accepted_by": payload.get("accepted_by"),
+                "proposed_at": proposal.proposed_at.isoformat(),
+                "executes_after": proposal.executes_after.isoformat(),
+            }
+        )
+    return pending
+
+
+def pending_payout_summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize pending payout proposal rows without treating them as paid."""
+    total_microunits = 0
+    for row in rows:
+        amount = row.get("amount_mrwk")
+        if amount is None:
+            continue
+        total_microunits += int(Decimal(str(amount)) * Decimal(1_000_000))
+    next_executes_after = min(
+        (str(row["executes_after"]) for row in rows if row.get("executes_after")),
+        default=None,
+    )
+    return {
+        "pending_awards": len(rows),
+        "pending_mrwk": format_mrwk(total_microunits),
+        "next_executes_after": next_executes_after,
+    }
+
+
 def empty_accepted_summary() -> dict[str, Any]:
     """Return the stable empty shape for accepted-work summaries."""
     return {

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -95,7 +95,7 @@
             {% set pending_issue_url = safe_public_url(payout.issue_url) %}
             <dd>
               {% if payout.bounty_url %}<a href="{{ payout.bounty_url }}">Bounty #{{ payout.bounty_id }}</a>{% endif %}
-              {% if payout.bounty_url and pending_issue_url %} Â· {% endif %}
+              {% if payout.bounty_url and pending_issue_url %} &middot; {% endif %}
               {% if pending_issue_url %}<a href="{{ pending_issue_url }}">{{ payout.repo }} #{{ payout.issue_number }}</a>{% elif not payout.bounty_url %}-{% endif %}
             </dd>
           </div>
@@ -145,7 +145,7 @@
             {% set issue_url = safe_public_url(work.issue_url) %}
             <dd>
               {% if work.bounty_url %}<a href="{{ work.bounty_url }}">Bounty #{{ work.bounty_id }}</a>{% endif %}
-              {% if work.bounty_url and issue_url %} · {% endif %}
+              {% if work.bounty_url and issue_url %} &middot; {% endif %}
               {% if issue_url %}<a href="{{ issue_url }}">{{ work.repo }} #{{ work.issue_number }}</a>{% elif not work.bounty_url %}-{% endif %}
             </dd>
           </div>

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -58,6 +58,70 @@
   {% endif %}
 </section>
 
+<section aria-labelledby="pending-payouts">
+  <div class="section-head">
+    <h2 id="pending-payouts">Pending payouts</h2>
+    <p>Accepted work queued for treasury execution, not proof-backed paid work.</p>
+  </div>
+  <div class="grid">
+    <article>
+      <strong>{{ pending_summary.pending_awards }}</strong>
+      <span>pending awards</span>
+    </article>
+    <article>
+      <strong>{{ pending_summary.pending_mrwk }} MRWK</strong>
+      <span>pending MRWK</span>
+    </article>
+    <article>
+      <strong>{{ pending_summary.next_executes_after or "-" }}</strong>
+      <span>next execution</span>
+    </article>
+  </div>
+  {% if pending_payouts %}
+  <div class="ledger-list">
+    {% for payout in pending_payouts %}
+    <article class="ledger-row">
+      <div class="ledger-entry-card">
+        <div class="ledger-card-head">
+          <div class="ledger-card-title">
+            <a class="ledger-entry-link" href="{{ payout.proposal_url }}">Proposal #{{ payout.proposal_id }}</a>
+            <span class="ledger-type">Pending</span>
+          </div>
+          <strong class="ledger-amount">{{ payout.amount_mrwk or "-" }}{% if payout.amount_mrwk %} MRWK{% endif %}</strong>
+        </div>
+        <dl class="ledger-card-grid">
+          <div class="ledger-field ledger-field--reference reference-cell">
+            <dt>Bounty</dt>
+            {% set pending_issue_url = safe_public_url(payout.issue_url) %}
+            <dd>
+              {% if payout.bounty_url %}<a href="{{ payout.bounty_url }}">Bounty #{{ payout.bounty_id }}</a>{% endif %}
+              {% if payout.bounty_url and pending_issue_url %} Â· {% endif %}
+              {% if pending_issue_url %}<a href="{{ pending_issue_url }}">{{ payout.repo }} #{{ payout.issue_number }}</a>{% elif not payout.bounty_url %}-{% endif %}
+            </dd>
+          </div>
+          <div class="ledger-field ledger-field--reference reference-cell">
+            <dt>Submission</dt>
+            {% set pending_submission_url = safe_public_url(payout.submission_url) %}
+            <dd>{% if pending_submission_url %}<a href="{{ pending_submission_url }}">{{ payout.submission_url | replace("https://github.com/", "") }}</a>{% elif payout.submission_url %}<code>{{ payout.submission_url }}</code>{% else %}-{% endif %}</dd>
+          </div>
+          <div class="ledger-field">
+            <dt>Accepted by</dt>
+            <dd>{{ payout.accepted_by or "-" }}</dd>
+          </div>
+          <div class="ledger-field">
+            <dt>Executes after</dt>
+            <dd>{{ payout.executes_after }}</dd>
+          </div>
+        </dl>
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+  {% else %}
+  <p>No pending payout proposals for this account.</p>
+  {% endif %}
+</section>
+
 <section>
   <div class="section-head">
     <h2>Accepted work</h2>

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from fastapi.testclient import TestClient
 
+import app.serializers as serializers_module
 from app.accounts import account_api_context, account_page_context, normalized_account
 from app.db import create_schema, session_scope
 from app.ledger.service import (
@@ -156,13 +157,14 @@ def test_account_routes_expose_pending_payouts_separately_from_paid_work(
         "latest_proof_hash": proof.hash,
         "latest_proof_url": f"/proofs/{proof.hash}",
     }
-    assert account_api["pending_payouts"] == {
+    assert account_api["pending_summary"] == {
         "pending_awards": 1,
         "pending_mrwk": "75",
         "next_executes_after": proposal.executes_after.isoformat(),
     }
     assert accepted_api["summary"] == account_api["accepted_work"]
-    assert accepted_api["pending_summary"] == account_api["pending_payouts"]
+    assert accepted_api["pending_summary"] == account_api["pending_summary"]
+    assert account_api["pending_payouts"] == accepted_api["pending_payouts"]
     assert accepted_api["pending_payouts"] == [
         {
             "proposal_id": proposal.id,
@@ -187,6 +189,32 @@ def test_account_routes_expose_pending_payouts_separately_from_paid_work(
     assert f'href="/api/v1/treasury/proposals/{proposal.id}"' in page
     assert "75 MRWK" in page
     assert "25 MRWK" in page
+    assert "Â" not in page
+    assert "&middot;" in page
+
+
+def test_account_pages_fall_back_when_pending_payouts_fail(sqlite_url: str, monkeypatch) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    def fail_pending_payouts(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+        raise RuntimeError("pending payout serializer unavailable")
+
+    monkeypatch.setattr(serializers_module, "pending_payouts_for_account", fail_pending_payouts)
+
+    with session_scope(sqlite_url) as session:
+        api_context = account_api_context(session, "github:alice")
+        page_context = account_page_context(session, "github:alice")
+
+    assert api_context["pending_summary"] == {
+        "pending_awards": 0,
+        "pending_mrwk": "0",
+        "next_executes_after": None,
+    }
+    assert api_context["pending_payouts"] == []
+    assert page_context["pending_summary"] == api_context["pending_summary"]
+    assert page_context["pending_payouts"] == []
 
 
 def test_account_page_filters_transactions_by_type(sqlite_url: str) -> None:

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -12,6 +12,7 @@ from app.ledger.service import (
     pay_bounty,
 )
 from app.main import create_app
+from app.treasury import propose_treasury_action
 
 
 def test_account_contexts_include_balance_status_and_proof_backed_rows(
@@ -94,6 +95,98 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     assert "25 MRWK" in page_response.text
     assert '<p class="reference-cell">' in page_response.text
     assert f'href="/proofs/{proof.hash}"' in page_response.text
+
+
+def test_account_routes_expose_pending_payouts_separately_from_paid_work(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        pending_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=180,
+            issue_url="https://github.com/ramimbo/mergework/issues/180",
+            title="Pending account payout",
+            reward_mrwk="75",
+            acceptance="Pending payouts should be visible but not counted as paid.",
+        )
+        paid_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=181,
+            issue_url="https://github.com/ramimbo/mergework/issues/181",
+            title="Paid account payout",
+            reward_mrwk="25",
+            acceptance="Paid work remains proof-backed.",
+        )
+        proposal = propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": pending_bounty.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/180",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=paid_bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/181",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    account_api = client.get("/api/v1/accounts/github:alice").json()
+    accepted_api = client.get("/api/v1/accounts/github:alice/accepted-work").json()
+    page = client.get("/accounts/github:alice").text
+
+    assert account_api["balance_mrwk"] == "25"
+    assert account_api["accepted_work"] == {
+        "accepted_awards": 1,
+        "accepted_mrwk": "25",
+        "latest_ledger_sequence": proof.ledger_sequence,
+        "latest_submission_url": "https://github.com/ramimbo/mergework/pull/181",
+        "latest_proof_hash": proof.hash,
+        "latest_proof_url": f"/proofs/{proof.hash}",
+    }
+    assert account_api["pending_payouts"] == {
+        "pending_awards": 1,
+        "pending_mrwk": "75",
+        "next_executes_after": proposal.executes_after.isoformat(),
+    }
+    assert accepted_api["summary"] == account_api["accepted_work"]
+    assert accepted_api["pending_summary"] == account_api["pending_payouts"]
+    assert accepted_api["pending_payouts"] == [
+        {
+            "proposal_id": proposal.id,
+            "proposal_url": f"/api/v1/treasury/proposals/{proposal.id}",
+            "status": "pending",
+            "amount_mrwk": "75",
+            "bounty_id": pending_bounty.id,
+            "bounty_url": f"/bounties/{pending_bounty.id}",
+            "repo": "ramimbo/mergework",
+            "issue_number": 180,
+            "issue_url": "https://github.com/ramimbo/mergework/issues/180",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/180",
+            "accepted_by": "maintainer",
+            "proposed_at": proposal.proposed_at.isoformat(),
+            "executes_after": proposal.executes_after.isoformat(),
+        }
+    ]
+    assert len(accepted_api["accepted_work"]) == 1
+    assert accepted_api["accepted_work"][0]["proof_hash"] == proof.hash
+    assert "Pending payouts" in page
+    assert "Accepted work queued for treasury execution, not proof-backed paid work." in page
+    assert f'href="/api/v1/treasury/proposals/{proposal.id}"' in page
+    assert "75 MRWK" in page
+    assert "25 MRWK" in page
 
 
 def test_account_page_filters_transactions_by_type(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #647
Source issue: #671

## Summary
- Adds account-level pending payout summaries for accepted-but-not-yet-executed `pay_bounty` proposals.
- Extends `/api/v1/accounts/{account}` with a separate `pending_payouts` summary.
- Extends `/api/v1/accounts/{account}/accepted-work` with separate `pending_summary` and `pending_payouts` rows.
- Adds a public account-page pending payouts section that clearly labels queued work as not proof-backed paid work.
- Keeps proof-backed `accepted_work`, balance, latest proof, and ledger fields unchanged until treasury execution creates a proof.

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests\test_account_routes.py -q` -> 6 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py -k "account" -q` -> 7 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests\test_serializers.py -k "account or accepted" -q` -> 2 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests\test_account_routes.py tests\test_api_mcp.py tests\test_serializers.py -k "account or accepted" -q` -> 16 passed
- `.\.venv\Scripts\python.exe -m ruff check app\accounts.py app\serializers.py tests\test_account_routes.py` -> All checks passed
- `.\.venv\Scripts\python.exe -m ruff format --check app\accounts.py app\serializers.py tests\test_account_routes.py` -> 3 files already formatted
- `git diff --check` -> passed

## Duplicate Check
- Open PRs checked for source issue #671 returned no existing PR.
- Bounty #649 accepted #671 as pending proposed work, and bounty #647 remains open with 9 effective awards remaining.
- Related work covers bounty-level pending capacity, activity views, and claim inventory; this PR is limited to account and accepted-work account surfaces.

## Scope
No balance, proof, ledger, wallet transfer, treasury execution, payout rule, exchange, bridge, cash-out, price, private data, credential, or production mutation behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Pending payouts" section to account pages showing pending awards, MRWK totals, and next execution time
  * Account APIs now expose pending treasury payouts separately from accepted work, and list proposal/bounty details and execution timing

* **Bug Fixes**
  * Account pages and APIs gracefully fall back to zeroed summary and empty list if pending-payout retrieval fails

* **Tests**
  * Added tests covering pending payouts display, API exposure, and fallback behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->