### PR TITLE
feat: add MCP input schemas

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -11,31 +11,142 @@ from app.ledger.service import LedgerError
 
 MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
 
+POSITIVE_INTEGER_SCHEMA: dict[str, Any] = {"type": "integer", "minimum": 1}
+LIST_LIMIT_SCHEMA: dict[str, Any] = {"type": "integer", "minimum": 1, "maximum": 100}
+
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
         "description": "List MRWK bounties with optional status, q, sort, and limit filters",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": ["open", "paid", "closed"],
+                    "default": "open",
+                },
+                "q": {"type": "string"},
+                "sort": {
+                    "type": "string",
+                    "enum": ["newest", "reward", "available", "awards"],
+                    "default": "newest",
+                },
+                "limit": LIST_LIMIT_SCHEMA,
+            },
+            "additionalProperties": False,
+        },
     },
     {
         "name": "get_bounty",
         "description": "Get a bounty by id, optionally with accepted awards",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "id": POSITIVE_INTEGER_SCHEMA,
+                "include_awards": {"type": "boolean", "default": False},
+            },
+            "required": ["id"],
+            "additionalProperties": False,
+        },
     },
     {
         "name": "list_bounty_attempts",
         "description": "List advisory active-attempt reservations for a bounty",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "bounty_id": POSITIVE_INTEGER_SCHEMA,
+                "include_expired": {"type": "boolean", "default": False},
+                "limit": LIST_LIMIT_SCHEMA,
+            },
+            "required": ["bounty_id"],
+            "additionalProperties": False,
+        },
     },
-    {"name": "get_balance", "description": "Get an account balance"},
+    {
+        "name": "get_balance",
+        "description": "Get an account balance",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"account": {"type": "string", "minLength": 1}},
+            "required": ["account"],
+            "additionalProperties": False,
+        },
+    },
     {
         "name": "register_wallet",
         "description": "Register an MRWK wallet public key",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "public_key_hex": {
+                    "type": "string",
+                    "pattern": "^[0-9a-f]{64}$",
+                    "description": "32-byte Ed25519 public key encoded as lowercase hex.",
+                },
+                "label": {"type": "string", "maxLength": 160},
+            },
+            "required": ["public_key_hex"],
+            "additionalProperties": False,
+        },
     },
-    {"name": "get_wallet", "description": "Get an MRWK wallet by address"},
+    {
+        "name": "get_wallet",
+        "description": "Get an MRWK wallet by address",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"address": {"type": "string", "pattern": "^mrwk1[0-9a-f]{40}$"}},
+            "required": ["address"],
+            "additionalProperties": False,
+        },
+    },
     {
         "name": "submit_wallet_transfer",
         "description": "Submit a signed MRWK wallet transfer",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "from_address": {"type": "string", "pattern": "^mrwk1[0-9a-f]{40}$"},
+                "to_address": {"type": "string", "pattern": "^mrwk1[0-9a-f]{40}$"},
+                "amount_mrwk": {
+                    "type": "string",
+                    "pattern": "^\\d+(?:\\.\\d{1,6})?$",
+                },
+                "nonce": {"type": "integer", "minimum": 0},
+                "memo": {"type": "string", "maxLength": 240, "default": ""},
+                "signature_hex": {"type": "string", "pattern": "^[0-9a-f]{128}$"},
+            },
+            "required": [
+                "from_address",
+                "to_address",
+                "amount_mrwk",
+                "nonce",
+                "signature_hex",
+            ],
+            "additionalProperties": False,
+        },
     },
