### PR TITLE
Honor activity feed limit

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
+from urllib.parse import urlencode
 
 from fastapi import FastAPI, Query, Request
 from fastapi.responses import HTMLResponse
@@ -10,19 +11,41 @@ from sqlalchemy.orm import Session
 from app.db import session_scope
 from app.serializers import activity_to_dict
 
+ACTIVITY_LIMIT_DEFAULT = 100
+ACTIVITY_LIMIT_MAX = 200
 
-def activity_context(session: Session, query: str | None = None) -> dict[str, Any]:
-    return activity_to_dict(session, query)
+
+def _activity_api_url(query: str, limit: int) -> str:
+    params: list[tuple[str, str]] = []
+    if query:
+        params.append(("q", query))
+    if limit != ACTIVITY_LIMIT_DEFAULT:
+        params.append(("limit", str(limit)))
+    return f"/api/v1/activity?{urlencode(params)}" if params else "/api/v1/activity"
+
+
+def activity_context(
+    session: Session, query: str | None = None, *, limit: int = ACTIVITY_LIMIT_DEFAULT
+) -> dict[str, Any]:
+    return activity_to_dict(session, query, limit=limit)
 
 
 def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
     @app.get("/api/v1/activity")
-    def api_activity(q: str | None = Query(None)) -> dict[str, Any]:
+    def api_activity(
+        q: str | None = Query(None),
+        limit: Annotated[int, Query(ge=1, le=ACTIVITY_LIMIT_MAX)] = ACTIVITY_LIMIT_DEFAULT,
+    ) -> dict[str, Any]:
         with session_scope(db_url) as session:
-            return activity_context(session, q)
+            return activity_context(session, q, limit=limit)
 
     @app.get("/activity", response_class=HTMLResponse)
-    def activity_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:
+    def activity_page(
+        request: Request,
+        q: str | None = Query(None),
+        limit: Annotated[int, Query(ge=1, le=ACTIVITY_LIMIT_MAX)] = ACTIVITY_LIMIT_DEFAULT,
+    ) -> HTMLResponse:
         with session_scope(db_url) as session:
-            context = activity_context(session, q)
+            context = activity_context(session, q, limit=limit)
+        context["api_results_url"] = _activity_api_url(str(context["query"]), limit)
         return templates.TemplateResponse(request, "activity.html", context)

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -527,7 +527,9 @@ def pending_activity_rows(session: Session, query: str | None = None) -> list[di
     return pending
 
 
-def activity_to_dict(session: Session, query: str | None = None) -> dict[str, Any]:
+def activity_to_dict(
+    session: Session, query: str | None = None, *, limit: int = 100
+) -> dict[str, Any]:
     """Build the public activity feed and contributor totals."""
     search_query = _activity_search_query(query)
     rows = session.execute(
@@ -598,9 +600,10 @@ def activity_to_dict(session: Session, query: str | None = None) -> dict[str, An
             "pending_mrwk": format_mrwk(pending_microunits),
         },
         "query": search_query,
-        "contributors": contributors,
-        "pending_payouts": pending_payouts[:100],
-        "recent": recent[:100],
+        "limit": limit,
+        "contributors": contributors[:limit],
+        "pending_payouts": pending_payouts[:limit],
+        "recent": recent[:limit],
     }
 
 

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -16,7 +16,7 @@
 <p class="notice">Showing accepted work matching “{{ query }}”.</p>
 {% endif %}
 <nav class="actions detail-actions" aria-label="Activity inspection links">
-  <a href="/api/v1/activity{% if query %}?q={{ query | urlencode }}{% endif %}">View JSON activity</a>
+  <a href="{{ api_results_url }}">View JSON activity</a>
 </nav>
 
 <section class="grid">

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -301,13 +301,17 @@ Read accepted-work activity summarized from proof-backed bounty payments:
 ```bash
 curl -s "$API_HOST/api/v1/activity"
 curl -s "$API_HOST/api/v1/activity?q=p3xill"
+curl -s "$API_HOST/api/v1/activity?q=p3xill&limit=25"
 ```
 
 The optional `q` parameter filters proof-backed and pending activity rows by
 account, amount, submission URL, proof hash, proposal id, bounty repo, bounty
 issue URL, internal bounty id, or GitHub issue number. In other words, the
 same search can match bounty repo, bounty issue URL, proposal, proof, or
-submission evidence. The response groups
+submission evidence. The optional `limit` parameter defaults to `100`, accepts
+values from `1` to `200`, and caps the returned `contributors`,
+`pending_payouts`, and `recent` row arrays while the totals still describe the
+full matching activity set. The response groups
 matching proof-backed bounty payments into `totals`, contributor rollups, and
 the most recent payment rows. Accepted-but-not-yet-executed `pay_bounty`
 proposals appear separately in `pending_totals` and `pending_payouts`; they are
@@ -326,6 +330,7 @@ execution creates a ledger proof:
     "pending_mrwk": "50"
   },
   "query": "p3xill",
