### PR TITLE
Show pending accepted work in activity

### DIFF
--- a/app/serializers.py
+++ b/app/serializers.py
@@ -487,13 +487,29 @@ def pending_activity_rows(session: Session, query: str | None = None) -> list[di
         .where(TreasuryProposal.status == "pending", TreasuryProposal.action == "pay_bounty")
         .order_by(TreasuryProposal.executes_after.asc(), TreasuryProposal.id.asc())
     ).all()
-    pending: list[dict[str, Any]] = []
+    parsed: list[tuple[TreasuryProposal, dict[str, Any], int | None]] = []
+    bounty_ids: set[int] = set()
     for proposal in proposals:
         payload = _proposal_payload(proposal)
         if payload is None:
             continue
         bounty_id = _proposal_bounty_id(payload)
-        bounty = session.get(Bounty, bounty_id) if bounty_id is not None else None
+        if bounty_id is not None:
+            bounty_ids.add(bounty_id)
+        parsed.append((proposal, payload, bounty_id))
+
+    bounty_by_id = (
+        {
+            bounty.id: bounty
+            for bounty in session.scalars(select(Bounty).where(Bounty.id.in_(bounty_ids))).all()
+        }
+        if bounty_ids
+        else {}
+    )
+
+    pending: list[dict[str, Any]] = []
+    for proposal, payload, bounty_id in parsed:
+        bounty = bounty_by_id.get(bounty_id) if bounty_id is not None else None
         row = _pending_activity_row(proposal, payload, bounty)
         if row["account"] is None or not _pending_activity_row_matches(row, search_query):
             continue

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -428,6 +428,79 @@ def _activity_row_matches(row: dict[str, Any], query: str) -> bool:
     }
 
 
+def _pending_activity_row(
+    proposal: TreasuryProposal, payload: dict[str, Any], bounty: Bounty | None
+) -> dict[str, Any]:
+    amount_microunits = bounty.reward_microunits if bounty else 0
+    return {
+        "proposal_id": proposal.id,
+        "proposal_url": f"/api/v1/treasury/proposals/{proposal.id}",
+        "status": proposal.status,
+        "account": payload.get("to_account"),
+        "amount_mrwk": format_mrwk(amount_microunits) if bounty else None,
+        "amount_microunits": amount_microunits,
+        "submission_url": payload.get("submission_url"),
+        "bounty_repo": bounty.repo if bounty else None,
+        "bounty_issue_number": bounty.issue_number if bounty else None,
+        "bounty_issue_url": bounty.issue_url if bounty else None,
+        "bounty_id": bounty.id if bounty else _proposal_bounty_id(payload),
+        "bounty_url": _bounty_detail_url(bounty.id if bounty else _proposal_bounty_id(payload)),
+        "accepted_by": payload.get("accepted_by"),
+        "proposed_at": proposal.proposed_at.isoformat(),
+        "executes_after": proposal.executes_after.isoformat(),
+    }
+
+
+def _pending_activity_row_matches(row: dict[str, Any], query: str) -> bool:
+    if not query:
+        return True
+    searchable_values = (
+        row["proposal_id"],
+        row["proposal_url"],
+        row["status"],
+        row["account"],
+        row["amount_mrwk"],
+        row["submission_url"],
+        row["bounty_id"],
+        row["bounty_repo"],
+        row["bounty_issue_url"],
+        row["bounty_issue_number"],
+        row["accepted_by"],
+    )
+    if any(query in str(value or "").lower() for value in searchable_values):
+        return True
+    issue_number = _activity_hash_issue_query(query)
+    if issue_number is None:
+        return False
+    return issue_number in {
+        str(row["proposal_id"] or ""),
+        str(row["bounty_id"] or ""),
+        str(row["bounty_issue_number"] or ""),
+    }
+
+
+def pending_activity_rows(session: Session, query: str | None = None) -> list[dict[str, Any]]:
+    """Return pending accepted work without treating it as proof-backed activity."""
+    search_query = _activity_search_query(query)
+    proposals = session.scalars(
+        select(TreasuryProposal)
+        .where(TreasuryProposal.status == "pending", TreasuryProposal.action == "pay_bounty")
+        .order_by(TreasuryProposal.executes_after.asc(), TreasuryProposal.id.asc())
+    ).all()
+    pending: list[dict[str, Any]] = []
+    for proposal in proposals:
+        payload = _proposal_payload(proposal)
+        if payload is None:
+            continue
+        bounty_id = _proposal_bounty_id(payload)
+        bounty = session.get(Bounty, bounty_id) if bounty_id is not None else None
+        row = _pending_activity_row(proposal, payload, bounty)
+        if row["account"] is None or not _pending_activity_row_matches(row, search_query):
+            continue
+        pending.append(row)
+    return pending
+
+
 def activity_to_dict(session: Session, query: str | None = None) -> dict[str, Any]:
     """Build the public activity feed and contributor totals."""
     search_query = _activity_search_query(query)
