### PR TITLE
Add OpenAPI request body schemas

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from app.db import session_scope
 from app.ledger.service import CONTROL_CHAR_RE, LedgerError, validate_public_url
 from app.models import Bounty, BountyAttempt
+from app.openapi_request_bodies import ATTEMPT_RELEASE_REQUEST_BODY, ATTEMPT_REQUEST_BODY
 
 DEFAULT_ATTEMPT_TTL_SECONDS = 24 * 60 * 60
 MIN_ATTEMPT_TTL_SECONDS = 60
@@ -164,7 +165,7 @@ def register_bounty_attempt_routes(
                 "attempts": listing["attempts"],
             }
 
-    @app.post("/api/v1/bounties/{bounty_id}/attempts")
+    @app.post("/api/v1/bounties/{bounty_id}/attempts", openapi_extra=ATTEMPT_REQUEST_BODY)
     async def api_create_bounty_attempt(
         bounty_id: int,
         request: Request,
@@ -271,7 +272,10 @@ def register_bounty_attempt_routes(
                 },
             )
 
-    @app.post("/api/v1/bounty-attempts/{attempt_id}/release")
+    @app.post(
+        "/api/v1/bounty-attempts/{attempt_id}/release",
+        openapi_extra=ATTEMPT_RELEASE_REQUEST_BODY,
+    )
     async def api_release_bounty_attempt(
         attempt_id: int,
         request: Request,

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -9,7 +9,7 @@ MRWK_ADDRESS_SCHEMA: dict[str, Any] = {
     "type": "string",
     "pattern": "^mrwk1[0-9a-f]{40}$",
 }
-NONNEGATIVE_INTEGER_SCHEMA: dict[str, Any] = {"type": "integer", "minimum": 0}
+POSITIVE_INTEGER_SCHEMA: dict[str, Any] = {"type": "integer", "minimum": 1}
 PUBLIC_URL_SCHEMA: dict[str, Any] = {"type": "string", "format": "uri"}
 SIGNATURE_HEX_SCHEMA: dict[str, Any] = {"type": "string", "pattern": "^[0-9a-f]{128}$"}
 
@@ -73,7 +73,7 @@ WALLET_AUTH_REQUEST_BODY = json_request_body(
         "type": "object",
         "properties": {
             "address": MRWK_ADDRESS_SCHEMA,
-            "nonce": NONNEGATIVE_INTEGER_SCHEMA,
+            "nonce": POSITIVE_INTEGER_SCHEMA,
             "signature_hex": SIGNATURE_HEX_SCHEMA,
         },
         "required": ["address", "nonce", "signature_hex"],
@@ -88,9 +88,9 @@ WALLET_TRANSFER_REQUEST_BODY = json_request_body(
             "to_address": MRWK_ADDRESS_SCHEMA,
             "amount_mrwk": {
                 "type": "string",
-                "pattern": "^\\d+(?:\\.\\d{1,6})?$",
+                "pattern": "^(?!0+(?:\\.0{1,6})?$)\\d+(?:\\.\\d{1,6})?$",
             },
-            "nonce": NONNEGATIVE_INTEGER_SCHEMA,
+            "nonce": POSITIVE_INTEGER_SCHEMA,
             "memo": {"type": "string", "maxLength": 240, "default": ""},
             "signature_hex": SIGNATURE_HEX_SCHEMA,
         },

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from typing import Any
+
+JSON_CONTENT_TYPE = "application/json"
+
+ACCOUNT_SCHEMA: dict[str, Any] = {"type": "string", "minLength": 1}
+MRWK_ADDRESS_SCHEMA: dict[str, Any] = {
+    "type": "string",
+    "pattern": "^mrwk1[0-9a-f]{40}$",
+}
+NONNEGATIVE_INTEGER_SCHEMA: dict[str, Any] = {"type": "integer", "minimum": 0}
+PUBLIC_URL_SCHEMA: dict[str, Any] = {"type": "string", "format": "uri"}
+SIGNATURE_HEX_SCHEMA: dict[str, Any] = {"type": "string", "pattern": "^[0-9a-f]{128}$"}
+
+
+def json_request_body(schema: dict[str, Any], *, required: bool = True) -> dict[str, Any]:
+    return {
+        "requestBody": {
+            "required": required,
+            "content": {
+                JSON_CONTENT_TYPE: {
+                    "schema": schema,
+                }
+            },
+        }
+    }
+
+
+ATTEMPT_REQUEST_BODY = json_request_body(
+    {
+        "type": "object",
+        "properties": {
+            "submitter_account": ACCOUNT_SCHEMA,
+            "source_url": PUBLIC_URL_SCHEMA,
+            "ttl_seconds": {
+                "type": "integer",
+                "minimum": 60,
+                "maximum": 604800,
+                "default": 86400,
+            },
+        },
+    },
+    required=False,
+)
+
+ATTEMPT_RELEASE_REQUEST_BODY = json_request_body(
+    {
+        "type": "object",
+        "properties": {
+            "submitter_account": ACCOUNT_SCHEMA,
+        },
+    },
+    required=False,
+)
+
+WALLET_REGISTER_REQUEST_BODY = json_request_body(
+    {
+        "type": "object",
+        "properties": {
+            "public_key_hex": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$",
+            },
+            "label": {"type": "string", "maxLength": 160},
+        },
+        "required": ["public_key_hex"],
+    }
+)
+
+WALLET_AUTH_REQUEST_BODY = json_request_body(
+    {
+        "type": "object",
+        "properties": {
+            "address": MRWK_ADDRESS_SCHEMA,
+            "nonce": NONNEGATIVE_INTEGER_SCHEMA,
+            "signature_hex": SIGNATURE_HEX_SCHEMA,
+        },
+        "required": ["address", "nonce", "signature_hex"],
+    }
+)
+
+WALLET_TRANSFER_REQUEST_BODY = json_request_body(
+    {
+        "type": "object",
+        "properties": {
+            "from_address": MRWK_ADDRESS_SCHEMA,
+            "to_address": MRWK_ADDRESS_SCHEMA,
+            "amount_mrwk": {
+                "type": "string",
+                "pattern": "^\\d+(?:\\.\\d{1,6})?$",
+            },
+            "nonce": NONNEGATIVE_INTEGER_SCHEMA,
+            "memo": {"type": "string", "maxLength": 240, "default": ""},
+            "signature_hex": SIGNATURE_HEX_SCHEMA,
+        },
+        "required": [
+            "from_address",
+            "to_address",
+            "amount_mrwk",
+            "nonce",
+            "signature_hex",
+        ],
+    }
+)
+
+TREASURY_CHALLENGE_REQUEST_BODY = json_request_body(
+    {
+        "type": "object",
+        "properties": {
+            "challenge_type": {
+                "type": "string",
+                "enum": [
+                    "bounty_not_open",
+                    "duplicate_bounty",
+                    "epoch_cap_exceeded",
+                    "insufficient_reserve",
+                    "subjective_note",
+                    "submission_already_paid",
+                ],
+                "maxLength": 80,
+            },
+            "reason": {"type": "string", "maxLength": 1000},
+        },
+        "required": ["challenge_type", "reason"],
+    }
+)

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from app.db import session_scope
 from app.ledger.service import LedgerError
 from app.models import TreasuryProposal
+from app.openapi_request_bodies import TREASURY_CHALLENGE_REQUEST_BODY
 from app.path_params import SQLITE_INTEGER_MAX
 from app.treasury import (
     challenge_to_dict,
@@ -111,7 +112,10 @@ def register_treasury_routes(
         except LedgerError as exc:
             raise _proposal_error(exc) from exc
 
-    @app.post("/api/v1/treasury/proposals/{proposal_id}/challenges")
+    @app.post(
+        "/api/v1/treasury/proposals/{proposal_id}/challenges",
+        openapi_extra=TREASURY_CHALLENGE_REQUEST_BODY,
+    )
     async def api_create_treasury_challenge(
         proposal_id: int,
         request: Request,

--- a/app/wallet_api.py
+++ b/app/wallet_api.py
@@ -14,6 +14,11 @@ from app.ledger.service import (
     submit_wallet_transfer,
 )
 from app.models import Wallet
+from app.openapi_request_bodies import (
+    WALLET_AUTH_REQUEST_BODY,
+    WALLET_REGISTER_REQUEST_BODY,
+    WALLET_TRANSFER_REQUEST_BODY,
+)
 from app.serializers import ledger_to_dict, wallet_to_dict, wallet_transfer_to_dict
 
 JsonObjectLoader = Callable[[Request], Awaitable[dict[str, Any]]]
@@ -37,7 +42,7 @@ def register_wallet_api_routes(
     normalized_wallet_address: NormalizeWalletAddress,
     post_only_route: PostOnlyRoute,
 ) -> None:
-    @app.post("/api/v1/wallets/register")
+    @app.post("/api/v1/wallets/register", openapi_extra=WALLET_REGISTER_REQUEST_BODY)
     async def api_register_wallet(request: Request) -> dict[str, Any]:
         data = await json_object(request)
         with session_scope(db_url) as session:
@@ -68,7 +73,7 @@ def register_wallet_api_routes(
                 raise HTTPException(status_code=404, detail="wallet not found")
             return wallet_to_dict(session, wallet)
 
-    @app.post("/api/v1/wallets/link-github")
+    @app.post("/api/v1/wallets/link-github", openapi_extra=WALLET_AUTH_REQUEST_BODY)
     async def api_link_wallet_github(
         request: Request, github_login: str = Depends(require_github_login)
     ) -> dict[str, Any]:
@@ -86,7 +91,7 @@ def register_wallet_api_routes(
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             return wallet_to_dict(session, wallet)
 
-    @app.post("/api/v1/github/claim")
+    @app.post("/api/v1/github/claim", openapi_extra=WALLET_AUTH_REQUEST_BODY)
     async def api_github_claim(
         request: Request, github_login: str = Depends(require_github_login)
     ) -> dict[str, Any]:
@@ -104,7 +109,7 @@ def register_wallet_api_routes(
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             return ledger_to_dict(entry)
 
-    @app.post("/api/v1/transfers")
+    @app.post("/api/v1/transfers", openapi_extra=WALLET_TRANSFER_REQUEST_BODY)
     async def api_submit_transfer(request: Request) -> dict[str, Any]:
         data = await json_object(request)
         with session_scope(db_url) as session:

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -143,6 +143,10 @@ Machine-checkable valid challenges block execution. Subjective notes are public
 but non-blocking. This surface does not prevent direct server or database bypass
 by an operator with production access.
 
+The generated `/openapi.json` includes request-body schemas for public JSON POST
+surfaces such as treasury challenges, attempt registration/release, wallet
+registration/linking, GitHub claims, and wallet transfers.
+
 ## Advisory Attempt Reservations
 
 Agents can register short-lived active attempts before opening a bounty PR so

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -147,6 +147,10 @@ The generated `/openapi.json` includes request-body schemas for public JSON POST
 surfaces such as treasury challenges, attempt registration/release, wallet
 registration/linking, GitHub claims, and wallet transfers.
 
+```bash
+curl -s "$API_HOST/openapi.json"
+```
+
 ## Advisory Attempt Reservations
 
 Agents can register short-lived active attempts before opening a bounty PR so

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -54,6 +54,7 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert '"id":4' in examples
     assert "not the GitHub issue" in examples
     assert "public_key_hex" in examples
+    assert "The generated `/openapi.json` includes request-body schemas" in examples
 
 
 def test_api_examples_document_mcp_get_proof_response_shape() -> None:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -55,6 +55,7 @@ def test_api_examples_document_internal_bounty_ids() -> None:
     assert "not the GitHub issue" in examples
     assert "public_key_hex" in examples
     assert "The generated `/openapi.json` includes request-body schemas" in examples
+    assert 'curl -s "$API_HOST/openapi.json"' in examples
 
 
 def test_api_examples_document_mcp_get_proof_response_shape() -> None:

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from app.db import create_schema, session_scope
+from app.ledger.service import ensure_genesis
+from app.main import create_app
+
+
+def _post_request_body(openapi: dict[str, Any], path: str) -> dict[str, Any]:
+    return openapi["paths"][path]["post"]["requestBody"]
+
+
+def _json_schema(request_body: dict[str, Any]) -> dict[str, Any]:
+    return request_body["content"]["application/json"]["schema"]
+
+
+def test_openapi_documents_public_post_request_bodies(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    openapi = client.get("/openapi.json").json()
+
+    attempt_body = _post_request_body(openapi, "/api/v1/bounties/{bounty_id}/attempts")
+    attempt_schema = _json_schema(attempt_body)
+    assert attempt_body["required"] is False
+    assert set(attempt_schema["properties"]) == {
+        "submitter_account",
+        "source_url",
+        "ttl_seconds",
+    }
+    assert attempt_schema["properties"]["ttl_seconds"]["maximum"] == 604800
+
+    release_body = _post_request_body(openapi, "/api/v1/bounty-attempts/{attempt_id}/release")
+    release_schema = _json_schema(release_body)
+    assert release_body["required"] is False
+    assert set(release_schema["properties"]) == {"submitter_account"}
+
+    register_schema = _json_schema(_post_request_body(openapi, "/api/v1/wallets/register"))
+    assert register_schema["required"] == ["public_key_hex"]
+    assert register_schema["properties"]["public_key_hex"]["pattern"] == "^[0-9a-f]{64}$"
+    assert register_schema["properties"]["label"]["maxLength"] == 160
+
+    link_schema = _json_schema(_post_request_body(openapi, "/api/v1/wallets/link-github"))
+    claim_schema = _json_schema(_post_request_body(openapi, "/api/v1/github/claim"))
+    assert link_schema == claim_schema
+    assert link_schema["required"] == ["address", "nonce", "signature_hex"]
+    assert link_schema["properties"]["address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
+
+    transfer_schema = _json_schema(_post_request_body(openapi, "/api/v1/transfers"))
+    assert transfer_schema["required"] == [
+        "from_address",
+        "to_address",
+        "amount_mrwk",
+        "nonce",
+        "signature_hex",
+    ]
+    assert transfer_schema["properties"]["amount_mrwk"]["pattern"] == "^\\d+(?:\\.\\d{1,6})?$"
+    assert transfer_schema["properties"]["memo"]["maxLength"] == 240
+
+    challenge_schema = _json_schema(
+        _post_request_body(openapi, "/api/v1/treasury/proposals/{proposal_id}/challenges")
+    )
+    assert challenge_schema["required"] == ["challenge_type", "reason"]
+    assert "subjective_note" in challenge_schema["properties"]["challenge_type"]["enum"]
+    assert challenge_schema["properties"]["reason"]["maxLength"] == 1000

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -40,18 +40,27 @@ def test_openapi_documents_public_post_request_bodies(sqlite_url: str) -> None:
     assert release_body["required"] is False
     assert set(release_schema["properties"]) == {"submitter_account"}
 
-    register_schema = _json_schema(_post_request_body(openapi, "/api/v1/wallets/register"))
+    register_body = _post_request_body(openapi, "/api/v1/wallets/register")
+    register_schema = _json_schema(register_body)
+    assert register_body["required"] is True
     assert register_schema["required"] == ["public_key_hex"]
     assert register_schema["properties"]["public_key_hex"]["pattern"] == "^[0-9a-f]{64}$"
     assert register_schema["properties"]["label"]["maxLength"] == 160
 
-    link_schema = _json_schema(_post_request_body(openapi, "/api/v1/wallets/link-github"))
-    claim_schema = _json_schema(_post_request_body(openapi, "/api/v1/github/claim"))
+    link_body = _post_request_body(openapi, "/api/v1/wallets/link-github")
+    claim_body = _post_request_body(openapi, "/api/v1/github/claim")
+    link_schema = _json_schema(link_body)
+    claim_schema = _json_schema(claim_body)
+    assert link_body["required"] is True
+    assert claim_body["required"] is True
     assert link_schema == claim_schema
     assert link_schema["required"] == ["address", "nonce", "signature_hex"]
     assert link_schema["properties"]["address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
+    assert link_schema["properties"]["nonce"]["minimum"] == 1
 
-    transfer_schema = _json_schema(_post_request_body(openapi, "/api/v1/transfers"))
+    transfer_body = _post_request_body(openapi, "/api/v1/transfers")
+    transfer_schema = _json_schema(transfer_body)
+    assert transfer_body["required"] is True
     assert transfer_schema["required"] == [
         "from_address",
         "to_address",
@@ -59,12 +68,18 @@ def test_openapi_documents_public_post_request_bodies(sqlite_url: str) -> None:
         "nonce",
         "signature_hex",
     ]
-    assert transfer_schema["properties"]["amount_mrwk"]["pattern"] == "^\\d+(?:\\.\\d{1,6})?$"
+    assert (
+        transfer_schema["properties"]["amount_mrwk"]["pattern"]
+        == "^(?!0+(?:\\.0{1,6})?$)\\d+(?:\\.\\d{1,6})?$"
+    )
+    assert transfer_schema["properties"]["nonce"]["minimum"] == 1
     assert transfer_schema["properties"]["memo"]["maxLength"] == 240
 
-    challenge_schema = _json_schema(
-        _post_request_body(openapi, "/api/v1/treasury/proposals/{proposal_id}/challenges")
+    challenge_body = _post_request_body(
+        openapi, "/api/v1/treasury/proposals/{proposal_id}/challenges"
     )
+    challenge_schema = _json_schema(challenge_body)
+    assert challenge_body["required"] is True
     assert challenge_schema["required"] == ["challenge_type", "reason"]
     assert "subjective_note" in challenge_schema["properties"]["challenge_type"]["enum"]
     assert challenge_schema["properties"]["reason"]["maxLength"] == 1000


### PR DESCRIPTION
Bounty #647
Source issue: #717

## Summary
- Adds explicit OpenAPI request-body schemas for public JSON POST endpoints that still read raw `Request` bodies at runtime.
- Covers bounty attempt registration/release, wallet registration/linking, GitHub wallet claims, wallet transfers, and treasury proposal challenges.
- Keeps the existing runtime validators and empty-body attempt behavior unchanged; this is OpenAPI documentation metadata only.
- Documents that `/openapi.json` now exposes schema-backed payloads for these public POST surfaces.

## Verification
- `.venv/bin/python -m pytest tests/test_openapi_request_bodies.py tests/test_bounty_attempts.py tests/test_wallet_api.py tests/test_treasury_proposals.py tests/test_docs_public_urls.py -q` -> 118 passed, 1 warning
- `.venv/bin/ruff check app/openapi_request_bodies.py app/bounty_attempts.py app/wallet_api.py app/treasury_routes.py tests/test_openapi_request_bodies.py tests/test_docs_public_urls.py` -> passed
- `.venv/bin/ruff format --check app/openapi_request_bodies.py app/bounty_attempts.py app/wallet_api.py app/treasury_routes.py tests/test_openapi_request_bodies.py tests/test_docs_public_urls.py` -> passed
- `.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> passed

## Duplicate Check
- Scanned current open PRs without GitHub search API; no open PR body/title referenced source issue #717 or requestBody/request-body schemas.
- Related open work covers MCP input schemas (#710), response schemas (#688), and treasury proposal queue filters (#716), not REST OpenAPI request bodies.

## Scope
No auth, payout, treasury execution, wallet signing, ledger, proof, balance, private-key, exchange, bridge, cash-out, or runtime validation behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenAPI request-body schemas are now published for public JSON POST endpoints (bounty attempts and release, treasury challenges, wallet registration/auth/transfer and related flows).

* **Documentation**
  * API docs updated with examples and a curl snippet showing `/openapi.json` contains these request-body schemas.

* **Tests**
  * Added tests that validate the published OpenAPI request-body schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->