### PR TITLE
Make accepted-work timestamps UTC explicit

### DIFF
--- a/app/serializers.py
+++ b/app/serializers.py
@@ -365,7 +365,7 @@ def ledger_to_dict(entry: LedgerEntry, proof_hash: str | None = None) -> dict[st
         "previous_hash": entry.previous_hash,
         "entry_hash": entry.entry_hash,
         "proof_hash": proof_hash,
-        "created_at": entry.created_at.isoformat(),
+        "created_at": public_utc_timestamp(entry.created_at),
     }
 
 
@@ -406,7 +406,7 @@ def _activity_row(entry: LedgerEntry, proof: Proof) -> dict[str, Any] | None:
         "proof_url": f"/proofs/{proof.hash}",
         "bounty_id": proof.bounty_id,
         "bounty_url": _bounty_detail_url(proof.bounty_id),
-        "created_at": entry.created_at.isoformat(),
+        "created_at": public_utc_timestamp(entry.created_at),
     }
 
 
@@ -680,7 +680,7 @@ def accepted_work_for_account(session: Session, account: str) -> list[dict[str, 
                 "bounty_id": proof.bounty_id,
                 "bounty_url": _bounty_detail_url(proof.bounty_id),
                 "accepted_by": data.get("accepted_by"),
-                "created_at": entry.created_at.isoformat(),
+                "created_at": public_utc_timestamp(entry.created_at),
             }
         )
     return accepted_work

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -186,6 +186,7 @@ def test_account_routes_expose_pending_payouts_separately_from_paid_work(
     assert account_api["pending_summary"]["next_executes_after"].endswith("Z")
     assert len(accepted_api["accepted_work"]) == 1
     assert accepted_api["accepted_work"][0]["proof_hash"] == proof.hash
+    assert accepted_api["accepted_work"][0]["created_at"].endswith("Z")
     assert "Pending payouts" in page
     assert "Accepted work queued for treasury execution, not proof-backed paid work." in page
     assert f'href="/api/v1/treasury/proposals/{proposal.id}"' in page

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -115,6 +115,7 @@ def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -
     assert payload["recent"][0]["bounty_issue_number"] == 11
     assert payload["recent"][0]["bounty_id"] == second_bounty.id
     assert payload["recent"][0]["bounty_url"] == f"/bounties/{second_bounty.id}"
+    assert payload["recent"][0]["created_at"].endswith("Z")
     assert all("unproved" not in row["submission_url"] for row in payload["recent"])
 
 

--- a/tests/test_ledger_views.py
+++ b/tests/test_ledger_views.py
@@ -39,8 +39,10 @@ def test_recent_ledger_entries_attach_payment_proof_hash(sqlite_url: str) -> Non
     payment_rows = [row for row in rows if row["sequence"] == proof.ledger_sequence]
     assert len(payment_rows) == 1
     assert payment_rows[0]["proof_hash"] == proof.hash
+    assert payment_rows[0]["created_at"].endswith("Z")
     assert detail is not None
     assert detail["proof_hash"] == proof.hash
+    assert detail["created_at"].endswith("Z")
     assert missing is None
 
 


### PR DESCRIPTION
/claim #655

## Summary
- Reuse `public_utc_timestamp()` for proof-backed ledger entry `created_at` serialization.
- Apply the same UTC-explicit `Z` timestamp format to activity `recent` rows and account accepted-work rows.
- Add focused regression assertions for ledger list/detail, activity API, and accepted-work API surfaces.

## Evidence
- Live report: https://github.com/ramimbo/mergework/issues/656#issuecomment-4592023877
- Bounty reference: MRWK bounty issue #655, 150 MRWK focused small-fix bounty.
- Current live inconsistency: `/api/v1/bounties/98` emits bounty and accepted-award timestamps with `Z`, while `/api/v1/ledger/1068`, `/api/v1/activity?q=github:jorel97`, and `/api/v1/accounts/github:jorel97/accepted-work` emit naive `created_at` strings for proof-backed accepted work.

## Intended scope
- Files/surfaces: `app/serializers.py`, ledger view tests, activity API tests, account accepted-work tests.
- Expected PR size: small public serialization consistency fix with focused regression coverage.
- Out of scope: payout execution, treasury proposals, ledger mutation, wallet keys, transfers, proof contents, exchange/bridge/cash-out behavior, and price claims.

## Validation
```text
..\mergework\.venv\Scripts\python.exe -m pytest tests/test_activity.py tests/test_account_routes.py tests/test_ledger_views.py -q
14 passed, 1 warning in 2.62s

..\mergework\.venv\Scripts\python.exe -m pytest tests/test_ledger_views.py tests/test_activity.py::test_activity_api_summarizes_proof_backed_bounty_payments tests/test_account_routes.py::test_account_routes_expose_pending_payouts_separately_from_paid_work -q
4 passed, 1 warning in 1.25s

..\mergework\.venv\Scripts\python.exe -m ruff check app/serializers.py tests/test_ledger_views.py tests/test_activity.py tests/test_account_routes.py
All checks passed!

..\mergework\.venv\Scripts\python.exe -m ruff format --check app/serializers.py tests/test_ledger_views.py tests/test_activity.py tests/test_account_routes.py
4 files already formatted

..\mergework\.venv\Scripts\python.exe -m mypy app/serializers.py
Success: no issues found in 1 source file

git diff --check
# pass
```

## Safety
This only changes public timestamp serialization for already-public proof-backed accepted-work rows. No private data, secrets, wallet material, payout execution, ledger entries, transfers, exchange, bridge, cash-out, or price behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timestamps in ledger entries, activity rows, and accepted-work records now consistently display in UTC timezone format (ISO-8601 with Z suffix).

* **Tests**
  * Added test assertions to verify UTC timestamp formatting across activity, ledger, and account API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->