### PR TITLE
Expose OpenAPI request body schemas

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from app.db import session_scope
 from app.ledger.service import CONTROL_CHAR_RE, LedgerError, validate_public_url
 from app.models import Bounty, BountyAttempt
+from app.openapi_request_bodies import OPTIONAL_ATTEMPT_BODY, OPTIONAL_ATTEMPT_RELEASE_BODY
 
 DEFAULT_ATTEMPT_TTL_SECONDS = 24 * 60 * 60
 MIN_ATTEMPT_TTL_SECONDS = 60
@@ -164,7 +165,7 @@ def register_bounty_attempt_routes(
                 "attempts": listing["attempts"],
             }
 
-    @app.post("/api/v1/bounties/{bounty_id}/attempts")
+    @app.post("/api/v1/bounties/{bounty_id}/attempts", openapi_extra=OPTIONAL_ATTEMPT_BODY)
     async def api_create_bounty_attempt(
         bounty_id: int,
         request: Request,
@@ -271,7 +272,10 @@ def register_bounty_attempt_routes(
                 },
             )
 
-    @app.post("/api/v1/bounty-attempts/{attempt_id}/release")
+    @app.post(
+        "/api/v1/bounty-attempts/{attempt_id}/release",
+        openapi_extra=OPTIONAL_ATTEMPT_RELEASE_BODY,
+    )
     async def api_release_bounty_attempt(
         attempt_id: int,
         request: Request,

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _request_body(schema: dict[str, Any], *, required: bool = True) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "content": {
+            "application/json": {
+                "schema": schema,
+            },
+        },
+    }
+    if required:
+        body["required"] = True
+    return body
+
+
+def _object_schema(
+    properties: dict[str, Any], *, required: list[str] | None = None, description: str | None = None
+) -> dict[str, Any]:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "additionalProperties": True,
+        "properties": properties,
+    }
+    if required:
+        schema["required"] = required
+    if description:
+        schema["description"] = description
+    return schema
+
+
+INTEGER_OR_STRING_SCHEMA = {
+    "anyOf": [
+        {"type": "integer"},
+        {"type": "string", "description": "Integer value encoded as a string."},
+    ],
+}
+
+OPTIONAL_ATTEMPT_BODY = {
+    "requestBody": _request_body(
+        _object_schema(
+            {
+                "submitter_account": {
+                    "type": "string",
+                    "description": (
+                        "Optional github:<login> account; must match the signed-in GitHub login."
+                    ),
+                },
+                "source_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Optional public work branch or pull request URL.",
+                },
+                "ttl_seconds": {
+                    **INTEGER_OR_STRING_SCHEMA,
+                    "default": 86400,
+                    "description": "Attempt lifetime in seconds, from 60 to 604800.",
+                },
+            },
+            description="Optional advisory attempt reservation payload.",
+        ),
+        required=False,
+    ),
+}
+
+OPTIONAL_ATTEMPT_RELEASE_BODY = {
+    "requestBody": _request_body(
+        _object_schema(
+            {
+                "submitter_account": {
+                    "type": "string",
+                    "description": (
+                        "Optional github:<login> account; must match the signed-in GitHub login."
+                    ),
+                },
+            },
+            description="Optional attempt release identity payload.",
+        ),
+        required=False,
+    ),
+}
+
+WALLET_REGISTER_BODY = {
+    "requestBody": _request_body(
+        _object_schema(
+            {
+                "public_key_hex": {
+                    "type": "string",
+                    "description": "64-character lowercase hex Ed25519 public key.",
+                },
+                "label": {"type": "string", "description": "Optional wallet display label."},
+            },
+            required=["public_key_hex"],
+        ),
+    ),
+}
+
+SIGNED_WALLET_ACTION_PROPERTIES = {
+    "address": {"type": "string", "description": "Registered mrwk1 wallet address."},
+    "nonce": INTEGER_OR_STRING_SCHEMA,
+    "signature_hex": {
+        "type": "string",
+        "description": "128-character lowercase hex Ed25519 signature.",
+    },
+}
+
+SIGNED_WALLET_ACTION_BODY = {
+    "requestBody": _request_body(
+        _object_schema(
+            SIGNED_WALLET_ACTION_PROPERTIES,
+            required=["address", "nonce", "signature_hex"],
+        ),
+    ),
+}
+
+WALLET_TRANSFER_BODY = {
+    "requestBody": _request_body(
+        _object_schema(
+            {
+                "from_address": {"type": "string", "description": "Sender mrwk1 wallet address."},
+                "to_address": {"type": "string", "description": "Receiver mrwk1 wallet address."},
+                "amount_mrwk": {"type": "string", "description": "Decimal MRWK amount."},
+                "nonce": INTEGER_OR_STRING_SCHEMA,
+                "memo": {"type": "string", "description": "Optional transfer memo."},
+                "signature_hex": {
+                    "type": "string",
+                    "description": "128-character lowercase hex Ed25519 signature.",
+                },
+            },
+            required=["from_address", "to_address", "amount_mrwk", "nonce", "signature_hex"],
+        ),
+    ),
+}
+
+TREASURY_PROPOSAL_BODY = {
+    "requestBody": _request_body(
+        _object_schema(
+            {
+                "action": {"type": "string", "description": "Treasury action name."},
+                "payload": {
+                    "type": "object",
+                    "additionalProperties": True,
+                    "description": "Action-specific treasury proposal payload.",
+                },
+            },
+            required=["action", "payload"],
+        ),
+    ),
+}
+
+TREASURY_CHALLENGE_BODY = {
+    "requestBody": _request_body(
+        _object_schema(
+            {
+                "challenge_type": {"type": "string", "description": "Challenge category."},
+                "reason": {"type": "string", "description": "Public challenge reason."},
+            },
+            required=["challenge_type", "reason"],
+        ),
+    ),
+}

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -33,9 +33,27 @@ def _object_schema(
 
 INTEGER_OR_STRING_SCHEMA = {
     "anyOf": [
-        {"type": "integer"},
-        {"type": "string", "description": "Integer value encoded as a string."},
+        {"type": "integer", "minimum": 1},
+        {
+            "type": "string",
+            "description": "Positive integer value encoded as a string.",
+            "pattern": "^[1-9][0-9]*$",
+        },
     ],
+}
+
+LOWERCASE_HEX_64_SCHEMA = {
+    "type": "string",
+    "minLength": 64,
+    "maxLength": 64,
+    "pattern": "^[0-9a-f]{64}$",
+}
+
+LOWERCASE_HEX_128_SCHEMA = {
+    "type": "string",
+    "minLength": 128,
+    "maxLength": 128,
+    "pattern": "^[0-9a-f]{128}$",
 }
 
 OPTIONAL_ATTEMPT_BODY = {
@@ -54,7 +72,14 @@ OPTIONAL_ATTEMPT_BODY = {
                     "description": "Optional public work branch or pull request URL.",
                 },
                 "ttl_seconds": {
-                    **INTEGER_OR_STRING_SCHEMA,
+                    "anyOf": [
+                        {"type": "integer", "minimum": 60, "maximum": 604800},
+                        {
+                            "type": "string",
+                            "description": "Integer value encoded as a string (60..604800).",
+                            "pattern": "^[0-9]+$",
+                        },
+                    ],
                     "default": 86400,
                     "description": "Attempt lifetime in seconds, from 60 to 604800.",
                 },
@@ -87,7 +112,7 @@ WALLET_REGISTER_BODY = {
         _object_schema(
             {
                 "public_key_hex": {
-                    "type": "string",
+                    **LOWERCASE_HEX_64_SCHEMA,
                     "description": "64-character lowercase hex Ed25519 public key.",
                 },
                 "label": {"type": "string", "description": "Optional wallet display label."},
@@ -101,7 +126,7 @@ SIGNED_WALLET_ACTION_PROPERTIES = {
     "address": {"type": "string", "description": "Registered mrwk1 wallet address."},
     "nonce": INTEGER_OR_STRING_SCHEMA,
     "signature_hex": {
-        "type": "string",
+        **LOWERCASE_HEX_128_SCHEMA,
         "description": "128-character lowercase hex Ed25519 signature.",
     },
 }
@@ -125,7 +150,7 @@ WALLET_TRANSFER_BODY = {
                 "nonce": INTEGER_OR_STRING_SCHEMA,
                 "memo": {"type": "string", "description": "Optional transfer memo."},
                 "signature_hex": {
-                    "type": "string",
+                    **LOWERCASE_HEX_128_SCHEMA,
                     "description": "128-character lowercase hex Ed25519 signature.",
                 },
             },

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -8,6 +8,7 @@ from sqlalchemy import select
 from app.db import session_scope
 from app.ledger.service import LedgerError
 from app.models import TreasuryProposal
+from app.openapi_request_bodies import TREASURY_CHALLENGE_BODY, TREASURY_PROPOSAL_BODY
 from app.path_params import SQLITE_INTEGER_MAX
 from app.treasury import (
     challenge_to_dict,
@@ -70,7 +71,7 @@ def register_treasury_routes(
                 raise HTTPException(status_code=404, detail="proposal not found")
             return proposal_to_dict(proposal)
 
-    @app.post("/api/v1/treasury/proposals")
+    @app.post("/api/v1/treasury/proposals", openapi_extra=TREASURY_PROPOSAL_BODY)
     async def api_create_treasury_proposal(
         request: Request,
         admin_login: str = Depends(require_admin_token),
@@ -111,7 +112,10 @@ def register_treasury_routes(
         except LedgerError as exc:
             raise _proposal_error(exc) from exc
 
-    @app.post("/api/v1/treasury/proposals/{proposal_id}/challenges")
+    @app.post(
+        "/api/v1/treasury/proposals/{proposal_id}/challenges",
+        openapi_extra=TREASURY_CHALLENGE_BODY,
+    )
     async def api_create_treasury_challenge(
         proposal_id: int,
         request: Request,

--- a/app/wallet_api.py
+++ b/app/wallet_api.py
@@ -14,6 +14,11 @@ from app.ledger.service import (
     submit_wallet_transfer,
 )
 from app.models import Wallet
+from app.openapi_request_bodies import (
+    SIGNED_WALLET_ACTION_BODY,
+    WALLET_REGISTER_BODY,
+    WALLET_TRANSFER_BODY,
+)
 from app.serializers import ledger_to_dict, wallet_to_dict, wallet_transfer_to_dict
 
 JsonObjectLoader = Callable[[Request], Awaitable[dict[str, Any]]]
@@ -37,7 +42,7 @@ def register_wallet_api_routes(
     normalized_wallet_address: NormalizeWalletAddress,
     post_only_route: PostOnlyRoute,
 ) -> None:
-    @app.post("/api/v1/wallets/register")
+    @app.post("/api/v1/wallets/register", openapi_extra=WALLET_REGISTER_BODY)
     async def api_register_wallet(request: Request) -> dict[str, Any]:
         data = await json_object(request)
         with session_scope(db_url) as session:
@@ -68,7 +73,7 @@ def register_wallet_api_routes(
                 raise HTTPException(status_code=404, detail="wallet not found")
             return wallet_to_dict(session, wallet)
 
-    @app.post("/api/v1/wallets/link-github")
+    @app.post("/api/v1/wallets/link-github", openapi_extra=SIGNED_WALLET_ACTION_BODY)
     async def api_link_wallet_github(
         request: Request, github_login: str = Depends(require_github_login)
     ) -> dict[str, Any]:
@@ -86,7 +91,7 @@ def register_wallet_api_routes(
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             return wallet_to_dict(session, wallet)
 
-    @app.post("/api/v1/github/claim")
+    @app.post("/api/v1/github/claim", openapi_extra=SIGNED_WALLET_ACTION_BODY)
     async def api_github_claim(
         request: Request, github_login: str = Depends(require_github_login)
     ) -> dict[str, Any]:
@@ -104,7 +109,7 @@ def register_wallet_api_routes(
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             return ledger_to_dict(entry)
 
-    @app.post("/api/v1/transfers")
+    @app.post("/api/v1/transfers", openapi_extra=WALLET_TRANSFER_BODY)
     async def api_submit_transfer(request: Request) -> dict[str, Any]:
         data = await json_object(request)
         with session_scope(db_url) as session:

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -10,6 +10,12 @@ MCP_HOST=https://mcp.mrwk.online
 The legacy-compatible hosts remain available for existing clients:
 `https://api.mrwk.ltclab.site` and `https://mcp.mrwk.ltclab.site`.
 
+Machine-readable REST docs are available at `$API_HOST/openapi.json`,
+`$API_HOST/api/docs`, and `$API_HOST/api/redoc`. Public JSON POST endpoints
+publish `requestBody` schemas for attempt reservations, wallet actions,
+transfers, and treasury challenges so clients can discover payload fields
+without reading source code.
+
 ## Status And Bounties
 
 Check service status and list bounties:

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+
+def _post_schema(openapi: dict, path: str) -> dict:
+    return openapi["paths"][path]["post"]["requestBody"]["content"]["application/json"]["schema"]
+
+
+def _assert_properties(schema: dict, expected: Iterable[str]) -> None:
+    assert set(expected).issubset(schema["properties"])
+
+
+def test_public_post_openapi_request_bodies_expose_expected_fields(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    expected_fields = {
+        "/api/v1/bounties/{bounty_id}/attempts": {
+            "submitter_account",
+            "source_url",
+            "ttl_seconds",
+        },
+        "/api/v1/bounty-attempts/{attempt_id}/release": {"submitter_account"},
+        "/api/v1/wallets/register": {"public_key_hex", "label"},
+        "/api/v1/wallets/link-github": {"address", "nonce", "signature_hex"},
+        "/api/v1/github/claim": {"address", "nonce", "signature_hex"},
+        "/api/v1/transfers": {
+            "from_address",
+            "to_address",
+            "amount_mrwk",
+            "nonce",
+            "memo",
+            "signature_hex",
+        },
+        "/api/v1/treasury/proposals": {"action", "payload"},
+        "/api/v1/treasury/proposals/{proposal_id}/challenges": {"challenge_type", "reason"},
+    }
+
+    for path, fields in expected_fields.items():
+        schema = _post_schema(openapi, path)
+        assert schema["type"] == "object"
+        _assert_properties(schema, fields)
+
+
+def test_public_post_openapi_request_bodies_mark_required_fields(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    assert _post_schema(openapi, "/api/v1/wallets/register")["required"] == ["public_key_hex"]
+    assert _post_schema(openapi, "/api/v1/wallets/link-github")["required"] == [
+        "address",
+        "nonce",
+        "signature_hex",
+    ]
+    assert _post_schema(openapi, "/api/v1/github/claim")["required"] == [
+        "address",
+        "nonce",
+        "signature_hex",
+    ]
+    assert _post_schema(openapi, "/api/v1/transfers")["required"] == [
+        "from_address",
+        "to_address",
+        "amount_mrwk",
+        "nonce",
+        "signature_hex",
+    ]
+    assert _post_schema(openapi, "/api/v1/treasury/proposals")["required"] == [
+        "action",
+        "payload",
+    ]
+    assert _post_schema(openapi, "/api/v1/treasury/proposals/{proposal_id}/challenges")[
+        "required"
+    ] == ["challenge_type", "reason"]
+
+
+def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    attempt_body = openapi["paths"]["/api/v1/bounties/{bounty_id}/attempts"]["post"]["requestBody"]
+    release_body = openapi["paths"]["/api/v1/bounty-attempts/{attempt_id}/release"]["post"][
+        "requestBody"
+    ]
+
+    assert attempt_body.get("required") is not True
+    assert release_body.get("required") is not True

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -51,31 +51,60 @@ def test_public_post_openapi_request_bodies_mark_required_fields(sqlite_url: str
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
     openapi = client.get("/openapi.json").json()
 
-    assert _post_schema(openapi, "/api/v1/wallets/register")["required"] == ["public_key_hex"]
-    assert _post_schema(openapi, "/api/v1/wallets/link-github")["required"] == [
+    assert set(_post_schema(openapi, "/api/v1/wallets/register")["required"]) == {"public_key_hex"}
+    assert set(_post_schema(openapi, "/api/v1/wallets/link-github")["required"]) == {
         "address",
         "nonce",
         "signature_hex",
-    ]
-    assert _post_schema(openapi, "/api/v1/github/claim")["required"] == [
+    }
+    assert set(_post_schema(openapi, "/api/v1/github/claim")["required"]) == {
         "address",
         "nonce",
         "signature_hex",
-    ]
-    assert _post_schema(openapi, "/api/v1/transfers")["required"] == [
+    }
+    assert set(_post_schema(openapi, "/api/v1/transfers")["required"]) == {
         "from_address",
         "to_address",
         "amount_mrwk",
         "nonce",
         "signature_hex",
-    ]
-    assert _post_schema(openapi, "/api/v1/treasury/proposals")["required"] == [
+    }
+    assert set(_post_schema(openapi, "/api/v1/treasury/proposals")["required"]) == {
         "action",
         "payload",
-    ]
-    assert _post_schema(openapi, "/api/v1/treasury/proposals/{proposal_id}/challenges")[
-        "required"
-    ] == ["challenge_type", "reason"]
+    }
+    assert set(
+        _post_schema(openapi, "/api/v1/treasury/proposals/{proposal_id}/challenges")["required"]
+    ) == {"challenge_type", "reason"}
+
+
+def test_public_post_openapi_request_bodies_publish_stable_constraints(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    attempt_props = _post_schema(openapi, "/api/v1/bounties/{bounty_id}/attempts")["properties"]
+    ttl_any_of = attempt_props["ttl_seconds"]["anyOf"]
+    assert {"type": "integer", "minimum": 60, "maximum": 604800} in ttl_any_of
+    assert any(
+        schema.get("type") == "string" and schema.get("pattern") == "^[0-9]+$"
+        for schema in ttl_any_of
+    )
+
+    wallet_props = _post_schema(openapi, "/api/v1/wallets/register")["properties"]
+    assert wallet_props["public_key_hex"]["minLength"] == 64
+    assert wallet_props["public_key_hex"]["maxLength"] == 64
+    assert wallet_props["public_key_hex"]["pattern"] == "^[0-9a-f]{64}$"
+
+    link_props = _post_schema(openapi, "/api/v1/wallets/link-github")["properties"]
+    assert link_props["signature_hex"]["minLength"] == 128
+    assert link_props["signature_hex"]["maxLength"] == 128
+    assert link_props["signature_hex"]["pattern"] == "^[0-9a-f]{128}$"
+    assert {"type": "integer", "minimum": 1} in link_props["nonce"]["anyOf"]
+
+    transfer_props = _post_schema(openapi, "/api/v1/transfers")["properties"]
+    assert transfer_props["signature_hex"]["pattern"] == "^[0-9a-f]{128}$"
 
 
 def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #647
Source issue: #717

## Summary
- Adds machine-readable OpenAPI `requestBody` schemas for public JSON POST routes without moving runtime validation into Pydantic.
- Covers advisory attempt registration/release, wallet registration/linking, GitHub claims, transfers, treasury proposals, and treasury challenges.
- Documents that `/openapi.json`, `/api/docs`, and `/api/redoc` expose schema-backed POST payload fields for clients and agents.

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py tests\test_wallet_api.py tests\test_bounty_attempts.py tests\test_treasury_proposals.py tests\test_docs_public_urls.py -q` -> 120 passed, 1 existing Starlette/httpx warning
- `.\.venv\Scripts\python.exe -m ruff check app\bounty_attempts.py app\wallet_api.py app\treasury_routes.py app\openapi_request_bodies.py tests\test_openapi_request_bodies.py` -> All checks passed
- `.\.venv\Scripts\python.exe -m ruff format --check app\bounty_attempts.py app\wallet_api.py app\treasury_routes.py app\openapi_request_bodies.py tests\test_openapi_request_bodies.py` -> 5 files already formatted
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check` -> passed

## Duplicate Check
- Open PRs checked for source issue #717 and OpenAPI request-body wording returned no active implementation PR.
- Related open PR #699 covers typed OpenAPI response/read API schemas, not REST POST requestBody schemas.
- Bounty #647 remains open with effective award capacity at pre-submission check time.

## Scope
No ledger, payout, proof, treasury execution, wallet signature verification, balance, exchange, bridge, cash-out, price, private-data, or production mutation behavior changed. Runtime request parsing and validation behavior stays with the existing route helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * API docs now publish machine-readable OpenAPI request-body schemas for attempt reservations/releases, wallet registration/actions, transfers, and treasury proposals/challenges so clients can discover payload fields and constraints without reading source.
  * Clarified where OpenAPI JSON and web docs are hosted for the configured API host.
* **Tests**
  * Added tests to validate published request-body schemas and ensure attempt bodies remain optional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->