### PR TITLE
Make public treasury timestamps UTC-explicit

### DIFF
--- a/app/serializers.py
+++ b/app/serializers.py
@@ -78,7 +78,7 @@ def bounty_to_dict(
         ),
         "status": bounty.status,
         "acceptance": bounty.acceptance,
-        "created_at": bounty.created_at.isoformat(),
+        "created_at": public_utc_timestamp(bounty.created_at),
     }
 
 
@@ -122,7 +122,7 @@ def bounty_awards_to_dict(session: Session, bounty_id: int) -> list[dict[str, An
                 "amount_mrwk": data.get("amount_mrwk"),
                 "submission_url": data.get("submission_url"),
                 "accepted_by": data.get("accepted_by"),
-                "created_at": proof.created_at.isoformat(),
+                "created_at": public_utc_timestamp(proof.created_at),
             }
         )
     return awards

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -17,6 +17,13 @@ from app.models import Bounty, LedgerEntry, Proof, TreasuryProposal, Wallet, Wal
 PendingBountyProposals = tuple[list[dict[str, Any]], dict[str, Any] | None]
 
 
+def public_utc_timestamp(value: datetime) -> str:
+    """Serialize public API timestamps with an explicit UTC marker."""
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
 def bounty_to_dict(
     bounty: Bounty,
     session: Session | None = None,
@@ -168,8 +175,8 @@ def _proposal_summary(
     summary = {
         "proposal_id": proposal.id,
         "proposed_by": proposal.proposed_by,
-        "proposed_at": proposal.proposed_at.isoformat(),
-        "executes_after": proposal.executes_after.isoformat(),
+        "proposed_at": public_utc_timestamp(proposal.proposed_at),
+        "executes_after": public_utc_timestamp(proposal.executes_after),
     }
     for field in fields:
         value = payload.get(field)
@@ -456,8 +463,8 @@ def _pending_activity_row(
         "bounty_id": bounty.id if bounty else _proposal_bounty_id(payload),
         "bounty_url": _bounty_detail_url(bounty.id if bounty else _proposal_bounty_id(payload)),
         "accepted_by": payload.get("accepted_by"),
-        "proposed_at": proposal.proposed_at.isoformat(),
-        "executes_after": proposal.executes_after.isoformat(),
+        "proposed_at": public_utc_timestamp(proposal.proposed_at),
+        "executes_after": public_utc_timestamp(proposal.executes_after),
     }
 
 
@@ -710,8 +717,8 @@ def pending_payouts_for_account(session: Session, account: str) -> list[dict[str
                 "issue_url": bounty.issue_url if bounty else None,
                 "submission_url": payload.get("submission_url"),
                 "accepted_by": payload.get("accepted_by"),
-                "proposed_at": proposal.proposed_at.isoformat(),
-                "executes_after": proposal.executes_after.isoformat(),
+                "proposed_at": public_utc_timestamp(proposal.proposed_at),
+                "executes_after": public_utc_timestamp(proposal.executes_after),
             }
         )
     return pending

--- a/app/treasury.py
+++ b/app/treasury.py
@@ -35,7 +35,7 @@ from app.models import (
     utc_now,
 )
 from app.path_params import SQLITE_INTEGER_MAX
-from app.serializers import bounty_to_dict
+from app.serializers import bounty_to_dict, public_utc_timestamp
 
 TREASURY_PROPOSAL_DELAY = timedelta(hours=24)
 TREASURY_EPOCH_WINDOW = timedelta(hours=24)
@@ -369,7 +369,7 @@ def challenge_to_dict(challenge: TreasuryChallenge) -> dict[str, Any]:
         "challenge_type": challenge.challenge_type,
         "status": challenge.status,
         "reason": challenge.reason,
-        "created_at": challenge.created_at.isoformat(),
+        "created_at": public_utc_timestamp(challenge.created_at),
     }
 
 
@@ -383,9 +383,11 @@ def proposal_to_dict(proposal: TreasuryProposal) -> dict[str, Any]:
         "payload": proposal_payload(proposal),
         "proposed_by": proposal.proposed_by,
         "executed_by": proposal.executed_by,
-        "proposed_at": proposal.proposed_at.isoformat(),
-        "executes_after": proposal.executes_after.isoformat(),
-        "executed_at": proposal.executed_at.isoformat() if proposal.executed_at else None,
+        "proposed_at": public_utc_timestamp(proposal.proposed_at),
+        "executes_after": public_utc_timestamp(proposal.executes_after),
+        "executed_at": (
+            public_utc_timestamp(proposal.executed_at) if proposal.executed_at else None
+        ),
         "executed_ledger_sequence": proposal.executed_ledger_sequence,
         "result": proposal_result(proposal),
         "challenges": [challenge_to_dict(challenge) for challenge in proposal.challenges],
@@ -530,7 +532,7 @@ def _projected_capacity_events(
         )
         events.append(
             {
-                "at": at.isoformat(),
+                "at": public_utc_timestamp(at),
                 "event_type": event_type,
                 "amount_mrwk": format_mrwk(amount),
                 "available_create_reserve_mrwk": format_mrwk(available),
@@ -562,9 +564,9 @@ def treasury_status(session: Session) -> dict[str, Any]:
                 "reward_mrwk": str(payload["reward_mrwk"]),
                 "max_awards": int(payload["max_awards"]),
                 "reserve_mrwk": format_mrwk(reserve),
-                "proposed_at": _db_utc(proposal.proposed_at).isoformat(),
-                "executes_after": executes_after.isoformat(),
-                "capacity_releases_at": capacity_releases_at.isoformat(),
+                "proposed_at": public_utc_timestamp(proposal.proposed_at),
+                "executes_after": public_utc_timestamp(executes_after),
+                "capacity_releases_at": public_utc_timestamp(capacity_releases_at),
             }
         )
         pending_create_projection.append(
@@ -579,7 +581,7 @@ def treasury_status(session: Session) -> dict[str, Any]:
         for entry in recent_reserves
         if _db_utc(entry.created_at) + TREASURY_EPOCH_WINDOW > now
     ]
-    next_capacity_release_at = min(release_times).isoformat() if release_times else None
+    next_capacity_release_at = public_utc_timestamp(min(release_times)) if release_times else None
     projected_capacity_events = _projected_capacity_events(
         now=now,
         executed_reserve=executed_reserve,
@@ -610,8 +612,10 @@ def treasury_status(session: Session) -> dict[str, Any]:
                 "ledger_sequence": entry.sequence,
                 "amount_mrwk": format_mrwk(entry.amount_microunits),
                 "reference": entry.reference,
-                "created_at": _db_utc(entry.created_at).isoformat(),
-                "expires_at": (_db_utc(entry.created_at) + TREASURY_EPOCH_WINDOW).isoformat(),
+                "created_at": public_utc_timestamp(entry.created_at),
+                "expires_at": public_utc_timestamp(
+                    _db_utc(entry.created_at) + TREASURY_EPOCH_WINDOW
+                ),
             }
             for entry in recent_reserves
         ],

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -13,6 +13,7 @@ from app.ledger.service import (
     pay_bounty,
 )
 from app.main import create_app
