### PR TITLE
feat: add structured MCP JSON content

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -81,6 +81,16 @@ def _jsonrpc_error(response_id: Any, code: int, message: str) -> dict[str, Any]:
     return {"jsonrpc": "2.0", "id": response_id, "error": {"code": code, "message": message}}
 
 
+def _structured_json_payload(text: str) -> dict[str, Any] | list[Any] | None:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(payload, (dict, list)):
+        return payload
+    return None
+
+
 def _tool_result_response(response_id: Any, tool_result: str | dict[str, Any]) -> dict[str, Any]:
     if isinstance(tool_result, dict):
         return {
@@ -89,6 +99,16 @@ def _tool_result_response(response_id: Any, tool_result: str | dict[str, Any]) -
             "result": {
                 "content": [{"type": "text", "text": json.dumps(tool_result)}],
                 "structuredContent": tool_result,
+            },
+        }
+    structured_payload = _structured_json_payload(tool_result)
+    if structured_payload is not None:
+        return {
+            "jsonrpc": "2.0",
+            "id": response_id,
+            "result": {
+                "content": [{"type": "text", "text": tool_result}],
+                "structuredContent": structured_payload,
             },
         }
     return {

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -241,6 +241,12 @@ Tools:
 - `submit_work_proof` (`format: "json"` returns structuredContent; `tools/list`
   advertises the selector and format schema)
 
+Successful MCP tools that return JSON objects or lists include both the
+backward-compatible JSON string in `result.content[0].text` and parsed
+`result.structuredContent`. Prefer `structuredContent` when present, and fall
+back to text for human-readable responses such as balances or not-found
+messages.
+
 ## Contribution Rules
 
 - Read `AGENTS.md` before starting.

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -612,9 +612,14 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -d '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"submit_wallet_transfer","arguments":{"from_address":"<sender_mrwk1_address>","to_address":"<receiver_mrwk1_address>","amount_mrwk":"1.5","nonce":3,"memo":"agent payout consolidation","signature_hex":"<128 lowercase hex chars>"}}}'
 ```
 
-Successful MCP transfer responses wrap a JSON-string transfer object in the
-first content block. Parse `result.content[0].text` to read the transfer hash,
-ledger sequence, addresses, amount, nonce, memo, and timestamp:
+Successful MCP tools that return JSON objects or lists include the
+backward-compatible JSON string in `result.content[0].text` and the parsed
+payload in `result.structuredContent`. Prefer `structuredContent` when present;
+fall back to text for human-readable responses such as balances and not-found
+messages.
+
+Successful MCP transfer responses expose the transfer hash, ledger sequence,
+addresses, amount, nonce, memo, and timestamp in that JSON payload:
 
 ```json
 {
@@ -631,8 +636,8 @@ ledger sequence, addresses, amount, nonce, memo, and timestamp:
 }
 ```
 
-The `get_proof` MCP response uses JSON-RPC content blocks. The first content
-block is a JSON string with proof metadata plus the stored public proof payload:
+The `get_proof` MCP response includes proof metadata plus the stored public
+proof payload as both JSON text and parsed `structuredContent`:
 
 ```json
 {
@@ -656,7 +661,7 @@ created from a GitHub bounty claim.
 Call `get_ledger_entry` with the immutable ledger sequence returned by
 `/api/v1/ledger`, `/api/v1/activity`, `get_bounty` award rows, or `get_proof`.
 The MCP response wraps the same ledger-entry shape as
-`/api/v1/ledger/<sequence>` in `result.content[0].text`:
+`/api/v1/ledger/<sequence>` in JSON text and `structuredContent`:
 
 ```bash
 curl -s -X POST "$MCP_HOST/mcp" \

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -225,6 +225,7 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     ).json()
     assert balance["result"]["content"][0]["type"] == "text"
     assert "100000000" in balance["result"]["content"][0]["text"]
+    assert "structuredContent" not in balance["result"]
 
 
 def test_mcp_list_bounty_attempts_reports_active_and_expired(sqlite_url: str) -> None:
@@ -415,6 +416,7 @@ def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> No
         },
     ).json()
     default_payload = json.loads(default_result["result"]["content"][0]["text"])
+    assert default_result["result"]["structuredContent"] == default_payload
     assert [item["id"] for item in default_payload] == [open_bounty.id]
 
     paid_result = client.post(
@@ -430,6 +432,7 @@ def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> No
         },
     ).json()
     paid_payload = json.loads(paid_result["result"]["content"][0]["text"])
+    assert paid_result["result"]["structuredContent"] == paid_payload
     assert [item["id"] for item in paid_payload] == [paid_bounty.id]
     assert paid_payload[0]["status"] == "paid"
 
@@ -690,6 +693,7 @@ def test_mcp_get_bounty_can_include_accepted_awards(sqlite_url: str) -> None:
         },
     ).json()
     default_payload = json.loads(default_result["result"]["content"][0]["text"])
+    assert default_result["result"]["structuredContent"] == default_payload
     assert "awards" not in default_payload
 
     result = client.post(
@@ -705,6 +709,7 @@ def test_mcp_get_bounty_can_include_accepted_awards(sqlite_url: str) -> None:
         },
     ).json()
     payload = json.loads(result["result"]["content"][0]["text"])
+    assert result["result"]["structuredContent"] == payload
     assert payload["id"] == bounty_id
     assert payload["status"] == "paid"
     assert payload["awards_paid"] == 1
@@ -1016,6 +1021,7 @@ def test_mcp_get_ledger_entry_includes_payment_proof_hash(sqlite_url: str) -> No
         },
     ).json()
     payload = json.loads(result["result"]["content"][0]["text"])
+    assert result["result"]["structuredContent"] == payload
 
     assert payload["sequence"] == ledger_sequence
     assert payload["proof_hash"] == proof_hash
@@ -1086,6 +1092,7 @@ def test_mcp_get_proof_returns_public_proof_details(sqlite_url: str) -> None:
     content = result["result"]["content"][0]
     payload = json.loads(content["text"])
     assert content["type"] == "text"
+    assert result["result"]["structuredContent"] == payload
     assert payload["hash"] == proof.hash
     assert payload["kind"] == "bounty_payment"
     assert payload["ledger_sequence"] == proof.ledger_sequence
@@ -2086,6 +2093,7 @@ def test_mcp_can_register_and_fetch_wallet(sqlite_url: str) -> None:
         },
     ).json()
     registered_wallet = json.loads(registered["result"]["content"][0]["text"])
+    assert registered["result"]["structuredContent"] == registered_wallet
     assert registered_wallet["address"].startswith("mrwk1")
 
     fetched = client.post(
@@ -2101,6 +2109,7 @@ def test_mcp_can_register_and_fetch_wallet(sqlite_url: str) -> None:
         },
     ).json()
     fetched_wallet = json.loads(fetched["result"]["content"][0]["text"])
+    assert fetched["result"]["structuredContent"] == fetched_wallet
 
     assert fetched_wallet["address"] == registered_wallet["address"]
     assert fetched_wallet["label"] == "MCP wallet"


### PR DESCRIPTION
Maintainer accepted live-lane reroute: this merged work is evaluated under live bounty #776 because it matches that acceptance scope; the original closed/exhausted round reference was issue 647.

Bounty #776
Source issue: #713

## Summary
- Adds parsed `structuredContent` for successful MCP tool responses whose text content is a JSON object or list.
- Keeps `result.content[0].text` unchanged for backward compatibility.
- Leaves human-readable text responses, including balances and not-found messages, text-only.
- Updates MCP docs to tell agents to prefer `structuredContent` when present and fall back to text.

## Verification
- `.venv/bin/python -m pytest tests/test_api_mcp.py -q` passed: 82 passed, 1 warning
- `.venv/bin/python scripts/docs_smoke.py` passed: docs smoke ok
- `.venv/bin/python -m ruff check app/mcp.py tests/test_api_mcp.py` passed
- `.venv/bin/python -m ruff format --check app/mcp.py tests/test_api_mcp.py` passed
- `git diff --check` passed

No payout, wallet, treasury, transfer signing, private data, off-ramp, exchange, or claimability behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP tool responses now automatically parse and provide JSON data in a `structuredContent` field alongside text content for backward compatibility.

* **Documentation**
  * Updated MCP guidance to recommend using `structuredContent` for structured data access when available.
  * Updated API examples demonstrating the new response format with structured content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->