### PR TITLE
Add OpenAPI request body schemas

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from app.db import session_scope
 from app.ledger.service import CONTROL_CHAR_RE, LedgerError, validate_public_url
 from app.models import Bounty, BountyAttempt
+from app.openapi_request_bodies import json_request_body
 
 DEFAULT_ATTEMPT_TTL_SECONDS = 24 * 60 * 60
 MIN_ATTEMPT_TTL_SECONDS = 60
@@ -24,6 +25,44 @@ RequiredString = Callable[[dict[str, Any], str], str]
 OptionalInteger = Callable[[dict[str, Any], str, int], int]
 NormalizeAccount = Callable[[str], str]
 PositiveBountyId = Callable[[int], int]
+
+ATTEMPT_CREATE_BODY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "submitter_account": {
+            "type": "string",
+            "description": (
+                "Optional github:<login> account; when present it must match the "
+                "authenticated session."
+            ),
+        },
+        "source_url": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 500,
+            "description": "Optional public URL for the branch, issue, PR, or other work source.",
+        },
+        "ttl_seconds": {
+            "type": "integer",
+            "minimum": MIN_ATTEMPT_TTL_SECONDS,
+            "maximum": MAX_ATTEMPT_TTL_SECONDS,
+            "default": DEFAULT_ATTEMPT_TTL_SECONDS,
+        },
+    },
+}
+
+ATTEMPT_RELEASE_BODY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "submitter_account": {
+            "type": "string",
+            "description": (
+                "Optional github:<login> account; when present it must match the "
+                "authenticated session."
+            ),
+        },
+    },
+}
 
 
 def _utc_now() -> datetime:
@@ -164,7 +203,10 @@ def register_bounty_attempt_routes(
                 "attempts": listing["attempts"],
             }
 
-    @app.post("/api/v1/bounties/{bounty_id}/attempts")
+    @app.post(
+        "/api/v1/bounties/{bounty_id}/attempts",
+        openapi_extra=json_request_body(ATTEMPT_CREATE_BODY_SCHEMA, required=False),
+    )
     async def api_create_bounty_attempt(
         bounty_id: int,
         request: Request,
@@ -271,7 +313,10 @@ def register_bounty_attempt_routes(
                 },
             )
 