+from app.serializers import public_utc_timestamp
 from app.treasury import propose_treasury_action
 
 
@@ -160,7 +161,7 @@ def test_account_routes_expose_pending_payouts_separately_from_paid_work(
     assert account_api["pending_summary"] == {
         "pending_awards": 1,
         "pending_mrwk": "75",
-        "next_executes_after": proposal.executes_after.isoformat(),
+        "next_executes_after": public_utc_timestamp(proposal.executes_after),
     }
     assert accepted_api["summary"] == account_api["accepted_work"]
     assert accepted_api["pending_summary"] == account_api["pending_summary"]
@@ -178,10 +179,11 @@ def test_account_routes_expose_pending_payouts_separately_from_paid_work(
             "issue_url": "https://github.com/ramimbo/mergework/issues/180",
             "submission_url": "https://github.com/ramimbo/mergework/pull/180",
             "accepted_by": "maintainer",
-            "proposed_at": proposal.proposed_at.isoformat(),
-            "executes_after": proposal.executes_after.isoformat(),
+            "proposed_at": public_utc_timestamp(proposal.proposed_at),
+            "executes_after": public_utc_timestamp(proposal.executes_after),
         }
     ]
+    assert account_api["pending_summary"]["next_executes_after"].endswith("Z")
     assert len(accepted_api["accepted_work"]) == 1
     assert accepted_api["accepted_work"][0]["proof_hash"] == proof.hash
     assert "Pending payouts" in page

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from app.db import create_schema, session_scope
 from app.ledger.service import add_ledger_entry, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
