### PR TITLE
Add standard quality gate status to PR queue health

### DIFF
--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -20,6 +20,7 @@ GH_TIMEOUT_SECONDS = 30
 GH_PR_SAFETY_CAP = 201
 GH_ISSUE_SAFETY_CAP = 201
 MAX_BOUNTY_REF = 2**63 - 1
+STANDARD_QUALITY_CHECK_NAME = "quality, readiness, docs, and image checks"
 
 
 def _labels(raw: dict[str, Any]) -> list[str]:
@@ -48,6 +49,32 @@ def _scope_key(raw: dict[str, Any]) -> str:
     title = str(raw.get("title") or "")
     title = NOISY_TITLE_PREFIX_RE.sub("", title)
     return " ".join(title.lower().split())
+
+
+def _standard_quality_check_status(raw: dict[str, Any]) -> str:
+    rollup = raw.get("statusCheckRollup")
+    if not isinstance(rollup, list) or not rollup:
+        return "missing"
+    for item in rollup:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or item.get("workflowName") or "").strip().lower()
+        if name != STANDARD_QUALITY_CHECK_NAME:
+            continue
+        conclusion = str(item.get("conclusion") or "").strip().lower()
+        status = str(item.get("status") or "").strip().lower()
+        if conclusion == "action_required":
+            return "action_required"
+        if conclusion in {"failure", "timed_out", "cancelled", "startup_failure"}:
+            return "failed"
+        if conclusion == "success":
+            return "passed"
+        if status in {"queued", "in_progress", "pending", "waiting"}:
+            return "pending"
+        if status in {"completed"} and not conclusion:
+            return "pending"
+        return "pending"
+    return "missing"
 
 
 def _bounty_refs(raw: dict[str, Any]) -> list[int]:
@@ -115,12 +142,14 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
                 "labels": _labels(pr),
                 "merge_state": _merge_state(pr),
                 "scope": _scope_key(pr),
+                "standard_quality_check_status": _standard_quality_check_status(pr),
             }
         )
 
     closed_bounty_references: list[dict[str, Any]] = []
     missing_bounty_references: list[dict[str, Any]] = []
     dirty_or_unstable_merge_state: list[dict[str, Any]] = []
+    standard_quality_gate_not_green: list[dict[str, Any]] = []
     needs_info: list[dict[str, Any]] = []
     duplicate_groups: dict[tuple[int, str], list[int]] = defaultdict(list)
 
@@ -157,6 +186,19 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
             dirty_or_unstable_merge_state.append(
                 _issue(pr, "dirty_or_unstable_merge_state", f"Merge state is {pr['merge_state']}")
             )
+        if pr["standard_quality_check_status"] != "passed":
+            status_detail = pr["standard_quality_check_status"]
+            if status_detail == "action_required":
+                detail = "Standard quality check is waiting for maintainer approval (action_required)"
+            elif status_detail == "failed":
+                detail = "Standard quality check failed"
+            elif status_detail == "pending":
+                detail = "Standard quality check is still pending"
+            else:
+                detail = "Standard quality check is missing"
+            standard_quality_gate_not_green.append(
+                _issue(pr, "standard_quality_gate_not_green", detail)
+            )
         if any(label.lower() == "mrwk:needs-info" for label in pr["labels"]):
             needs_info.append(_issue(pr, "mrwk_needs_info", "PR has mrwk:needs-info label"))
 
@@ -176,12 +218,14 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
             "closed_bounty_references": len(closed_bounty_references),
             "missing_bounty_references": len(missing_bounty_references),
             "dirty_or_unstable_merge_state": len(dirty_or_unstable_merge_state),
+            "standard_quality_gate_not_green": len(standard_quality_gate_not_green),
             "needs_info": len(needs_info),
             "duplicate_scope_groups": len(duplicate_scope_groups),
         },
         "closed_bounty_references": closed_bounty_references,
         "missing_bounty_references": missing_bounty_references,
         "dirty_or_unstable_merge_state": dirty_or_unstable_merge_state,
+        "standard_quality_gate_not_green": standard_quality_gate_not_green,
         "needs_info": needs_info,
         "duplicate_scope_groups": duplicate_scope_groups,
     }
@@ -195,6 +239,7 @@ def has_queue_issues(report: dict[str, Any]) -> bool:
             "closed_bounty_references",
             "missing_bounty_references",
             "dirty_or_unstable_merge_state",
+            "standard_quality_gate_not_green",
             "needs_info",
             "duplicate_scope_groups",
         )
@@ -213,6 +258,7 @@ def format_text_report(report: dict[str, Any]) -> str:
         ("Closed or exhausted bounty references", "closed_bounty_references"),
         ("Missing bounty references", "missing_bounty_references"),
         ("Dirty or unstable merge state", "dirty_or_unstable_merge_state"),
+        ("Standard quality gate not green", "standard_quality_gate_not_green"),
         ("Needs info", "needs_info"),
     ]
     for title, key in sections:
