### PR TITLE
Reject control characters in public filters

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -136,6 +136,10 @@ def account_accepted_work_context(session: Session, account: str) -> dict[str, A
 
 
 def _transaction_type_filter(tx_type: str | None) -> tuple[str, str | None]:
+    if tx_type is not None and contains_control_character(tx_type):
+        raise HTTPException(
+            status_code=400, detail="transaction type must not contain control characters"
+        )
     selected = (tx_type or "all").strip().lower()
     if selected in {"", "all"}:
         return "all", None

--- a/app/activity.py
+++ b/app/activity.py
@@ -2,16 +2,19 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import FastAPI, Query, Request
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
+from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.serializers import activity_to_dict
 
 
 def activity_context(session: Session, query: str | None = None) -> dict[str, Any]:
+    if query is not None and contains_control_character(query):
+        raise HTTPException(status_code=400, detail="q must not contain control characters")
     return activity_to_dict(session, query)
 
 

--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -138,6 +138,10 @@ def register_bounty_api_routes(
                     )
                 query = query.where(Bounty.status == normalized_status)
             if query_text is not None:
+                if contains_control_character(query_text):
+                    raise HTTPException(
+                        status_code=400, detail="q must not contain control characters"
+                    )
                 normalized_query = query_text.strip()
                 if normalized_query:
                     escaped_query = (

--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -22,7 +22,6 @@ from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.reconciliation import payout_reconciliation_summary, reconcile_accepted_payouts
 from app.ledger.service import (
-    CONTROL_CHAR_RE,
     LedgerError,
     validate_public_url,
 )
@@ -316,7 +315,7 @@ def register_bounty_api_routes(
         if data.get("note") is not None:
             note = optional_str(data, "note").strip()
             if note:
-                if CONTROL_CHAR_RE.search(note):
+                if contains_control_character(note):
                     raise HTTPException(
                         status_code=400,
                         detail="verifier_result.note must not contain control characters",

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from app.accounts import normalized_wallet_address
 from app.bounty_availability import normalize_bounty_availability_filter
 from app.bounty_sorting import BOUNTY_SORT_LABELS, normalize_bounty_sort
+from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger_views import account_ledger_transaction_types, account_ledger_transactions
 from app.models import Wallet
@@ -169,6 +170,8 @@ def public_bounties_context(
 
 
 def wallets_page_context(session: Session, q: str | None = None) -> dict[str, Any]:
+    if q is not None and contains_control_character(q):
+        raise HTTPException(status_code=400, detail="q must not contain control characters")
     query_text = q.strip() if q is not None else ""
     query = select(Wallet)
     if query_text:
@@ -197,6 +200,10 @@ def wallet_page_context(
     wallet = session.get(Wallet, normalized_address)
     if wallet is None:
         raise HTTPException(status_code=404, detail="wallet not found")
+    if transaction_type is not None and contains_control_character(transaction_type):
+        raise HTTPException(
+            status_code=400, detail="transaction type must not contain control characters"
+        )
     selected_transaction_type = transaction_type.strip() if transaction_type is not None else ""
     return {
         "wallet": wallet_to_dict(session, wallet),

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -263,6 +263,7 @@ def test_account_page_filters_transactions_by_type(sqlite_url: str) -> None:
     payments = client.get("/accounts/github:alice?tx_type=bounty_payment")
     claims = client.get("/accounts/github:alice?tx_type=github_claim")
     invalid = client.get("/accounts/github:alice?tx_type=bogus")
+    control = client.get("/accounts/github:alice?tx_type=%C2%85bounty_payment")
 
     assert all_rows.status_code == 200
     assert "Transaction type filters" in all_rows.text
@@ -282,6 +283,9 @@ def test_account_page_filters_transactions_by_type(sqlite_url: str) -> None:
 
     assert invalid.status_code == 400
     assert "transaction type must be one of" in invalid.text
+
+    assert control.status_code == 400
+    assert control.json()["detail"] == "transaction type must not contain control characters"
 
 
 def test_account_api_does_not_advertise_wallet_transfers_for_plain_accounts(

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -199,6 +199,22 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
         assert invalid_hash_query["recent"] == []
 
 
+def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    api_response = client.get("/api/v1/activity?q=%C2%85github")
+    page_response = client.get("/activity?q=github%09")
+
+    assert api_response.status_code == 400
+    assert api_response.json()["detail"] == "q must not contain control characters"
+    assert page_response.status_code == 400
+    assert page_response.json()["detail"] == "q must not contain control characters"
+
+
 def test_activity_api_exposes_pending_payouts_separately_from_paid_work(
     sqlite_url: str,
 ) -> None:

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -354,6 +354,22 @@ def test_bounty_api_filters_by_status(sqlite_url: str) -> None:
     assert invalid.json()["detail"] == "status must be one of: open, paid, closed"
 
 
+def test_bounty_api_search_query_rejects_control_characters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    list_response = client.get("/api/v1/bounties?q=%C2%85open")
+    summary_response = client.get("/api/v1/bounties/summary?q=open%09")
+
+    assert list_response.status_code == 400
+    assert list_response.json()["detail"] == "q must not contain control characters"
+    assert summary_response.status_code == 400
+    assert summary_response.json()["detail"] == "q must not contain control characters"
+
+
 def test_bounty_api_limit_caps_filtered_rows(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -686,6 +686,22 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Link a wallet" in me
 
 
+def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    _, public_hex, address = _keypair()
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _register_wallet(client, public_hex, "Main smoke wallet")
+    _fund_wallet(sqlite_url, address)
+
+    search_response = client.get("/wallets", params={"q": "\u0085Main"})
+    type_response = client.get(f"/wallets/{address}", params={"type": "test_funding\t"})
+
+    assert search_response.status_code == 400
+    assert search_response.json()["detail"] == "q must not contain control characters"
+    assert type_response.status_code == 400
+    assert type_response.json()["detail"] == "transaction type must not contain control characters"
+
+
 def test_me_page_shows_signed_in_github_claim_balance(sqlite_url: str, monkeypatch) -> None:
     monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
     create_schema(sqlite_url)


### PR DESCRIPTION
## Summary

- Reject raw control characters in public read-only filter inputs before trimming or normalizing.
- Covers bounty search `q`, activity search `q`, account page `tx_type`, wallet page search `q`, and wallet transaction `type`.
- Adds focused regression coverage for C1/tab-padded filter values while preserving clean filters.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: live public endpoints currently accept malformed filter values such as `/api/v1/activity?q=%C2%85github`, `/api/v1/bounties?q=%C2%85open`, `/accounts/github:attaboy11?tx_type=%C2%85bounty_payment`, `/wallets?q=%C2%85mrwk`, and `/wallets/<address>?type=transfer%09` with HTTP 200, treating them as clean filters after trimming.
- Bounty capacity and active attempts/open PRs checked: #655 and #656 are live; checked current #655/#656 comments and open PR list before opening and expanding this focused fix. This is distinct from PR #750, which only hardens account identifiers.
- Intended files or surfaces: `app/bounty_api.py`, `app/activity.py`, `app/accounts.py`, `app/public_routes.py`, `tests/test_bounty_api_routes.py`, `tests/test_activity.py`, `tests/test_account_routes.py`, and `tests/test_wallet_api.py`.
- Expected PR size: small route validation/test change.
- Out of scope: no ledger entries, payouts, treasury execution, wallet material, proof creation, private data, exchange/bridge/cash-out behavior, or price claims.

## Test Evidence

- [x] targeted pytest: `tests/test_wallet_api.py::test_wallet_pages_reject_control_character_filters tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows tests/test_bounty_api_routes.py tests/test_activity.py tests/test_account_routes.py` -> 26 passed, 1 warning
- [x] full pytest: 611 passed, 1 warning
- [x] targeted Ruff check/format for changed route/test files
- [x] `mypy app/public_routes.py app/bounty_api.py app/activity.py app/accounts.py`
- [x] `git diff --check origin/main...HEAD` and `git diff --check`
- [x] `git merge-tree --write-tree origin/main HEAD` -> clean tree `61372474c57bf2e948549784df757ef9afdcbd83`

## MRWK

Bounty #655
Refs #656


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Various search and filter inputs (activity, bounties, account transactions, wallet listings/detail) now reject control characters, returning HTTP 400 with clear error messages.

* **Tests**
  * Added/expanded tests to assert control-character rejection for activity queries, bounty search endpoints, account transaction filters, and wallet pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->