### PR TITLE
feat: add MCP issue-number bounty selectors

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -18,11 +18,17 @@ MCP_TOOLS: list[dict[str, Any]] = [
     },
     {
         "name": "get_bounty",
-        "description": "Get a bounty by id, optionally with accepted awards",
+        "description": (
+            "Get a bounty by internal id, or by GitHub issue_number with optional repo, "
+            "optionally with accepted awards"
+        ),
     },
     {
         "name": "list_bounty_attempts",
-        "description": "List advisory active-attempt reservations for a bounty",
+        "description": (
+            "List advisory active-attempt reservations for a bounty by internal bounty_id, "
+            "or by GitHub issue_number with optional repo"
+        ),
     },
     {"name": "get_balance", "description": "Get an account balance"},
     {

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -120,6 +120,31 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             raise ValueError(f"{field} must be a boolean")
         return value
 
+    def bounty_by_issue_number(repo_selector: str | None) -> Bounty | None:
+        issue_query = select(Bounty).where(Bounty.issue_number == positive_int_arg("issue_number"))
+        if repo_selector is not None:
+            issue_query = issue_query.where(func.lower(Bounty.repo) == repo_selector)
+        bounties = session.scalars(issue_query.order_by(Bounty.id.desc()).limit(2)).all()
+        if not bounties:
+            return None
+        if len(bounties) > 1:
+            raise ValueError("issue_number matches multiple bounties")
+        return bounties[0]
+
+    def selected_bounty(internal_id_field: str) -> Bounty | None:
+        has_internal_id = internal_id_field in args and args.get(internal_id_field) is not None
+        has_issue_number = "issue_number" in args and args.get("issue_number") is not None
+        repo_selector = optional_repo_selector_arg()
+        if has_internal_id and has_issue_number:
+            raise ValueError(f"use {internal_id_field} or issue_number, not both")
+        if repo_selector is not None and not has_issue_number:
+            raise ValueError("repo can only be used with issue_number")
+        if has_internal_id:
+            return session.get(Bounty, positive_int_arg(internal_id_field))
+        if has_issue_number:
+            return bounty_by_issue_number(repo_selector)
+        raise ValueError(f"{internal_id_field} or issue_number is required")
+
     with session_scope(database_url) as session:
         if name == "list_bounties":
             status = optional_clean_str_arg("status") or "open"
@@ -153,7 +178,7 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             sorted_bounties = sort_bounties(bounties_to_dict(bounties, session=session), sort)
             return json.dumps(sorted_bounties[:limit])
         if name == "get_bounty":
-            bounty = session.get(Bounty, positive_int_arg("id"))
+            bounty = selected_bounty("id")
             if bounty is None:
                 return "bounty not found"
             bounty_data = bounty_to_dict(bounty, session=session)
@@ -161,8 +186,7 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 bounty_data["awards"] = bounty_awards_to_dict(session, bounty.id)
             return json.dumps(bounty_data)
         if name == "list_bounty_attempts":
-            bounty_id = positive_int_arg("bounty_id")
-            bounty = session.get(Bounty, bounty_id)
+            bounty = selected_bounty("bounty_id")
             if bounty is None:
                 return "bounty not found"
             attempt_listing = list_bounty_attempts(
@@ -172,7 +196,7 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 limit=list_limit_arg(),
             )
             return {
-                "bounty_id": bounty_id,
+                "bounty_id": bounty.id,
                 "issue_number": bounty.issue_number,
                 "status": bounty.status,
                 "warnings": attempt_listing["warnings"],
@@ -249,20 +273,13 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                     else work_proof_guidance(bounty, session=session)
                 )
             if has_issue_number:
-                issue_query = select(Bounty).where(
-                    Bounty.issue_number == positive_int_arg("issue_number")
-                )
-                if repo_selector is not None:
-                    issue_query = issue_query.where(func.lower(Bounty.repo) == repo_selector)
-                bounties = session.scalars(issue_query.order_by(Bounty.id.desc()).limit(2)).all()
-                if not bounties:
+                bounty = bounty_by_issue_number(repo_selector)
+                if bounty is None:
                     return "bounty not found"
-                if len(bounties) > 1:
-                    raise ValueError("issue_number matches multiple bounties")
                 return (
-                    work_proof_guidance_json(bounties[0], session=session)
+                    work_proof_guidance_json(bounty, session=session)
                     if output_format == "json"
-                    else work_proof_guidance(bounties[0], session=session)
+                    else work_proof_guidance(bounty, session=session)
                 )
             if output_format == "json":
                 return generic_work_proof_guidance_json()

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -211,12 +211,17 @@ curl -s -X POST "$MCP_HOST/mcp" \
 ```
 
 Inspect active attempt reservations for a bounty before opening overlapping
-work:
+work. Use the internal `bounty_id` from `list_bounties`, or `issue_number` with
+`repo` when you start from a GitHub issue URL:
 
 ```bash
 curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_bounty_attempts","arguments":{"bounty_id":11}}}'
+
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_bounty_attempts","arguments":{"issue_number":404,"repo":"ramimbo/mergework"}}}'
 ```
 
 Look up a public proof by hash:

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -589,7 +589,7 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_bounty","arguments":{"issue_number":404,"repo":"ramimbo/mergework"}}}'
 ```
 
-Call `list_bounty_attempts` with the same internal bounty `id`, or the GitHub
+Call `list_bounty_attempts` with the same internal `bounty_id`, or the GitHub
 `issue_number` plus `repo`, before opening a PR. Omit `include_expired` to see
 only active attempts:
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -576,21 +576,31 @@ curl -s -X POST "$MCP_HOST/mcp" \
 ```
 
 Call `get_bounty` with the internal bounty `id` returned by `list_bounties`,
-not the GitHub issue number:
+or use the GitHub `issue_number` with `repo` when your workflow starts from an
+issue URL:
 
 ```bash
 curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_bounty","arguments":{"id":11}}}'
+
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_bounty","arguments":{"issue_number":404,"repo":"ramimbo/mergework"}}}'
 ```
 
-Call `list_bounty_attempts` with the same internal bounty `id` before opening a
-PR. Omit `include_expired` to see only active attempts:
+Call `list_bounty_attempts` with the same internal bounty `id`, or the GitHub
+`issue_number` plus `repo`, before opening a PR. Omit `include_expired` to see
+only active attempts:
 
 ```bash
 curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"list_bounty_attempts","arguments":{"bounty_id":11,"include_expired":false}}}'
