### PR TITLE
Limit public activity feed rows

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -11,18 +11,27 @@ from app.db import session_scope
 from app.serializers import activity_to_dict
 
 
-def activity_context(session: Session, query: str | None = None) -> dict[str, Any]:
-    return activity_to_dict(session, query)
+def activity_context(
+    session: Session, query: str | None = None, limit: int | None = None
+) -> dict[str, Any]:
+    return activity_to_dict(session, query, limit=limit)
 
 
 def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
     @app.get("/api/v1/activity")
-    def api_activity(q: str | None = Query(None)) -> dict[str, Any]:
+    def api_activity(
+        q: str | None = Query(None),
+        limit: int | None = Query(None, ge=1, le=200),
+    ) -> dict[str, Any]:
         with session_scope(db_url) as session:
-            return activity_context(session, q)
+            return activity_context(session, q, limit=limit)
 
     @app.get("/activity", response_class=HTMLResponse)
-    def activity_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:
+    def activity_page(
+        request: Request,
+        q: str | None = Query(None),
+        limit: int | None = Query(None, ge=1, le=200),
+    ) -> HTMLResponse:
         with session_scope(db_url) as session:
-            context = activity_context(session, q)
+            context = activity_context(session, q, limit=limit)
         return templates.TemplateResponse(request, "activity.html", context)

--- a/app/activity.py
+++ b/app/activity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
+from urllib.parse import urlencode
 
 from fastapi import FastAPI, Query, Request
 from fastapi.responses import HTMLResponse
@@ -10,9 +11,21 @@ from sqlalchemy.orm import Session
 from app.db import session_scope
 from app.serializers import activity_to_dict
 
+ACTIVITY_LIMIT_DEFAULT = 100
+ACTIVITY_LIMIT_MAX = 200
+
+
+def _activity_api_url(query: str, limit: int) -> str:
+    params: list[tuple[str, str]] = []
+    if query:
+        params.append(("q", query))
+    if limit != ACTIVITY_LIMIT_DEFAULT:
+        params.append(("limit", str(limit)))
+    return f"/api/v1/activity?{urlencode(params)}" if params else "/api/v1/activity"
+
 
 def activity_context(
-    session: Session, query: str | None = None, limit: int | None = None
+    session: Session, query: str | None = None, limit: int = ACTIVITY_LIMIT_DEFAULT
 ) -> dict[str, Any]:
     return activity_to_dict(session, query, limit=limit)
 
@@ -21,7 +34,7 @@ def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Temp
     @app.get("/api/v1/activity")
     def api_activity(
         q: str | None = Query(None),
-        limit: int | None = Query(None, ge=1, le=200),
+        limit: Annotated[int, Query(ge=1, le=ACTIVITY_LIMIT_MAX)] = ACTIVITY_LIMIT_DEFAULT,
     ) -> dict[str, Any]:
         with session_scope(db_url) as session:
             return activity_context(session, q, limit=limit)
@@ -30,8 +43,9 @@ def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Temp
     def activity_page(
         request: Request,
         q: str | None = Query(None),
-        limit: int | None = Query(None, ge=1, le=200),
+        limit: Annotated[int, Query(ge=1, le=ACTIVITY_LIMIT_MAX)] = ACTIVITY_LIMIT_DEFAULT,
     ) -> HTMLResponse:
         with session_scope(db_url) as session:
             context = activity_context(session, q, limit=limit)