-    @app.post("/api/v1/bounty-attempts/{attempt_id}/release")
+    @app.post(
+        "/api/v1/bounty-attempts/{attempt_id}/release",
+        openapi_extra=json_request_body(ATTEMPT_RELEASE_BODY_SCHEMA, required=False),
+    )
     async def api_release_bounty_attempt(
         attempt_id: int,
         request: Request,

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def json_request_body(schema: dict[str, Any], *, required: bool = True) -> dict[str, Any]:
+    return {
+        "requestBody": {
+            "required": required,
+            "content": {"application/json": {"schema": schema}},
+        }
+    }

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -8,8 +8,10 @@ from sqlalchemy import select
 from app.db import session_scope
 from app.ledger.service import LedgerError
 from app.models import TreasuryProposal
+from app.openapi_request_bodies import json_request_body
 from app.path_params import SQLITE_INTEGER_MAX
 from app.treasury import (
+    CHALLENGE_TYPES,
     challenge_to_dict,
     create_treasury_challenge,
     proposal_to_dict,
@@ -17,6 +19,19 @@ from app.treasury import (
     treasury_status,
 )
 from app.treasury_executor import execute_treasury_proposal_with_finalization
+
+TREASURY_CHALLENGE_BODY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["challenge_type", "reason"],
+    "properties": {
+        "challenge_type": {
+            "type": "string",
+            "enum": sorted(CHALLENGE_TYPES),
+            "maxLength": 80,
+        },
+        "reason": {"type": "string", "maxLength": 1000},
+    },
+}
 
 
 def _positive_proposal_id(proposal_id: int) -> int:
@@ -111,7 +126,10 @@ def register_treasury_routes(
         except LedgerError as exc:
             raise _proposal_error(exc) from exc
 
-    @app.post("/api/v1/treasury/proposals/{proposal_id}/challenges")
+    @app.post(
+        "/api/v1/treasury/proposals/{proposal_id}/challenges",
+        openapi_extra=json_request_body(TREASURY_CHALLENGE_BODY_SCHEMA),
+    )
     async def api_create_treasury_challenge(
         proposal_id: int,
         request: Request,

--- a/app/wallet_api.py
+++ b/app/wallet_api.py
@@ -14,6 +14,7 @@ from app.ledger.service import (
     submit_wallet_transfer,
 )
 from app.models import Wallet
+from app.openapi_request_bodies import json_request_body
 from app.serializers import ledger_to_dict, wallet_to_dict, wallet_transfer_to_dict
 
 JsonObjectLoader = Callable[[Request], Awaitable[dict[str, Any]]]
@@ -23,6 +24,61 @@ RequiredInteger = Callable[[dict[str, Any], str], int]
 OptionalString = Callable[[dict[str, Any], str], str]
 NormalizeWalletAddress = Callable[[str], str]
 PostOnlyRoute = Callable[[], None]
+
+PUBLIC_KEY_HEX_SCHEMA: dict[str, Any] = {
+    "type": "string",
+    "pattern": "^[0-9a-f]{64}$",
+    "description": "32-byte Ed25519 public key encoded as lowercase hex.",
+}
+WALLET_ADDRESS_SCHEMA: dict[str, Any] = {
+    "type": "string",
+    "pattern": "^mrwk1[0-9a-f]{40}$",
+}
+SIGNATURE_HEX_SCHEMA: dict[str, Any] = {
+    "type": "string",
+    "pattern": "^[0-9a-f]{128}$",
+    "description": "64-byte Ed25519 signature encoded as lowercase hex.",
+}
+NONCE_SCHEMA: dict[str, Any] = {"type": "integer", "minimum": 1}
+
+WALLET_REGISTER_BODY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["public_key_hex"],
+    "properties": {
+        "public_key_hex": PUBLIC_KEY_HEX_SCHEMA,
+        "label": {"type": "string", "maxLength": 160},
+    },
+}
+WALLET_SIGNED_ACCOUNT_BODY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["address", "nonce", "signature_hex"],
+    "properties": {
+        "address": WALLET_ADDRESS_SCHEMA,
+        "nonce": NONCE_SCHEMA,
+        "signature_hex": SIGNATURE_HEX_SCHEMA,
+    },
+}
+WALLET_TRANSFER_BODY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": [
+        "from_address",
+        "to_address",
+        "amount_mrwk",
+        "nonce",
+        "signature_hex",
+    ],
+    "properties": {
+        "from_address": WALLET_ADDRESS_SCHEMA,
+        "to_address": WALLET_ADDRESS_SCHEMA,
+        "amount_mrwk": {
+            "type": "string",
+            "description": "MRWK amount as a decimal string.",
+        },
+        "nonce": NONCE_SCHEMA,
+        "memo": {"type": "string", "maxLength": 240},
+        "signature_hex": SIGNATURE_HEX_SCHEMA,
+    },
+}
 
 
 def register_wallet_api_routes(
@@ -37,7 +93,10 @@ def register_wallet_api_routes(
     normalized_wallet_address: NormalizeWalletAddress,
     post_only_route: PostOnlyRoute,
 ) -> None:
-    @app.post("/api/v1/wallets/register")
+    @app.post(
+        "/api/v1/wallets/register",
+        openapi_extra=json_request_body(WALLET_REGISTER_BODY_SCHEMA),
+    )
     async def api_register_wallet(request: Request) -> dict[str, Any]:
         data = await json_object(request)
         with session_scope(db_url) as session:
@@ -68,7 +127,10 @@ def register_wallet_api_routes(
                 raise HTTPException(status_code=404, detail="wallet not found")
             return wallet_to_dict(session, wallet)
 
-    @app.post("/api/v1/wallets/link-github")
+    @app.post(
+        "/api/v1/wallets/link-github",
+        openapi_extra=json_request_body(WALLET_SIGNED_ACCOUNT_BODY_SCHEMA),
+    )
     async def api_link_wallet_github(
         request: Request, github_login: str = Depends(require_github_login)
     ) -> dict[str, Any]:
@@ -86,7 +148,10 @@ def register_wallet_api_routes(
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             return wallet_to_dict(session, wallet)
 
-    @app.post("/api/v1/github/claim")
+    @app.post(
+        "/api/v1/github/claim",
+        openapi_extra=json_request_body(WALLET_SIGNED_ACCOUNT_BODY_SCHEMA),
+    )
     async def api_github_claim(
         request: Request, github_login: str = Depends(require_github_login)
     ) -> dict[str, Any]:
@@ -104,7 +169,10 @@ def register_wallet_api_routes(
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             return ledger_to_dict(entry)
 
-    @app.post("/api/v1/transfers")
+    @app.post(
+        "/api/v1/transfers",
+        openapi_extra=json_request_body(WALLET_TRANSFER_BODY_SCHEMA),
+    )
     async def api_submit_transfer(request: Request) -> dict[str, Any]:
         data = await json_object(request)
         with session_scope(db_url) as session:

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -28,6 +28,10 @@ Submit small, reviewable work and include evidence.
 - `POST /api/v1/github/claim`
 - `POST /api/v1/transfers`
 
+JSON POST payloads for attempts, wallet registration/linking, GitHub claims,
+wallet transfers, and treasury challenges are also described in
+`GET /openapi.json` as OpenAPI `requestBody` schemas.
+
 ## Public API Examples
 
 Use the live public API host for read-only examples:

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -132,6 +132,10 @@ curl -s -X POST "$API_HOST/api/v1/treasury/proposals/<proposal_id>/execute" \
 GitHub-authenticated users with at least one accepted MRWK award can submit
 challenges:
 
+Public JSON POST examples in this document match the OpenAPI `requestBody`
+schemas exposed by `GET /openapi.json`, including attempts, wallet
+registration/linking, GitHub claims, wallet transfers, and treasury challenges.
+
 ```bash
 curl -s -X POST "$API_HOST/api/v1/treasury/proposals/<proposal_id>/challenges" \
   -b "mrwk_user=<session-cookie>" \

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -240,6 +240,10 @@ def test_api_examples_document_attempt_list_response_shape() -> None:
 
     assert "/api/v1/bounties/<bounty_id>/attempts" in examples
     assert "returns the bounty id, advisory warnings, and active attempt reservations" in examples
+    assert "OpenAPI `requestBody`" in examples
+    assert "schemas exposed by `GET /openapi.json`" in examples
+    assert "including attempts, wallet" in examples
+    assert "registration/linking, GitHub claims, wallet transfers" in examples
     assert '"bounty_id": 65' in examples
     assert '"warnings": []' in examples
     assert '"attempts": [' in examples

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+
+def _post_request_body(openapi: dict[str, Any], path: str) -> dict[str, Any]:
+    return openapi["paths"][path]["post"]["requestBody"]
+
+
+def _json_schema(body: dict[str, Any]) -> dict[str, Any]:
+    return body["content"]["application/json"]["schema"]
+
+
+def test_openapi_exposes_attempt_request_body_schemas(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    create_body = _post_request_body(openapi, "/api/v1/bounties/{bounty_id}/attempts")
+    create_schema = _json_schema(create_body)
+    assert create_body["required"] is False
+    assert set(create_schema["properties"]) == {
+        "submitter_account",
+        "source_url",
+        "ttl_seconds",
+    }
+    assert create_schema["properties"]["ttl_seconds"]["minimum"] == 60
+    assert create_schema["properties"]["ttl_seconds"]["maximum"] == 604800
+    assert create_schema["properties"]["source_url"]["format"] == "uri"
+
+    release_body = _post_request_body(openapi, "/api/v1/bounty-attempts/{attempt_id}/release")
+    release_schema = _json_schema(release_body)
+    assert release_body["required"] is False
+    assert set(release_schema["properties"]) == {"submitter_account"}
+
+
+def test_openapi_exposes_wallet_request_body_schemas(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    register_body = _post_request_body(openapi, "/api/v1/wallets/register")
+    register_schema = _json_schema(register_body)
+    assert register_body["required"] is True
+    assert register_schema["required"] == ["public_key_hex"]
+    assert register_schema["properties"]["public_key_hex"]["pattern"] == "^[0-9a-f]{64}$"
+    assert register_schema["properties"]["label"]["maxLength"] == 160
+
+    for path in ["/api/v1/wallets/link-github", "/api/v1/github/claim"]:
+        body = _post_request_body(openapi, path)
+        schema = _json_schema(body)
+        assert body["required"] is True
+        assert schema["required"] == ["address", "nonce", "signature_hex"]
+        assert schema["properties"]["address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
+        assert schema["properties"]["nonce"]["minimum"] == 1
+        assert schema["properties"]["signature_hex"]["pattern"] == "^[0-9a-f]{128}$"
+
+    transfer_body = _post_request_body(openapi, "/api/v1/transfers")
+    transfer_schema = _json_schema(transfer_body)
+    assert transfer_body["required"] is True
+    assert transfer_schema["required"] == [
+        "from_address",
+        "to_address",
+        "amount_mrwk",
+        "nonce",
+        "signature_hex",
+    ]
+    assert transfer_schema["properties"]["from_address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
+    assert transfer_schema["properties"]["to_address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
+    assert transfer_schema["properties"]["memo"]["maxLength"] == 240
+
+
+def test_openapi_exposes_treasury_challenge_request_body_schema(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    body = _post_request_body(openapi, "/api/v1/treasury/proposals/{proposal_id}/challenges")
+    schema = _json_schema(body)
+
+    assert body["required"] is True
+    assert schema["required"] == ["challenge_type", "reason"]
+    assert "subjective_note" in schema["properties"]["challenge_type"]["enum"]
+    assert "duplicate_bounty" in schema["properties"]["challenge_type"]["enum"]
+    assert schema["properties"]["challenge_type"]["maxLength"] == 80
+    assert schema["properties"]["reason"]["maxLength"] == 1000


### PR DESCRIPTION
Bounty #647
Source issue: #717

## Summary
- Adds OpenAPI `requestBody` schemas for public JSON POST endpoints that previously only parsed raw `Request` bodies.
- Covers attempt registration/release, wallet registration/linking, GitHub balance claims, wallet transfers, and treasury proposal challenges.
- Keeps runtime request parsing, auth, validation, treasury, wallet, payout, ledger, and proof behavior unchanged by using route-level OpenAPI metadata.
- Updates agent/API docs to point clients at the schema-backed POST payloads.

## Verification
- `python -m pytest tests/test_openapi_request_bodies.py tests/test_wallet_api.py tests/test_bounty_attempts.py tests/test_treasury_proposals.py tests/test_docs_public_urls.py -q` -> 120 passed, 1 warning
- `python -m pytest -q` -> 564 passed, 1 warning
- `python scripts/docs_smoke.py` -> docs smoke ok
- `python -m ruff check .` -> passed
- `python -m ruff format --check .` -> 98 files already formatted
- `python -m mypy app` -> success
- `git diff --check` -> passed

## Duplicate Check
- Open PR search for source issue #717 returned no results immediately before submission.
- Related open work covers MCP input schemas (#710), exact bounty source filters (#712), and treasury proposal list filters (#716), not REST OpenAPI request bodies for public POST endpoints.
- Bounty API row #95 was open with 9 effective awards remaining and no pending payout awards at submission time.

## Scope
No private data, credentials, wallet private keys, production mutation, proposal creation/execution, payout/proof/ledger behavior, balance, exchange, bridge, cash-out, price behavior, or fabricated payout claims used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive OpenAPI request body documentation for bounty, wallet, and treasury API endpoints

* **Documentation**
  * Enhanced API documentation with detailed request payload schemas
  * Updated guides to reference OpenAPI specifications for request body requirements

* **Tests**
  * Added validation tests for API request body schema documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->