### PR TITLE
Validate treasury proposal filters

### DIFF
--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -13,6 +13,7 @@ from app.models import TreasuryProposal
 from app.openapi_request_bodies import TREASURY_CHALLENGE_BODY, TREASURY_PROPOSAL_BODY
 from app.path_params import SQLITE_INTEGER_MAX
 from app.treasury import (
+    TREASURY_ACTIONS,
     challenge_to_dict,
     create_treasury_challenge,
     proposal_to_dict,
@@ -20,6 +21,8 @@ from app.treasury import (
     treasury_status,
 )
 from app.treasury_executor import execute_treasury_proposal_with_finalization
+
+TREASURY_PROPOSAL_STATUSES = ("pending", "executed", "blocked")
 
 
 def _positive_proposal_id(proposal_id: int) -> int:
@@ -45,6 +48,8 @@ def _optional_query_filter(
     *,
     max_length: int,
     blank_detail: str | None = None,
+    allowed_values: tuple[str, ...] | None = None,
+    lower: bool = False,
 ) -> str | None:
     if value is None:
         return None
@@ -53,8 +58,15 @@ def _optional_query_filter(
     clean = value.strip()
     if not clean:
         raise HTTPException(status_code=400, detail=blank_detail or f"{field} is required")
+    if lower:
+        clean = clean.lower()
     if len(clean) > max_length:
         raise HTTPException(status_code=400, detail=f"{field} is too long")
+    if allowed_values is not None and clean not in allowed_values:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{field} must be one of: {', '.join(allowed_values)}",
+        )
     return clean
 
 
@@ -109,8 +121,20 @@ def register_treasury_routes(
         to_account: Annotated[str | None, Query(max_length=128)] = None,
         bounty_id: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
     ) -> list[dict[str, Any]]:
-        action_filter = _optional_query_filter(action, "action", max_length=40)
-        status_filter = _optional_query_filter(status, "status", max_length=40)
+        action_filter = _optional_query_filter(
+            action,
+            "action",
+            max_length=40,
+            allowed_values=tuple(sorted(TREASURY_ACTIONS)),
+            lower=True,
+        )
+        status_filter = _optional_query_filter(
+            status,
+            "status",
+            max_length=40,
+            allowed_values=TREASURY_PROPOSAL_STATUSES,
+            lower=True,
+        )
         to_account_filter = _optional_query_filter(
             to_account,
             "to_account",

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from sqlalchemy import select
 
+from app.accounts import normalized_account
 from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import LedgerError
@@ -141,6 +142,8 @@ def register_treasury_routes(
             max_length=128,
             blank_detail="to_account must not be blank",
         )
+        if to_account_filter is not None:
+            to_account_filter = normalized_account(to_account_filter)
         with session_scope(db_url) as session:
             query = select(TreasuryProposal).order_by(TreasuryProposal.id.desc())
             if action_filter is not None:

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -458,6 +458,15 @@ def test_treasury_proposals_list_filters_by_recipient_before_limit(
         "/api/v1/treasury/proposals"
         "?status=pending&action=pay_bounty&to_account=github%3Aalice&limit=1"
     )
+    uppercase_recipient_filtered = client.get(
+        "/api/v1/treasury/proposals",
+        params={
+            "status": "pending",
+            "action": "pay_bounty",
+            "to_account": " GitHub:Alice ",
+            "limit": "1",
+        },
+    )
     bob_filtered = client.get(
         "/api/v1/treasury/proposals"
         "?status=pending&action=pay_bounty&to_account=github%3Abob&limit=1"
@@ -468,6 +477,8 @@ def test_treasury_proposals_list_filters_by_recipient_before_limit(
     assert filtered.status_code == 200
     assert [proposal["id"] for proposal in filtered.json()] == [alice.json()["id"]]
     assert filtered.json()[0]["payload"]["to_account"] == "github:alice"
+    assert uppercase_recipient_filtered.status_code == 200
+    assert uppercase_recipient_filtered.json() == filtered.json()
     assert bob_filtered.status_code == 200
     assert [proposal["id"] for proposal in bob_filtered.json()] == [bob.json()["id"]]
 
@@ -480,6 +491,7 @@ def test_treasury_proposals_list_filters_by_recipient_before_limit(
             "to_account=github%3Aalice%0Abad",
             "to_account must not contain control characters",
         ),
+        ("to_account=github%3A%20", "github login must be valid"),
     ],
 )
 def test_treasury_proposals_list_rejects_invalid_recipient_filter(

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -552,7 +552,9 @@ def test_treasury_proposals_list_filters_by_action_status_and_bounty_id(
     assert executed.status_code == 200
 
     action_filtered = client.get("/api/v1/treasury/proposals?action=pay_bounty")
+    uppercase_action_filtered = client.get("/api/v1/treasury/proposals?action=PAY_BOUNTY")
     pending_filtered = client.get("/api/v1/treasury/proposals?status=pending")
+    uppercase_pending_filtered = client.get("/api/v1/treasury/proposals?status=PENDING")
     bounty_filtered = client.get(f"/api/v1/treasury/proposals?bounty_id={first_bounty_id}")
     composed_filtered = client.get(
         "/api/v1/treasury/proposals",
@@ -569,11 +571,15 @@ def test_treasury_proposals_list_filters_by_action_status_and_bounty_id(
         second_payout["id"],
         first_payout["id"],
     ]
+    assert uppercase_action_filtered.status_code == 200
+    assert uppercase_action_filtered.json() == action_filtered.json()
     assert pending_filtered.status_code == 200
     assert [proposal["id"] for proposal in pending_filtered.json()] == [
         create_bounty_proposal["id"],
         second_payout["id"],
     ]
+    assert uppercase_pending_filtered.status_code == 200
+    assert uppercase_pending_filtered.json() == pending_filtered.json()
     assert bounty_filtered.status_code == 200
     assert [proposal["id"] for proposal in bounty_filtered.json()] == [first_payout["id"]]
     assert composed_filtered.status_code == 200
@@ -587,6 +593,8 @@ def test_treasury_proposals_list_filters_by_action_status_and_bounty_id(
     (
         ("action", "\tpay_bounty", "action must not contain control characters"),
         ("status", " ", "status is required"),
+        ("action", "paybounty", "action must be one of: close_bounty, create_bounty, pay_bounty"),
+        ("status", "complete", "status must be one of: pending, executed, blocked"),
     ),
 )
 def test_treasury_proposals_list_rejects_invalid_filters(


### PR DESCRIPTION
## Summary
- normalize public treasury proposal `action` and `status` query filters before matching so uppercase callers do not get a misleading empty result
- reject unknown treasury proposal `action` / `status` filters with a 400 and field-specific guidance
- add regression coverage for uppercase filters plus invalid filter values

## Why
Live read-only checks showed `/api/v1/treasury/proposals?status=pending` and `action=pay_bounty` return active proposal rows, but `status=PENDING`, `action=PAY_BOUNTY`, or typoed values returned HTTP 200 with an empty list. That can make payout/proposal monitors think there are no pending proposals.

Refs #655 and #656.

## Validation
- `.venv/bin/python -m pytest tests/test_treasury_proposals.py -q` -> `45 passed, 1 warning in 1.80s`
- `.venv/bin/ruff check app/treasury_routes.py tests/test_treasury_proposals.py` -> passed
- `.venv/bin/ruff format --check app/treasury_routes.py tests/test_treasury_proposals.py` -> passed
- `.venv/bin/mypy app/treasury_routes.py` -> passed
- `git diff --check` -> passed

No ledger, payout execution, wallet, transfer, proof creation, exchange, bridge, cash-out, or private account behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Treasury proposals API now accepts case-insensitive and whitespace-tolerant values for `action`, `status`, and recipient (`to_account`) query filters.
  * Invalid filter values are rejected with clearer validation error messages listing allowed options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->