+  "limit": 25,
   "contributors": [
     {
       "account": "github:p3xill",

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -75,9 +75,14 @@ def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
     response = client.get("/api/v1/activity")
+    limited = client.get("/api/v1/activity?limit=1")
+    invalid_limit = client.get("/api/v1/activity?limit=notanint")
+    too_low_limit = client.get("/api/v1/activity?limit=0")
+    too_high_limit = client.get("/api/v1/activity?limit=201")
 
     assert response.status_code == 200
     payload = response.json()
+    assert payload["limit"] == 100
     assert payload["totals"] == {
         "accepted_awards": 3,
         "accepted_mrwk": "90",
@@ -116,6 +121,19 @@ def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -
     assert payload["recent"][0]["bounty_url"] == f"/bounties/{second_bounty.id}"
     assert all("unproved" not in row["submission_url"] for row in payload["recent"])
 
+    assert limited.status_code == 200
+    limited_payload = limited.json()
+    assert limited_payload["limit"] == 1
+    assert limited_payload["totals"] == payload["totals"]
+    assert limited_payload["pending_totals"] == payload["pending_totals"]
+    assert len(limited_payload["contributors"]) == 1
+    assert len(limited_payload["recent"]) == 1
+    assert limited_payload["contributors"][0]["account"] == "github:alice"
+    assert limited_payload["recent"][0]["proof_hash"] == wallet_proof.hash
+    assert invalid_limit.status_code == 422
+    assert too_low_limit.status_code == 422
+    assert too_high_limit.status_code == 422
+
 
 def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
     create_schema(sqlite_url)
@@ -151,6 +169,7 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
     by_account = client.get("/api/v1/activity?q=ALICE").json()
+    by_account_limited = client.get("/api/v1/activity?q=ALICE&limit=1").json()
     by_repo = client.get("/api/v1/activity?q=ramimbo%2Fmergework").json()
     by_proof = client.get(f"/api/v1/activity?q={alice_proof.hash[:12]}").json()
     by_issue_ref = client.get("/api/v1/activity?q=%23164").json()
@@ -166,6 +185,11 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
         "accepted_mrwk": "100",
         "contributors": 1,
     }
+    assert by_account_limited["query"] == "alice"
+    assert by_account_limited["limit"] == 1
+    assert by_account_limited["totals"] == by_account["totals"]
+    assert len(by_account_limited["contributors"]) == 1
+    assert len(by_account_limited["recent"]) == 1
     assert by_account["contributors"][0]["account"] == "github:alice"
     assert by_account["recent"][0]["submission_url"].endswith("/pull/164")
     assert by_issue_ref["query"] == "#164"
@@ -349,6 +373,7 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert "Pending accepted work" in paid.text
 
     filtered = client.get("/activity?q=bob")
+    limited_filtered = client.get("/activity?q=bob&limit=25")
     issue_ref = client.get("/activity?q=%2312")
 
     assert filtered.status_code == 200
@@ -358,6 +383,10 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert 'href="/activity">Clear</a>' in filtered.text
     assert "No contributors match this search." not in filtered.text
     assert "No accepted work matches this search." not in filtered.text
+    assert limited_filtered.status_code == 200
+    assert 'href="/api/v1/activity?q=bob&amp;limit=25">View JSON activity</a>' in (
+        limited_filtered.text
+    )
     assert issue_ref.status_code == 200
     assert 'value="#12"' in issue_ref.text
     assert "Showing accepted work matching “#12”." in issue_ref.text

--- a/tests/test_activity_routes.py
+++ b/tests/test_activity_routes.py
@@ -19,6 +19,7 @@ def test_activity_context_preserves_empty_feed_shape(sqlite_url: str) -> None:
                 "pending_awards": 0,
                 "pending_mrwk": "0",
             },
+            "limit": 100,
             "contributors": [],
             "pending_payouts": [],
             "recent": [],

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -423,9 +423,14 @@ def test_api_examples_document_activity_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 
     assert "/api/v1/activity?q=p3xill" in examples
+    assert "/api/v1/activity?q=p3xill&limit=25" in examples
+    assert "defaults to `100`" in examples
+    assert "values from `1` to `200`" in examples
+    assert "`contributors`,\n`pending_payouts`, and `recent` row arrays" in examples
     assert '"totals": {' in examples
     assert '"accepted_awards": 2' in examples
     assert '"accepted_mrwk": "115"' in examples
+    assert '"limit": 25' in examples
     assert '"contributors": [' in examples
     assert '"account": "github:p3xill"' in examples
     assert (

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -293,6 +293,7 @@ def test_activity_serializers_skip_malformed_public_proofs(sqlite_url: str) -> N
         "totals": {"accepted_awards": 0, "accepted_mrwk": "0", "contributors": 0},
         "pending_totals": {"pending_awards": 0, "pending_mrwk": "0"},
         "query": "",
+        "limit": 100,
         "contributors": [],
         "pending_payouts": [],
         "recent": [],


### PR DESCRIPTION
## Summary
- validate `limit` on `/api/v1/activity` and `/activity` as 1..200 with default 100
- apply the limit to `contributors`, `pending_payouts`, and `recent` while preserving full-match totals
- keep the activity page JSON link aligned with the current search and non-default limit
- document the limit parameter and response field

## Why
A live report in #656 showed `/api/v1/activity?limit=1`, `limit=2`, and invalid `limit=notanint` returning 200 with the full contributor list. This makes API polling unexpectedly unbounded and hides invalid client input.

The older closed #495 only capped `recent` and was closed unmerged after a previous bounty pool was exhausted; this PR addresses the currently reported behavior, including contributor and pending payout arrays.

Refs #655. Related report: #656.

## Validation
- `.venv/bin/python -m pytest tests/test_activity.py tests/test_docs_public_urls.py::test_api_examples_document_activity_response_shape -q` -> 6 passed, 1 warning
- `.venv/bin/ruff check app/activity.py app/serializers.py tests/test_activity.py tests/test_docs_public_urls.py` -> passed
- `.venv/bin/ruff format --check app/activity.py app/serializers.py tests/test_activity.py tests/test_docs_public_urls.py` -> passed
- `.venv/bin/mypy app/activity.py app/serializers.py` -> passed
- `.venv/bin/python scripts/docs_smoke.py` -> passed
- `git diff --check` -> passed
- `git merge-tree --write-tree origin/main HEAD` -> no merge conflict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity endpoints (API and HTML) accept a limit query parameter to cap returned rows; defaults to 100 and is capped at 200. HTML links now reflect the current query and limit.
* **Documentation**
  * API docs updated with examples and notes on default, valid range, and how totals vs. returned rows behave.
* **Tests**
  * Added/expanded tests to cover limit validation, payload truncation, and link rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->