@@ -483,14 +556,24 @@ def activity_to_dict(session: Session, query: str | None = None) -> dict[str, An
     for row in recent:
         del row["amount_microunits"]
 
+    pending_payouts = pending_activity_rows(session, search_query)
+    pending_microunits = sum(int(row["amount_microunits"]) for row in pending_payouts)
+    for row in pending_payouts:
+        del row["amount_microunits"]
+
     return {
         "totals": {
             "accepted_awards": len(recent),
             "accepted_mrwk": format_mrwk(total_microunits),
             "contributors": len(contributors),
         },
+        "pending_totals": {
+            "pending_awards": len(pending_payouts),
+            "pending_mrwk": format_mrwk(pending_microunits),
+        },
         "query": search_query,
         "contributors": contributors,
+        "pending_payouts": pending_payouts[:100],
         "recent": recent[:100],
     }
 

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -23,6 +23,8 @@
   <article><strong>{{ totals.accepted_awards }}</strong><span>accepted awards</span></article>
   <article><strong>{{ totals.accepted_mrwk }}</strong><span>accepted MRWK</span></article>
   <article><strong>{{ totals.contributors }}</strong><span>contributors</span></article>
+  <article><strong>{{ pending_totals.pending_awards }}</strong><span>pending awards</span></article>
+  <article><strong>{{ pending_totals.pending_mrwk }}</strong><span>pending MRWK</span></article>
 </section>
 
 <section>
@@ -69,6 +71,62 @@
 </section>
 
 <section>
+  <h2>Pending accepted work</h2>
+  <p>Queued for treasury execution, not proof-backed paid work.</p>
+  {% if pending_payouts %}
+  <div class="ledger-list">
+    {% for row in pending_payouts %}
+    <article class="ledger-row">
+      <div class="ledger-entry-card">
+        <div class="ledger-card-head">
+          <div class="ledger-card-title">
+            <a class="ledger-entry-link" href="{{ row.proposal_url }}">Proposal #{{ row.proposal_id }}</a>
+            <span class="ledger-type">Pending</span>
+          </div>
+          <strong class="ledger-amount">{{ row.amount_mrwk or "-" }}{% if row.amount_mrwk %} MRWK{% endif %}</strong>
+        </div>
+        <dl class="ledger-card-grid">
+          <div class="ledger-field ledger-field--to">
+            <dt>Contributor</dt>
+            <dd><a href="/accounts/{{ row.account }}">{{ row.account }}</a></dd>
+          </div>
+          <div class="ledger-field ledger-field--reference reference-cell">
+            <dt>Bounty</dt>
+            {% set pending_bounty_issue_url = safe_public_url(row.bounty_issue_url) %}
+            <dd>
+              {% if row.bounty_url %}<a href="{{ row.bounty_url }}">Bounty #{{ row.bounty_id }}</a>{% endif %}
+              {% if row.bounty_url and pending_bounty_issue_url %} &middot; {% endif %}
+              {% if pending_bounty_issue_url %}<a href="{{ pending_bounty_issue_url }}">{{ row.bounty_repo }} #{{ row.bounty_issue_number }}</a>{% elif not row.bounty_url %}-{% endif %}
+            </dd>
+          </div>
+          <div class="ledger-field ledger-field--reference reference-cell">
+            <dt>Accepted work</dt>
+            {% set pending_submission_url = safe_public_url(row.submission_url) %}
+            <dd>{% if pending_submission_url %}<a href="{{ pending_submission_url }}">{{ row.submission_url | replace("https://github.com/", "") }}</a>{% elif row.submission_url %}<code>{{ row.submission_url }}</code>{% else %}-{% endif %}</dd>
+          </div>
+          <div class="ledger-field">
+            <dt>Accepted by</dt>
+            <dd>{{ row.accepted_by or "-" }}</dd>
+          </div>
+          <div class="ledger-field">
+            <dt>Executes after</dt>
+            <dd>{{ row.executes_after }}</dd>
+          </div>
+        </dl>
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+  {% else %}
+  {% if query %}
+  <p>No pending accepted work matches this search.</p>
+  {% else %}
+  <p>No pending accepted work rows.</p>
+  {% endif %}
+  {% endif %}
+</section>
+
+<section>
   <h2>Recent accepted work</h2>
   {% if recent %}
   <div class="ledger-list">
@@ -92,7 +150,7 @@
             {% set bounty_issue_url = safe_public_url(row.bounty_issue_url) %}
             <dd>
               {% if row.bounty_url %}<a href="{{ row.bounty_url }}">Bounty #{{ row.bounty_id }}</a>{% endif %}
-              {% if row.bounty_url and bounty_issue_url %} · {% endif %}
+              {% if row.bounty_url and bounty_issue_url %} &middot; {% endif %}
               {% if bounty_issue_url %}<a href="{{ bounty_issue_url }}">{{ row.bounty_repo }} #{{ row.bounty_issue_number }}</a>{% elif not row.bounty_url %}-{% endif %}
             </dd>
           </div>

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -279,10 +279,16 @@ curl -s "$API_HOST/api/v1/activity"
 curl -s "$API_HOST/api/v1/activity?q=p3xill"
 ```
 
-The optional `q` parameter filters activity rows by account, amount, submission
-URL, proof hash, bounty repo, bounty issue URL, internal bounty id, or GitHub
-issue number. The response groups matching proof-backed bounty payments into
-`totals`, contributor rollups, and the most recent payment rows:
+The optional `q` parameter filters proof-backed and pending activity rows by
+account, amount, submission URL, proof hash, proposal id, bounty repo, bounty
+issue URL, internal bounty id, or GitHub issue number. In other words, the
+same search can match bounty repo, bounty issue URL, proposal, proof, or
+submission evidence. The response groups
+matching proof-backed bounty payments into `totals`, contributor rollups, and
+the most recent payment rows. Accepted-but-not-yet-executed `pay_bounty`
+proposals appear separately in `pending_totals` and `pending_payouts`; they are
+not counted as paid, proof-backed, received, or withdrawable work until treasury
+execution creates a ledger proof:
 
 ```json
 {
@@ -290,6 +296,10 @@ issue number. The response groups matching proof-backed bounty payments into
     "accepted_awards": 2,
     "accepted_mrwk": "115",
     "contributors": 1
+  },
+  "pending_totals": {
+    "pending_awards": 1,
+    "pending_mrwk": "50"
   },
   "query": "p3xill",
   "contributors": [
@@ -303,6 +313,24 @@ issue number. The response groups matching proof-backed bounty payments into
       "latest_bounty_issue_url": "https://github.com/ramimbo/mergework/issues/219",
       "latest_proof_hash": "99f78d41b9a493ba2e6136cba0b0762f013a913c9d90c562976282e93d00b81f",
       "latest_proof_url": "/proofs/99f78d41b9a493ba2e6136cba0b0762f013a913c9d90c562976282e93d00b81f"
+    }
+  ],
+  "pending_payouts": [
+    {
+      "proposal_id": 67,
+      "proposal_url": "/api/v1/treasury/proposals/67",
+      "status": "pending",
+      "account": "github:p3xill",
+      "amount_mrwk": "50",
+      "submission_url": "https://github.com/ramimbo/mergework/pull/226#pullrequestreview-4354910919",
+      "bounty_repo": "ramimbo/mergework",
+      "bounty_id": 91,
+      "bounty_issue_number": 643,
+      "bounty_issue_url": "https://github.com/ramimbo/mergework/issues/643",
+      "bounty_url": "/bounties/91",
+      "accepted_by": "ramimbo",
+      "proposed_at": "2026-05-31T11:41:45.307945",
+      "executes_after": "2026-06-01T11:41:45.307945"
     }
   ],
   "recent": [

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from app.db import create_schema, session_scope
 from app.ledger.service import add_ledger_entry, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
+from app.treasury import propose_treasury_action
 
 
 def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -> None:
@@ -82,6 +83,11 @@ def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -
         "accepted_mrwk": "90",
         "contributors": 2,
     }