+
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"list_bounty_attempts","arguments":{"issue_number":404,"repo":"ramimbo/mergework","include_expired":false}}}'
 ```
 
 Call `get_proof` with the proof hash returned by `/api/v1/ledger`,

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -319,6 +319,54 @@ def test_mcp_list_bounty_attempts_reports_active_and_expired(sqlite_url: str) ->
     ]
 
 
+def test_mcp_list_bounty_attempts_accepts_issue_number_selector(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    now = datetime.now(UTC)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=322,
+            issue_url="https://github.com/ramimbo/mergework/issues/322",
+            title="Attempt lookup by issue",
+            reward_mrwk="250",
+            max_awards=2,
+            acceptance="Agents can inspect attempts from a GitHub issue number.",
+        )
+        session.add(
+            BountyAttempt(
+                bounty_id=bounty.id,
+                submitter_account="github:alice",
+                source_url="https://github.com/ramimbo/mergework/pull/522",
+                status="active",
+                expires_at=now + timedelta(hours=1),
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 24,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounty_attempts",
+                "arguments": {"issue_number": 322, "repo": "RAMIMBO/MERGEWORK"},
+            },
+        },
+    ).json()["result"]["structuredContent"]
+
+    assert result["bounty_id"] == bounty_id
+    assert result["issue_number"] == 322
+    assert result["attempts"][0]["submitter_account"] == "github:alice"
+
+
 def test_mcp_list_bounty_attempts_rejects_invalid_arguments(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -722,6 +770,126 @@ def test_mcp_get_bounty_can_include_accepted_awards(sqlite_url: str) -> None:
             "created_at": proof.created_at.replace(tzinfo=None).isoformat(),
         }
     ]
+
+
+def test_mcp_get_bounty_accepts_issue_number_selector(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=286,
+            issue_url="https://github.com/ramimbo/mergework/issues/286",
+            title="MCP issue-number lookup",
+            reward_mrwk="75",
+            acceptance="Agents should inspect bounties from GitHub issue numbers.",
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "get_bounty",
+                "arguments": {"issue_number": 286, "repo": "RAMIMBO/MERGEWORK"},
+            },
+        },
+    ).json()
+
+    payload = json.loads(result["result"]["content"][0]["text"])
+    assert payload["id"] == bounty_id
+    assert payload["issue_number"] == 286
+
+
+def test_mcp_get_bounty_rejects_ambiguous_issue_number_selector(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=287,
+            issue_url="https://github.com/ramimbo/mergework/issues/287",
+            title="MCP issue lookup",
+            reward_mrwk="75",
+            acceptance="First repo issue.",
+        )
+        create_bounty(
+            session,
+            repo="other/repo",
+            issue_number=287,
+            issue_url="https://github.com/other/repo/issues/287",
+            title="MCP issue lookup duplicate",
+            reward_mrwk="75",
+            acceptance="Second repo issue.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {"name": "get_bounty", "arguments": {"issue_number": 287}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 4,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
+def test_mcp_get_bounty_rejects_mixed_selectors(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=288,
+            issue_url="https://github.com/ramimbo/mergework/issues/288",
+            title="MCP mixed selector validation",
+            reward_mrwk="75",
+            acceptance="Agents should choose one selector.",
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {
+                "name": "get_bounty",
+                "arguments": {
+                    "id": bounty_id,
+                    "issue_number": 288,
+                    "repo": "ramimbo/mergework",
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 5,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
 
 
 def test_mcp_get_bounty_skips_malformed_award_proof_payloads(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #647
Source issue: #711

## Summary
- Lets MCP `get_bounty` accept either internal `id` or GitHub `issue_number` with optional `repo` scoping.
- Lets MCP `list_bounty_attempts` accept either internal `bounty_id` or GitHub `issue_number` with optional `repo` scoping.
- Reuses the existing issue-number ambiguity behavior from `submit_work_proof` and keeps mixed selectors invalid.
- Updates MCP docs/examples to show issue-number lookup when starting from a GitHub issue URL.

## Verification
- `.venv/bin/python -m pytest tests/test_api_mcp.py -q` passed: 86 passed, 1 warning
- `.venv/bin/python scripts/docs_smoke.py` passed: docs smoke ok
- `.venv/bin/python -m ruff check app/mcp.py app/mcp_tools.py tests/test_api_mcp.py` passed
- `.venv/bin/python -m ruff format --check app/mcp.py app/mcp_tools.py tests/test_api_mcp.py` passed
- `git diff --check` passed

No payout, wallet, treasury, transfer signing, private data, off-ramp, exchange, or claimability behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * get_bounty and list_bounty_attempts now accept GitHub issue number + repo as alternative lookup inputs (in addition to internal bounty IDs).

* **Documentation**
  * Agent guide and API examples updated with GitHub issue–based lookup workflows and request examples.

* **Tests**
  * Added tests covering issue-number selection, ambiguous selectors, and mixed-selector validation for the MCP bounty tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->