-    {"name": "get_ledger_entry", "description": "Get a ledger entry"},
-    {"name": "get_proof", "description": "Get a public proof by hash"},
+    {
+        "name": "get_ledger_entry",
+        "description": "Get a ledger entry",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"sequence": POSITIVE_INTEGER_SCHEMA},
+            "required": ["sequence"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "get_proof",
+        "description": "Get a public proof by hash",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"}},
+            "required": ["hash"],
+            "additionalProperties": False,
+        },
+    },
     {
         "name": "submit_work_proof",
         "description": (

--- a/app/mcp.py
+++ b/app/mcp.py
@@ -134,9 +134,9 @@ MCP_TOOLS: list[dict[str, Any]] = [
                 "to_address": {"type": "string", "pattern": "^mrwk1[0-9a-f]{40}$"},
                 "amount_mrwk": {
                     "type": "string",
-                    "pattern": "^\\d+(?:\\.\\d{1,6})?$",
+                    "pattern": "^(?!0+(?:\\.0{1,6})?$)\\d+(?:\\.\\d{1,6})?$",
                 },
-                "nonce": NONNEGATIVE_INTEGER_SCHEMA,
+                "nonce": POSITIVE_INTEGER_SCHEMA,
                 "memo": {"type": "string", "maxLength": 240, "default": ""},
                 "signature_hex": {"type": "string", "pattern": "^[0-9a-f]{128}$"},
             },

--- a/app/mcp.py
+++ b/app/mcp.py
@@ -11,22 +11,29 @@ from app.ledger.service import LedgerError
 
 MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
 
+INTEGER_STRING_PADDING = r"(?!.*[\u0000-\u001f\u007f-\u009f])\s*"
 POSITIVE_INTEGER_SCHEMA: dict[str, Any] = {
     "anyOf": [
         {"type": "integer", "minimum": 1},
-        {"type": "string", "pattern": r"^ *\+?(?:0*[1-9][0-9]*) *$"},
+        {
+            "type": "string",
+            "pattern": rf"^{INTEGER_STRING_PADDING}\+?(?:0*[1-9][0-9]*)\s*$",
+        },
     ]
 }
 NONNEGATIVE_INTEGER_SCHEMA: dict[str, Any] = {
     "anyOf": [
         {"type": "integer", "minimum": 0},
-        {"type": "string", "pattern": r"^ *\+?[0-9]+ *$"},
+        {"type": "string", "pattern": rf"^{INTEGER_STRING_PADDING}\+?[0-9]+\s*$"},
     ]
 }
 LIST_LIMIT_SCHEMA: dict[str, Any] = {
     "anyOf": [
         {"type": "integer", "minimum": 1, "maximum": 100},
-        {"type": "string", "pattern": r"^ *\+?0*(?:[1-9]|[1-9][0-9]|100) *$"},
+        {
+            "type": "string",
+            "pattern": rf"^{INTEGER_STRING_PADDING}\+?0*(?:[1-9]|[1-9][0-9]|100)\s*$",
+        },
     ]
 }
 

--- a/app/mcp.py
+++ b/app/mcp.py
@@ -11,8 +11,24 @@ from app.ledger.service import LedgerError
 
 MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
 
-POSITIVE_INTEGER_SCHEMA: dict[str, Any] = {"type": "integer", "minimum": 1}
-LIST_LIMIT_SCHEMA: dict[str, Any] = {"type": "integer", "minimum": 1, "maximum": 100}
+POSITIVE_INTEGER_SCHEMA: dict[str, Any] = {
+    "anyOf": [
+        {"type": "integer", "minimum": 1},
+        {"type": "string", "pattern": r"^ *\+?(?:0*[1-9][0-9]*) *$"},
+    ]
+}
+NONNEGATIVE_INTEGER_SCHEMA: dict[str, Any] = {
+    "anyOf": [
+        {"type": "integer", "minimum": 0},
+        {"type": "string", "pattern": r"^ *\+?[0-9]+ *$"},
+    ]
+}
+LIST_LIMIT_SCHEMA: dict[str, Any] = {
+    "anyOf": [
+        {"type": "integer", "minimum": 1, "maximum": 100},
+        {"type": "string", "pattern": r"^ *\+?0*(?:[1-9]|[1-9][0-9]|100) *$"},
+    ]
+}
 
 MCP_TOOLS: list[dict[str, Any]] = [
     {
@@ -113,7 +129,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
                     "type": "string",
                     "pattern": "^\\d+(?:\\.\\d{1,6})?$",
                 },
-                "nonce": {"type": "integer", "minimum": 0},
+                "nonce": NONNEGATIVE_INTEGER_SCHEMA,
                 "memo": {"type": "string", "maxLength": 240, "default": ""},
                 "signature_hex": {"type": "string", "pattern": "^[0-9a-f]{128}$"},
             },
@@ -157,13 +173,11 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "type": "object",
             "properties": {
                 "bounty_id": {
-                    "type": "integer",
-                    "minimum": 1,
+                    **POSITIVE_INTEGER_SCHEMA,
                     "description": "Internal MRWK bounty id. Use either bounty_id or issue_number.",
                 },
                 "issue_number": {
-                    "type": "integer",
-                    "minimum": 1,
+                    **POSITIVE_INTEGER_SCHEMA,
                     "description": (
                         "GitHub issue number for an MRWK bounty. "
                         "Use either issue_number or bounty_id."

--- a/app/mcp.py
+++ b/app/mcp.py
@@ -11,20 +11,20 @@ from app.ledger.service import LedgerError
 
 MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
 
-INTEGER_STRING_PADDING = r"(?!.*[\u0000-\u001f\u007f-\u009f])\s*"
+INTEGER_STRING_GUARD = r"(?!.*[\u0000-\u001f\u007f-\u009f])"
 POSITIVE_INTEGER_SCHEMA: dict[str, Any] = {
     "anyOf": [
         {"type": "integer", "minimum": 1},
         {
             "type": "string",
-            "pattern": rf"^{INTEGER_STRING_PADDING}\+?(?:0*[1-9][0-9]*)\s*$",
+            "pattern": rf"^{INTEGER_STRING_GUARD}[1-9][0-9]*$",
         },
     ]
 }
 NONNEGATIVE_INTEGER_SCHEMA: dict[str, Any] = {
     "anyOf": [
         {"type": "integer", "minimum": 0},
-        {"type": "string", "pattern": rf"^{INTEGER_STRING_PADDING}\+?[0-9]+\s*$"},
+        {"type": "string", "pattern": rf"^{INTEGER_STRING_GUARD}(?:0|[1-9][0-9]*)$"},
     ]
 }
 LIST_LIMIT_SCHEMA: dict[str, Any] = {
@@ -32,7 +32,7 @@ LIST_LIMIT_SCHEMA: dict[str, Any] = {
         {"type": "integer", "minimum": 1, "maximum": 100},
         {
             "type": "string",
-            "pattern": rf"^{INTEGER_STRING_PADDING}\+?0*(?:[1-9]|[1-9][0-9]|100)\s*$",
+            "pattern": rf"^{INTEGER_STRING_GUARD}(?:[1-9][0-9]?|100)$",
         },
     ]
 }
@@ -210,7 +210,35 @@ MCP_TOOLS: list[dict[str, Any]] = [
                 },
             },
             "additionalProperties": False,
-            "not": {"required": ["bounty_id", "issue_number"]},
+            "oneOf": [
+                {
+                    "description": "Generic submission guidance without a bounty selector.",
+                    "not": {
+                        "anyOf": [
+                            {"required": ["bounty_id"]},
+                            {"required": ["issue_number"]},
+                            {"required": ["repo"]},
+                        ]
+                    },
+                },
+                {
+                    "description": "Submission guidance by internal MRWK bounty id.",
+                    "required": ["bounty_id"],
+                    "not": {
+                        "anyOf": [
+                            {"required": ["issue_number"]},
+                            {"required": ["repo"]},
+                        ]
+                    },
+                },
+                {
+                    "description": (
+                        "Submission guidance by GitHub issue number, optionally scoped by repo."
+                    ),
+                    "required": ["issue_number"],
+                    "not": {"required": ["bounty_id"]},
+                },
+            ],
         },
     },
 ]

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -562,6 +562,10 @@ curl -s -X POST "$MCP_HOST/mcp" \
 The `tools/list` response includes an `inputSchema` for each argument-taking
 tool. Agent callers can use those schemas as the preflight argument contract,
 while the server-side validators remain authoritative at call time.
+For MCP tools, numeric ids and limits accept JSON integers or integer strings
+that match the runtime parsers. The MCP `list_bounties` and
+`list_bounty_attempts` `limit` argument is capped at `100`; REST bounty list
+endpoints described earlier on this page still accept limits up to `200`.
 
 Call `get_balance`:
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -559,6 +559,10 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
 
+The `tools/list` response includes an `inputSchema` for each argument-taking
+tool. Agent callers can use those schemas as the preflight argument contract,
+while the server-side validators remain authoritative at call time.
+
 Call `get_balance`:
 
 ```bash

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -614,8 +614,9 @@ curl -s -X POST "$MCP_HOST/mcp" \
 The `tools/list` response includes an `inputSchema` for each argument-taking
 tool. Agent callers can use those schemas as the preflight argument contract,
 while the server-side validators remain authoritative at call time.
-For MCP tools, numeric ids and limits accept JSON integers or integer strings
-that match the runtime parsers. The MCP `list_bounties` and
+For MCP tools, numeric ids and limits accept JSON integers or canonical integer
+strings that match the runtime parsers: no whitespace, no leading `+`, and no
+leading zeroes except the single string `"0"` where zero is allowed. The MCP `list_bounties` and
 `list_bounty_attempts` `limit` argument is capped at `100`; REST bounty list
 endpoints described earlier on this page still accept limits up to `200`.
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -24,7 +24,7 @@ def _assert_integer_or_string_schema(
     else:
         assert "maximum" not in integer_branch
     assert string_branch["type"] == "string"
-    assert "pattern" in string_branch
+    assert r"(?!.*[\u0000-\u001f\u007f-\u009f])\s*" in string_branch["pattern"]
 
 
 def test_health_status_and_bounty_api(sqlite_url: str) -> None:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -195,6 +195,50 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()
     assert tools["result"]["tools"][0]["name"] == "list_bounties"
     assert "status, q, sort, and limit filters" in tools["result"]["tools"][0]["description"]
+    tools_by_name = {tool["name"]: tool for tool in tools["result"]["tools"]}
+    assert len(tools_by_name) == len(tools["result"]["tools"])
+    assert all("inputSchema" in tool for tool in tools["result"]["tools"])
+
+    list_schema = tools_by_name["list_bounties"]["inputSchema"]
+    assert list_schema["additionalProperties"] is False
+    assert list_schema["properties"]["status"]["enum"] == ["open", "paid", "closed"]
+    assert list_schema["properties"]["status"]["default"] == "open"
+    assert list_schema["properties"]["sort"]["enum"] == [
+        "newest",
+        "reward",
+        "available",
+        "awards",
+    ]
+    assert list_schema["properties"]["limit"]["maximum"] == 100
+
+    bounty_schema = tools_by_name["get_bounty"]["inputSchema"]
+    assert bounty_schema["required"] == ["id"]
+    assert bounty_schema["properties"]["id"]["minimum"] == 1
+    assert bounty_schema["properties"]["include_awards"]["type"] == "boolean"
+
+    attempt_schema = tools_by_name["list_bounty_attempts"]["inputSchema"]
+    assert attempt_schema["required"] == ["bounty_id"]
+    assert attempt_schema["properties"]["bounty_id"]["minimum"] == 1
+    assert attempt_schema["properties"]["include_expired"]["default"] is False
+    assert attempt_schema["properties"]["limit"]["maximum"] == 100
+
+    assert tools_by_name["get_balance"]["inputSchema"]["required"] == ["account"]
+    assert tools_by_name["register_wallet"]["inputSchema"]["required"] == ["public_key_hex"]
+    register_schema = tools_by_name["register_wallet"]["inputSchema"]
+    assert register_schema["properties"]["label"]["maxLength"] == 160
+    assert tools_by_name["get_wallet"]["inputSchema"]["required"] == ["address"]
+    transfer_schema = tools_by_name["submit_wallet_transfer"]["inputSchema"]
+    assert transfer_schema["required"] == [
+        "from_address",
+        "to_address",
+        "amount_mrwk",
+        "nonce",
+        "signature_hex",
+    ]
+    assert transfer_schema["properties"]["memo"]["maxLength"] == 240
+    assert tools_by_name["get_ledger_entry"]["inputSchema"]["required"] == ["sequence"]
+    assert tools_by_name["get_proof"]["inputSchema"]["required"] == ["hash"]
+
     submit_tool = next(
         tool for tool in tools["result"]["tools"] if tool["name"] == "submit_work_proof"
     )

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -10,6 +11,20 @@ from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
 from app.models import BountyAttempt, Proof
+
+
+def _assert_integer_or_string_schema(
+    schema: dict[str, Any], *, minimum: int, maximum: int | None = None
+) -> None:
+    integer_branch, string_branch = schema["anyOf"]
+    assert integer_branch["type"] == "integer"
+    assert integer_branch["minimum"] == minimum
+    if maximum is not None:
+        assert integer_branch["maximum"] == maximum
+    else:
+        assert "maximum" not in integer_branch
+    assert string_branch["type"] == "string"
+    assert "pattern" in string_branch
 
 
 def test_health_status_and_bounty_api(sqlite_url: str) -> None:
@@ -209,18 +224,18 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
         "available",
         "awards",
     ]
-    assert list_schema["properties"]["limit"]["maximum"] == 100
+    _assert_integer_or_string_schema(list_schema["properties"]["limit"], minimum=1, maximum=100)
 
     bounty_schema = tools_by_name["get_bounty"]["inputSchema"]
     assert bounty_schema["required"] == ["id"]
-    assert bounty_schema["properties"]["id"]["minimum"] == 1
+    _assert_integer_or_string_schema(bounty_schema["properties"]["id"], minimum=1)
     assert bounty_schema["properties"]["include_awards"]["type"] == "boolean"
 
     attempt_schema = tools_by_name["list_bounty_attempts"]["inputSchema"]
     assert attempt_schema["required"] == ["bounty_id"]
-    assert attempt_schema["properties"]["bounty_id"]["minimum"] == 1
+    _assert_integer_or_string_schema(attempt_schema["properties"]["bounty_id"], minimum=1)
     assert attempt_schema["properties"]["include_expired"]["default"] is False
-    assert attempt_schema["properties"]["limit"]["maximum"] == 100
+    _assert_integer_or_string_schema(attempt_schema["properties"]["limit"], minimum=1, maximum=100)
 
     assert tools_by_name["get_balance"]["inputSchema"]["required"] == ["account"]
     assert tools_by_name["register_wallet"]["inputSchema"]["required"] == ["public_key_hex"]
@@ -235,8 +250,13 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
         "nonce",
         "signature_hex",
     ]
+    _assert_integer_or_string_schema(transfer_schema["properties"]["nonce"], minimum=0)
     assert transfer_schema["properties"]["memo"]["maxLength"] == 240
     assert tools_by_name["get_ledger_entry"]["inputSchema"]["required"] == ["sequence"]
+    _assert_integer_or_string_schema(
+        tools_by_name["get_ledger_entry"]["inputSchema"]["properties"]["sequence"],
+        minimum=1,
+    )
     assert tools_by_name["get_proof"]["inputSchema"]["required"] == ["hash"]
 
     submit_tool = next(
@@ -247,8 +267,8 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert submit_schema["additionalProperties"] is False
     assert submit_schema["properties"]["format"]["enum"] == ["text", "json"]
     assert submit_schema["properties"]["format"]["default"] == "text"
-    assert submit_schema["properties"]["bounty_id"]["minimum"] == 1
-    assert submit_schema["properties"]["issue_number"]["minimum"] == 1
+    _assert_integer_or_string_schema(submit_schema["properties"]["bounty_id"], minimum=1)
+    _assert_integer_or_string_schema(submit_schema["properties"]["issue_number"], minimum=1)
     assert submit_schema["properties"]["repo"]["maxLength"] == 200
     assert submit_schema["not"] == {"required": ["bounty_id", "issue_number"]}
     bounty_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_bounty")

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -26,7 +27,21 @@ def _assert_integer_or_string_schema(
     else:
         assert "maximum" not in integer_branch
     assert string_branch["type"] == "string"
-    assert r"(?!.*[\u0000-\u001f\u007f-\u009f])\s*" in string_branch["pattern"]
+    pattern = string_branch["pattern"]
+    assert r"(?!.*[\u0000-\u001f\u007f-\u009f])" in pattern
+    if minimum == 0:
+        accepted_strings = ["0", "1", "99"]
+        rejected_strings = ["-1", "00", "01", "+1", " 1", "1 ", "\u00851"]
+    elif maximum == 100:
+        accepted_strings = ["1", "99", "100"]
+        rejected_strings = ["0", "101", "001", "+1", " 1", "1 ", "\u00851"]
+    else:
+        accepted_strings = ["1", "99", "100"]
+        rejected_strings = ["0", "01", "+1", " 1", "1 ", "-1", "\u00851"]
+    for value in accepted_strings:
+        assert re.fullmatch(pattern, value), value
+    for value in rejected_strings:
+        assert not re.fullmatch(pattern, value), value
 
 
 def test_health_status_and_bounty_api(sqlite_url: str) -> None:
@@ -331,7 +346,33 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     _assert_integer_or_string_schema(submit_schema["properties"]["bounty_id"], minimum=1)
     _assert_integer_or_string_schema(submit_schema["properties"]["issue_number"], minimum=1)
     assert submit_schema["properties"]["repo"]["maxLength"] == 200
-    assert submit_schema["not"] == {"required": ["bounty_id", "issue_number"]}
+    assert submit_schema["oneOf"] == [
+        {
+            "description": "Generic submission guidance without a bounty selector.",
+            "not": {
+                "anyOf": [
+                    {"required": ["bounty_id"]},
+                    {"required": ["issue_number"]},
+                    {"required": ["repo"]},
+                ]
+            },
+        },
+        {
+            "description": "Submission guidance by internal MRWK bounty id.",
+            "required": ["bounty_id"],
+            "not": {
+                "anyOf": [
+                    {"required": ["issue_number"]},
+                    {"required": ["repo"]},
+                ]
+            },
+        },
+        {
+            "description": "Submission guidance by GitHub issue number, optionally scoped by repo.",
+            "required": ["issue_number"],
+            "not": {"required": ["bounty_id"]},
+        },
+    ]
     bounty_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_bounty")
     assert "accepted awards" in bounty_tool["description"]
     attempt_tool = next(

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -250,7 +250,11 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
         "nonce",
         "signature_hex",
     ]
-    _assert_integer_or_string_schema(transfer_schema["properties"]["nonce"], minimum=0)
+    assert (
+        transfer_schema["properties"]["amount_mrwk"]["pattern"]
+        == "^(?!0+(?:\\.0{1,6})?$)\\d+(?:\\.\\d{1,6})?$"
+    )
+    _assert_integer_or_string_schema(transfer_schema["properties"]["nonce"], minimum=1)
     assert transfer_schema["properties"]["memo"]["maxLength"] == 240
     assert tools_by_name["get_ledger_entry"]["inputSchema"]["required"] == ["sequence"]
     _assert_integer_or_string_schema(

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -360,7 +360,9 @@ def test_api_examples_document_mcp_lookup_response_shapes() -> None:
     assert '\\"address\\":\\"<wallet_address>\\"' in examples
     assert '\\"label\\":\\"MCP wallet\\"' in examples
     assert '\\"next_nonce\\":1' in examples
-    assert "numeric ids and limits accept JSON integers or integer strings" in examples
+    assert "numeric ids and limits accept JSON integers or canonical integer" in examples
+    assert "no whitespace, no leading `+`, and no" in examples
+    assert "leading zeroes except the single string" in examples
     assert "MCP `list_bounties` and" in examples
     assert "limit` argument is capped at `100`" in examples
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -346,6 +346,9 @@ def test_api_examples_document_mcp_lookup_response_shapes() -> None:
     assert '\\"address\\":\\"<wallet_address>\\"' in examples
     assert '\\"label\\":\\"MCP wallet\\"' in examples
     assert '\\"next_nonce\\":1' in examples
+    assert "numeric ids and limits accept JSON integers or integer strings" in examples
+    assert "MCP `list_bounties` and" in examples
+    assert "limit` argument is capped at `100`" in examples
 
 
 def test_api_examples_document_mcp_submit_work_proof_structured_response() -> None:


### PR DESCRIPTION
## Summary
- Addresses #710 by adding conservative `inputSchema` metadata for every MCP tool that accepts arguments.
- Mirrors existing runtime validation for integer bounds, enums, booleans, wallet/public-key/signature/hash patterns, labels, memos, and required fields without changing handler behavior.
- Documents `tools/list` schemas as the preflight argument contract while keeping server validators authoritative.

## Testing
- `.venv/bin/python -m pytest tests/test_api_mcp.py tests/test_docs_public_urls.py -q` (114 passed, 1 warning)
- `.venv/bin/python scripts/docs_smoke.py`
- `.venv/bin/python -m ruff check app/mcp.py tests/test_api_mcp.py`
- `.venv/bin/python -m ruff format --check app/mcp.py tests/test_api_mcp.py`
- `git diff --check`

Source issue: #710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools now publish per-tool input validation schemas with standardized numeric-id/limit handling (accepts JSON integers or integer-strings) and reused integer/limit validators.

* **Documentation**
  * Clarified that tools expose inputSchema for preflight checking and that list limits for certain endpoints are capped at 100.

* **Tests**
  * Added assertions verifying inputSchema presence and correctness, including integer-or-string numeric checks, enums, patterns, required fields, and limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->