+    assert payload["pending_totals"] == {
+        "pending_awards": 0,
+        "pending_mrwk": "0",
+    }
+    assert payload["pending_payouts"] == []
     assert payload["contributors"][0] == {
         "account": "github:alice",
         "accepted_awards": 2,
@@ -192,6 +198,92 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
         assert invalid_hash_query["recent"] == []
 
 
+def test_activity_api_exposes_pending_payouts_separately_from_paid_work(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        pending_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=167,
+            issue_url="https://github.com/ramimbo/mergework/issues/167",
+            title="Pending activity bounty",
+            reward_mrwk="75",
+            acceptance="Activity should show queued accepted work separately.",
+        )
+        paid_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=168,
+            issue_url="https://github.com/ramimbo/mergework/issues/168",
+            title="Paid activity bounty",
+            reward_mrwk="25",
+            acceptance="Activity should keep proof-backed totals unchanged.",
+        )
+        proposal = propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": pending_bounty.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/167",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=paid_bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/168",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    payload = client.get("/api/v1/activity").json()
+    by_account = client.get("/api/v1/activity?q=alice").json()
+    by_proposal = client.get(f"/api/v1/activity?q=#{proposal.id}").json()
+    by_submission = client.get("/api/v1/activity?q=pull%2F167").json()
+
+    assert payload["totals"] == {
+        "accepted_awards": 1,
+        "accepted_mrwk": "25",
+        "contributors": 1,
+    }
+    assert payload["recent"][0]["proof_hash"] == proof.hash
+    assert payload["pending_totals"] == {
+        "pending_awards": 1,
+        "pending_mrwk": "75",
+    }
+    assert payload["pending_payouts"] == [
+        {
+            "proposal_id": proposal.id,
+            "proposal_url": f"/api/v1/treasury/proposals/{proposal.id}",
+            "status": "pending",
+            "account": "github:alice",
+            "amount_mrwk": "75",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/167",
+            "bounty_repo": "ramimbo/mergework",
+            "bounty_issue_number": 167,
+            "bounty_issue_url": "https://github.com/ramimbo/mergework/issues/167",
+            "bounty_id": pending_bounty.id,
+            "bounty_url": f"/bounties/{pending_bounty.id}",
+            "accepted_by": "maintainer",
+            "proposed_at": proposal.proposed_at.isoformat(),
+            "executes_after": proposal.executes_after.isoformat(),
+        }
+    ]
+    assert by_account["pending_payouts"][0]["proposal_id"] == proposal.id
+    assert by_proposal["pending_payouts"][0]["proposal_id"] == proposal.id
+    assert by_submission["pending_payouts"][0]["proposal_id"] == proposal.id
+    assert by_submission["recent"] == []
+    assert by_submission["totals"]["accepted_awards"] == 0
+
+
 def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
