### PR TITLE
fix: treat wallet type=all as unfiltered

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -198,6 +198,8 @@ def wallet_page_context(
     if wallet is None:
         raise HTTPException(status_code=404, detail="wallet not found")
     selected_transaction_type = transaction_type.strip() if transaction_type is not None else ""
+    if selected_transaction_type.lower() == "all":
+        selected_transaction_type = ""
     return {
         "wallet": wallet_to_dict(session, wallet),
         "transactions": account_ledger_transactions(

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -644,6 +644,9 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     detail = client.get(f"/wallets/{address}").text
     funded_detail = client.get(f"/wallets/{funded_address}").text
     funded_type_filter = client.get(f"/wallets/{funded_address}?type=test_funding").text
+    funded_all_type_filter = client.get(f"/wallets/{funded_address}?type=all").text
+    funded_all_type_filter_upper = client.get(f"/wallets/{funded_address}?type=ALL").text
+    funded_all_type_filter_spaced = client.get(f"/wallets/{funded_address}?type=%20all%20").text
     funded_missing_type = client.get(f"/wallets/{funded_address}?type=bounty_payment").text
     transfer = client.get("/transfer").text
     me = client.get("/me").text
@@ -679,6 +682,14 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Filter wallet transactions" in funded_detail
     assert 'value="test_funding" selected' in funded_type_filter
     assert "Showing test_funding transactions." in funded_type_filter
+    assert "Showing all transactions." not in funded_all_type_filter
+    assert "wallet_transfer" in funded_all_type_filter
+    assert "test_funding" in funded_all_type_filter
+    assert "No wallet transactions match this type." not in funded_all_type_filter
+    assert "wallet_transfer" in funded_all_type_filter_upper
+    assert "test_funding" in funded_all_type_filter_upper
+    assert "wallet_transfer" in funded_all_type_filter_spaced
+    assert "test_funding" in funded_all_type_filter_spaced
     assert "No wallet transactions match this type." in funded_missing_type
     assert "Signed transfer" in transfer
     assert "both wallets are registered" in transfer


### PR DESCRIPTION
Bounty #655
Source live report / verification bounty: #656

## Summary
- normalize wallet detail `type=all` to the same unfiltered transaction view as no `type` parameter
- add regression coverage so `?type=all` shows all wallet transactions instead of an empty table

## Live report
On the live wallet page, a wallet with public transactions shows rows with no filter, but `?type=all` renders a normal-looking page that says “Showing all transactions.” while filtering by the literal entry type `all` and hiding every row.

Read-only reproduction against live MRWK:

```bash
python3 - <<'PY'
import re, urllib.request

wallet = "mrwk1bf68eecedfdc1d75cca6f675364d5455893547f1"
base = "https://mrwk.online/wallets/" + wallet
for name, suffix in {"no filter": "", "all": "?type=all"}.items():
    with urllib.request.urlopen(base + suffix, timeout=20) as response:
        html = response.read().decode(errors="replace")
    print(name, response.status, re.findall(r'href="/ledger/(\d+)"', html), "no_match=", "No wallet transactions match this type" in html)
PY
```

Observed 2026-06-01 UTC:

```text
no filter 200 ['1052', '1047'] no_match= False
all 200 [] no_match= True
```

Expected: `type=all` should mean the same all-transaction view as no `type` filter, matching account transaction filter semantics.

Actual: `type=all` is treated as a concrete transaction type and returns a false empty result.

## Why it matters
Wallet pages are public reconciliation surfaces for MRWK balances, GitHub claims, and payout history. A contributor or monitor using `type=all` can incorrectly conclude that a wallet has no matching transaction rows.

## Tests
- `pytest tests/test_wallet_api.py -q` — 40 passed, 1 warning
- `ruff check app/public_routes.py tests/test_wallet_api.py` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transaction type filtering now treats "all" case-insensitively and with surrounding whitespace as a request to show all transactions (no type-based restriction).

* **Tests**
  * Wallet transaction tests updated to verify "all" handling across different casings and spacing, ensuring all transactions are displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->