+from app.serializers import public_utc_timestamp
 from app.treasury import propose_treasury_action
 
 
@@ -243,8 +244,8 @@ def test_activity_api_exposes_pending_payouts_separately_from_paid_work(
         )
         pending_bounty_id = pending_bounty.id
         proposal_id = proposal.id
-        proposal_proposed_at = proposal.proposed_at.isoformat()
-        proposal_executes_after = proposal.executes_after.isoformat()
+        proposal_proposed_at = public_utc_timestamp(proposal.proposed_at)
+        proposal_executes_after = public_utc_timestamp(proposal.executes_after)
         proof_hash = proof.hash
 
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
@@ -285,6 +286,7 @@ def test_activity_api_exposes_pending_payouts_separately_from_paid_work(
             "executes_after": proposal_executes_after,
         }
     ]
+    assert payload["pending_payouts"][0]["executes_after"].endswith("Z")
     assert by_account["pending_payouts"][0]["proposal_id"] == proposal_id
     assert by_proposal["pending_payouts"][0]["proposal_id"] == proposal_id
     assert by_submission["pending_payouts"][0]["proposal_id"] == proposal_id

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -10,6 +10,7 @@ from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
 from app.models import BountyAttempt, Proof
+from app.serializers import public_utc_timestamp
 from app.treasury import propose_treasury_action
 
 
@@ -776,7 +777,7 @@ def test_mcp_get_bounty_can_include_accepted_awards(sqlite_url: str) -> None:
             "amount_mrwk": "75",
             "submission_url": "https://github.com/ramimbo/mergework/pull/284",
             "accepted_by": "maintainer",
-            "created_at": proof.created_at.replace(tzinfo=None).isoformat(),
+            "created_at": public_utc_timestamp(proof.created_at),
         }
     ]
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -50,6 +50,7 @@ def test_bounty_serializers_preserve_public_capacity_fields(sqlite_url: str) -> 
     assert bounty_data["available_mrwk"] == "100"
     assert bounty_data["reserved_mrwk"] == "100"
     assert bounty_data["awards_remaining"] == 4
+    assert bounty_data["created_at"].endswith("Z")
     assert bounty_list_summary([bounty_data]) == {
         "bounties_shown": 1,
         "open_awards": 4,
@@ -299,6 +300,34 @@ def test_activity_serializers_skip_malformed_public_proofs(sqlite_url: str) -> N
     }
     assert summary == empty_accepted_summary()
     assert accepted_work == []