@@ -255,6 +301,7 @@ def format_markdown_report(report: dict[str, Any]) -> str:
         ("Closed or exhausted bounty references", "closed_bounty_references"),
         ("Missing bounty references", "missing_bounty_references"),
         ("Dirty or unstable merge state", "dirty_or_unstable_merge_state"),
+        ("Standard quality gate not green", "standard_quality_gate_not_green"),
         ("Needs info", "needs_info"),
     ]
     for title, key in sections:
@@ -309,7 +356,7 @@ def load_live_queue(repo: str) -> dict[str, Any]:
             "--limit",
             str(GH_PR_SAFETY_CAP),
             "--json",
-            "number,title,url,body,labels,mergeStateStatus",
+            "number,title,url,body,labels,mergeStateStatus,statusCheckRollup",
         ]
     )
     if len(prs) >= GH_PR_SAFETY_CAP:

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -11,6 +11,7 @@ from scripts import pr_queue_health
 from scripts.pr_queue_health import analyze_queue, format_markdown_report, format_text_report, main
 
 ROOT = Path(__file__).resolve().parents[1]
+STANDARD_CHECK = "Quality, readiness, docs, and image checks"
 
 
 def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
@@ -28,6 +29,7 @@ def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
                 "body": "Refs #293",
                 "merge_state": "clean",
                 "labels": [],
+                "statusCheckRollup": [{"name": STANDARD_CHECK, "conclusion": "SUCCESS"}],
             },
             {
                 "number": 2,
@@ -36,6 +38,7 @@ def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
                 "body": "",
                 "merge_state": "clean",
                 "labels": [],
+                "statusCheckRollup": [{"name": STANDARD_CHECK, "status": "IN_PROGRESS"}],
             },
             {
                 "number": 3,
@@ -44,6 +47,7 @@ def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
                 "body": "Bounty #292",
                 "merge_state": "dirty",
                 "labels": ["mrwk:needs-info"],
+                "statusCheckRollup": [{"name": STANDARD_CHECK, "conclusion": "FAILURE"}],
             },
             {
                 "number": 4,
@@ -52,6 +56,7 @@ def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
                 "body": "Refs #292",
                 "merge_state": "unknown",
                 "labels": [],
+                "statusCheckRollup": [{"name": STANDARD_CHECK, "conclusion": "ACTION_REQUIRED"}],
             },
         ],
     }
@@ -65,12 +70,14 @@ def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
         "closed_bounty_references": 1,
         "missing_bounty_references": 1,
         "dirty_or_unstable_merge_state": 2,
+        "standard_quality_gate_not_green": 3,
         "needs_info": 1,
         "duplicate_scope_groups": 1,
     }
     assert report["closed_bounty_references"][0]["pull_request"] == 1
     assert report["missing_bounty_references"][0]["pull_request"] == 2
     assert {item["pull_request"] for item in report["dirty_or_unstable_merge_state"]} == {3, 4}
+    assert {item["pull_request"] for item in report["standard_quality_gate_not_green"]} == {2, 3, 4}
     assert report["needs_info"][0]["pull_request"] == 3
     assert report["duplicate_scope_groups"] == [
         {
@@ -112,6 +119,7 @@ def test_pr_queue_health_text_report_is_pasteable() -> None:
                     "body": "Refs #310",
                     "merge_state": "clean",
                     "labels": [],
+                    "statusCheckRollup": [{"name": STANDARD_CHECK, "conclusion": "SUCCESS"}],
                 }
             ],
         }
@@ -135,6 +143,7 @@ def test_pr_queue_health_accepts_claim_command_reference() -> None:
                     "body": "/claim #310",
                     "merge_state": "clean",
                     "labels": [],
+                    "statusCheckRollup": [{"name": STANDARD_CHECK, "conclusion": "SUCCESS"}],
                 }
             ],
         }
@@ -175,6 +184,7 @@ def test_pr_queue_health_accepts_github_linking_keywords() -> None:
                     "body": reference,
                     "merge_state": "clean",
                     "labels": [],
+                    "statusCheckRollup": [{"name": STANDARD_CHECK, "conclusion": "SUCCESS"}],
                 }
                 for index, reference in enumerate(references, start=1)
             ],
@@ -218,6 +228,7 @@ def test_pr_queue_health_ignores_oversized_numeric_bounty_refs() -> None:
                     "body": f"Refs #{oversized_ref}\nRefs #406",
                     "merge_state": "clean",
                     "labels": [],
+                    "statusCheckRollup": [{"name": STANDARD_CHECK, "conclusion": "SUCCESS"}],
                 }
             ],
         }
@@ -242,6 +253,7 @@ def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
                     "body": "Refs #293",
                     "merge_state": "clean",
                     "labels": [],