@@ -201,6 +293,7 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert empty.status_code == 200
     assert "Accepted work activity" in empty.text
     assert "No accepted bounty payments yet." in empty.text
+    assert "No pending accepted work rows." in empty.text
 
     with session_scope(sqlite_url) as session:
         bounty = create_bounty(
@@ -236,6 +329,7 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert 'href="https://github.com/ramimbo/mergework/pull/12"' in paid.text
     assert f'href="/proofs/{proof.hash}"' in paid.text
     assert "/accounts/github:bob" in paid.text
+    assert "Pending accepted work" in paid.text
 
     filtered = client.get("/activity?q=bob")
     issue_ref = client.get("/activity?q=%2312")
@@ -260,6 +354,55 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert "Showing accepted work matching “alice”." in no_match.text
     assert "No contributors match this search." in no_match.text
     assert "No accepted work matches this search." in no_match.text
+    assert "No pending accepted work matches this search." in no_match.text
     assert "No accepted bounty payments yet." not in no_match.text
     assert "No proof-backed accepted work rows yet." not in no_match.text
     assert 'href="/activity">Clear search</a>' in no_match.text
+
+
+def test_activity_page_renders_pending_accepted_work(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=169,
+            issue_url="https://github.com/ramimbo/mergework/issues/169",
+            title="Pending activity page bounty",
+            reward_mrwk="125",
+            acceptance="Activity page should label pending work safely.",
+        )
+        proposal = propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": bounty.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/169",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    page = client.get("/activity")
+    filtered = client.get(f"/activity?q=%23{proposal.id}")
+
+    assert page.status_code == 200
+    assert "Pending accepted work" in page.text
+    assert "Queued for treasury execution, not proof-backed paid work." in page.text
+    assert f'href="/api/v1/treasury/proposals/{proposal.id}"' in page.text
+    assert "Proposal #" in page.text
+    assert "github:alice" in page.text
+    assert "125 MRWK" in page.text
+    assert 'href="https://github.com/ramimbo/mergework/pull/169"' in page.text
+    assert "No proof-backed accepted work rows yet." in page.text
+    assert "accepted MRWK" in page.text
+    assert "pending MRWK" in page.text
+
+    assert filtered.status_code == 200
+    assert f'value="#{proposal.id}"' in filtered.text
+    assert f"Proposal #{proposal.id}" in filtered.text
+    assert "No accepted work matches this search." in filtered.text

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -204,6 +204,15 @@ def test_activity_api_exposes_pending_payouts_separately_from_paid_work(
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
         ensure_genesis(session)
+        paid_bounty = create_bounty(
+            session,
+            repo="ramimbo/paidwork",
+            issue_number=268,
+            issue_url="https://github.com/ramimbo/paidwork/issues/268",
+            title="Paid activity bounty",
+            reward_mrwk="25",
+            acceptance="Activity should keep proof-backed totals unchanged.",
+        )
         pending_bounty = create_bounty(
             session,
             repo="ramimbo/mergework",
@@ -212,15 +221,6 @@ def test_activity_api_exposes_pending_payouts_separately_from_paid_work(
             title="Pending activity bounty",
             reward_mrwk="75",
             acceptance="Activity should show queued accepted work separately.",
-        )
-        paid_bounty = create_bounty(
-            session,
-            repo="ramimbo/mergework",
-            issue_number=168,
-            issue_url="https://github.com/ramimbo/mergework/issues/168",
-            title="Paid activity bounty",
-            reward_mrwk="25",
-            acceptance="Activity should keep proof-backed totals unchanged.",
         )
         proposal = propose_treasury_action(
             session,
@@ -237,32 +237,40 @@ def test_activity_api_exposes_pending_payouts_separately_from_paid_work(
             session,
             bounty_id=paid_bounty.id,
             to_account="github:alice",
-            submission_url="https://github.com/ramimbo/mergework/pull/168",
+            submission_url="https://github.com/ramimbo/paidwork/pull/268",
             accepted_by="maintainer",
             verifier_result={"label": "mrwk:accepted"},
         )
+        pending_bounty_id = pending_bounty.id
+        proposal_id = proposal.id
+        proposal_proposed_at = proposal.proposed_at.isoformat()
+        proposal_executes_after = proposal.executes_after.isoformat()
+        proof_hash = proof.hash
 
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
     payload = client.get("/api/v1/activity").json()
     by_account = client.get("/api/v1/activity?q=alice").json()
-    by_proposal = client.get(f"/api/v1/activity?q=#{proposal.id}").json()
+    by_proposal = client.get(f"/api/v1/activity?q=%23{proposal_id}").json()
     by_submission = client.get("/api/v1/activity?q=pull%2F167").json()
+    by_bounty_id = client.get(f"/api/v1/activity?q=%23{pending_bounty_id}").json()
+    by_repo = client.get("/api/v1/activity?q=ramimbo%2Fmergework").json()
+    by_issue = client.get("/api/v1/activity?q=%23167").json()
 
     assert payload["totals"] == {
         "accepted_awards": 1,
         "accepted_mrwk": "25",
         "contributors": 1,
     }
-    assert payload["recent"][0]["proof_hash"] == proof.hash
+    assert payload["recent"][0]["proof_hash"] == proof_hash
     assert payload["pending_totals"] == {
         "pending_awards": 1,
         "pending_mrwk": "75",
     }
     assert payload["pending_payouts"] == [
         {
-            "proposal_id": proposal.id,
-            "proposal_url": f"/api/v1/treasury/proposals/{proposal.id}",
+            "proposal_id": proposal_id,
+            "proposal_url": f"/api/v1/treasury/proposals/{proposal_id}",
             "status": "pending",
             "account": "github:alice",
             "amount_mrwk": "75",
@@ -270,18 +278,27 @@ def test_activity_api_exposes_pending_payouts_separately_from_paid_work(
             "bounty_repo": "ramimbo/mergework",
             "bounty_issue_number": 167,
             "bounty_issue_url": "https://github.com/ramimbo/mergework/issues/167",
-            "bounty_id": pending_bounty.id,
-            "bounty_url": f"/bounties/{pending_bounty.id}",
+            "bounty_id": pending_bounty_id,
+            "bounty_url": f"/bounties/{pending_bounty_id}",
             "accepted_by": "maintainer",
-            "proposed_at": proposal.proposed_at.isoformat(),
-            "executes_after": proposal.executes_after.isoformat(),
+            "proposed_at": proposal_proposed_at,
+            "executes_after": proposal_executes_after,
         }
     ]
-    assert by_account["pending_payouts"][0]["proposal_id"] == proposal.id
-    assert by_proposal["pending_payouts"][0]["proposal_id"] == proposal.id
-    assert by_submission["pending_payouts"][0]["proposal_id"] == proposal.id
+    assert by_account["pending_payouts"][0]["proposal_id"] == proposal_id
+    assert by_proposal["pending_payouts"][0]["proposal_id"] == proposal_id
+    assert by_submission["pending_payouts"][0]["proposal_id"] == proposal_id
+    assert by_bounty_id["pending_payouts"][0]["proposal_id"] == proposal_id
+    assert by_repo["pending_payouts"][0]["proposal_id"] == proposal_id
+    assert by_issue["pending_payouts"][0]["proposal_id"] == proposal_id
     assert by_submission["recent"] == []
+    assert by_bounty_id["recent"] == []
+    assert by_repo["recent"] == []
+    assert by_issue["recent"] == []
     assert by_submission["totals"]["accepted_awards"] == 0
+    assert by_bounty_id["totals"]["accepted_awards"] == 0
+    assert by_repo["totals"]["accepted_awards"] == 0
+    assert by_issue["totals"]["accepted_awards"] == 0
 
 
 def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:

--- a/tests/test_activity_routes.py
+++ b/tests/test_activity_routes.py
@@ -15,6 +15,11 @@ def test_activity_context_preserves_empty_feed_shape(sqlite_url: str) -> None:
                 "accepted_mrwk": "0",
                 "contributors": 0,
             },
+            "pending_totals": {
+                "pending_awards": 0,
+                "pending_mrwk": "0",
+            },
             "contributors": [],
+            "pending_payouts": [],
             "recent": [],
         }

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -291,8 +291,10 @@ def test_activity_serializers_skip_malformed_public_proofs(sqlite_url: str) -> N
 
     assert activity == {
         "totals": {"accepted_awards": 0, "accepted_mrwk": "0", "contributors": 0},
+        "pending_totals": {"pending_awards": 0, "pending_mrwk": "0"},
         "query": "",
         "contributors": [],
+        "pending_payouts": [],
         "recent": [],
     }
     assert summary == empty_accepted_summary()


### PR DESCRIPTION
Bounty #647
Source issue: #673

## Summary
- Adds a separate `pending_totals` summary and `pending_payouts` list to `/api/v1/activity` for accepted-but-not-yet-executed `pay_bounty` proposals.
- Keeps proof-backed `totals`, contributor rankings, and `recent` rows unchanged until ledger/proof execution happens.
- Extends activity search so pending rows can be found by account, submission URL, proposal id, bounty id, repo, and issue number.
- Adds a clearly labeled pending accepted-work section to `/activity` with wording that pending work is not proof-backed paid work.
- Documents the pending activity shape in API examples.

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests\test_activity.py tests\test_activity_routes.py tests\test_serializers.py tests\test_docs_public_urls.py -q` -> 46 passed
- `.\.venv\Scripts\python.exe -m ruff check app\serializers.py tests\test_activity.py tests\test_activity_routes.py tests\test_serializers.py` -> All checks passed
- `.\.venv\Scripts\python.exe -m ruff format --check app\serializers.py tests\test_activity.py tests\test_activity_routes.py tests\test_serializers.py` -> 4 files already formatted
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check` -> passed

## Duplicate Check
- Open PRs checked for source issue #673 returned no existing PR.
- Related open #647 PRs cover account-level pending payouts (#671), partial availability (#697), attempt capacity (#715), and other discovery/schema surfaces, but not global `/activity` pending accepted-work visibility.
- Bounty API row #95 was open with 9 effective awards remaining at submission time.

## Scope
No payout execution, proof generation, ledger mutation, treasury execution, wallet behavior, balance, exchange, bridge, cash-out, price, private data, or production mutation behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity feed now shows pending accepted work (treasury proposals awaiting execution) with pending totals and a ledger-style list of pending payouts.
  * Search extended to match pending payouts (including issue-number style queries).

* **Documentation**
  * API docs updated to include pending_totals and pending_payouts and to describe expanded q-filter behavior.

* **Tests**
  * Tests added/updated to cover pending payouts in API and HTML activity page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->