### PR TITLE
Finalize paid bounty GitHub issues

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -61,6 +61,14 @@ def _migrate_schema(engine: Engine) -> None:
                 text("ALTER TABLE bounties ADD COLUMN awards_paid INTEGER NOT NULL DEFAULT 0")
             )
             connection.execute(text("UPDATE bounties SET awards_paid = 1 WHERE status = 'paid'"))
+        if "github_paid_issue_finalized_at" not in bounty_columns:
+            connection.execute(
+                text("ALTER TABLE bounties ADD COLUMN github_paid_issue_finalized_at DATETIME")
+            )
+        if "github_paid_issue_finalization" not in bounty_columns:
+            connection.execute(
+                text("ALTER TABLE bounties ADD COLUMN github_paid_issue_finalization TEXT")
+            )
         if "submissions" in inspector.get_table_names():
             connection.execute(
                 text(

--- a/app/db.py
+++ b/app/db.py
@@ -63,7 +63,7 @@ def _migrate_schema(engine: Engine) -> None:
             connection.execute(text("UPDATE bounties SET awards_paid = 1 WHERE status = 'paid'"))
         if "github_paid_issue_finalized_at" not in bounty_columns:
             connection.execute(
-                text("ALTER TABLE bounties ADD COLUMN github_paid_issue_finalized_at DATETIME")
+                text("ALTER TABLE bounties ADD COLUMN github_paid_issue_finalized_at TIMESTAMP")
             )
         if "github_paid_issue_finalization" not in bounty_columns:
             connection.execute(

--- a/app/github_issue_finalization.py
+++ b/app/github_issue_finalization.py
@@ -11,6 +11,7 @@ GITHUB_LABEL = "mrwk:bounty"
 GITHUB_PAID_LABEL = "mrwk:paid"
 USER_AGENT = "MergeWork"
 API_VERSION = "2022-11-28"
+PAID_BOUNTY_FINALIZATION_COMMENT_MARKER = "<!-- mergework:mrwk:paid-bounty-finalized -->"
 
 
 def _github_request(
@@ -38,11 +39,15 @@ def _github_request(
     )
 
 
-def _read_json(response: Any) -> dict[str, Any]:
+def _read_json_value(response: Any) -> Any:
     body = response.read()
     if not body:
         return {}
-    data = json.loads(body.decode())
+    return json.loads(body.decode())
+
+
+def _read_json(response: Any) -> dict[str, Any]:
+    data = _read_json_value(response)
     return cast(dict[str, Any], data) if isinstance(data, dict) else {}
 
 
@@ -67,6 +72,20 @@ def _get_json(
     request = _github_request(url, github_token, method="GET")
     with opener(request, timeout=10) as response:
         return _read_json(response)
+
+
+def _get_json_list(
+    *,
+    opener: Callable[..., Any],
+    url: str,
+    github_token: str,
+) -> list[dict[str, Any]]:
+    request = _github_request(url, github_token, method="GET")
+    with opener(request, timeout=10) as response:
+        data = _read_json_value(response)
+    if not isinstance(data, list):
+        return []
+    return [item for item in data if isinstance(item, dict)]
 
 
 def _patch_json(
@@ -112,6 +131,25 @@ def _has_label(issue: dict[str, Any], label: str) -> bool:
         if isinstance(name, str) and name.lower() == label.lower():
             return True
     return False
+
+
+def _paid_finalization_comment_body(bounty_url: str) -> str:
+    return (
+        f"Filled and paid on MergeWork: {bounty_url}\n\n"
+        "All awards for this bounty have proof-backed payments, "
+        "so this bounty issue is closed.\n\n"
+        f"{PAID_BOUNTY_FINALIZATION_COMMENT_MARKER}"
+    )
+
+
+def _existing_paid_finalization_comment_url(comments: list[dict[str, Any]]) -> str | None:
+    for comment in comments:
+        body = comment.get("body")
+        if not isinstance(body, str) or PAID_BOUNTY_FINALIZATION_COMMENT_MARKER not in body:
+            continue
+        html_url = comment.get("html_url")
+        return str(html_url) if html_url is not None else None
+    return None
 
 
 def finalize_created_bounty_issue(
@@ -195,18 +233,20 @@ def finalize_paid_bounty_issue(
             )
         comment_url = None
         if issue_state != "closed":
-            comment = (
-                f"Filled and paid on MergeWork: {bounty_url}\n\n"
-                "All awards for this bounty have proof-backed payments, "
-                "so this bounty issue is closed."
-            )
-            comment_response = _post_json(
+            comments = _get_json_list(
                 opener=opener,
-                url=f"{issue_api_base}/comments",
+                url=f"{issue_api_base}/comments?per_page=100",
                 github_token=clean_token,
-                payload={"body": comment},
             )
-            comment_url = comment_response.get("html_url")
+            comment_url = _existing_paid_finalization_comment_url(comments)
+            if comment_url is None:
+                comment_response = _post_json(
+                    opener=opener,
+                    url=f"{issue_api_base}/comments",
+                    github_token=clean_token,
+                    payload={"body": _paid_finalization_comment_body(bounty_url)},
+                )
+                comment_url = comment_response.get("html_url")
         if issue_state != "closed":
             _patch_json(
                 opener=opener,

--- a/app/github_issue_finalization.py
+++ b/app/github_issue_finalization.py
@@ -8,22 +8,33 @@ from urllib.parse import quote
 from urllib.request import Request, urlopen
 
 GITHUB_LABEL = "mrwk:bounty"
+GITHUB_PAID_LABEL = "mrwk:paid"
 USER_AGENT = "MergeWork"
 API_VERSION = "2022-11-28"
 
 
-def _github_request(url: str, github_token: str, payload: dict[str, Any]) -> Request:
+def _github_request(
+    url: str,
+    github_token: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    method: str = "POST",
+) -> Request:
+    data = None
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {github_token}",
+        "User-Agent": USER_AGENT,
+        "X-GitHub-Api-Version": API_VERSION,
+    }
+    if payload is not None:
+        data = json.dumps(payload, separators=(",", ":")).encode()
+        headers["Content-Type"] = "application/json"
     return Request(
         url,
-        data=json.dumps(payload, separators=(",", ":")).encode(),
-        method="POST",
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {github_token}",
-            "Content-Type": "application/json",
-            "User-Agent": USER_AGENT,
-            "X-GitHub-Api-Version": API_VERSION,
-        },
+        data=data,
+        method=method,
+        headers=headers,
     )
 
 
@@ -47,6 +58,29 @@ def _post_json(
         return _read_json(response)
 
 
+def _get_json(
+    *,
+    opener: Callable[..., Any],
+    url: str,
+    github_token: str,
+) -> dict[str, Any]:
+    request = _github_request(url, github_token, method="GET")
+    with opener(request, timeout=10) as response:
+        return _read_json(response)
+
+
+def _patch_json(
+    *,
+    opener: Callable[..., Any],
+    url: str,
+    github_token: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    request = _github_request(url, github_token, payload, method="PATCH")
+    with opener(request, timeout=10) as response:
+        return _read_json(response)
+
+
 def _bounty_issue_target(bounty: dict[str, object]) -> tuple[str, int, int] | None:
     try:
         bounty_id = int(str(bounty.get("id", "")))
@@ -58,6 +92,26 @@ def _bounty_issue_target(bounty: dict[str, object]) -> tuple[str, int, int] | No
     if bounty_id <= 0 or issue_number <= 0 or len(repo_parts) != 2 or not all(repo_parts):
         return None
     return repo, issue_number, bounty_id
+
+
+def _github_issue_api_base(repo: str, issue_number: int) -> str:
+    owner_part, name_part = repo.split("/", 1)
+    owner = quote(owner_part, safe="")
+    name = quote(name_part, safe="")
+    return f"https://api.github.com/repos/{owner}/{name}/issues/{issue_number}"
+
+
+def _has_label(issue: dict[str, Any], label: str) -> bool:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return False
+    for item in labels:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if isinstance(name, str) and name.lower() == label.lower():
+            return True
+    return False
 
 
 def finalize_created_bounty_issue(
@@ -74,10 +128,7 @@ def finalize_created_bounty_issue(
     if target is None:
         return {"status": "failed", "reason": "bounty issue target missing or invalid"}
     repo, issue_number, bounty_id = target
-    owner_part, name_part = repo.split("/", 1)
-    owner = quote(owner_part, safe="")
-    name = quote(name_part, safe="")
-    issue_api_base = f"https://api.github.com/repos/{owner}/{name}/issues/{issue_number}"
+    issue_api_base = _github_issue_api_base(repo, issue_number)
     bounty_url = f"{public_base_url.rstrip('/')}/bounties/{bounty_id}"
     comment = (
         f"Reserved on MergeWork: {bounty_url}\n\n"
@@ -106,3 +157,73 @@ def finalize_created_bounty_issue(
         "bounty_url": bounty_url,
         "comment_url": comment_response.get("html_url"),
     }
+
+
+def finalize_paid_bounty_issue(
+    *,
+    github_token: str,
+    public_base_url: str,
+    bounty: dict[str, object],
+    opener: Callable[..., Any] = urlopen,
+) -> dict[str, Any]:
+    clean_token = github_token.strip()
+    if not clean_token:
+        return {"status": "skipped", "reason": "github issue token not configured"}
+    target = _bounty_issue_target(bounty)
+    if target is None:
+        return {"status": "failed", "reason": "bounty issue target missing or invalid"}
+    repo, issue_number, bounty_id = target
+    issue_api_base = _github_issue_api_base(repo, issue_number)
+    bounty_url = f"{public_base_url.rstrip('/')}/bounties/{bounty_id}"
+    try:
+        issue = _get_json(opener=opener, url=issue_api_base, github_token=clean_token)
+        issue_state = str(issue.get("state") or "").lower()
+        has_paid_label = _has_label(issue, GITHUB_PAID_LABEL)
+        if issue_state == "closed" and has_paid_label:
+            return {
+                "status": "already_finalized",
+                "label": GITHUB_PAID_LABEL,
+                "bounty_url": bounty_url,
+                "closed": True,
+            }
+        if not has_paid_label:
+            _post_json(
+                opener=opener,
+                url=f"{issue_api_base}/labels",
+                github_token=clean_token,
+                payload={"labels": [GITHUB_PAID_LABEL]},
+            )
+        comment_url = None
+        if issue_state != "closed":
+            comment = (
+                f"Filled and paid on MergeWork: {bounty_url}\n\n"
+                "All awards for this bounty have proof-backed payments, "
+                "so this bounty issue is closed."
+            )
+            comment_response = _post_json(
+                opener=opener,
+                url=f"{issue_api_base}/comments",
+                github_token=clean_token,
+                payload={"body": comment},
+            )
+            comment_url = comment_response.get("html_url")
+        if issue_state != "closed":
+            _patch_json(
+                opener=opener,
+                url=issue_api_base,
+                github_token=clean_token,
+                payload={"state": "closed", "state_reason": "completed"},
+            )
+        result = {
+            "status": "updated",
+            "label": GITHUB_PAID_LABEL,
+            "bounty_url": bounty_url,
+            "closed": True,
+        }
+        if comment_url is not None:
+            result["comment_url"] = comment_url
+        return result
+    except HTTPError as exc:
+        return {"status": "failed", "reason": f"github issue update failed: HTTP {exc.code}"}
+    except (OSError, ValueError) as exc:
+        return {"status": "failed", "reason": f"github issue update failed: {type(exc).__name__}"}

--- a/app/models.py
+++ b/app/models.py
@@ -51,6 +51,8 @@ class Bounty(Base):
     status: Mapped[str] = mapped_column(String(40), default="open", index=True)
     acceptance: Mapped[str] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(default=utc_now)
+    github_paid_issue_finalized_at: Mapped[datetime | None] = mapped_column(default=None)
+    github_paid_issue_finalization: Mapped[str | None] = mapped_column(Text, default=None)
     submissions: Mapped[list[Submission]] = relationship(back_populates="bounty")
     attempts: Mapped[list[BountyAttempt]] = relationship(back_populates="bounty")
 

--- a/app/treasury_executor.py
+++ b/app/treasury_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any
@@ -7,9 +8,9 @@ from typing import Any
 from sqlalchemy import select
 
 from app.db import session_scope
-from app.github_issue_finalization import finalize_created_bounty_issue
+from app.github_issue_finalization import finalize_created_bounty_issue, finalize_paid_bounty_issue
 from app.ledger.service import LedgerError
-from app.models import TreasuryProposal, utc_now
+from app.models import Bounty, TreasuryProposal, utc_now
 from app.treasury import (
     execute_treasury_proposal,
     proposal_to_dict,
@@ -17,6 +18,8 @@ from app.treasury import (
 )
 
 Finalizer = Callable[..., dict[str, Any]]
+PaidIssueFinalizer = Callable[..., dict[str, Any]]
+PAID_ISSUE_FINALIZED_STATUSES = {"updated", "closed", "already_finalized"}
 
 
 def _db_utc(value: datetime) -> datetime:
@@ -40,6 +43,32 @@ def due_treasury_proposal_ids(db_url: str, *, limit: int = 25) -> list[int]:
                 .limit(limit)
             ).all()
         ]
+
+
+def paid_bounty_ids_needing_github_finalization(db_url: str, *, limit: int = 25) -> list[int]:
+    with session_scope(db_url) as session:
+        return [
+            int(bounty_id)
+            for bounty_id in session.scalars(
+                select(Bounty.id)
+                .where(
+                    Bounty.status == "paid",
+                    Bounty.github_paid_issue_finalized_at.is_(None),
+                )
+                .order_by(Bounty.id.asc())
+                .limit(limit)
+            ).all()
+        ]
+
+
+def _paid_bounty_finalization_payload(bounty: Bounty) -> dict[str, object]:
+    return {
+        "id": int(bounty.id),
+        "repo": bounty.repo,
+        "issue_number": int(bounty.issue_number),
+        "issue_url": bounty.issue_url,
+        "title": bounty.title,
+    }
 
 
 def execute_treasury_proposal_with_finalization(
@@ -83,6 +112,76 @@ def execute_treasury_proposal_with_finalization(
         return proposal_to_dict(proposal)
 
 
+def finalize_paid_bounty_issues(
+    db_url: str,
+    *,
+    github_issue_token: str,
+    public_base_url: str,
+    limit: int = 25,
+    finalizer: PaidIssueFinalizer | None = None,
+) -> dict[str, Any]:
+    bounty_ids = paid_bounty_ids_needing_github_finalization(db_url, limit=limit)
+    issue_finalizer = finalizer or finalize_paid_bounty_issue
+    results: list[dict[str, Any]] = []
+    updated = 0
+    failed = 0
+    skipped = 0
+    for bounty_id in bounty_ids:
+        with session_scope(db_url) as session:
+            bounty = session.get(Bounty, bounty_id)
+            if (
+                bounty is None
+                or bounty.status != "paid"
+                or bounty.github_paid_issue_finalized_at is not None
+            ):
+                continue
+            bounty_payload = _paid_bounty_finalization_payload(bounty)
+        try:
+            finalization = issue_finalizer(
+                github_token=github_issue_token,
+                public_base_url=public_base_url,
+                bounty=bounty_payload,
+            )
+        except Exception as exc:
+            finalization = {
+                "status": "failed",
+                "reason": f"github paid issue finalization failed: {type(exc).__name__}",
+            }
+        status = str(finalization.get("status") or "")
+        if status in PAID_ISSUE_FINALIZED_STATUSES:
+            with session_scope(db_url) as session:
+                bounty = session.get(Bounty, bounty_id)
+                if (
+                    bounty is not None
+                    and bounty.status == "paid"
+                    and bounty.github_paid_issue_finalized_at is None
+                ):
+                    bounty.github_paid_issue_finalized_at = utc_now()
+                    bounty.github_paid_issue_finalization = json.dumps(
+                        finalization, sort_keys=True, separators=(",", ":")
+                    )
+            updated += 1
+        elif status == "skipped":
+            skipped += 1
+        else:
+            failed += 1
+        results.append(
+            {
+                "bounty_id": int(bounty_id),
+                "status": status or "unknown",
+                "result": finalization,
+            }
+        )
+    return {
+        "type": "paid_bounty_issue_finalization",
+        "attempted": len(bounty_ids),
+        "updated": updated,
+        "failed": failed,
+        "skipped": skipped,
+        "results": results,
+    }
+
+
 def execute_due_treasury_proposals(
     db_url: str,
     *,
@@ -91,6 +190,7 @@ def execute_due_treasury_proposals(
     executed_by: str = "treasury-executor",
     limit: int = 25,
     finalizer: Finalizer | None = None,
+    paid_issue_finalizer: PaidIssueFinalizer | None = None,
 ) -> dict[str, Any]:
     proposal_ids = due_treasury_proposal_ids(db_url, limit=limit)
     results: list[dict[str, Any]] = []
@@ -133,10 +233,18 @@ def execute_due_treasury_proposals(
         if finalization is not None:
             item["github_issue_finalization"] = finalization
         results.append(item)
+    paid_issue_report = finalize_paid_bounty_issues(
+        db_url,
+        github_issue_token=github_issue_token,
+        public_base_url=public_base_url,
+        limit=limit,
+        finalizer=paid_issue_finalizer,
+    )
     return {
         "type": "treasury_executor_run",
         "attempted": len(proposal_ids),
         "executed": executed,
         "failed": failed,
         "results": results,
+        "paid_issue_finalization": paid_issue_report,
     }

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -142,6 +142,13 @@ on the proposal and confirm the issue has both `mrwk:bounty` and the
 or partial, use the manual fallback rules above after confirming the public
 bounty row exists.
 
+The production treasury executor also finalizes fully paid bounty issues. It
+only acts on bounty rows whose stored status is `paid`; it must not close rounds
+that are merely full because pending payout proposals consume effective
+capacity. Successful paid-issue finalization adds `mrwk:paid`, posts a concise
+filled-and-paid comment when needed, closes the GitHub issue, and records a
+local finalization marker so later executor passes do not repeat the comment.
+
 ## Accept Work
 
 ### PR Bounties

--- a/tests/test_github_issue_finalization.py
+++ b/tests/test_github_issue_finalization.py
@@ -9,7 +9,7 @@ from app.github_issue_finalization import finalize_created_bounty_issue, finaliz
 
 
 class _FakeResponse:
-    def __init__(self, body: dict[str, Any]) -> None:
+    def __init__(self, body: Any) -> None:
         self._body = body
 
     def __enter__(self) -> _FakeResponse:
@@ -121,6 +121,8 @@ def test_finalize_paid_bounty_issue_adds_label_comment_and_closes_open_issue() -
 
     def fake_opener(request: Request, timeout: float) -> _FakeResponse:
         requests.append(request)
+        if request.full_url.endswith("/comments?per_page=100"):
+            return _FakeResponse([])
         if request.get_method() == "GET":
             return _FakeResponse({"state": "open", "labels": [{"name": "mrwk:bounty"}]})
         if request.full_url.endswith("/comments"):
@@ -147,16 +149,23 @@ def test_finalize_paid_bounty_issue_adds_label_comment_and_closes_open_issue() -
         "comment_url": "https://github.com/ramimbo/mergework/issues/77#issuecomment-2",
         "closed": True,
     }
-    assert [request.get_method() for request in requests] == ["GET", "POST", "POST", "PATCH"]
+    assert [request.get_method() for request in requests] == [
+        "GET",
+        "POST",
+        "GET",
+        "POST",
+        "PATCH",
+    ]
     assert requests[1].full_url == (
         "https://api.github.com/repos/ramimbo/mergework/issues/77/labels"
     )
     assert json.loads((requests[1].data or b"").decode()) == {"labels": ["mrwk:paid"]}
-    comment_body = json.loads((requests[2].data or b"").decode())["body"]
+    comment_body = json.loads((requests[3].data or b"").decode())["body"]
     assert "Filled and paid on MergeWork" in comment_body
     assert "https://mrwk.example/bounties/123" in comment_body
-    assert requests[3].full_url == "https://api.github.com/repos/ramimbo/mergework/issues/77"
-    assert json.loads((requests[3].data or b"").decode()) == {
+    assert "mergework:mrwk:paid-bounty-finalized" in comment_body
+    assert requests[4].full_url == "https://api.github.com/repos/ramimbo/mergework/issues/77"
+    assert json.loads((requests[4].data or b"").decode()) == {
         "state": "closed",
         "state_reason": "completed",
     }
@@ -192,6 +201,8 @@ def test_finalize_paid_bounty_issue_comments_and_closes_when_paid_label_exists_o
 
     def fake_opener(request: Request, timeout: float) -> _FakeResponse:
         requests.append(request)
+        if request.full_url.endswith("/comments?per_page=100"):
+            return _FakeResponse([])
         if request.full_url.endswith("/comments"):
             return _FakeResponse(
                 {"html_url": "https://github.com/ramimbo/mergework/issues/77#issuecomment-2"}
@@ -212,9 +223,83 @@ def test_finalize_paid_bounty_issue_comments_and_closes_when_paid_label_exists_o
         "comment_url": "https://github.com/ramimbo/mergework/issues/77#issuecomment-2",
         "closed": True,
     }
-    assert [request.get_method() for request in requests] == ["GET", "POST", "PATCH"]
-    comment_body = json.loads((requests[1].data or b"").decode())["body"]
+    assert [request.get_method() for request in requests] == ["GET", "GET", "POST", "PATCH"]
+    comment_body = json.loads((requests[2].data or b"").decode())["body"]
     assert "Filled and paid on MergeWork" in comment_body
+    assert "mergework:mrwk:paid-bounty-finalized" in comment_body
+
+
+def test_finalize_paid_bounty_issue_reuses_marker_comment_after_close_failure() -> None:
+    requests: list[Request] = []
+    issue: dict[str, Any] = {"state": "open", "labels": [{"name": "mrwk:bounty"}]}
+    comments: list[dict[str, Any]] = []
+    patch_attempts = 0
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        nonlocal patch_attempts
+        requests.append(request)
+        if request.get_method() == "GET" and request.full_url.endswith("/comments?per_page=100"):
+            return _FakeResponse(comments)
+        if request.get_method() == "GET":
+            return _FakeResponse(issue)
+        if request.full_url.endswith("/labels"):
+            issue["labels"] = [{"name": "mrwk:bounty"}, {"name": "mrwk:paid"}]
+            return _FakeResponse({})
+        if request.full_url.endswith("/comments"):
+            body = json.loads((request.data or b"").decode())["body"]
+            comments.append(
+                {
+                    "body": body,
+                    "html_url": "https://github.com/ramimbo/mergework/issues/77#issuecomment-2",
+                }
+            )
+            return _FakeResponse(comments[-1])
+        if request.get_method() == "PATCH":
+            patch_attempts += 1
+            if patch_attempts == 1:
+                raise HTTPError(
+                    url=request.full_url,
+                    code=500,
+                    msg="temporary github failure",
+                    hdrs=None,
+                    fp=None,
+                )
+            issue["state"] = "closed"
+            return _FakeResponse({})
+        raise AssertionError(f"unexpected request {request.get_method()} {request.full_url}")
+
+    first_result = finalize_paid_bounty_issue(
+        github_token="github-token",
+        public_base_url="https://mrwk.example",
+        bounty={"id": 123, "repo": "ramimbo/mergework", "issue_number": 77},
+        opener=fake_opener,
+    )
+    retry_result = finalize_paid_bounty_issue(
+        github_token="github-token",
+        public_base_url="https://mrwk.example",
+        bounty={"id": 123, "repo": "ramimbo/mergework", "issue_number": 77},
+        opener=fake_opener,
+    )
+
+    assert first_result == {
+        "status": "failed",
+        "reason": "github issue update failed: HTTP 500",
+    }
+    assert retry_result == {
+        "status": "updated",
+        "label": "mrwk:paid",
+        "bounty_url": "https://mrwk.example/bounties/123",
+        "comment_url": "https://github.com/ramimbo/mergework/issues/77#issuecomment-2",
+        "closed": True,
+    }
+    comment_posts = [
+        request
+        for request in requests
+        if request.get_method() == "POST" and request.full_url.endswith("/comments")
+    ]
+    assert len(comment_posts) == 1
+    assert len(comments) == 1
+    assert "mergework:mrwk:paid-bounty-finalized" in comments[0]["body"]
 
 
 def test_finalize_paid_bounty_issue_skips_without_token() -> None:

--- a/tests/test_github_issue_finalization.py
+++ b/tests/test_github_issue_finalization.py
@@ -5,7 +5,7 @@ from typing import Any
 from urllib.error import HTTPError
 from urllib.request import Request
 
-from app.github_issue_finalization import finalize_created_bounty_issue
+from app.github_issue_finalization import finalize_created_bounty_issue, finalize_paid_bounty_issue
 
 
 class _FakeResponse:
@@ -114,3 +114,123 @@ def test_finalize_created_bounty_issue_reports_http_error_code() -> None:
     )
 
     assert result == {"status": "failed", "reason": "github issue update failed: HTTP 403"}
+
+
+def test_finalize_paid_bounty_issue_adds_label_comment_and_closes_open_issue() -> None:
+    requests: list[Request] = []
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        requests.append(request)
+        if request.get_method() == "GET":
+            return _FakeResponse({"state": "open", "labels": [{"name": "mrwk:bounty"}]})
+        if request.full_url.endswith("/comments"):
+            return _FakeResponse(
+                {"html_url": "https://github.com/ramimbo/mergework/issues/77#issuecomment-2"}
+            )
+        return _FakeResponse({})
+
+    result = finalize_paid_bounty_issue(
+        github_token="github-token",
+        public_base_url="https://mrwk.example/",
+        bounty={
+            "id": 123,
+            "repo": "ramimbo/mergework",
+            "issue_number": 77,
+        },
+        opener=fake_opener,
+    )
+
+    assert result == {
+        "status": "updated",
+        "label": "mrwk:paid",
+        "bounty_url": "https://mrwk.example/bounties/123",
+        "comment_url": "https://github.com/ramimbo/mergework/issues/77#issuecomment-2",
+        "closed": True,
+    }
+    assert [request.get_method() for request in requests] == ["GET", "POST", "POST", "PATCH"]
+    assert requests[1].full_url == (
+        "https://api.github.com/repos/ramimbo/mergework/issues/77/labels"
+    )
+    assert json.loads((requests[1].data or b"").decode()) == {"labels": ["mrwk:paid"]}
+    comment_body = json.loads((requests[2].data or b"").decode())["body"]
+    assert "Filled and paid on MergeWork" in comment_body
+    assert "https://mrwk.example/bounties/123" in comment_body
+    assert requests[3].full_url == "https://api.github.com/repos/ramimbo/mergework/issues/77"
+    assert json.loads((requests[3].data or b"").decode()) == {
+        "state": "closed",
+        "state_reason": "completed",
+    }
+
+
+def test_finalize_paid_bounty_issue_noops_when_already_closed_with_paid_label() -> None:
+    requests: list[Request] = []
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        requests.append(request)
+        return _FakeResponse({"state": "closed", "labels": [{"name": "mrwk:paid"}]})
+
+    result = finalize_paid_bounty_issue(
+        github_token="github-token",
+        public_base_url="https://mrwk.example",
+        bounty={"id": 123, "repo": "ramimbo/mergework", "issue_number": 77},
+        opener=fake_opener,
+    )
+
+    assert result == {
+        "status": "already_finalized",
+        "label": "mrwk:paid",
+        "bounty_url": "https://mrwk.example/bounties/123",
+        "closed": True,
+    }
+    assert [request.get_method() for request in requests] == ["GET"]
+
+
+def test_finalize_paid_bounty_issue_comments_and_closes_when_paid_label_exists_on_open_issue() -> (
+    None
+):
+    requests: list[Request] = []
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        requests.append(request)
+        if request.full_url.endswith("/comments"):
+            return _FakeResponse(
+                {"html_url": "https://github.com/ramimbo/mergework/issues/77#issuecomment-2"}
+            )
+        return _FakeResponse({"state": "open", "labels": [{"name": "mrwk:paid"}]})
+
+    result = finalize_paid_bounty_issue(
+        github_token="github-token",
+        public_base_url="https://mrwk.example",
+        bounty={"id": 123, "repo": "ramimbo/mergework", "issue_number": 77},
+        opener=fake_opener,
+    )
+
+    assert result == {
+        "status": "updated",
+        "label": "mrwk:paid",
+        "bounty_url": "https://mrwk.example/bounties/123",
+        "comment_url": "https://github.com/ramimbo/mergework/issues/77#issuecomment-2",
+        "closed": True,
+    }
+    assert [request.get_method() for request in requests] == ["GET", "POST", "PATCH"]
+    comment_body = json.loads((requests[1].data or b"").decode())["body"]
+    assert "Filled and paid on MergeWork" in comment_body
+
+
+def test_finalize_paid_bounty_issue_skips_without_token() -> None:
+    calls = 0
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        nonlocal calls
+        calls += 1
+        return _FakeResponse({})
+
+    result = finalize_paid_bounty_issue(
+        github_token="",
+        public_base_url="https://mrwk.example",
+        bounty={"id": 123, "repo": "ramimbo/mergework", "issue_number": 77},
+        opener=fake_opener,
+    )
+
+    assert result == {"status": "skipped", "reason": "github issue token not configured"}
+    assert calls == 0

--- a/tests/test_treasury_executor.py
+++ b/tests/test_treasury_executor.py
@@ -5,7 +5,13 @@ from datetime import timedelta
 from sqlalchemy import func, select
 
 from app.db import create_schema, session_scope
-from app.ledger.service import create_bounty, ensure_genesis, get_balance, register_wallet
+from app.ledger.service import (
+    create_bounty,
+    ensure_genesis,
+    get_balance,
+    pay_bounty,
+    register_wallet,
+)
 from app.models import Bounty, TreasuryProposal, utc_now
 from app.treasury import canonical_json, proposal_result, propose_treasury_action
 from app.treasury_executor import execute_due_treasury_proposals
@@ -158,6 +164,194 @@ def test_executor_executes_due_manual_payout(sqlite_url: str) -> None:
     assert report["results"][0]["result"]["payout"]["proof_url"].startswith("/proofs/")
     with session_scope(sqlite_url) as session:
         assert get_balance(session, wallet_address) == 15_000_000
+
+
+def test_executor_finalizes_github_issue_for_paid_bounty(sqlite_url: str) -> None:
+    _init_db(sqlite_url)
+    finalizer_calls: list[dict[str, object]] = []
+
+    def fake_paid_finalizer(
+        *,
+        github_token: str,
+        public_base_url: str,
+        bounty: dict[str, object],
+    ) -> dict[str, object]:
+        finalizer_calls.append(
+            {
+                "github_token": github_token,
+                "public_base_url": public_base_url,
+                "bounty": bounty,
+            }
+        )
+        return {
+            "status": "updated",
+            "label": "mrwk:paid",
+            "bounty_url": "https://mrwk.example/bounties/1",
+            "comment_url": "https://github.com/ramimbo/mergework/issues/95#issuecomment-2",
+            "closed": True,
+        }
+
+    with session_scope(sqlite_url) as session:
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=95,
+            issue_url="https://github.com/ramimbo/mergework/issues/95",
+            title="Paid issue finalization bounty",
+            reward_mrwk="15",
+            acceptance="Accepted work fills this bounty.",
+        )
+        proposal = propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": bounty.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/95",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+        proposal_id = int(proposal.id)
+    _make_due(sqlite_url, proposal_id)
+
+    report = execute_due_treasury_proposals(
+        sqlite_url,
+        github_issue_token="github-issue-token",
+        public_base_url="https://mrwk.example",
+        executed_by="treasury-executor",
+        paid_issue_finalizer=fake_paid_finalizer,
+    )
+
+    assert report["attempted"] == 1
+    assert report["executed"] == 1
+    assert report["paid_issue_finalization"]["attempted"] == 1
+    assert report["paid_issue_finalization"]["updated"] == 1
+    assert len(finalizer_calls) == 1
+    assert finalizer_calls[0]["github_token"] == "github-issue-token"
+    assert finalizer_calls[0]["public_base_url"] == "https://mrwk.example"
+    assert finalizer_calls[0]["bounty"]["issue_number"] == 95
+
+    with session_scope(sqlite_url) as session:
+        bounty = session.scalar(select(Bounty).where(Bounty.issue_number == 95))
+        assert bounty is not None
+        assert bounty.status == "paid"
+        assert bounty.github_paid_issue_finalized_at is not None
+        assert "mrwk:paid" in bounty.github_paid_issue_finalization
+
+    second_report = execute_due_treasury_proposals(
+        sqlite_url,
+        github_issue_token="github-issue-token",
+        public_base_url="https://mrwk.example",
+        executed_by="treasury-executor",
+        paid_issue_finalizer=fake_paid_finalizer,
+    )
+    assert second_report["attempted"] == 0
+    assert second_report["paid_issue_finalization"]["attempted"] == 0
+    assert len(finalizer_calls) == 1
+
+
+def test_executor_does_not_finalize_pending_payout_full_bounty(sqlite_url: str) -> None:
+    _init_db(sqlite_url)
+    finalizer_calls = 0
+
+    def fake_paid_finalizer(
+        *,
+        github_token: str,
+        public_base_url: str,
+        bounty: dict[str, object],
+    ) -> dict[str, object]:
+        nonlocal finalizer_calls
+        finalizer_calls += 1
+        return {"status": "updated"}
+
+    with session_scope(sqlite_url) as session:
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=96,
+            issue_url="https://github.com/ramimbo/mergework/issues/96",
+            title="Pending payout is not paid",
+            reward_mrwk="15",
+            acceptance="Accepted work has a pending proposal.",
+        )
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": bounty.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/96",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+    report = execute_due_treasury_proposals(
+        sqlite_url,
+        github_issue_token="github-issue-token",
+        public_base_url="https://mrwk.example",
+        executed_by="treasury-executor",
+        paid_issue_finalizer=fake_paid_finalizer,
+    )
+
+    assert report["attempted"] == 0
+    assert report["paid_issue_finalization"]["attempted"] == 0
+    assert finalizer_calls == 0
+    with session_scope(sqlite_url) as session:
+        bounty = session.scalar(select(Bounty).where(Bounty.issue_number == 96))
+        assert bounty is not None
+        assert bounty.status == "open"
+        assert bounty.github_paid_issue_finalized_at is None
+
+
+def test_executor_keeps_retrying_failed_paid_issue_finalization(sqlite_url: str) -> None:
+    _init_db(sqlite_url)
+
+    def fake_paid_finalizer(
+        *,
+        github_token: str,
+        public_base_url: str,
+        bounty: dict[str, object],
+    ) -> dict[str, object]:
+        return {"status": "failed", "reason": "github unavailable"}
+
+    with session_scope(sqlite_url) as session:
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=97,
+            issue_url="https://github.com/ramimbo/mergework/issues/97",
+            title="Failed paid issue finalization",
+            reward_mrwk="15",
+            acceptance="Accepted work fills this bounty.",
+        )
+        bounty_id = int(bounty.id)
+    with session_scope(sqlite_url) as session:
+        pay_bounty(
+            session,
+            bounty_id=bounty_id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/97",
+            accepted_by="maintainer",
+            verifier_result={"source": "test"},
+        )
+
+    report = execute_due_treasury_proposals(
+        sqlite_url,
+        github_issue_token="github-issue-token",
+        public_base_url="https://mrwk.example",
+        executed_by="treasury-executor",
+        paid_issue_finalizer=fake_paid_finalizer,
+    )
+
+    assert report["paid_issue_finalization"]["attempted"] == 1
+    assert report["paid_issue_finalization"]["failed"] == 1
+    with session_scope(sqlite_url) as session:
+        bounty = session.scalar(select(Bounty).where(Bounty.issue_number == 97))
+        assert bounty is not None
+        assert bounty.status == "paid"
+        assert bounty.github_paid_issue_finalized_at is None
 
 
 def test_executor_continues_after_failed_due_proposal(sqlite_url: str) -> None:

--- a/tests/test_treasury_executor.py
+++ b/tests/test_treasury_executor.py
@@ -307,6 +307,7 @@ def test_executor_does_not_finalize_pending_payout_full_bounty(sqlite_url: str) 
 
 def test_executor_keeps_retrying_failed_paid_issue_finalization(sqlite_url: str) -> None:
     _init_db(sqlite_url)
+    finalizer_calls = 0
 
     def fake_paid_finalizer(
         *,
@@ -314,6 +315,8 @@ def test_executor_keeps_retrying_failed_paid_issue_finalization(sqlite_url: str)
         public_base_url: str,
         bounty: dict[str, object],
     ) -> dict[str, object]:
+        nonlocal finalizer_calls
+        finalizer_calls += 1
         return {"status": "failed", "reason": "github unavailable"}
 
     with session_scope(sqlite_url) as session:
@@ -347,6 +350,24 @@ def test_executor_keeps_retrying_failed_paid_issue_finalization(sqlite_url: str)
 
     assert report["paid_issue_finalization"]["attempted"] == 1
     assert report["paid_issue_finalization"]["failed"] == 1
+    assert finalizer_calls == 1
+    with session_scope(sqlite_url) as session:
+        bounty = session.scalar(select(Bounty).where(Bounty.issue_number == 97))
+        assert bounty is not None
+        assert bounty.status == "paid"
+        assert bounty.github_paid_issue_finalized_at is None
+
+    retry_report = execute_due_treasury_proposals(
+        sqlite_url,
+        github_issue_token="github-issue-token",
+        public_base_url="https://mrwk.example",
+        executed_by="treasury-executor",
+        paid_issue_finalizer=fake_paid_finalizer,
+    )
+
+    assert retry_report["paid_issue_finalization"]["attempted"] == 1
+    assert retry_report["paid_issue_finalization"]["failed"] == 1
+    assert finalizer_calls == 2
     with session_scope(sqlite_url) as session:
         bounty = session.scalar(select(Bounty).where(Bounty.issue_number == 97))
         assert bounty is not None


### PR DESCRIPTION
## Summary
- add persisted paid-issue finalization markers on bounty rows
- have the treasury executor close only proof-backed `status == paid` bounty issues
- add `mrwk:paid`, a concise filled-and-paid comment, and idempotent GitHub close behavior
- document that pending-payout/full-by-effective-capacity rounds must not be auto-closed

Maintainer PR; no bounty requested.

## Safety
- does not act on `effective_awards_remaining == 0` by itself
- does not close pending payout rounds
- does not close proposed-work issues
- failed/skipped GitHub finalization does not roll back treasury execution and is retried later
- GitHub closure comments include a hidden `mrwk:paid` finalization marker so retries do not duplicate the public comment after a partial GitHub write

## Evidence
- Problem addressed: paid bounty rows can be proof-backed and `status == paid` in the API while the linked GitHub bounty issue remains open, which leaves contributors and maintainer agents with stale public issue state.
- Intended surfaces: production treasury executor, bounty row finalization fields, GitHub issue labels/comments/close state, and the private admin runbook.
- Bounty capacity status: this is maintainer infrastructure work and is not claiming any live bounty; it should not consume review, small-fix, verification, or proposed-work capacity.
- Expected PR size: small executor/finalizer slice with focused tests for successful finalization, idempotency, skipped token, failure retry, and paid-only selection.
- Out of scope: no payout execution changes, no ledger/proof mutation beyond existing executed payments, no pending-payout closure, no proposed-work closure, no reserve-cap changes, no wallet/exchange/bridge/cash-out behavior.

## Tests
- `./.venv/bin/python scripts/check_agents.py`
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m mypy app`
- `./.venv/bin/python scripts/docs_smoke.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic finalization of GitHub issues for fully paid bounties: adds paid label, posts completion comment when needed, and closes the issue.
  * Stores a finalization timestamp and details per bounty to prevent duplicate actions and enable reporting.
  * Treasury executor includes paid-issue finalization and returns a sub-report of results.

* **Documentation**
  * Updated admin runbook with production executor paid-bounty finalization details.

* **Tests**
  * Added tests covering paid-issue finalization flows, idempotency, retry and executor behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->