+        context["api_results_url"] = _activity_api_url(str(context["query"]), limit)
         return templates.TemplateResponse(request, "activity.html", context)

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -527,7 +527,9 @@ def pending_activity_rows(session: Session, query: str | None = None) -> list[di
     return pending
 
 
-def activity_to_dict(session: Session, query: str | None = None) -> dict[str, Any]:
+def activity_to_dict(
+    session: Session, query: str | None = None, *, limit: int | None = None
+) -> dict[str, Any]:
     """Build the public activity feed and contributor totals."""
     search_query = _activity_search_query(query)
     rows = session.execute(
@@ -587,6 +589,10 @@ def activity_to_dict(session: Session, query: str | None = None) -> dict[str, An
     for row in pending_payouts:
         del row["amount_microunits"]
 
+    contributor_rows = contributors[:limit] if limit is not None else contributors
+    pending_rows = pending_payouts[:limit] if limit is not None else pending_payouts[:100]
+    recent_rows = recent[:limit] if limit is not None else recent[:100]
+
     return {
         "totals": {
             "accepted_awards": len(recent),
@@ -598,9 +604,9 @@ def activity_to_dict(session: Session, query: str | None = None) -> dict[str, An
             "pending_mrwk": format_mrwk(pending_microunits),
         },
         "query": search_query,
-        "contributors": contributors,
-        "pending_payouts": pending_payouts[:100],
-        "recent": recent[:100],
+        "contributors": contributor_rows,
+        "pending_payouts": pending_rows,
+        "recent": recent_rows,
     }
 
 

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -528,7 +528,7 @@ def pending_activity_rows(session: Session, query: str | None = None) -> list[di
 
 
 def activity_to_dict(
-    session: Session, query: str | None = None, *, limit: int | None = None
+    session: Session, query: str | None = None, *, limit: int = 100
 ) -> dict[str, Any]:
     """Build the public activity feed and contributor totals."""
     search_query = _activity_search_query(query)
@@ -589,9 +589,9 @@ def activity_to_dict(
     for row in pending_payouts:
         del row["amount_microunits"]
 
-    contributor_rows = contributors[:limit] if limit is not None else contributors
-    pending_rows = pending_payouts[:limit] if limit is not None else pending_payouts[:100]
-    recent_rows = recent[:limit] if limit is not None else recent[:100]
+    contributor_rows = contributors[:limit]
+    pending_rows = pending_payouts[:limit]
+    recent_rows = recent[:limit]
 
     return {
         "totals": {
@@ -604,6 +604,7 @@ def activity_to_dict(
             "pending_mrwk": format_mrwk(pending_microunits),
         },
         "query": search_query,
+        "limit": limit,
         "contributors": contributor_rows,
         "pending_payouts": pending_rows,
         "recent": recent_rows,

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -16,7 +16,7 @@
 <p class="notice">Showing accepted work matching “{{ query }}”.</p>
 {% endif %}
 <nav class="actions detail-actions" aria-label="Activity inspection links">
-  <a href="/api/v1/activity{% if query %}?q={{ query | urlencode }}{% endif %}">View JSON activity</a>
+  <a href="{{ api_results_url }}">View JSON activity</a>
 </nav>
 
 <section class="grid">

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -301,18 +301,22 @@ Read accepted-work activity summarized from proof-backed bounty payments:
 ```bash
 curl -s "$API_HOST/api/v1/activity"
 curl -s "$API_HOST/api/v1/activity?q=p3xill"
+curl -s "$API_HOST/api/v1/activity?q=p3xill&limit=25"
 ```
 
 The optional `q` parameter filters proof-backed and pending activity rows by
 account, amount, submission URL, proof hash, proposal id, bounty repo, bounty
 issue URL, internal bounty id, or GitHub issue number. In other words, the
 same search can match bounty repo, bounty issue URL, proposal, proof, or
-submission evidence. The response groups
-matching proof-backed bounty payments into `totals`, contributor rollups, and
-the most recent payment rows. Accepted-but-not-yet-executed `pay_bounty`
-proposals appear separately in `pending_totals` and `pending_payouts`; they are
-not counted as paid, proof-backed, received, or withdrawable work until treasury
-execution creates a ledger proof:
+submission evidence. The optional `limit` parameter defaults to `100`, accepts
+values from `1` to `200`, and caps returned `contributors`, `pending_payouts`,
+and `recent` arrays while totals still describe the full matching set. The
+response groups matching proof-backed bounty payments into `totals`,
+contributor rollups, and the most recent payment rows.
+Accepted-but-not-yet-executed `pay_bounty` proposals appear separately in
+`pending_totals` and `pending_payouts`; they are not counted as paid,
+proof-backed, received, or withdrawable work until treasury execution creates a
+ledger proof:
 
 ```json
 {
@@ -326,6 +330,7 @@ execution creates a ledger proof:
     "pending_mrwk": "50"
   },
   "query": "p3xill",
+  "limit": 25,
   "contributors": [
     {
       "account": "github:p3xill",
@@ -377,7 +382,7 @@ execution creates a ledger proof:
 ```
 
 `contributors` is sorted by accepted MRWK amount, while `recent` is sorted by
-newest ledger sequence and capped to the latest 100 matching rows. Use
+newest ledger sequence. Use
 `proof_hash` with `/api/v1/proofs/<proof_hash>` to inspect the public proof
 payload for a payment.
 

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -232,6 +232,7 @@ def test_activity_api_validates_and_applies_limit(sqlite_url: str) -> None:
 
     assert limited.status_code == 200
     limited_payload = limited.json()
+    assert limited_payload["limit"] == 1
     assert limited_payload["totals"] == {
         "accepted_awards": 3,
         "accepted_mrwk": "225",
@@ -244,6 +245,7 @@ def test_activity_api_validates_and_applies_limit(sqlite_url: str) -> None:
     assert filtered_limited.status_code == 200
     filtered_payload = filtered_limited.json()
     assert filtered_payload["query"] == "github"
+    assert filtered_payload["limit"] == 2
     assert filtered_payload["totals"]["contributors"] == 3
     assert len(filtered_payload["contributors"]) == 2
     assert len(filtered_payload["recent"]) == 2
@@ -404,12 +406,17 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert "Pending accepted work" in paid.text
 
     filtered = client.get("/activity?q=bob")
+    limited_filtered = client.get("/activity?q=bob&limit=25")
     issue_ref = client.get("/activity?q=%2312")
 
     assert filtered.status_code == 200
     assert 'value="bob"' in filtered.text
     assert "Showing accepted work matching “bob”." in filtered.text
     assert 'href="/api/v1/activity?q=bob">View JSON activity</a>' in filtered.text
+    assert limited_filtered.status_code == 200
+    assert 'href="/api/v1/activity?q=bob&amp;limit=25">View JSON activity</a>' in (
+        limited_filtered.text
+    )
     assert 'href="/activity">Clear</a>' in filtered.text
     assert "No contributors match this search." not in filtered.text
     assert "No accepted work matches this search." not in filtered.text

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -198,6 +198,57 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
         assert invalid_hash_query["recent"] == []
 
 
+def test_activity_api_validates_and_applies_limit(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=656,
+            issue_url="https://github.com/ramimbo/mergework/issues/656",
+            title="Activity limit bounty",
+            reward_mrwk="75",
+            max_awards=3,
+            acceptance="Activity list consumers should be able to request bounded feeds.",
+        )
+        for login in ("alice", "bob", "carol"):
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account=f"github:{login}",
+                submission_url=f"https://github.com/ramimbo/mergework/pull/{login}",
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted"},
+            )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    limited = client.get("/api/v1/activity?limit=1")
+    filtered_limited = client.get("/api/v1/activity?q=github&limit=2")
+    invalid = client.get("/api/v1/activity?limit=notanint")
+
+    assert limited.status_code == 200
+    limited_payload = limited.json()
+    assert limited_payload["totals"] == {
+        "accepted_awards": 3,
+        "accepted_mrwk": "225",
+        "contributors": 3,
+    }
+    assert len(limited_payload["contributors"]) == 1
+    assert len(limited_payload["recent"]) == 1
+    assert len(limited_payload["pending_payouts"]) == 0
+
+    assert filtered_limited.status_code == 200
+    filtered_payload = filtered_limited.json()
+    assert filtered_payload["query"] == "github"
+    assert filtered_payload["totals"]["contributors"] == 3
+    assert len(filtered_payload["contributors"]) == 2
+    assert len(filtered_payload["recent"]) == 2
+
+    assert invalid.status_code == 422
+
+
 def test_activity_api_exposes_pending_payouts_separately_from_paid_work(
     sqlite_url: str,
 ) -> None:

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -212,6 +212,28 @@ def test_activity_api_validates_and_applies_limit(sqlite_url: str) -> None:
             max_awards=3,
             acceptance="Activity list consumers should be able to request bounded feeds.",
         )
+        pending_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=657,
+            issue_url="https://github.com/ramimbo/mergework/issues/657",
+            title="Pending activity limit bounty",
+            reward_mrwk="50",
+            max_awards=2,
+            acceptance="Pending payout rows should be limited with the rest of activity.",
+        )
+        for login in ("alice", "bob"):
+            propose_treasury_action(
+                session,
+                action="pay_bounty",
+                payload={
+                    "bounty_id": pending_bounty.id,
+                    "to_account": f"github:{login}",
+                    "submission_url": f"https://github.com/ramimbo/mergework/pull/pending-{login}",
+                    "accepted_by": "maintainer",
+                },
+                proposed_by="maintainer",
+            )
         for login in ("alice", "bob", "carol"):
             pay_bounty(
                 session,
@@ -226,6 +248,8 @@ def test_activity_api_validates_and_applies_limit(sqlite_url: str) -> None:
 
     limited = client.get("/api/v1/activity?limit=1")
     filtered_limited = client.get("/api/v1/activity?q=github&limit=2")
+    exact_size = client.get("/api/v1/activity?limit=3")
+    exceeds_size = client.get("/api/v1/activity?limit=100")
     invalid = client.get("/api/v1/activity?limit=notanint")
     below_min = client.get("/api/v1/activity?limit=0")
     above_max = client.get("/api/v1/activity?limit=201")
@@ -240,7 +264,7 @@ def test_activity_api_validates_and_applies_limit(sqlite_url: str) -> None:
     }
     assert len(limited_payload["contributors"]) == 1
     assert len(limited_payload["recent"]) == 1
-    assert len(limited_payload["pending_payouts"]) == 0
+    assert len(limited_payload["pending_payouts"]) == 1
 
     assert filtered_limited.status_code == 200
     filtered_payload = filtered_limited.json()
@@ -249,6 +273,19 @@ def test_activity_api_validates_and_applies_limit(sqlite_url: str) -> None:
     assert filtered_payload["totals"]["contributors"] == 3
     assert len(filtered_payload["contributors"]) == 2
     assert len(filtered_payload["recent"]) == 2
+    assert len(filtered_payload["pending_payouts"]) == 2
+
+    assert exact_size.status_code == 200
+    exact_payload = exact_size.json()
+    assert len(exact_payload["contributors"]) == 3
+    assert len(exact_payload["recent"]) == 3
+    assert len(exact_payload["pending_payouts"]) == 2
+
+    assert exceeds_size.status_code == 200
+    exceeds_payload = exceeds_size.json()
+    assert len(exceeds_payload["contributors"]) == 3
+    assert len(exceeds_payload["recent"]) == 3
+    assert len(exceeds_payload["pending_payouts"]) == 2
 
     assert invalid.status_code == 422
     assert below_min.status_code == 422

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -227,6 +227,8 @@ def test_activity_api_validates_and_applies_limit(sqlite_url: str) -> None:
     limited = client.get("/api/v1/activity?limit=1")
     filtered_limited = client.get("/api/v1/activity?q=github&limit=2")
     invalid = client.get("/api/v1/activity?limit=notanint")
+    below_min = client.get("/api/v1/activity?limit=0")
+    above_max = client.get("/api/v1/activity?limit=201")
 
     assert limited.status_code == 200
     limited_payload = limited.json()
@@ -247,6 +249,8 @@ def test_activity_api_validates_and_applies_limit(sqlite_url: str) -> None:
     assert len(filtered_payload["recent"]) == 2
 
     assert invalid.status_code == 422
+    assert below_min.status_code == 422
+    assert above_max.status_code == 422
 
 
 def test_activity_api_exposes_pending_payouts_separately_from_paid_work(

--- a/tests/test_activity_routes.py
+++ b/tests/test_activity_routes.py
@@ -19,6 +19,7 @@ def test_activity_context_preserves_empty_feed_shape(sqlite_url: str) -> None:
                 "pending_awards": 0,
                 "pending_mrwk": "0",
             },
+            "limit": 100,
             "contributors": [],
             "pending_payouts": [],
             "recent": [],

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -107,6 +107,15 @@ def test_api_examples_document_ledger_response_shape() -> None:
     assert "bounty-payment ledger entries" in examples
 
 
+def test_api_examples_document_activity_limit() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "/api/v1/activity?q=p3xill&limit=25" in examples
+    assert "The optional `limit` parameter defaults to `100`" in examples
+    assert "values from `1` to `200`" in examples
+    assert '"limit": 25' in examples
+
+
 def test_api_examples_document_auth_me_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -293,6 +293,7 @@ def test_activity_serializers_skip_malformed_public_proofs(sqlite_url: str) -> N
         "totals": {"accepted_awards": 0, "accepted_mrwk": "0", "contributors": 0},
         "pending_totals": {"pending_awards": 0, "pending_mrwk": "0"},
         "query": "",
+        "limit": 100,
         "contributors": [],
         "pending_payouts": [],
         "recent": [],


### PR DESCRIPTION
/claim #656

## Summary
- Add a bounded `limit` query parameter to `/api/v1/activity` and `/activity`.
- Apply the limit to public activity list sections after filtering while keeping aggregate totals for the full matching set.
- Return FastAPI validation errors for invalid limits instead of silently ignoring them.
- Preserve `q` and non-default `limit` in the activity page JSON link, and document the activity limit response shape.

## Evidence
- Confusion/bug: `/api/v1/activity?limit=...` accepted a caller-supplied limit but returned the full activity lists, so public consumers could not request bounded feeds.
- Bounty reference: MRWK bounty issue #656, 75 MRWK implementation bounty.
- Report: https://github.com/ramimbo/mergework/issues/656#issuecomment-4591531693

## Intended scope
- Files/surfaces: `app/activity.py`, `app/serializers.py`, `app/templates/activity.html`, `docs/api-examples.md`, and focused tests.
- Expected PR size: small route/serializer validation fix plus activity docs and regression coverage.
- Out of scope: payout logic, treasury proposal flow, ledger accounting, and unrelated activity UI changes.

## Checklist
- [x] `/claim #656` included.
- [x] Bounty capacity checked before submission.
- [x] API and HTML activity handlers pass the bounded `limit` value through the shared context.
- [x] Invalid `limit` values return FastAPI validation errors.
- [x] Regression tests cover valid limits, filtered limits, non-integer limits, exact-size limits, over-dataset limits, and numeric boundaries `0` and `201`.
- [x] Regression tests prove `contributors`, `recent`, and `pending_payouts` are all limited.
- [x] Activity docs describe default/range/returned rows vs totals.
- [x] HTML activity page keeps filtered JSON inspection links aligned with the selected limit.

## Validation
```text
.\.venv\Scripts\python.exe -m pytest -q
593 passed, 1 warning in 57.82s

.\.venv\Scripts\python.exe -m pytest tests/test_activity.py tests/test_activity_routes.py tests/test_serializers.py::test_activity_serializers_skip_malformed_public_proofs tests/test_docs_public_urls.py::test_api_examples_document_activity_limit -q
9 passed, 1 warning in 2.06s

.\.venv\Scripts\python.exe -m ruff check app/activity.py app/serializers.py tests/test_activity.py tests/test_activity_routes.py tests/test_serializers.py tests/test_docs_public_urls.py
All checks passed!

.\.venv\Scripts\python.exe -m ruff format --check app/activity.py app/serializers.py tests/test_activity.py tests/test_activity_routes.py tests/test_serializers.py tests/test_docs_public_urls.py
6 files already formatted

.\.venv\Scripts\python.exe -m mypy app/activity.py app/serializers.py
Success: no issues found in 2 source files

git diff --check
# pass
```

## Safety
Testing and reproduction were read-only against public MRWK endpoints. This PR only changes list limiting/validation for activity surfaces and adds regression/documentation coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `limit` query parameter to activity endpoints (default 100, range 1–200). Returned arrays (`contributors`, `pending_payouts`, `recent`) are capped to `limit` while totals reflect the full matching set; responses include the effective `limit`.

* **UI**
  * Activity page’s “View JSON activity” link preserves the effective `limit` in the query string.

* **Tests**
  * Added/updated tests covering valid/invalid limits and rendered links.

* **Documentation**
  * API docs updated with `limit` examples and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->