### PR TITLE
Add treasury proposal queue filters

### DIFF
--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -80,12 +80,12 @@ def register_treasury_routes(
     @app.get("/api/v1/treasury/proposals")
     def api_treasury_proposals(
         limit: Annotated[int, Query(ge=1, le=200)] = 100,
-        action: Annotated[str | None, Query(max_length=80)] = None,
-        status: Annotated[str | None, Query(max_length=80)] = None,
+        action: Annotated[str | None, Query(max_length=40)] = None,
+        status: Annotated[str | None, Query(max_length=40)] = None,
         bounty_id: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
     ) -> list[dict[str, Any]]:
-        action_filter = _optional_query_filter(action, "action")
-        status_filter = _optional_query_filter(status, "status")
+        action_filter = _optional_query_filter(action, "action", max_length=40)
+        status_filter = _optional_query_filter(status, "status", max_length=40)
         with session_scope(db_url) as session:
             query = select(TreasuryProposal)
             if action_filter is not None:

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Annotated, Any
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
@@ -36,6 +37,36 @@ def _proposal_error(exc: LedgerError) -> HTTPException:
     return HTTPException(status_code=400, detail=detail)
 
 
+def _contains_control_character(value: str) -> bool:
+    return any(ord(char) < 32 or ord(char) == 127 or 0x80 <= ord(char) <= 0x9F for char in value)
+
+
+def _optional_query_filter(value: str | None, field: str, max_length: int = 80) -> str | None:
+    if value is None:
+        return None
+    if _contains_control_character(value):
+        raise HTTPException(status_code=400, detail=f"{field} must not contain control characters")
+    clean = value.strip()
+    if not clean:
+        raise HTTPException(status_code=400, detail=f"{field} is required")
+    if len(clean) > max_length:
+        raise HTTPException(status_code=400, detail=f"{field} is too long")
+    return clean
+
+
+def _proposal_payload_bounty_id(proposal: TreasuryProposal) -> int | None:
+    try:
+        payload = json.loads(proposal.payload_json)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    bounty_id = payload.get("bounty_id")
+    if isinstance(bounty_id, bool) or not isinstance(bounty_id, int):
+        return None
+    return bounty_id
+
+
 def register_treasury_routes(
     app: FastAPI,
     *,
@@ -49,11 +80,29 @@ def register_treasury_routes(
     @app.get("/api/v1/treasury/proposals")
     def api_treasury_proposals(
         limit: Annotated[int, Query(ge=1, le=200)] = 100,
+        action: Annotated[str | None, Query(max_length=80)] = None,
+        status: Annotated[str | None, Query(max_length=80)] = None,
+        bounty_id: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
     ) -> list[dict[str, Any]]:
+        action_filter = _optional_query_filter(action, "action")
+        status_filter = _optional_query_filter(status, "status")
         with session_scope(db_url) as session:
-            proposals = session.scalars(
-                select(TreasuryProposal).order_by(TreasuryProposal.id.desc()).limit(limit)
-            ).all()
+            query = select(TreasuryProposal)
+            if action_filter is not None:
+                query = query.where(TreasuryProposal.action == action_filter)
+            if status_filter is not None:
+                query = query.where(TreasuryProposal.status == status_filter)
+            query = query.order_by(TreasuryProposal.id.desc())
+            if bounty_id is None:
+                proposals = session.scalars(query.limit(limit)).all()
+            else:
+                proposals = []
+                for proposal in session.scalars(query):
+                    if _proposal_payload_bounty_id(proposal) != bounty_id:
+                        continue
+                    proposals.append(proposal)
+                    if len(proposals) >= limit:
+                        break
             return [proposal_to_dict(proposal) for proposal in proposals]
 
     @app.get("/api/v1/treasury/status")

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -79,12 +79,15 @@ Inspect treasury proposals:
 ```bash
 curl -s "$API_HOST/api/v1/treasury/status"
 curl -s "$API_HOST/api/v1/treasury/proposals"
+curl -s "$API_HOST/api/v1/treasury/proposals?action=pay_bounty&status=pending&bounty_id=<bounty_id>"
 curl -s "$API_HOST/api/v1/treasury/proposals/<proposal_id>"
 ```
 
 Use `/api/v1/treasury/status` before proposing fresh bounty rounds. It reports
 the rolling 24-hour reserve cap, recent reserve usage, pending create-bounty
 reserve, remaining create capacity, and the next capacity release time.
+Use proposal-list filters when you need one queue slice, such as pending
+`pay_bounty` proposals for one internal MergeWork bounty id.
 Use [docs/bounty-lifecycle.md](bounty-lifecycle.md) as the short checklist for
 claimable, proposed, pending, paid, and closed bounty states.
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -108,8 +108,14 @@ Read proposals:
 ```bash
 curl -s "$API_HOST/api/v1/treasury/status"
 curl -s "$API_HOST/api/v1/treasury/proposals"
+curl -s "$API_HOST/api/v1/treasury/proposals?action=pay_bounty&status=pending&bounty_id=<bounty_id>"
 curl -s "$API_HOST/api/v1/treasury/proposals/<proposal_id>"
 ```
+
+Use the optional `action`, `status`, and `bounty_id` filters to inspect one
+queue slice without client-side scanning. The `bounty_id` filter matches
+proposal payloads such as pending payout or close-bounty proposals, not GitHub
+issue numbers.
 
 The treasury status endpoint reports the 24-hour create-bounty reserve cap,
 recent executed reserves, pending create-bounty proposal reserves, remaining

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -417,6 +417,105 @@ def test_treasury_proposals_list_honors_limit(
     assert too_large.status_code == 422
 
 
+def test_treasury_proposals_list_filters_by_action_status_and_bounty_id(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _client(sqlite_url, monkeypatch)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        first_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=90,
+            issue_url="https://github.com/ramimbo/mergework/issues/90",
+            title="First filtered payout",
+            reward_mrwk="5",
+            acceptance="Contributor comments with proof.",
+        )
+        second_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=91,
+            issue_url="https://github.com/ramimbo/mergework/issues/91",
+            title="Second filtered payout",
+            reward_mrwk="5",
+            acceptance="Contributor comments with proof.",
+        )
+        first_bounty_id = first_bounty.id
+        second_bounty_id = second_bounty.id
+
+    first_payout = client.post(
+        f"/api/v1/bounties/{first_bounty_id}/pay",
+        headers=ADMIN_HEADERS,
+        json={
+            "to_account": "github:alice",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/90",
+            "accepted_by": "maintainer",
+        },
+    ).json()
+    second_payout = client.post(
+        f"/api/v1/bounties/{second_bounty_id}/pay",
+        headers=ADMIN_HEADERS,
+        json={
+            "to_account": "github:bob",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/91",
+            "accepted_by": "maintainer",
+        },
+    ).json()
+    create_bounty_proposal = client.post(
+        "/api/v1/bounties",
+        headers=ADMIN_HEADERS,
+        json=_bounty_payload(issue_number=92),
+    ).json()
+    _make_executable(sqlite_url, first_payout["id"])
+    executed = client.post(
+        f"/api/v1/treasury/proposals/{first_payout['id']}/execute",
+        headers=ADMIN_HEADERS,
+    )
+    assert executed.status_code == 200
+
+    action_filtered = client.get("/api/v1/treasury/proposals?action=pay_bounty")
+    pending_filtered = client.get("/api/v1/treasury/proposals?status=pending")
+    bounty_filtered = client.get(f"/api/v1/treasury/proposals?bounty_id={first_bounty_id}")
+    composed_filtered = client.get(
+        "/api/v1/treasury/proposals",
+        params={
+            "action": "pay_bounty",
+            "status": "pending",
+            "bounty_id": second_bounty_id,
+        },
+    )
+    limited_after_filter = client.get("/api/v1/treasury/proposals?action=pay_bounty&limit=1")
+
+    assert action_filtered.status_code == 200
+    assert [proposal["id"] for proposal in action_filtered.json()] == [
+        second_payout["id"],
+        first_payout["id"],
+    ]
+    assert pending_filtered.status_code == 200
+    assert [proposal["id"] for proposal in pending_filtered.json()] == [
+        create_bounty_proposal["id"],
+        second_payout["id"],
+    ]
+    assert bounty_filtered.status_code == 200
+    assert [proposal["id"] for proposal in bounty_filtered.json()] == [first_payout["id"]]
+    assert composed_filtered.status_code == 200
+    assert [proposal["id"] for proposal in composed_filtered.json()] == [second_payout["id"]]
+    assert limited_after_filter.status_code == 200
+    assert [proposal["id"] for proposal in limited_after_filter.json()] == [second_payout["id"]]
+
+
+@pytest.mark.parametrize(("field", "value"), (("action", "\tpay_bounty"), ("status", " ")))
+def test_treasury_proposals_list_rejects_invalid_filters(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch, field: str, value: str
+) -> None:
+    client = _client(sqlite_url, monkeypatch)
+
+    response = client.get("/api/v1/treasury/proposals", params={field: value})
+
+    assert response.status_code == 400
+
+
 def test_direct_proposal_creation_requires_admin_token(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -505,15 +505,26 @@ def test_treasury_proposals_list_filters_by_action_status_and_bounty_id(
     assert [proposal["id"] for proposal in limited_after_filter.json()] == [second_payout["id"]]
 
 
-@pytest.mark.parametrize(("field", "value"), (("action", "\tpay_bounty"), ("status", " ")))
+@pytest.mark.parametrize(
+    ("field", "value", "expected_detail"),
+    (
+        ("action", "\tpay_bounty", "action must not contain control characters"),
+        ("status", " ", "status is required"),
+    ),
+)
 def test_treasury_proposals_list_rejects_invalid_filters(
-    sqlite_url: str, monkeypatch: pytest.MonkeyPatch, field: str, value: str
+    sqlite_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: str,
+    expected_detail: str,
 ) -> None:
     client = _client(sqlite_url, monkeypatch)
 
     response = client.get("/api/v1/treasury/proposals", params={field: value})
 
     assert response.status_code == 400
+    assert response.json()["detail"] == expected_detail
 
 
 def test_direct_proposal_creation_requires_admin_token(


### PR DESCRIPTION
Bounty #647
Source issue: #716

## Summary
- Adds read-only `action`, `status`, and `bounty_id` filters to `/api/v1/treasury/proposals`.
- Keeps newest-first ordering and applies `limit` after matching payload `bounty_id` so queue scans answer one bounty slice accurately.
- Rejects blank/control-character action/status filters with safe 400 errors.
- Documents filtered proposal lookups for pending payout queue inspection.

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests\test_treasury_proposals.py tests\test_docs_public_urls.py -q` -> 72 passed, 1 existing Starlette/httpx warning
- `.\.venv\Scripts\python.exe -m ruff check app\treasury_routes.py tests\test_treasury_proposals.py` -> All checks passed
- `.\.venv\Scripts\python.exe -m ruff format --check app\treasury_routes.py tests\test_treasury_proposals.py` -> 2 files already formatted
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check` -> passed

## Duplicate Check
- Open PRs checked for source issue #716 returned no existing PR.
- Related open work covers recipient filtering (#680), MCP schemas (#710), and exact bounty source filters (#712), not treasury proposal action/status/bounty-id queue filters.
- Bounty #647 remains open with 9 effective awards available and no active attempts at submission time.

## Scope
No proposal creation, execution, challenge, payout, proof, ledger, wallet, balance, exchange, bridge, cash-out, price, private data, or production mutation behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Treasury proposals endpoint now supports filtering by action, status, and bounty_id for more precise listing.

* **Bug Fixes**
  * Query parameters are now validated to reject invalid/unsafe values, returning clear errors for malformed filters.

* **Documentation**
  * API guides and examples updated to show usage of the new treasury proposal filters.

* **Tests**
  * Added tests covering valid filtering combinations and rejection of invalid filter values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->