+                    "statusCheckRollup": [{"name": STANDARD_CHECK, "conclusion": "SUCCESS"}],
                 },
                 {
                     "number": 2,
@@ -250,6 +262,7 @@ def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
                     "body": "",
                     "merge_state": "clean",
                     "labels": [],
+                    "statusCheckRollup": [{"name": STANDARD_CHECK, "status": "IN_PROGRESS"}],
                 },
                 {
                     "number": 3,
@@ -258,6 +271,7 @@ def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
                     "body": "Bounty #292",
                     "merge_state": "dirty",
                     "labels": ["mrwk:needs-info"],
+                    "statusCheckRollup": [{"name": STANDARD_CHECK, "conclusion": "FAILURE"}],
                 },
                 {
                     "number": 4,
@@ -266,6 +280,7 @@ def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
                     "body": "Refs #292",
                     "merge_state": "unknown",
                     "labels": [],
+                    "statusCheckRollup": [{"name": STANDARD_CHECK, "conclusion": "ACTION_REQUIRED"}],
                 },
             ],
         }
@@ -288,6 +303,8 @@ def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     ) in markdown
     assert "### Dirty or unstable merge state" in markdown
     assert "Merge state is dirty" in markdown
+    assert "### Standard quality gate not green" in markdown
+    assert "waiting for maintainer approval (action_required)" in markdown
     assert "### Needs info" in markdown
     assert "PR has mrwk:needs-info label" in markdown
     assert "### Likely duplicate bounty scope" in markdown
@@ -304,6 +321,7 @@ def test_pr_queue_health_markdown_no_issues_output_is_pasteable(tmp_path, capsys
                 "body": "Refs #310",
                 "merge_state": "clean",
                 "labels": [],
+                "statusCheckRollup": [{"name": STANDARD_CHECK, "conclusion": "SUCCESS"}],
             }
         ],
     }
@@ -342,6 +360,70 @@ def test_pr_queue_health_wraps_gh_timeouts(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="gh command timed out"):
         pr_queue_health._run_gh_json(["gh", "pr", "list"])
+
+
+def test_standard_quality_check_status_bucket_variants() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 10}],
+            "pull_requests": [
+                {
+                    "number": 11,
+                    "title": "passed",
+                    "body": "Refs #310",
+                    "labels": [],
+                    "merge_state": "clean",
+                    "statusCheckRollup": [{"name": STANDARD_CHECK, "conclusion": "SUCCESS"}],
+                },
+                {
+                    "number": 12,
+                    "title": "failed",
+                    "body": "Refs #310",
+                    "labels": [],
+                    "merge_state": "clean",
+                    "statusCheckRollup": [{"name": STANDARD_CHECK, "conclusion": "FAILURE"}],
+                },
+                {
+                    "number": 13,
+                    "title": "action required",
+                    "body": "Refs #310",
+                    "labels": [],
+                    "merge_state": "clean",
+                    "statusCheckRollup": [{"name": STANDARD_CHECK, "conclusion": "ACTION_REQUIRED"}],
+                },
+                {
+                    "number": 14,
+                    "title": "pending",
+                    "body": "Refs #310",
+                    "labels": [],
+                    "merge_state": "clean",
+                    "statusCheckRollup": [{"name": STANDARD_CHECK, "status": "IN_PROGRESS"}],
+                },
+                {
+                    "number": 15,
+                    "title": "missing",
+                    "body": "Refs #310",
+                    "labels": [],
+                    "merge_state": "clean",
+                    "statusCheckRollup": [],
+                },
+            ],
+        }
+    )
+
+    assert report["summary"]["standard_quality_gate_not_green"] == 4
+    details_by_pr = {
+        item["pull_request"]: item["detail"]
+        for item in report["standard_quality_gate_not_green"]
+    }
+    assert 11 not in details_by_pr
+    assert details_by_pr[12] == "Standard quality check failed"
+    assert (
+        details_by_pr[13]
+        == "Standard quality check is waiting for maintainer approval (action_required)"
+    )
+    assert details_by_pr[14] == "Standard quality check is still pending"
+    assert details_by_pr[15] == "Standard quality check is missing"
 
 
 def test_pr_queue_health_fails_fast_when_issue_fetch_hits_cap(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add standard quality-check readiness classification to `scripts/pr_queue_health.py`
- surface non-green states in queue reports: `missing`, `action_required`, `failed`, `pending`
- include a new report section: `Standard quality gate not green`
- fetch `statusCheckRollup` in live `gh pr list` collection

## Why
CodeRabbit success alone is not enough for bounty-readiness triage.  
This change makes the standard `Quality, readiness, docs, and image checks` status explicit in queue-health output so maintainers/reviewers can quickly spot PRs that are not fully ready.

## Tests
- updated `tests/test_pr_queue_health.py` fixtures and assertions for new summary/report bucket
- added coverage for all status variants (`passed`, `failed`, `action_required`, `pending`, `missing`)
- `python3 -m py_compile scripts/pr_queue_health.py tests/test_pr_queue_health.py`

Refs #692
/claim #655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented quality check status detection and reporting for pull requests
  * New report section displays PRs that do not pass quality gate checks
  * Enhanced data collection to track quality status across the queue

* **Tests**
  * Updated test fixtures and assertions to support quality check status reporting
  * Added test coverage for quality check status classification variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->