### PR TITLE
feat: add exact bounty source filters

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -22,7 +22,7 @@ from app.ledger.service import (
     validate_public_url,
 )
 from app.models import Bounty, Proof, Submission
-from app.path_params import issue_number_search_value, positive_bounty_id
+from app.path_params import SQLITE_INTEGER_MAX, issue_number_search_value, positive_bounty_id
 from app.serializers import (
     bounties_to_dict,
     bounty_awards_to_dict,
@@ -97,11 +97,25 @@ def register_bounty_api_routes(
 ) -> dict[str, Any]:
     """Register bounty listing, CRUD, payment, close, and reconciliation routes."""
 
+    def _repo_filter_value(repo: str | None) -> str | None:
+        if repo is None:
+            return None
+        if contains_control_character(repo):
+            raise HTTPException(status_code=400, detail="repo must not contain control characters")
+        clean = repo.strip().lower()
+        if not clean:
+            return None
+        if len(clean) > 200:
+            raise HTTPException(status_code=400, detail="repo is too long")
+        return clean
+
     def _list_bounties_by_status(
         status: str | None = None,
         query_text: str | None = None,
         sort: str | None = None,
         limit: int | None = None,
+        repo: str | None = None,
+        issue_number: int | None = None,
     ) -> list[dict[str, Any]]:
         try:
             normalized_sort = normalize_bounty_sort(sort)
@@ -110,6 +124,7 @@ def register_bounty_api_routes(
             if "control characters" not in detail:
                 detail = BOUNTY_SORT_ERROR
             raise HTTPException(status_code=400, detail=detail) from exc
+        repo_filter = _repo_filter_value(repo)
         with session_scope(db_url) as session:
             query = select(Bounty)
             if status is not None:
@@ -123,6 +138,10 @@ def register_bounty_api_routes(
                         status_code=400, detail="status must be one of: open, paid, closed"
                     )
                 query = query.where(Bounty.status == normalized_status)
+            if repo_filter is not None:
+                query = query.where(func.lower(Bounty.repo) == repo_filter)
+            if issue_number is not None:
+                query = query.where(Bounty.issue_number == issue_number)
             if query_text is not None:
                 normalized_query = query_text.strip()
                 if normalized_query:
@@ -157,8 +176,17 @@ def register_bounty_api_routes(
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
         sort: str | None = Query(None),
+        repo: str | None = Query(None),
+        issue_number: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
     ) -> list[dict[str, Any]]:
-        return _list_bounties_by_status(status, q, sort=sort, limit=limit)
+        return _list_bounties_by_status(
+            status,
+            q,
+            sort=sort,
+            limit=limit,
+            repo=repo,
+            issue_number=issue_number,
+        )
 
     @app.get("/api/v1/bounties/summary")
     def api_bounties_summary(
@@ -166,8 +194,19 @@ def register_bounty_api_routes(
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
         sort: str | None = Query(None),
+        repo: str | None = Query(None),
+        issue_number: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
     ) -> dict[str, Any]:
-        return bounty_list_summary(_list_bounties_by_status(status, q, sort=sort, limit=limit))
+        return bounty_list_summary(
+            _list_bounties_by_status(
+                status,
+                q,
+                sort=sort,
+                limit=limit,
+                repo=repo,
+                issue_number=issue_number,
+            )
+        )
 
     @app.get("/api/v1/admin/webhook-events")
     def api_admin_webhook_events(

--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -152,14 +152,14 @@ def register_bounty_api_routes(
                         .replace("_", "\\_")
                     )
                     like_query = f"%{escaped_query}%"
-                    issue_number = issue_number_search_value(normalized_query)
+                    parsed_issue_number = issue_number_search_value(normalized_query)
                     text_filter = or_(
                         func.lower(Bounty.repo).like(like_query, escape="\\"),
                         func.lower(Bounty.title).like(like_query, escape="\\"),
                         func.lower(Bounty.acceptance).like(like_query, escape="\\"),
                     )
-                    if issue_number is not None:
-                        text_filter = or_(text_filter, Bounty.issue_number == issue_number)
+                    if parsed_issue_number is not None:
+                        text_filter = or_(text_filter, Bounty.issue_number == parsed_issue_number)
                     query = query.where(text_filter)
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             sorted_bounties = sort_bounties(

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
@@ -15,7 +15,7 @@ from app.bounty_sorting import BOUNTY_SORT_LABELS, normalize_bounty_sort
 from app.db import session_scope
 from app.ledger_views import account_ledger_transaction_types, account_ledger_transactions
 from app.models import Wallet
-from app.path_params import proof_hash_from_path
+from app.path_params import SQLITE_INTEGER_MAX, proof_hash_from_path
 from app.serializers import bounty_list_summary, wallet_to_dict
 from app.status import (
     CURRENT_TRANSFER_PATHS,
@@ -24,19 +24,52 @@ from app.status import (
 )
 
 
-def _bounties_api_url(
-    status: str | None, query_text: str, selected_sort: str, limit: int | None
+def _bounties_query_params(
+    status: str | None,
+    query_text: str,
+    selected_sort: str,
+    limit: int | None,
+    repo: str,
+    issue_number: int | None,
 ) -> str:
     params: list[tuple[str, str]] = []
     if status:
         params.append(("status", status))
+    if repo:
+        params.append(("repo", repo))
+    if issue_number is not None:
+        params.append(("issue_number", str(issue_number)))
     if query_text:
         params.append(("q", query_text))
     if selected_sort != "newest":
         params.append(("sort", selected_sort))
     if limit is not None:
         params.append(("limit", str(limit)))
-    return f"/api/v1/bounties?{urlencode(params)}" if params else "/api/v1/bounties"
+    return urlencode(params, quote_via=quote)
+
+
+def _bounties_api_url(
+    status: str | None,
+    query_text: str,
+    selected_sort: str,
+    limit: int | None,
+    repo: str,
+    issue_number: int | None,
+) -> str:
+    query = _bounties_query_params(status, query_text, selected_sort, limit, repo, issue_number)
+    return f"/api/v1/bounties?{query}" if query else "/api/v1/bounties"
+
+
+def _bounties_page_url(
+    status: str | None,
+    query_text: str,
+    selected_sort: str,
+    limit: int | None,
+    repo: str,
+    issue_number: int | None,
+) -> str:
+    query = _bounties_query_params(status, query_text, selected_sort, limit, repo, issue_number)
+    return f"/bounties?{query}" if query else "/bounties"
 
 
 def public_bounties_context(
@@ -45,23 +78,45 @@ def public_bounties_context(
     q: str | None,
     sort: str | None = None,
     limit: int | None = None,
+    repo: str | None = None,
+    issue_number: int | None = None,
 ) -> dict[str, Any]:
     selected_status = status.strip().lower() if status is not None else None
     query_text = q.strip() if q is not None else ""
     selected_sort = normalize_bounty_sort(sort)
+    repo_filter = repo.strip().lower() if repo is not None else ""
     limit_options: tuple[int, ...] = (10, 25, 50, 100, 200)
     if limit is not None and limit not in limit_options:
         limit_options = tuple(sorted((*limit_options, limit)))
+    status_links = {
+        status_key or "all": _bounties_page_url(
+            status_key,
+            query_text,
+            selected_sort,
+            limit,
+            repo_filter,
+            issue_number,
+        )
+        for status_key in (None, "open", "paid", "closed")
+    }
     return {
         "bounties": bounties,
         "summary": bounty_list_summary(bounties),
         "selected_status": selected_status,
         "query_text": query_text,
+        "repo_filter": repo_filter,
+        "issue_number_filter": issue_number,
         "selected_sort": selected_sort,
         "sort_options": BOUNTY_SORT_LABELS,
         "selected_limit": limit,
         "limit_options": limit_options,
-        "api_results_url": _bounties_api_url(selected_status, query_text, selected_sort, limit),
+        "status_links": status_links,
+        "clear_search_url": _bounties_page_url(
+            selected_status, "", selected_sort, limit, repo_filter, issue_number
+        ),
+        "api_results_url": _bounties_api_url(
+            selected_status, query_text, selected_sort, limit, repo_filter, issue_number
+        ),
     }
 
 
@@ -129,9 +184,7 @@ def register_public_routes(
     *,
     db_url: str,
     templates: Jinja2Templates,
-    list_bounties_by_status: Callable[
-        [str | None, str | None, str | None, int | None], list[dict[str, Any]]
-    ],
+    list_bounties_by_status: Callable[..., list[dict[str, Any]]],
     api_bounty: Callable[[int], dict[str, Any]],
     api_ledger: Callable[[], list[dict[str, Any]]],
     api_ledger_entry: Callable[[int], dict[str, Any]],
@@ -144,12 +197,16 @@ def register_public_routes(
         q: str | None = Query(None),
         sort: str | None = Query(None),
         limit: int | None = Query(None, ge=1, le=200),
+        repo: str | None = Query(None),
+        issue_number: int | None = Query(None, ge=1, le=SQLITE_INTEGER_MAX),
     ) -> HTMLResponse:
-        bounties = list_bounties_by_status(status, q, sort, limit)
+        bounties = list_bounties_by_status(
+            status, q, sort=sort, limit=limit, repo=repo, issue_number=issue_number
+        )
         return templates.TemplateResponse(
             request,
             "bounties.html",
-            public_bounties_context(bounties, status, q, sort, limit),
+            public_bounties_context(bounties, status, q, sort, limit, repo, issue_number),
         )
 
     @app.get("/bounties/{bounty_id}", response_class=HTMLResponse)

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -4,6 +4,10 @@
 <h1>Bounties</h1>
 <form method="get" action="/bounties" aria-label="Search bounties">
   {% if selected_status %}<input type="hidden" name="status" value="{{ selected_status }}">{% endif %}
+  <label for="bounty-repo">Repo</label>
+  <input id="bounty-repo" name="repo" type="search" value="{{ repo_filter }}" placeholder="owner/name">
+  <label for="bounty-issue-number">Issue number</label>
+  <input id="bounty-issue-number" name="issue_number" type="number" min="1" value="{% if issue_number_filter %}{{ issue_number_filter }}{% endif %}" placeholder="GitHub issue">
   <label for="bounty-search">Search bounties</label>
   <input id="bounty-search" name="q" type="search" value="{{ query_text }}" placeholder="repo, title, issue number, or acceptance text">
   <label for="bounty-sort">Sort</label>
@@ -20,15 +24,16 @@
     {% endfor %}
   </select>
   <button type="submit">Search</button>
-  {% if query_text %}<a href="/bounties{% if selected_status or selected_sort != "newest" or selected_limit %}?{% if selected_status %}status={{ selected_status }}{% endif %}{% if selected_status and (selected_sort != "newest" or selected_limit) %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% if selected_sort != "newest" and selected_limit %}&{% endif %}{% if selected_limit %}limit={{ selected_limit }}{% endif %}{% endif %}">Clear search</a>{% endif %}
+  {% if query_text %}<a href="{{ clear_search_url }}">Clear search</a>{% endif %}
 </form>
 <nav aria-label="Bounty status filters">
-  <a href="/bounties{% if query_text or selected_sort != "newest" or selected_limit %}?{% if query_text %}q={{ query_text | urlencode }}{% endif %}{% if query_text and (selected_sort != "newest" or selected_limit) %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% if selected_sort != "newest" and selected_limit %}&{% endif %}{% if selected_limit %}limit={{ selected_limit }}{% endif %}{% endif %}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
-  <a href="/bounties?status=open{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
-  <a href="/bounties?status=paid{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
-  <a href="/bounties?status=closed{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
+  <a href="{{ status_links.all }}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
+  <a href="{{ status_links.open }}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
+  <a href="{{ status_links.paid }}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
+  <a href="{{ status_links.closed }}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
 </nav>
 {% if query_text %}<p>Showing matches for “{{ query_text }}”.</p>{% endif %}
+{% if repo_filter or issue_number_filter %}<p>Showing source filter{% if repo_filter %} for {{ repo_filter }}{% endif %}{% if issue_number_filter %} #{{ issue_number_filter }}{% endif %}.</p>{% endif %}
 <section class="bounty-list-summary" aria-label="Bounty list summary">
   <article>
     <span>Bounties shown</span>
@@ -80,7 +85,7 @@
     <p>{{ bounty.acceptance }}</p>
   </article>
   {% else %}
-  {% if query_text or selected_status %}
+  {% if query_text or selected_status or repo_filter or issue_number_filter %}
   <p>No bounties match these filters.</p>
   <p><a href="/bounties">Clear filters</a></p>
   {% else %}

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -53,6 +53,7 @@ filters:
 curl -s "$API_HOST/api/v1/bounties/summary"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open"
 curl -s "$API_HOST/api/v1/bounties/summary?q=docs"
+curl -s "$API_HOST/api/v1/bounties/summary?repo=ramimbo%2Fmergework&issue_number=647"
 ```
 
 Inspect one bounty, accepted-work activity, a ledger page, and a proof:
@@ -73,6 +74,13 @@ curl -s "$API_HOST/api/v1/ledger/1"
 
 The `<bounty_id>` value is the internal MergeWork bounty id returned by
 `/api/v1/bounties`, not the GitHub issue number.
+
+When an agent starts from a GitHub issue URL, use exact source filters before
+falling back to broad search:
+
+```bash
+curl -s "$API_HOST/api/v1/bounties?repo=ramimbo%2Fmergework&issue_number=647"
+```
 
 Inspect treasury proposals:
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -19,8 +19,10 @@ curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
 curl -s "$API_HOST/api/v1/bounties?status=open"
 curl -s "$API_HOST/api/v1/bounties?status=open&sort=available&limit=5"
+curl -s "$API_HOST/api/v1/bounties?repo=ramimbo%2Fmergework&issue_number=647"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open&q=proof"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open&sort=awards&limit=5"
+curl -s "$API_HOST/api/v1/bounties/summary?repo=ramimbo%2Fmergework&issue_number=647"
 ```
 
 The bounties list returns public bounty rows. `status` can be omitted or set to
@@ -66,9 +68,14 @@ by per-award reward, `available` sorts by the remaining MRWK pool, and `awards`
 sorts by remaining award slots. Use `limit` from `1` to `200` to cap returned
 rows after filtering and sorting.
 
+Use exact source filters when starting from a GitHub issue URL:
+`repo=owner/name` narrows to one repository, `issue_number=N` narrows to one
+GitHub issue number, and both together identify a source issue without relying
+on broad `q` search.
+
 Use `/api/v1/bounties/summary` with the same optional `status`, `q`, `sort`, and
 `limit` filters when an agent only needs capacity totals instead of full bounty
-rows:
+rows. It also accepts the exact `repo` and `issue_number` source filters:
 
 ```json
 {

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -397,6 +397,70 @@ def test_bounty_api_limit_caps_filtered_rows(sqlite_url: str) -> None:
     assert first.id not in [item["id"] for item in limited.json()]
 
 
+def test_bounty_api_filters_by_exact_source_repo_and_issue(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        first = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=61,
+            issue_url="https://github.com/ramimbo/mergework/issues/61",
+            title="MergeWork exact source",
+            reward_mrwk="10",
+            acceptance="Exact source lookup should find this bounty.",
+        )
+        second = create_bounty(
+            session,
+            repo="example/mergework",
+            issue_number=61,
+            issue_url="https://github.com/example/mergework/issues/61",
+            title="Other repo same issue",
+            reward_mrwk="20",
+            acceptance="Issue-only lookup should include this bounty too.",
+        )
+        third = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=62,
+            issue_url="https://github.com/ramimbo/mergework/issues/62",
+            title="MergeWork other issue",
+            reward_mrwk="30",
+            acceptance="Repo-only lookup should include this bounty too.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    repo_rows = client.get("/api/v1/bounties?repo=RAMIMBO%2FMergeWork").json()
+    issue_rows = client.get("/api/v1/bounties?issue_number=61").json()
+    exact_rows = client.get("/api/v1/bounties?repo=ramimbo%2Fmergework&issue_number=61").json()
+    summary = client.get("/api/v1/bounties/summary?repo=ramimbo%2Fmergework&issue_number=61").json()
+
+    assert [item["id"] for item in repo_rows] == [third.id, first.id]
+    assert [item["id"] for item in issue_rows] == [second.id, first.id]
+    assert [item["id"] for item in exact_rows] == [first.id]
+    assert summary["bounties_shown"] == 1
+    assert summary["open_awards"] == 1
+
+
+def test_bounty_api_rejects_invalid_source_filters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    control = client.get("/api/v1/bounties?repo=%C2%85ramimbo%2Fmergework")
+    oversized = client.get(f"/api/v1/bounties?repo={'a' * 201}")
+
+    assert control.status_code == 400
+    assert control.json()["detail"] == "repo must not contain control characters"
+    assert oversized.status_code == 400
+    assert oversized.json()["detail"] == "repo is too long"
+    assert client.get("/api/v1/bounties?issue_number=0").status_code == 422
+    assert client.get("/api/v1/bounties/summary?issue_number=0").status_code == 422
+
+
 def test_bounty_api_limit_rejects_out_of_range_values(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -271,7 +271,7 @@ def test_bounties_page_honors_limit_filter(sqlite_url: str) -> None:
     assert "<strong>2</strong>" in limited_page.text
     assert '<option value="2" selected>2</option>' in limited_page.text
     assert '<option value=""' in limited_page.text
-    assert 'href="/bounties?status=open&limit=2"' in limited_page.text
+    assert 'href="/bounties?status=open&amp;limit=2"' in limited_page.text
 
     filtered_limited_page = client.get("/bounties?q=public&sort=reward&limit=2")
     assert filtered_limited_page.status_code == 200
@@ -279,7 +279,7 @@ def test_bounties_page_honors_limit_filter(sqlite_url: str) -> None:
         '<option value="reward" selected>Highest per-award reward</option>'
         in filtered_limited_page.text
     )
-    assert 'href="/bounties?sort=reward&limit=2">Clear search</a>' in filtered_limited_page.text
+    assert 'href="/bounties?sort=reward&amp;limit=2">Clear search</a>' in filtered_limited_page.text
     assert (
         'href="/api/v1/bounties?q=public&amp;sort=reward&amp;limit=2">View JSON results</a>'
         in filtered_limited_page.text
@@ -335,7 +335,7 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     assert "Showing matches for “proof inspection”." in text_search.text
     assert "Improve public bounty discovery" in text_search.text
     assert "Internal admin cleanup" not in text_search.text
-    assert 'href="/bounties?status=open&q=proof%20inspection"' in text_search.text
+    assert 'href="/bounties?status=open&amp;q=proof%20inspection"' in text_search.text
 
     issue_search = client.get("/api/v1/bounties?q=65")
     assert issue_search.status_code == 200
@@ -350,6 +350,21 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     assert "Showing matches for “#65”." in hash_issue_page.text
     assert "Internal admin cleanup" in hash_issue_page.text
     assert "Improve public bounty discovery" not in hash_issue_page.text
+
+    exact_source_page = client.get("/bounties?repo=Ramimbo%2FMergeWork&issue_number=65")
+    assert exact_source_page.status_code == 200
+    assert 'name="repo" type="search" value="ramimbo/mergework"' in exact_source_page.text
+    assert 'name="issue_number" type="number" min="1" value="65"' in exact_source_page.text
+    assert "Showing source filter for ramimbo/mergework #65." in exact_source_page.text
+    assert "Internal admin cleanup" in exact_source_page.text
+    assert "Improve public bounty discovery" not in exact_source_page.text
+    assert (
+        'href="/api/v1/bounties?repo=ramimbo%2Fmergework&amp;issue_number=65">View JSON results</a>'
+    ) in exact_source_page.text
+    assert (
+        'href="/bounties?status=open&amp;repo=ramimbo%2Fmergework&amp;issue_number=65"'
+        in exact_source_page.text
+    )
 
     oversized_issue_search = client.get("/api/v1/bounties", params={"q": "9" * 40})
     assert oversized_issue_search.status_code == 200
@@ -444,7 +459,7 @@ def test_bounties_page_and_api_sort_public_rows(sqlite_url: str) -> None:
     )
     assert 'name="sort"' in available_page.text
     assert '<option value="available" selected>Most MRWK available</option>' in available_page.text
-    assert 'href="/bounties?status=open&sort=available"' in available_page.text
+    assert 'href="/bounties?status=open&amp;sort=available"' in available_page.text
 
     whitespace_sort_page = client.get("/bounties", params={"sort": "   "})
     assert whitespace_sort_page.status_code == 200

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -29,6 +29,8 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
         },
         "selected_status": "open",
         "query_text": "proof",
+        "repo_filter": "",
+        "issue_number_filter": None,
         "selected_sort": "reward",
         "sort_options": {
             "newest": "Newest first",
@@ -38,6 +40,13 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
         },
         "selected_limit": None,
         "limit_options": (10, 25, 50, 100, 200),
+        "status_links": {
+            "all": "/bounties?q=proof&sort=reward",
+            "open": "/bounties?status=open&q=proof&sort=reward",
+            "paid": "/bounties?status=paid&q=proof&sort=reward",
+            "closed": "/bounties?status=closed&q=proof&sort=reward",
+        },
+        "clear_search_url": "/bounties?status=open&sort=reward",
         "api_results_url": "/api/v1/bounties?status=open&q=proof&sort=reward",
     }
 
@@ -45,7 +54,33 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
 def test_public_bounties_context_preserves_limited_json_results_url() -> None:
     context = public_bounties_context([], status=None, q="issue #580", sort="newest", limit=25)
 
-    assert context["api_results_url"] == "/api/v1/bounties?q=issue+%23580&limit=25"
+    assert context["api_results_url"] == "/api/v1/bounties?q=issue%20%23580&limit=25"
+
+
+def test_public_bounties_context_preserves_exact_source_filters() -> None:
+    context = public_bounties_context(
+        [],
+        status="open",
+        q=" proof ",
+        sort="available",
+        limit=25,
+        repo=" Ramimbo/MergeWork ",
+        issue_number=647,
+    )
+
+    assert context["repo_filter"] == "ramimbo/mergework"
+    assert context["issue_number_filter"] == 647
+    assert context["api_results_url"] == (
+        "/api/v1/bounties?status=open&repo=ramimbo%2Fmergework&issue_number=647"
+        "&q=proof&sort=available&limit=25"
+    )
+    assert context["status_links"]["paid"] == (
+        "/bounties?status=paid&repo=ramimbo%2Fmergework&issue_number=647"
+        "&q=proof&sort=available&limit=25"
+    )
+    assert context["clear_search_url"] == (
+        "/bounties?status=open&repo=ramimbo%2Fmergework&issue_number=647&sort=available&limit=25"
+    )
 
 
 def test_docs_page_marks_static_github_links_as_untrusted(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- Addresses #712 by adding exact optional `repo` and `issue_number` filters to `/api/v1/bounties` and `/api/v1/bounties/summary`.
- Keeps existing `status`, `q`, `sort`, and `limit` behavior intact while allowing agents to locate a bounty from a GitHub issue URL without broad text search.
- Documents the new source filters in the API examples and agent guide.

## Testing
- `.venv/bin/python -m pytest tests/test_bounty_api_routes.py tests/test_docs_public_urls.py -q` (43 passed, 1 warning)
- `.venv/bin/python scripts/docs_smoke.py`
- `.venv/bin/python -m ruff check app/bounty_api.py tests/test_bounty_api_routes.py`
- `.venv/bin/python -m ruff format --check app/bounty_api.py tests/test_bounty_api_routes.py`
- `git diff --check`

Bounty context: #647

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounty list and summary endpoints and the public bounties page now support exact source filters: repository and issue number, with validation and clearer UI inputs/labels.

* **Documentation**
  * Updated API examples and agent guide to demonstrate repo+issue filtering and usage guidance.

* **Tests**
  * Added/updated tests for exact-source filtering, invalid filter handling, URL encoding, and rendered page links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->