### PR TITLE
feat: add MCP validation error details

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -79,8 +79,52 @@ MCP_TOOLS: list[dict[str, Any]] = [
 ]
 
 
-def _jsonrpc_error(response_id: Any, code: int, message: str) -> dict[str, Any]:
-    return {"jsonrpc": "2.0", "id": response_id, "error": {"code": code, "message": message}}
+def _jsonrpc_error(
+    response_id: Any, code: int, message: str, data: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    error: dict[str, Any] = {"code": code, "message": message}
+    if data:
+        error["data"] = data
+    return {"jsonrpc": "2.0", "id": response_id, "error": error}
+
+
+def _argument_from_reason(reason: str, args: dict[str, Any]) -> str | None:
+    for argument in sorted(args):
+        if not isinstance(argument, str):
+            continue
+        if reason.startswith(f"{argument} ") or reason.startswith(f"use {argument} "):
+            return argument
+    return None
+
+
+def _safe_argument_error_data(
+    error: BaseException,
+    *,
+    tool_name: str,
+    args: dict[str, Any],
+) -> dict[str, Any] | None:
+    reason: str | None = None
+    argument: str | None = None
+    if isinstance(error, KeyError) and len(error.args) == 1 and isinstance(error.args[0], str):
+        argument = error.args[0]
+        reason = f"{argument} is required"
+    elif isinstance(error, HTTPException):
+        if error.status_code >= 500 or not isinstance(error.detail, str):
+            return None
+        reason = error.detail
+    elif isinstance(error, ValueError | LedgerError):
+        reason = str(error)
+        if reason == "unknown tool":
+            return None
+    if not reason:
+        return None
+
+    data: dict[str, Any] = {"reason": reason, "tool": tool_name}
+    if argument is None:
+        argument = _argument_from_reason(reason, args)
+    if argument is not None:
+        data["argument"] = argument
+    return data
 
 
 def _tool_result_response(response_id: Any, tool_result: str | dict[str, Any]) -> dict[str, Any]:
@@ -136,7 +180,14 @@ async def handle_mcp_request(
 
     try:
         tool_result = call_tool(database_url, name, args)
-    except (KeyError, TypeError, ValueError, LedgerError, HTTPException):
+    except (KeyError, ValueError, LedgerError, HTTPException) as exc:
+        return _jsonrpc_error(
+            response_id,
+            -32602,
+            "invalid tool arguments",
+            _safe_argument_error_data(exc, tool_name=name, args=args),
+        )
+    except TypeError:
         return _jsonrpc_error(response_id, -32602, "invalid tool arguments")
 
     return _tool_result_response(response_id, tool_result)

--- a/app/mcp.py
+++ b/app/mcp.py
@@ -180,7 +180,16 @@ async def handle_mcp_request(
 
     try:
         tool_result = call_tool(database_url, name, args)
-    except (KeyError, ValueError, LedgerError, HTTPException) as exc:
+    except HTTPException as exc:
+        if exc.status_code >= 500:
+            return _jsonrpc_error(response_id, -32603, "internal error")
+        return _jsonrpc_error(
+            response_id,
+            -32602,
+            "invalid tool arguments",
+            _safe_argument_error_data(exc, tool_name=name, args=args),
+        )
+    except (KeyError, ValueError, LedgerError) as exc:
         return _jsonrpc_error(
             response_id,
             -32602,

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -606,7 +606,8 @@ Successful claim responses use the same immutable ledger-entry shape as
 MCP tool validation errors keep JSON-RPC code `-32602` and message
 `invalid tool arguments` for compatibility. When present, inspect
 `error.data.reason` for the safe field-level correction, such as
-`limit must be at most 100` or `format must be text or json`.
+`limit must be at most 100` or `format must be text or json`. Internal server
+errors remain generic `-32603` responses without stack traces or private detail.
 
 List MCP tools:
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -603,6 +603,11 @@ Successful claim responses use the same immutable ledger-entry shape as
 
 ## MCP Examples
 
+MCP tool validation errors keep JSON-RPC code `-32602` and message
+`invalid tool arguments` for compatibility. When present, inspect
+`error.data.reason` for the safe field-level correction, such as
+`limit must be at most 100` or `format must be text or json`.
+
 List MCP tools:
 
 ```bash

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -4,6 +4,7 @@ import json
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
@@ -759,6 +760,36 @@ def test_mcp_rejects_unknown_tool_name(sqlite_url: str) -> None:
     )
 
     assert_mcp_argument_error(response, 12)
+
+
+def test_mcp_internal_http_exception_stays_generic(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def failing_tool(database_url: str, name: str, args: dict[str, object]) -> str:
+        raise HTTPException(status_code=500, detail="database connection failed")
+
+    monkeypatch.setattr("app.main.call_mcp_tool", failing_tool)
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        raise_server_exceptions=False,
+    )
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 13,
+            "method": "tools/call",
+            "params": {"name": "get_bounty", "arguments": {"id": 1}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 13,
+        "error": {"code": -32603, "message": "internal error"},
+    }
 
 
 def test_mcp_get_bounty_can_include_accepted_awards(sqlite_url: str) -> None:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1090,12 +1090,7 @@ def test_mcp_rejects_noncanonical_integer_string_arguments(
         },
     )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": request_id,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    assert_mcp_argument_error(response, request_id)
 
 
 def test_mcp_accepts_canonical_integer_string_arguments(sqlite_url: str) -> None:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -14,6 +14,19 @@ from app.serializers import public_utc_timestamp
 from app.treasury import propose_treasury_action
 
 
+def assert_mcp_argument_error(response: object, request_id: int, reason: str | None = None) -> None:
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["jsonrpc"] == "2.0"
+    assert payload["id"] == request_id
+    error = payload["error"]
+    assert error["code"] == -32602
+    assert error["message"] == "invalid tool arguments"
+    if reason is not None:
+        assert error["data"]["reason"] == reason
+    assert "traceback" not in json.dumps(error).lower()
+
+
 def test_health_status_and_bounty_api(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -404,12 +417,7 @@ def test_mcp_list_bounty_attempts_rejects_invalid_arguments(sqlite_url: str) -> 
         },
     )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 23,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    assert_mcp_argument_error(response, 23, "include_expired must be a boolean")
 
 
 def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> None:
@@ -637,19 +645,19 @@ def test_mcp_list_bounties_filters_effective_availability(sqlite_url: str) -> No
 
 
 @pytest.mark.parametrize(
-    ("arguments", "request_id"),
+    ("arguments", "request_id", "reason"),
     [
-        ({"status": "all"}, 31),
-        ({"status": True}, 32),
-        ({"q": 284}, 33),
-        ({"limit": 0}, 34),
-        ({"limit": 101}, 35),
-        ({"sort": "invalid"}, 36),
-        ({"availability": "maybe"}, 37),
+        ({"status": "all"}, 31, "status must be one of: open, paid, closed"),
+        ({"status": True}, 32, "status must be a string"),
+        ({"q": 284}, 33, "q must be a string"),
+        ({"limit": 0}, 34, "limit must be positive"),
+        ({"limit": 101}, 35, "limit must be at most 100"),
+        ({"sort": "invalid"}, 36, "sort must be one of: newest, reward, available, awards"),
+        ({"availability": "maybe"}, 37, "availability must be one of: all, effectively_open"),
     ],
 )
 def test_mcp_list_bounties_rejects_invalid_filters(
-    sqlite_url: str, arguments: dict[str, object], request_id: int
+    sqlite_url: str, arguments: dict[str, object], request_id: int, reason: str
 ) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -667,12 +675,7 @@ def test_mcp_list_bounties_rejects_invalid_filters(
         },
     )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": request_id,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    assert_mcp_argument_error(response, request_id, reason)
 
 
 def test_mcp_rejects_malformed_requests_without_500(sqlite_url: str) -> None:
@@ -755,12 +758,7 @@ def test_mcp_rejects_unknown_tool_name(sqlite_url: str) -> None:
         },
     )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 12,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    assert_mcp_argument_error(response, 12)
 
 
 def test_mcp_get_bounty_can_include_accepted_awards(sqlite_url: str) -> None:
@@ -906,12 +904,7 @@ def test_mcp_get_bounty_rejects_fractional_id(sqlite_url: str) -> None:
         },
     )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 12,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    assert_mcp_argument_error(response, 12, "id must be an integer")
 
 
 @pytest.mark.parametrize("include_awards", ["true", 1, []])
@@ -947,12 +940,7 @@ def test_mcp_get_bounty_rejects_non_boolean_include_awards(
         },
     )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 12,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    assert_mcp_argument_error(response, 12, "include_awards must be a boolean")
 
 
 @pytest.mark.parametrize("bounty_id", [0, -1])
@@ -973,12 +961,7 @@ def test_mcp_get_bounty_rejects_non_positive_id(sqlite_url: str, bounty_id: int)
         },
     )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 12,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    assert_mcp_argument_error(response, 12, "id must be positive")
 
 
 def test_mcp_get_wallet_returns_not_found_for_unregistered_wallet(sqlite_url: str) -> None:
@@ -1039,12 +1022,7 @@ def test_mcp_rejects_oversized_integer_arguments_without_500(
         },
     )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": request_id,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    assert_mcp_argument_error(response, request_id)
 
 
 @pytest.mark.parametrize(
@@ -1150,12 +1128,7 @@ def test_mcp_rejects_invalid_string_arguments(
         },
     )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": request_id,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    assert_mcp_argument_error(response, request_id)
 
 
 def test_mcp_get_ledger_entry_includes_payment_proof_hash(sqlite_url: str) -> None:
@@ -1219,12 +1192,7 @@ def test_mcp_get_ledger_entry_rejects_non_positive_sequence(sqlite_url: str) -> 
         },
     )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 2,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    assert_mcp_argument_error(response, 2, "sequence must be positive")
 
 
 def test_mcp_get_proof_returns_public_proof_details(sqlite_url: str) -> None:
@@ -1385,12 +1353,7 @@ def test_mcp_get_proof_rejects_malformed_hash(sqlite_url: str) -> None:
         },
     )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 3,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    assert_mcp_argument_error(response, 3, "proof hash must be 64 hex characters")
 
 
 def test_mcp_submit_work_proof_returns_bounty_specific_guidance(sqlite_url: str) -> None:
@@ -1801,23 +1764,27 @@ def test_mcp_submit_work_proof_scopes_issue_number_by_repo(sqlite_url: str) -> N
 
 
 @pytest.mark.parametrize(
-    ("arguments", "request_id"),
+    ("arguments", "request_id", "reason"),
     [
-        ({"bounty_id": 0}, 21),
-        ({"bounty_id": True}, 22),
-        ({"issue_number": 0}, 23),
-        ({"issue_number": 1.5}, 24),
-        ({"bounty_id": 1, "issue_number": 1}, 25),
-        ({"format": "xml"}, 26),
-        ({"format": 1}, 27),
-        ({"repo": "ramimbo/mergework"}, 29),
-        ({"bounty_id": 1, "repo": "ramimbo/mergework"}, 30),
-        ({"issue_number": 1, "repo": 1}, 31),
-        ({"issue_number": 1, "repo": "a" * 201}, 32),
+        ({"bounty_id": 0}, 21, "bounty_id must be positive"),
+        ({"bounty_id": True}, 22, "bounty_id must be an integer"),
+        ({"issue_number": 0}, 23, "issue_number must be positive"),
+        ({"issue_number": 1.5}, 24, "issue_number must be an integer"),
+        ({"bounty_id": 1, "issue_number": 1}, 25, "use bounty_id or issue_number, not both"),
+        ({"format": "xml"}, 26, "format must be text or json"),
+        ({"format": 1}, 27, "format must be a string"),
+        ({"repo": "ramimbo/mergework"}, 29, "repo can only be used with issue_number"),
+        (
+            {"bounty_id": 1, "repo": "ramimbo/mergework"},
+            30,
+            "repo can only be used with issue_number",
+        ),
+        ({"issue_number": 1, "repo": 1}, 31, "repo must be a string"),
+        ({"issue_number": 1, "repo": "a" * 201}, 32, "repo is too long"),
     ],
 )
 def test_mcp_submit_work_proof_rejects_invalid_bounty_selectors(
-    sqlite_url: str, arguments: dict[str, object], request_id: int
+    sqlite_url: str, arguments: dict[str, object], request_id: int, reason: str
 ) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -1835,12 +1802,7 @@ def test_mcp_submit_work_proof_rejects_invalid_bounty_selectors(
         },
     )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": request_id,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    assert_mcp_argument_error(response, request_id, reason)
 
 
 def test_mcp_submit_work_proof_rejects_ambiguous_issue_number(sqlite_url: str) -> None:
@@ -1878,12 +1840,7 @@ def test_mcp_submit_work_proof_rejects_ambiguous_issue_number(sqlite_url: str) -
         },
     )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 26,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    assert_mcp_argument_error(response, 26, "issue_number matches multiple bounties")
 
 
 def test_host_specific_homepages(sqlite_url: str) -> None:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1431,7 +1431,11 @@ def test_mcp_malformed_tool_call_returns_jsonrpc_error(sqlite_url: str) -> None:
     )
 
     assert response.status_code == 200
-    assert response.json()["error"] == {"code": -32602, "message": "invalid tool arguments"}
+    error = response.json()["error"]
+    assert error["code"] == -32602
+    assert error["message"] == "invalid tool arguments"
+    assert error["data"]["reason"] == "id is required"
+    assert "traceback" not in json.dumps(error).lower()
 
 
 def test_pay_bounty_rejects_reentrant_duplicate_before_ledger_write(


### PR DESCRIPTION
## Summary
- Addresses #714 by keeping JSON-RPC `-32602` / `invalid tool arguments` compatibility while adding safe `error.data.reason` details for expected MCP validation failures.
- Adds optional `tool` and easy-to-derive `argument` fields without exposing stack traces or internal TypeError details.
- Documents the MCP error detail contract for agent callers.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/test_api_mcp.py tests/test_security.py -q` (158 passed, 1 warning)
- `.venv/bin/python scripts/docs_smoke.py`
- `.venv/bin/python -m ruff check app/mcp.py tests/test_api_mcp.py tests/test_security.py`
- `.venv/bin/python -m ruff format --check app/mcp.py tests/test_api_mcp.py tests/test_security.py`
- `git diff --check`

Source issue: #714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer JSON‑RPC error responses for tool validation failures, including structured diagnostic data, inferred argument names, and field-level correction hints for invalid tool arguments.

* **Documentation**
  * Added API examples showing how to read and use diagnostic details from error responses, and clarifying that internal server errors remain generic.

* **Tests**
  * Added/updated tests and helpers to validate the new error structure and ensure internal errors stay generic and tracebacks are not exposed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->