### PR TITLE
Filter treasury proposals by payout recipient

### DIFF
--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -95,15 +95,15 @@ def register_treasury_routes(
             if action is not None:
                 query = query.where(TreasuryProposal.action == action.strip())
 
-            proposals = session.scalars(query.order_by(TreasuryProposal.id.desc())).all()
-
             import json
 
             results = []
-            for proposal in proposals:
+            for proposal in session.scalars(query.order_by(TreasuryProposal.id.desc())):
                 try:
                     payload = json.loads(proposal.payload_json)
                 except Exception:
+                    continue
+                if not isinstance(payload, dict):
                     continue
 
                 if to_account is not None:

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from sqlalchemy import select
 
+from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import LedgerError
 from app.models import TreasuryProposal
@@ -58,7 +59,7 @@ def register_treasury_routes(
         if to_account is not None:
             if not to_account.strip():
                 raise HTTPException(status_code=400, detail="to_account must not be blank")
-            if any(ord(c) < 32 or ord(c) == 127 or 0x80 <= ord(c) <= 0x9F for c in to_account):
+            if contains_control_character(to_account):
                 raise HTTPException(
                     status_code=400,
                     detail="to_account must not contain control characters",
@@ -66,7 +67,7 @@ def register_treasury_routes(
         if status is not None:
             if not status.strip():
                 raise HTTPException(status_code=400, detail="status must not be blank")
-            if any(ord(c) < 32 or ord(c) == 127 or 0x80 <= ord(c) <= 0x9F for c in status):
+            if contains_control_character(status):
                 raise HTTPException(
                     status_code=400,
                     detail="status must not contain control characters",
@@ -74,7 +75,7 @@ def register_treasury_routes(
         if action is not None:
             if not action.strip():
                 raise HTTPException(status_code=400, detail="action must not be blank")
-            if any(ord(c) < 32 or ord(c) == 127 or 0x80 <= ord(c) <= 0x9F for c in action):
+            if contains_control_character(action):
                 raise HTTPException(
                     status_code=400,
                     detail="action must not contain control characters",
@@ -82,7 +83,7 @@ def register_treasury_routes(
         if submission_url is not None:
             if not submission_url.strip():
                 raise HTTPException(status_code=400, detail="submission_url must not be blank")
-            if any(ord(c) < 32 or ord(c) == 127 or 0x80 <= ord(c) <= 0x9F for c in submission_url):
+            if contains_control_character(submission_url):
                 raise HTTPException(
                     status_code=400,
                     detail="submission_url must not contain control characters",

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -49,12 +49,78 @@ def register_treasury_routes(
     @app.get("/api/v1/treasury/proposals")
     def api_treasury_proposals(
         limit: Annotated[int, Query(ge=1, le=200)] = 100,
+        status: str | None = None,
+        action: str | None = None,
+        to_account: str | None = None,
+        bounty_id: int | None = None,
+        submission_url: str | None = None,
     ) -> list[dict[str, Any]]:
+        if to_account is not None:
+            if not to_account.strip():
+                raise HTTPException(status_code=400, detail="to_account must not be blank")
+            if any(ord(c) < 32 or ord(c) == 127 or 0x80 <= ord(c) <= 0x9F for c in to_account):
+                raise HTTPException(
+                    status_code=400,
+                    detail="to_account must not contain control characters",
+                )
+        if status is not None:
+            if not status.strip():
+                raise HTTPException(status_code=400, detail="status must not be blank")
+            if any(ord(c) < 32 or ord(c) == 127 or 0x80 <= ord(c) <= 0x9F for c in status):
+                raise HTTPException(
+                    status_code=400,
+                    detail="status must not contain control characters",
+                )
+        if action is not None:
+            if not action.strip():
+                raise HTTPException(status_code=400, detail="action must not be blank")
+            if any(ord(c) < 32 or ord(c) == 127 or 0x80 <= ord(c) <= 0x9F for c in action):
+                raise HTTPException(
+                    status_code=400,
+                    detail="action must not contain control characters",
+                )
+        if submission_url is not None:
+            if not submission_url.strip():
+                raise HTTPException(status_code=400, detail="submission_url must not be blank")
+            if any(ord(c) < 32 or ord(c) == 127 or 0x80 <= ord(c) <= 0x9F for c in submission_url):
+                raise HTTPException(
+                    status_code=400,
+                    detail="submission_url must not contain control characters",
+                )
+
         with session_scope(db_url) as session:
-            proposals = session.scalars(
-                select(TreasuryProposal).order_by(TreasuryProposal.id.desc()).limit(limit)
-            ).all()
-            return [proposal_to_dict(proposal) for proposal in proposals]
+            query = select(TreasuryProposal)
+            if status is not None:
+                query = query.where(TreasuryProposal.status == status.strip())
+            if action is not None:
+                query = query.where(TreasuryProposal.action == action.strip())
+
+            proposals = session.scalars(query.order_by(TreasuryProposal.id.desc())).all()
+
+            import json
+
+            results = []
+            for proposal in proposals:
+                try:
+                    payload = json.loads(proposal.payload_json)
+                except Exception:
+                    continue
+
+                if to_account is not None:
+                    payload_to = str(payload.get("to_account", "")).lower()
+                    if payload_to != to_account.strip().lower():
+                        continue
+                if bounty_id is not None and payload.get("bounty_id") != bounty_id:
+                    continue
+                if submission_url is not None:
+                    payload_sub = str(payload.get("submission_url", "")).lower()
+                    if payload_sub != submission_url.strip().lower():
+                        continue
+
+                results.append(proposal_to_dict(proposal))
+                if len(results) >= limit:
+                    break
+            return results
 
     @app.get("/api/v1/treasury/status")
     def api_treasury_status() -> dict[str, Any]:

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -47,6 +47,13 @@ curl -s https://api.mrwk.online/api/v1/treasury/proposals
 curl -s https://api.mrwk.online/api/v1/treasury/proposals/<proposal_id>
 ```
 
+Filter proposals by payout recipient (`to_account`), bounty (`bounty_id`), submission (`submission_url`), status, action, or limit:
+
+```bash
+curl -s "https://api.mrwk.online/api/v1/treasury/proposals?to_account=github:gwani-28"
+curl -s "https://api.mrwk.online/api/v1/treasury/proposals?status=pending&action=pay_bounty&limit=10"
+```
+
 Legacy-compatible admin API reads remain available at
 `https://api.mrwk.ltclab.site` for existing scripts, but new examples should use
 `https://api.mrwk.online`.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -82,6 +82,15 @@ curl -s "$API_HOST/api/v1/treasury/proposals"
 curl -s "$API_HOST/api/v1/treasury/proposals/<proposal_id>"
 ```
 
+You can filter proposals by payout recipient (`to_account`), bounty ID (`bounty_id`), submission URL (`submission_url`), `status`, `action`, or `limit` (default 100, max 200). Note that blank filters or filters containing control characters will be rejected with a `400 Bad Request`.
+
+```bash
+curl -s "$API_HOST/api/v1/treasury/proposals?to_account=github:gwani-28"
+curl -s "$API_HOST/api/v1/treasury/proposals?bounty_id=11"
+curl -s "$API_HOST/api/v1/treasury/proposals?submission_url=https://github.com/ramimbo/mergework/pull/10"
+curl -s "$API_HOST/api/v1/treasury/proposals?status=pending&action=pay_bounty&limit=5"
+```
+
 Use `/api/v1/treasury/status` before proposing fresh bounty rounds. It reports
 the rolling 24-hour reserve cap, recent reserve usage, pending create-bounty
 reserve, remaining create capacity, and the next capacity release time.

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -111,6 +111,15 @@ curl -s "$API_HOST/api/v1/treasury/proposals"
 curl -s "$API_HOST/api/v1/treasury/proposals/<proposal_id>"
 ```
 
+Proposals can be filtered by recipient (`to_account`), bounty ID (`bounty_id`), submission URL (`submission_url`), status, action, and limit:
+
+```bash
+curl -s "$API_HOST/api/v1/treasury/proposals?to_account=github:gwani-28"
+curl -s "$API_HOST/api/v1/treasury/proposals?bounty_id=11"
+curl -s "$API_HOST/api/v1/treasury/proposals?submission_url=https://github.com/ramimbo/mergework/pull/10"
+curl -s "$API_HOST/api/v1/treasury/proposals?status=pending&action=pay_bounty&limit=5"
+```
+
 The treasury status endpoint reports the 24-hour create-bounty reserve cap,
 recent executed reserves, pending create-bounty proposal reserves, remaining
 create capacity, the next reserve capacity release time, and pending

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -417,6 +417,93 @@ def test_treasury_proposals_list_honors_limit(
     assert too_large.status_code == 422
 
 
+def test_treasury_proposals_list_filters(sqlite_url: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(sqlite_url, monkeypatch)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        b1 = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=10,
+            issue_url="https://github.com/ramimbo/mergework/issues/10",
+            title="Bounty 1",
+            reward_mrwk="10",
+            acceptance="Acceptance",
+        )
+        b2 = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=11,
+            issue_url="https://github.com/ramimbo/mergework/issues/11",
+            title="Bounty 2",
+            reward_mrwk="10",
+            acceptance="Acceptance",
+        )
+        session.flush()
+        b1_id = b1.id
+        b2_id = b2.id
+
+    p1 = client.post(
+        f"/api/v1/bounties/{b1_id}/pay",
+        headers=ADMIN_HEADERS,
+        json={
+            "to_account": "github:gwani-28",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/10",
+            "accepted_by": "maintainer",
+        },
+    ).json()
+
+    p2 = client.post(
+        f"/api/v1/bounties/{b2_id}/pay",
+        headers=ADMIN_HEADERS,
+        json={
+            "to_account": "github:otherguy",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/11",
+            "accepted_by": "maintainer",
+        },
+    ).json()
+
+    unfiltered = client.get("/api/v1/treasury/proposals")
+    assert unfiltered.status_code == 200
+    assert len(unfiltered.json()) >= 2
+
+    filtered_gwani = client.get("/api/v1/treasury/proposals?to_account=github:gwani-28")
+    assert filtered_gwani.status_code == 200
+    assert [p["id"] for p in filtered_gwani.json()] == [p1["id"]]
+
+    filtered_gwani_upper = client.get("/api/v1/treasury/proposals?to_account=GITHUB:GWANI-28")
+    assert filtered_gwani_upper.status_code == 200
+    assert [p["id"] for p in filtered_gwani_upper.json()] == [p1["id"]]
+
+    filtered_other = client.get("/api/v1/treasury/proposals?to_account=github:otherguy")
+    assert filtered_other.status_code == 200
+    assert [p["id"] for p in filtered_other.json()] == [p2["id"]]
+
+    comp = client.get(
+        "/api/v1/treasury/proposals?to_account=github:gwani-28&status=pending&action=pay_bounty&limit=1"
+    )
+    assert comp.status_code == 200
+    assert [p["id"] for p in comp.json()] == [p1["id"]]
+
+    blank = client.get("/api/v1/treasury/proposals?to_account=%20")
+    assert blank.status_code == 400
+    assert blank.json()["detail"] == "to_account must not be blank"
+
+    ctrl = client.get("/api/v1/treasury/proposals", params={"to_account": "github:gwani\t28"})
+    assert ctrl.status_code == 400
+    assert ctrl.json()["detail"] == "to_account must not contain control characters"
+
+    filtered_bounty = client.get(f"/api/v1/treasury/proposals?bounty_id={b1_id}")
+    assert filtered_bounty.status_code == 200
+    assert [p["id"] for p in filtered_bounty.json()] == [p1["id"]]
+
+    filtered_submission = client.get(
+        "/api/v1/treasury/proposals?submission_url=https://github.com/ramimbo/mergework/pull/10"
+    )
+    assert filtered_submission.status_code == 200
+    assert [p["id"] for p in filtered_submission.json()] == [p1["id"]]
+
+
 def test_direct_proposal_creation_requires_admin_token(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -493,6 +493,18 @@ def test_treasury_proposals_list_filters(sqlite_url: str, monkeypatch: pytest.Mo
     assert ctrl.status_code == 400
     assert ctrl.json()["detail"] == "to_account must not contain control characters"
 
+    blank_status = client.get("/api/v1/treasury/proposals?status=%20")
+    assert blank_status.status_code == 400
+    assert blank_status.json()["detail"] == "status must not be blank"
+
+    ctrl_action = client.get("/api/v1/treasury/proposals", params={"action": "pay_bounty\t"})
+    assert ctrl_action.status_code == 400
+    assert ctrl_action.json()["detail"] == "action must not contain control characters"
+
+    blank_submission = client.get("/api/v1/treasury/proposals?submission_url=%20")
+    assert blank_submission.status_code == 400
+    assert blank_submission.json()["detail"] == "submission_url must not be blank"
+
     filtered_bounty = client.get(f"/api/v1/treasury/proposals?bounty_id={b1_id}")
     assert filtered_bounty.status_code == 200
     assert [p["id"] for p in filtered_bounty.json()] == [p1["id"]]


### PR DESCRIPTION
Bounty #647
Source issue: #680

### Overview
This pull request implements the requested feature to filter public treasury proposals by payout recipient (`to_account`), bounty ID (`bounty_id`), and submission URL (`submission_url`).

### Proposed Changes
- Modified `GET /api/v1/treasury/proposals` in `app/treasury_routes.py` to accept query parameters:
  - `to_account` (case-insensitive)
  - `bounty_id`
  - `submission_url` (case-insensitive)
  - `status`
  - `action`
  - `limit` (default 100, max 200)
- Implemented robust string input validation rejecting blank filters or filters containing control characters with a `400 Bad Request`.
- Verified filtering logic cleanly composes with status, action, and limit.
- Updated documentation in `docs/agent-guide.md`, `docs/admin-runbook.md`, and `docs/api-examples.md` with descriptions and curl examples.
- Added comprehensive unit tests in `tests/test_treasury_proposals.py` verifying all filters, composition, and edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Treasury proposal listings support filtering by recipient account (case-insensitive), bounty ID (exact), submission URL (case-insensitive), status, action, and result limit.

* **Bug Fixes**
  * Invalid or blank filter values (including control characters) now return a 400 error.

* **Documentation**
  * Admin and developer docs updated with examples and validation details for all query parameters.

* **Tests**
  * Added tests covering filtering behavior, case-insensitivity, combined filters, and validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->