+
+
+def test_bounty_award_serializer_uses_explicit_utc_timestamp(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=321,
+            issue_url="https://github.com/ramimbo/mergework/issues/321",
+            title="Public bounty award history",
+            reward_mrwk="40",
+            acceptance="Award history timestamps should be explicit UTC.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:tatelyman",
+            submission_url="https://github.com/ramimbo/mergework/pull/321",
+            accepted_by="ramimbo",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+        awards = bounty_awards_to_dict(session, bounty.id)
+
+    assert len(awards) == 1
+    assert awards[0]["created_at"].endswith("Z")
 
 
 def test_bounty_award_serializer_skips_malformed_public_proofs(sqlite_url: str) -> None:

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -24,6 +24,7 @@ from app.ledger.service import (
 from app.main import create_app
 from app.models import Bounty, LedgerEntry, Submission, TreasuryChallenge, TreasuryProposal, utc_now
 from app.path_params import SQLITE_INTEGER_MAX
+from app.serializers import public_utc_timestamp
 
 ADMIN_HEADERS = {"x-mergework-admin-token": "admin-token-for-tests"}
 
@@ -100,6 +101,8 @@ def test_admin_bounty_creation_creates_public_delayed_proposal(
     assert body["payload"]["repo"] == "ramimbo/mergework"
     assert body["payload"]["reward_mrwk"] == "25"
     assert body["executes_after"] > body["proposed_at"]
+    assert body["proposed_at"].endswith("Z")
+    assert body["executes_after"].endswith("Z")
     with session_scope(sqlite_url) as session:
         assert session.scalar(select(func.count(Bounty.id))) == 0
         assert get_balance(session, TREASURY_ACCOUNT) == 100_000_000_000_000
@@ -201,9 +204,8 @@ def test_treasury_status_reports_reserve_capacity_and_pending_create_proposals(
     assert body["executed_reserve_24h_mrwk"] == "9000"
     assert body["pending_create_reserve_mrwk"] == "500"
     assert body["available_create_reserve_mrwk"] == "500"
-    assert (
-        body["next_capacity_release_at"]
-        == (recent_time.replace(tzinfo=None) + timedelta(hours=24)).isoformat()
+    assert body["next_capacity_release_at"] == public_utc_timestamp(
+        recent_time + timedelta(hours=24)
     )
     assert body["pending_create_bounties"] == [
         {
@@ -216,9 +218,9 @@ def test_treasury_status_reports_reserve_capacity_and_pending_create_proposals(
             "reserve_mrwk": "500",
             "proposed_at": proposal.json()["proposed_at"],
             "executes_after": proposal.json()["executes_after"],
-            "capacity_releases_at": (
+            "capacity_releases_at": public_utc_timestamp(
                 datetime.fromisoformat(proposal.json()["executes_after"]) + timedelta(hours=24)
-            ).isoformat(),
+            ),
         }
     ]
     assert body["recent_reserves"] == [
@@ -226,8 +228,8 @@ def test_treasury_status_reports_reserve_capacity_and_pending_create_proposals(
             "ledger_sequence": recent_entry.sequence,
             "amount_mrwk": "9000",
             "reference": "https://github.com/ramimbo/mergework/issues/1",
-            "created_at": recent_time.replace(tzinfo=None).isoformat(),
-            "expires_at": (recent_time.replace(tzinfo=None) + timedelta(hours=24)).isoformat(),
+            "created_at": public_utc_timestamp(recent_time),
+            "expires_at": public_utc_timestamp(recent_time + timedelta(hours=24)),
         }
     ]
 
@@ -269,8 +271,8 @@ def test_treasury_status_includes_reserve_at_exact_24h_boundary(
             "ledger_sequence": entry.sequence,
             "amount_mrwk": "1",
             "reference": "https://github.com/ramimbo/mergework/issues/42",
-            "created_at": boundary_time.replace(tzinfo=None).isoformat(),
-            "expires_at": fixed_now.replace(tzinfo=None).isoformat(),
+            "created_at": public_utc_timestamp(boundary_time),
+            "expires_at": public_utc_timestamp(fixed_now),
         }
     ]
     assert body["next_capacity_release_at"] is None
@@ -313,37 +315,36 @@ def test_treasury_status_projects_pending_create_capacity_events(
     assert proposal.status_code == 200
     assert response.status_code == 200
     body = response.json()
-    pending_release_at = fixed_now.replace(tzinfo=None) + timedelta(hours=48)
+    pending_release_at = fixed_now + timedelta(hours=48)
     assert body["available_create_reserve_mrwk"] == "1000"
     assert body["pending_create_bounties"][0]["capacity_releases_at"] == (
-        pending_release_at.isoformat()
+        public_utc_timestamp(pending_release_at)
     )
     assert body["projected_capacity_events"] == [
         {
-            "at": (recent_time.replace(tzinfo=None) + timedelta(hours=24)).isoformat(),
+            "at": public_utc_timestamp(recent_time + timedelta(hours=24)),
             "event_type": "recent_reserve_releases",
             "amount_mrwk": "8000",
             "available_create_reserve_mrwk": "9000",
             "note": "Executed reserve leaves the 24h cap window.",
         },
         {
-            "at": (fixed_now.replace(tzinfo=None) + timedelta(hours=24)).isoformat(),
+            "at": public_utc_timestamp(fixed_now + timedelta(hours=24)),
             "event_type": "pending_create_executes",
             "amount_mrwk": "1000",
             "available_create_reserve_mrwk": "9000",
             "note": "Pending create reserve becomes executed reserve; capacity does not increase.",
         },
         {
-            "at": pending_release_at.isoformat(),
+            "at": public_utc_timestamp(pending_release_at),
             "event_type": "pending_create_releases",
             "amount_mrwk": "1000",
             "available_create_reserve_mrwk": "10000",
             "note": "Executed reserve from this pending create leaves the 24h cap window.",
         },
     ]
-    assert (
-        body["next_projected_capacity_release_at"]
-        == (recent_time.replace(tzinfo=None) + timedelta(hours=24)).isoformat()
+    assert body["next_projected_capacity_release_at"] == public_utc_timestamp(
+        recent_time + timedelta(hours=24)
     )
 
 
@@ -368,31 +369,30 @@ def test_treasury_status_clamps_overdue_pending_create_projection_to_now(
 
     assert response.status_code == 200
     body = response.json()
-    pending_release_at = fixed_now.replace(tzinfo=None) + timedelta(hours=24)
-    assert (
-        body["pending_create_bounties"][0]["executes_after"]
-        == (fixed_now.replace(tzinfo=None) - timedelta(hours=2)).isoformat()
+    pending_release_at = fixed_now + timedelta(hours=24)
+    assert body["pending_create_bounties"][0]["executes_after"] == public_utc_timestamp(
+        fixed_now - timedelta(hours=2)
     )
     assert body["pending_create_bounties"][0]["capacity_releases_at"] == (
-        pending_release_at.isoformat()
+        public_utc_timestamp(pending_release_at)
     )
     assert body["projected_capacity_events"] == [
         {
-            "at": fixed_now.replace(tzinfo=None).isoformat(),
+            "at": public_utc_timestamp(fixed_now),
             "event_type": "pending_create_executes",
             "amount_mrwk": "1000",
             "available_create_reserve_mrwk": "9000",
             "note": "Pending create reserve becomes executed reserve; capacity does not increase.",
         },
         {
-            "at": pending_release_at.isoformat(),
+            "at": public_utc_timestamp(pending_release_at),
             "event_type": "pending_create_releases",
             "amount_mrwk": "1000",
             "available_create_reserve_mrwk": "10000",
             "note": "Executed reserve from this pending create leaves the 24h cap window.",
         },
     ]
-    assert body["next_projected_capacity_release_at"] == pending_release_at.isoformat()
+    assert body["next_projected_capacity_release_at"] == public_utc_timestamp(pending_release_at)
 
 
 def test_treasury_proposals_list_honors_limit(


### PR DESCRIPTION
Bounty #655

## Summary
- add a shared `public_utc_timestamp()` serializer for public API timestamps
- apply explicit `Z` UTC timestamps to treasury proposals, proposal challenges, pending payout proposal rows, account pending payouts, activity pending payouts, and treasury status capacity timing fields
- update coverage so pending payout and treasury status timestamps preserve the explicit UTC marker

## Why
Live public APIs currently expose execution-critical pending payout / treasury proposal timestamps without a timezone marker, which makes delayed payout execution windows easy to misread as local time. This keeps the stored DB values unchanged and only makes the public serialization explicit.

## Validation
- `.venv/bin/pytest` -> 591 passed, 1 warning
- `.venv/bin/ruff check app/serializers.py app/treasury.py tests/test_account_routes.py tests/test_activity.py tests/test_treasury_proposals.py`
- `.venv/bin/ruff format --check app/serializers.py app/treasury.py tests/test_account_routes.py tests/test_activity.py tests/test_treasury_proposals.py`
- `.venv/bin/mypy app`
- `git diff --check`

Out of scope: no payout/proof/ledger/wallet/exchange/cash-out behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * API timestamps now consistently use ISO-8601 with explicit UTC ("Z") across treasury, proposal, bounty, challenge, pending payout, and reserve-related responses.
* **Tests**
  * Test suite updated to assert and enforce the new UTC/ISO timestamp formatting; one test adjusted to reflect these timestamp expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->