### PR TITLE
Add exact bounty source filters

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -102,6 +102,8 @@ def register_bounty_api_routes(
         query_text: str | None = None,
         sort: str | None = None,
         limit: int | None = None,
+        repo: str | None = None,
+        issue_number: int | None = None,
     ) -> list[dict[str, Any]]:
         try:
             normalized_sort = normalize_bounty_sort(sort)
@@ -133,15 +135,25 @@ def register_bounty_api_routes(
                         .replace("_", "\\_")
                     )
                     like_query = f"%{escaped_query}%"
-                    issue_number = issue_number_search_value(normalized_query)
+                    query_issue_number = issue_number_search_value(normalized_query)
                     text_filter = or_(
                         func.lower(Bounty.repo).like(like_query, escape="\\"),
                         func.lower(Bounty.title).like(like_query, escape="\\"),
                         func.lower(Bounty.acceptance).like(like_query, escape="\\"),
                     )
-                    if issue_number is not None:
-                        text_filter = or_(text_filter, Bounty.issue_number == issue_number)
+                    if query_issue_number is not None:
+                        text_filter = or_(text_filter, Bounty.issue_number == query_issue_number)
                     query = query.where(text_filter)
+            if repo is not None:
+                if contains_control_character(repo):
+                    raise HTTPException(
+                        status_code=400, detail="repo must not contain control characters"
+                    )
+                normalized_repo = repo.strip().lower()
+                if normalized_repo:
+                    query = query.where(func.lower(Bounty.repo) == normalized_repo)
+            if issue_number is not None:
+                query = query.where(Bounty.issue_number == issue_number)
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             sorted_bounties = sort_bounties(
                 bounties_to_dict(bounties, session=session),
@@ -157,8 +169,12 @@ def register_bounty_api_routes(
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
         sort: str | None = Query(None),
+        repo: str | None = Query(None),
+        issue_number: Annotated[int | None, Query(ge=1)] = None,
     ) -> list[dict[str, Any]]:
-        return _list_bounties_by_status(status, q, sort=sort, limit=limit)
+        return _list_bounties_by_status(
+            status, q, sort=sort, limit=limit, repo=repo, issue_number=issue_number
+        )
 
     @app.get("/api/v1/bounties/summary")
     def api_bounties_summary(
@@ -166,8 +182,14 @@ def register_bounty_api_routes(
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
         sort: str | None = Query(None),
+        repo: str | None = Query(None),
+        issue_number: Annotated[int | None, Query(ge=1)] = None,
     ) -> dict[str, Any]:
-        return bounty_list_summary(_list_bounties_by_status(status, q, sort=sort, limit=limit))
+        return bounty_list_summary(
+            _list_bounties_by_status(
+                status, q, sort=sort, limit=limit, repo=repo, issue_number=issue_number
+            )
+        )
 
     @app.get("/api/v1/admin/webhook-events")
     def api_admin_webhook_events(

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -25,13 +25,22 @@ from app.status import (
 
 
 def _bounties_api_url(
-    status: str | None, query_text: str, selected_sort: str, limit: int | None
+    status: str | None,
+    query_text: str,
+    selected_sort: str,
+    limit: int | None,
+    repo: str,
+    issue_number: int | None,
 ) -> str:
     params: list[tuple[str, str]] = []
     if status:
         params.append(("status", status))
     if query_text:
         params.append(("q", query_text))
+    if repo:
+        params.append(("repo", repo))
+    if issue_number is not None:
+        params.append(("issue_number", str(issue_number)))
     if selected_sort != "newest":
         params.append(("sort", selected_sort))
     if limit is not None:
@@ -45,9 +54,12 @@ def public_bounties_context(
     q: str | None,
     sort: str | None = None,
     limit: int | None = None,
+    repo: str | None = None,
+    issue_number: int | None = None,
 ) -> dict[str, Any]:
     selected_status = status.strip().lower() if status is not None else None
     query_text = q.strip() if q is not None else ""
+    selected_repo = repo.strip().lower() if repo is not None else ""
     selected_sort = normalize_bounty_sort(sort)
     limit_options: tuple[int, ...] = (10, 25, 50, 100, 200)
     if limit is not None and limit not in limit_options:
@@ -57,11 +69,15 @@ def public_bounties_context(
         "summary": bounty_list_summary(bounties),
         "selected_status": selected_status,
         "query_text": query_text,
+        "selected_repo": selected_repo,
+        "selected_issue_number": issue_number,
         "selected_sort": selected_sort,
         "sort_options": BOUNTY_SORT_LABELS,
         "selected_limit": limit,
         "limit_options": limit_options,
-        "api_results_url": _bounties_api_url(selected_status, query_text, selected_sort, limit),
+        "api_results_url": _bounties_api_url(
+            selected_status, query_text, selected_sort, limit, selected_repo, issue_number
+        ),
     }
 
 
@@ -130,7 +146,8 @@ def register_public_routes(
     db_url: str,
     templates: Jinja2Templates,
     list_bounties_by_status: Callable[
-        [str | None, str | None, str | None, int | None], list[dict[str, Any]]
+        [str | None, str | None, str | None, int | None, str | None, int | None],
+        list[dict[str, Any]],
     ],
     api_bounty: Callable[[int], dict[str, Any]],
     api_ledger: Callable[[], list[dict[str, Any]]],
@@ -144,12 +161,14 @@ def register_public_routes(
         q: str | None = Query(None),
         sort: str | None = Query(None),
         limit: int | None = Query(None, ge=1, le=200),
+        repo: str | None = Query(None),
+        issue_number: int | None = Query(None, ge=1),
     ) -> HTMLResponse:
-        bounties = list_bounties_by_status(status, q, sort, limit)
+        bounties = list_bounties_by_status(status, q, sort, limit, repo, issue_number)
         return templates.TemplateResponse(
             request,
             "bounties.html",
-            public_bounties_context(bounties, status, q, sort, limit),
+            public_bounties_context(bounties, status, q, sort, limit, repo, issue_number),
         )
 
     @app.get("/bounties/{bounty_id}", response_class=HTMLResponse)

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
@@ -48,6 +48,30 @@ def _bounties_api_url(
     return f"/api/v1/bounties?{urlencode(params)}" if params else "/api/v1/bounties"
 
 
+def _bounties_page_url(
+    status: str | None,
+    query_text: str,
+    selected_sort: str,
+    limit: int | None,
+    repo: str,
+    issue_number: int | None,
+) -> str:
+    params: list[tuple[str, str]] = []
+    if status:
+        params.append(("status", status))
+    if query_text:
+        params.append(("q", query_text))
+    if repo:
+        params.append(("repo", repo))
+    if issue_number is not None:
+        params.append(("issue_number", str(issue_number)))
+    if selected_sort != "newest":
+        params.append(("sort", selected_sort))
+    if limit is not None:
+        params.append(("limit", str(limit)))
+    return f"/bounties?{urlencode(params, quote_via=quote)}" if params else "/bounties"
+
+
 def public_bounties_context(
     bounties: list[dict[str, Any]],
     status: str | None,
@@ -78,6 +102,20 @@ def public_bounties_context(
         "api_results_url": _bounties_api_url(
             selected_status, query_text, selected_sort, limit, selected_repo, issue_number
         ),
+        "status_filter_urls": {
+            "all": _bounties_page_url(
+                None, query_text, selected_sort, limit, selected_repo, issue_number
+            ),
+            "open": _bounties_page_url(
+                "open", query_text, selected_sort, limit, selected_repo, issue_number
+            ),
+            "paid": _bounties_page_url(
+                "paid", query_text, selected_sort, limit, selected_repo, issue_number
+            ),
+            "closed": _bounties_page_url(
+                "closed", query_text, selected_sort, limit, selected_repo, issue_number
+            ),
+        },
     }
 
 

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -32,7 +32,7 @@
 </nav>
 {% if query_text %}<p>Showing matches for “{{ query_text }}”.</p>{% endif %}
 {% if selected_repo or selected_issue_number %}
-<p>Source filter{% if selected_repo %}: {{ selected_repo }}{% endif %}{% if selected_issue_number %}#{{ selected_issue_number }}{% endif %}.</p>
+<p>Source filter:{% if selected_repo %} {{ selected_repo }}{% endif %}{% if selected_issue_number %} #{{ selected_issue_number }}{% endif %}.</p>
 {% endif %}
 <section class="bounty-list-summary" aria-label="Bounty list summary">
   <article>

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -4,6 +4,8 @@
 <h1>Bounties</h1>
 <form method="get" action="/bounties" aria-label="Search bounties">
   {% if selected_status %}<input type="hidden" name="status" value="{{ selected_status }}">{% endif %}
+  {% if selected_repo %}<input type="hidden" name="repo" value="{{ selected_repo }}">{% endif %}
+  {% if selected_issue_number %}<input type="hidden" name="issue_number" value="{{ selected_issue_number }}">{% endif %}
   <label for="bounty-search">Search bounties</label>
   <input id="bounty-search" name="q" type="search" value="{{ query_text }}" placeholder="repo, title, issue number, or acceptance text">
   <label for="bounty-sort">Sort</label>
@@ -29,6 +31,9 @@
   <a href="/bounties?status=closed{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
 </nav>
 {% if query_text %}<p>Showing matches for “{{ query_text }}”.</p>{% endif %}
+{% if selected_repo or selected_issue_number %}
+<p>Source filter{% if selected_repo %}: {{ selected_repo }}{% endif %}{% if selected_issue_number %}#{{ selected_issue_number }}{% endif %}.</p>
+{% endif %}
 <section class="bounty-list-summary" aria-label="Bounty list summary">
   <article>
     <span>Bounties shown</span>

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -25,10 +25,10 @@
   {% if query_text %}<a href="/bounties{% if selected_status or selected_sort != "newest" or selected_limit %}?{% if selected_status %}status={{ selected_status }}{% endif %}{% if selected_status and (selected_sort != "newest" or selected_limit) %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% if selected_sort != "newest" and selected_limit %}&{% endif %}{% if selected_limit %}limit={{ selected_limit }}{% endif %}{% endif %}">Clear search</a>{% endif %}
 </form>
 <nav aria-label="Bounty status filters">
-  <a href="/bounties{% if query_text or selected_sort != "newest" or selected_limit %}?{% if query_text %}q={{ query_text | urlencode }}{% endif %}{% if query_text and (selected_sort != "newest" or selected_limit) %}&{% endif %}{% if selected_sort != "newest" %}sort={{ selected_sort }}{% endif %}{% if selected_sort != "newest" and selected_limit %}&{% endif %}{% if selected_limit %}limit={{ selected_limit }}{% endif %}{% endif %}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
-  <a href="/bounties?status=open{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
-  <a href="/bounties?status=paid{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
-  <a href="/bounties?status=closed{% if query_text %}&q={{ query_text | urlencode }}{% endif %}{% if selected_sort != "newest" %}&sort={{ selected_sort }}{% endif %}{% if selected_limit %}&limit={{ selected_limit }}{% endif %}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
+  <a href="{{ status_filter_urls.all | safe }}"{% if not selected_status %} aria-current="page"{% endif %}>All</a>
+  <a href="{{ status_filter_urls.open | safe }}"{% if selected_status == "open" %} aria-current="page"{% endif %}>Open</a>
+  <a href="{{ status_filter_urls.paid | safe }}"{% if selected_status == "paid" %} aria-current="page"{% endif %}>Paid</a>
+  <a href="{{ status_filter_urls.closed | safe }}"{% if selected_status == "closed" %} aria-current="page"{% endif %}>Closed</a>
 </nav>
 {% if query_text %}<p>Showing matches for “{{ query_text }}”.</p>{% endif %}
 {% if selected_repo or selected_issue_number %}

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -53,7 +53,12 @@ filters:
 curl -s "$API_HOST/api/v1/bounties/summary"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open"
 curl -s "$API_HOST/api/v1/bounties/summary?q=docs"
+curl -s "$API_HOST/api/v1/bounties/summary?repo=ramimbo%2Fmergework&issue_number=649"
 ```
+
+When your workflow starts from a GitHub issue URL, prefer exact
+`repo=owner/name` and `issue_number=N` filters on `/api/v1/bounties` or
+`/api/v1/bounties/summary`. Use `q` only for broader text discovery.
 
 Inspect one bounty, accepted-work activity, a ledger page, and a proof:
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -19,7 +19,9 @@ curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
 curl -s "$API_HOST/api/v1/bounties?status=open"
 curl -s "$API_HOST/api/v1/bounties?status=open&sort=available&limit=5"
+curl -s "$API_HOST/api/v1/bounties?repo=ramimbo%2Fmergework&issue_number=649"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open&q=proof"
+curl -s "$API_HOST/api/v1/bounties/summary?repo=ramimbo%2Fmergework"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open&sort=awards&limit=5"
 ```
 
@@ -66,9 +68,14 @@ by per-award reward, `available` sorts by the remaining MRWK pool, and `awards`
 sorts by remaining award slots. Use `limit` from `1` to `200` to cap returned
 rows after filtering and sorting.
 
-Use `/api/v1/bounties/summary` with the same optional `status`, `q`, `sort`, and
-`limit` filters when an agent only needs capacity totals instead of full bounty
-rows:
+Use exact source filters when starting from a GitHub issue URL: `repo=owner/name`
+matches the normalized source repository, `issue_number=N` matches the GitHub
+issue number across repos, and the two together identify one source issue. Keep
+`q` for broad text search.
+
+Use `/api/v1/bounties/summary` with the same optional `status`, `q`, `repo`,
+`issue_number`, `sort`, and `limit` filters when an agent only needs capacity totals
+instead of full bounty rows:
 
 ```json
 {

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -408,3 +408,59 @@ def test_bounty_api_limit_rejects_out_of_range_values(sqlite_url: str) -> None:
     assert client.get("/api/v1/bounties?limit=201").status_code == 422
     assert client.get("/api/v1/bounties/summary?limit=0").status_code == 422
     assert client.get("/api/v1/bounties/summary?limit=201").status_code == 422
+
+
+def test_bounty_api_filters_by_exact_repo_and_issue_number(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        mergework_649 = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=649,
+            issue_url="https://github.com/ramimbo/mergework/issues/649",
+            title="MergeWork proposed-work intake",
+            reward_mrwk="50",
+            max_awards=20,
+            acceptance="Useful proposed-work issue submissions.",
+        )
+        other_mergework = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=650,
+            issue_url="https://github.com/ramimbo/mergework/issues/650",
+            title="Other MergeWork bounty",
+            reward_mrwk="25",
+            acceptance="Other source issue.",
+        )
+        other_repo_same_issue = create_bounty(
+            session,
+            repo="example/other",
+            issue_number=649,
+            issue_url="https://github.com/example/other/issues/649",
+            title="Same issue number in another repo",
+            reward_mrwk="10",
+            acceptance="Same issue number should remain distinguishable by repo.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    by_repo = client.get("/api/v1/bounties?repo=RAMIMBO%2FMergeWork")
+    exact = client.get("/api/v1/bounties?repo=ramimbo%2Fmergework&issue_number=649")
+    by_issue = client.get("/api/v1/bounties?issue_number=649")
+    summary = client.get("/api/v1/bounties/summary?repo=ramimbo%2Fmergework")
+    composed = client.get("/api/v1/bounties?repo=ramimbo%2Fmergework&q=proposed-work")
+
+    assert [row["id"] for row in by_repo.json()] == [other_mergework.id, mergework_649.id]
+    assert [row["id"] for row in exact.json()] == [mergework_649.id]
+    assert [row["id"] for row in by_issue.json()] == [
+        other_repo_same_issue.id,
+        mergework_649.id,
+    ]
+    assert summary.json()["bounties_shown"] == 2
+    assert summary.json()["open_awards"] == 21
+    assert [row["id"] for row in composed.json()] == [mergework_649.id]
+
+    invalid_repo = client.get("/api/v1/bounties?repo=ramimbo%C2%85mergework")
+    assert invalid_repo.status_code == 400
+    assert invalid_repo.json()["detail"] == "repo must not contain control characters"

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -326,6 +326,15 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
             reward_mrwk="100",
             acceptance=r"Document C:\work\mergework examples.",
         )
+        create_bounty(
+            session,
+            repo="example/other",
+            issue_number=64,
+            issue_url="https://github.com/example/other/issues/64",
+            title="Other repo same issue",
+            reward_mrwk="25",
+            acceptance="Other repository bounty.",
+        )
 
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
@@ -376,6 +385,15 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     underscore_search = client.get("/api/v1/bounties?q=_")
     assert underscore_search.status_code == 200
     assert [row["issue_number"] for row in underscore_search.json()] == [66]
+
+    source_filter_page = client.get("/bounties?repo=ramimbo%2Fmergework&issue_number=64")
+    assert source_filter_page.status_code == 200
+    assert "Source filter: ramimbo/mergework#64." in source_filter_page.text
+    assert "Improve public bounty discovery" in source_filter_page.text
+    assert "Other repo same issue" not in source_filter_page.text
+    assert (
+        'href="/api/v1/bounties?repo=ramimbo%2Fmergework&amp;issue_number=64">View JSON results</a>'
+    ) in source_filter_page.text
 
     backslash_search = client.get("/api/v1/bounties", params={"q": "\\"})
     assert backslash_search.status_code == 200

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -392,6 +392,15 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     assert "Improve public bounty discovery" in source_filter_page.text
     assert "Other repo same issue" not in source_filter_page.text
     assert (
+        'href="/bounties?status=open&repo=ramimbo%2Fmergework&issue_number=64"'
+        in source_filter_page.text
+    )
+    assert (
+        'href="/bounties?status=paid&repo=ramimbo%2Fmergework&issue_number=64"'
+        in source_filter_page.text
+    )
+    assert 'href="/bounties?repo=ramimbo%2Fmergework&issue_number=64"' in source_filter_page.text
+    assert (
         'href="/api/v1/bounties?repo=ramimbo%2Fmergework&amp;issue_number=64">View JSON results</a>'
     ) in source_filter_page.text
 

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -388,7 +388,7 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
 
     source_filter_page = client.get("/bounties?repo=ramimbo%2Fmergework&issue_number=64")
     assert source_filter_page.status_code == 200
-    assert "Source filter: ramimbo/mergework#64." in source_filter_page.text
+    assert "Source filter: ramimbo/mergework #64." in source_filter_page.text
     assert "Improve public bounty discovery" in source_filter_page.text
     assert "Other repo same issue" not in source_filter_page.text
     assert (

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -209,7 +209,9 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
 
     assert "/api/v1/bounties?status=open" in examples
     assert "/api/v1/bounties?status=open&sort=available&limit=5" in examples
+    assert "/api/v1/bounties?repo=ramimbo%2Fmergework&issue_number=649" in examples
     assert "/api/v1/bounties/summary?status=open&q=proof" in examples
+    assert "/api/v1/bounties/summary?repo=ramimbo%2Fmergework" in examples
     assert "/api/v1/bounties/summary?status=open&sort=awards&limit=5" in examples
     assert "status` can be omitted or set to" in examples
     assert "`newest` is the default" in examples
@@ -231,7 +233,8 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert "Award counters can change" in examples
     assert "capacity totals" in examples
     assert "full bounty" in examples
-    assert "same optional `status`, `q`, `sort`, and" in examples
+    assert "same optional `status`, `q`, `repo`," in examples
+    assert "`issue_number`, `sort`, and `limit` filters" in examples
     assert "Use `id` for the single-bounty API path" in examples
 
 

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -16,7 +16,14 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
         }
     ]
 
-    context = public_bounties_context(bounties, status=" OPEN ", q=" proof ", sort=" Reward ")
+    context = public_bounties_context(
+        bounties,
+        status=" OPEN ",
+        q=" proof ",
+        sort=" Reward ",
+        repo=" Ramimbo/MergeWork ",
+        issue_number=649,
+    )
 
     assert context == {
         "bounties": bounties,
@@ -29,6 +36,8 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
         },
         "selected_status": "open",
         "query_text": "proof",
+        "selected_repo": "ramimbo/mergework",
+        "selected_issue_number": 649,
         "selected_sort": "reward",
         "sort_options": {
             "newest": "Newest first",
@@ -38,7 +47,10 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
         },
         "selected_limit": None,
         "limit_options": (10, 25, 50, 100, 200),
-        "api_results_url": "/api/v1/bounties?status=open&q=proof&sort=reward",
+        "api_results_url": (
+            "/api/v1/bounties?status=open&q=proof&repo=ramimbo%2Fmergework"
+            "&issue_number=649&sort=reward"
+        ),
     }
 
 

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -51,6 +51,21 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
             "/api/v1/bounties?status=open&q=proof&repo=ramimbo%2Fmergework"
             "&issue_number=649&sort=reward"
         ),
+        "status_filter_urls": {
+            "all": ("/bounties?q=proof&repo=ramimbo%2Fmergework&issue_number=649&sort=reward"),
+            "open": (
+                "/bounties?status=open&q=proof&repo=ramimbo%2Fmergework"
+                "&issue_number=649&sort=reward"
+            ),
+            "paid": (
+                "/bounties?status=paid&q=proof&repo=ramimbo%2Fmergework"
+                "&issue_number=649&sort=reward"
+            ),
+            "closed": (
+                "/bounties?status=closed&q=proof&repo=ramimbo%2Fmergework"
+                "&issue_number=649&sort=reward"
+            ),
+        },
     }
 
 
@@ -58,6 +73,9 @@ def test_public_bounties_context_preserves_limited_json_results_url() -> None:
     context = public_bounties_context([], status=None, q="issue #580", sort="newest", limit=25)
 
     assert context["api_results_url"] == "/api/v1/bounties?q=issue+%23580&limit=25"
+    assert (
+        context["status_filter_urls"]["open"] == "/bounties?status=open&q=issue%20%23580&limit=25"
+    )
 
 
 def test_docs_page_marks_static_github_links_as_untrusted(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #647
Source issue: #712

## Summary
- Adds exact `repo` and `issue_number` filters to `/api/v1/bounties`.
- Applies the same filters to `/api/v1/bounties/summary` so capacity totals can be scoped to a source repo or exact source issue.
- Wires `/bounties` through the same source filters and preserves them in the JSON results link/search form state.
- Documents when agents should use exact source filters instead of broad `q` search.

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests\test_bounty_api_routes.py tests\test_bounty_pages.py tests\test_public_routes.py tests\test_docs_public_urls.py -q` -> 63 passed, 1 existing Starlette/httpx warning
- `.\.venv\Scripts\python.exe -m ruff check app\bounty_api.py app\public_routes.py tests\test_bounty_api_routes.py tests\test_bounty_pages.py tests\test_public_routes.py tests\test_docs_public_urls.py` -> All checks passed
- `.\.venv\Scripts\python.exe -m ruff format --check app\bounty_api.py app\public_routes.py tests\test_bounty_api_routes.py tests\test_bounty_pages.py tests\test_public_routes.py tests\test_docs_public_urls.py` -> 6 files already formatted
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check` -> passed

## Duplicate Check
- Open PRs checked for source issue #712 returned no existing PR.
- Related open PR #732 covers MCP issue-number selectors (#711), not REST/UI bounty list and summary exact source filters.
- Related open PR #707 covers effective availability filtering (#683), not exact repo/issue selectors.

## Scope
No payout execution, proof generation, ledger mutation, treasury execution, wallet behavior, balance, exchange, bridge, cash-out, price, private data, or production mutation behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter bounties by repository name and issue number via the web UI and API
  * UI preserves and displays active repository/issue filters (includes "Source filter") and includes them in the "View JSON results" link
  * `/api/v1/bounties` and `/api/v1/bounties/summary` accept repo and issue_number parameters (issue_number >= 1)

* **Validation**
  * Repo input is validated; invalid values return a 400 error

* **Documentation**
  * Docs and examples updated to show exact repo/issue_number queries

* **Tests**
  * Added/updated tests covering repo+issue filtering and validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->