### PR TITLE
fix: bound bounty issue number filters

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -27,7 +27,7 @@ from app.ledger.service import (
     validate_public_url,
 )
 from app.models import Bounty, Proof, Submission
-from app.path_params import issue_number_search_value, positive_bounty_id
+from app.path_params import SQLITE_INTEGER_MAX, issue_number_search_value, positive_bounty_id
 from app.serializers import (
     bounties_to_dict,
     bounty_awards_to_dict,
@@ -185,7 +185,7 @@ def register_bounty_api_routes(
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
         sort: str | None = Query(None),
         repo: str | None = Query(None),
-        issue_number: Annotated[int | None, Query(ge=1)] = None,
+        issue_number: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
         availability: str | None = Query(None),
     ) -> list[dict[str, Any]]:
         return _list_bounties_by_status(
@@ -205,7 +205,7 @@ def register_bounty_api_routes(
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
         sort: str | None = Query(None),
         repo: str | None = Query(None),
-        issue_number: Annotated[int | None, Query(ge=1)] = None,
+        issue_number: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
         availability: str | None = Query(None),
     ) -> dict[str, Any]:
         return bounty_list_summary(

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
+from app.path_params import SQLITE_INTEGER_MAX
 from app.treasury import propose_treasury_action
 
 
@@ -408,6 +409,27 @@ def test_bounty_api_limit_rejects_out_of_range_values(sqlite_url: str) -> None:
     assert client.get("/api/v1/bounties?limit=201").status_code == 422
     assert client.get("/api/v1/bounties/summary?limit=0").status_code == 422
     assert client.get("/api/v1/bounties/summary?limit=201").status_code == 422
+
+
+def test_bounty_api_issue_number_rejects_sqlite_overflow_values(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    oversized_issue_number = SQLITE_INTEGER_MAX + 1
+
+    bounties = client.get(f"/api/v1/bounties?issue_number={oversized_issue_number}")
+    summary = client.get(f"/api/v1/bounties/summary?issue_number={oversized_issue_number}")
+
+    assert bounties.status_code == 422
+    assert summary.status_code == 422
+
+    at_limit_bounties = client.get(f"/api/v1/bounties?issue_number={SQLITE_INTEGER_MAX}")
+    at_limit_summary = client.get(f"/api/v1/bounties/summary?issue_number={SQLITE_INTEGER_MAX}")
+
+    assert at_limit_bounties.status_code == 200
+    assert at_limit_summary.status_code == 200
 
 
 def test_bounty_api_filters_by_exact_repo_and_issue_number(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #655
Source live report / verification bounty: #656

## Summary
- Adds the same SQLite integer upper bound to the public bounty issue_number query filter that path/query helpers already use elsewhere.
- Applies the bound to both /api/v1/bounties and /api/v1/bounties/summary so oversized issue-number filters fail validation instead of reaching the database.
- Adds regression coverage for an oversized issue_number on both endpoints.

## Live report
Read-only reproduction against live MRWK on 2026-06-01 UTC:

Command checked both endpoints with issue_number=999999999999999999999999999999999999999999999999.

Observed:
- /api/v1/bounties?issue_number=<oversized> -> 500 Internal Server Error
- /api/v1/bounties/summary?issue_number=<oversized> -> 500 Internal Server Error

Expected: malformed/out-of-range public filters should return bounded validation errors, like limit does, and should not surface as 500s.

## Validation
- PYTHONPATH=. .venv/bin/python -m pytest tests/test_bounty_api_routes.py -q -> 11 passed, 1 warning
- .venv/bin/python -m ruff check app/bounty_api.py tests/test_bounty_api_routes.py -> passed
- .venv/bin/python -m ruff format --check app/bounty_api.py tests/test_bounty_api_routes.py -> 2 files already formatted
- git diff --check -> clean

## Safety
Read-only public API validation only. No private data, credentials, wallet material, payout execution, ledger mutation, transfer, exchange/bridge/cash-out behavior, or price claims.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for issue number parameters in bounty API endpoints to reject integer overflow/out-of-range values.

* **Tests**
  * Added tests to verify boundary behavior and ensure endpoints accept maximum allowed values but reject values that overflow the database integer limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->