### PR TITLE
docs: add bounty focus false-positive triage steps to admin runbook

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -168,6 +168,14 @@ post comments. It reports missing bounty references, closed or exhausted bounty
 references, dirty or unknown merge state, `mrwk:needs-info`, and likely duplicate
 PR scope within the same bounty issue.
 
+When CodeRabbit reports a large `Bounty Pr Focus` file count, verify current PR
+scope before treating it as unresolved scope creep:
+
+1. Check the GitHub PR "Files changed" tab for the current head.
+2. Run `gh pr diff <number> --name-only` and compare with GitHub's file list.
+3. Treat it as a real scope warning only when both sources show a broad diff.
+4. If they disagree, post a short scope-sanity note with the current-head file list.
+
 ### Claim Inventory
 
 Use the claim-inventory report when a busy bounty round needs a public,

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -70,6 +70,11 @@ REQUIRED_PUBLIC_PHRASES = {
         "Internal ledger accounts use the same account response shape",
         ("Treasury and reserve balances change as bounties are reserved, paid, and released."),
     ],
+    "docs/admin-runbook.md": [
+        "When CodeRabbit reports a large `Bounty Pr Focus` file count",
+        "Run `gh pr diff <number> --name-only`",
+        "If they disagree, post a short scope-sanity note",
+    ],
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"


### PR DESCRIPTION
## Summary
- add maintainer-facing triage guidance in `docs/admin-runbook.md` for CodeRabbit `Bounty Pr Focus` large-file warnings
- document a 4-step verification flow:
  1. check current GitHub PR `Files changed`
  2. run `gh pr diff <number> --name-only`
  3. treat as real scope creep only when both sources show broad diff
  4. post a short scope-sanity note when they disagree
- add docs-smoke required phrases for this guidance in `scripts/docs_smoke.py`

## Why
Maintainers need a consistent way to distinguish real broad-scope PRs from stale/false-positive bot file-count warnings, without weakening actual scope controls.

## Validation
- `python3 scripts/docs_smoke.py` -> `docs smoke ok`

Refs #691
/claim #655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced admin runbook with guidance on validating file count metrics to identify potential scope changes.

* **Tests**
  * Updated documentation validation checks to verify admin runbook content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->