### PR TITLE
Bound public bounty issue-number filter

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -16,7 +16,7 @@ from app.bounty_sorting import BOUNTY_SORT_LABELS, normalize_bounty_sort
 from app.db import session_scope
 from app.ledger_views import account_ledger_transaction_types, account_ledger_transactions
 from app.models import Wallet
-from app.path_params import proof_hash_from_path
+from app.path_params import SQLITE_INTEGER_MAX, proof_hash_from_path
 from app.serializers import bounty_list_summary, wallet_to_dict
 from app.status import (
     CURRENT_TRANSFER_PATHS,
@@ -249,7 +249,7 @@ def register_public_routes(
         sort: str | None = Query(None),
         limit: int | None = Query(None, ge=1, le=200),
         repo: str | None = Query(None),
-        issue_number: int | None = Query(None, ge=1),
+        issue_number: int | None = Query(None, ge=1, le=SQLITE_INTEGER_MAX),
         availability: str | None = Query(None),
     ) -> HTMLResponse:
         bounties = list_bounties_by_status(status, q, sort, limit, repo, issue_number, availability)

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -8,6 +8,7 @@ from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
 from app.models import LedgerEntry, Proof
+from app.path_params import SQLITE_INTEGER_MAX
 from app.treasury import propose_treasury_action
 
 
@@ -293,6 +294,20 @@ def test_bounties_page_honors_limit_filter(sqlite_url: str) -> None:
 
     too_large_limit = client.get("/bounties?limit=201")
     assert too_large_limit.status_code == 422
+
+
+def test_bounties_page_rejects_sqlite_overflow_issue_number(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    max_issue_number = client.get(f"/bounties?issue_number={SQLITE_INTEGER_MAX}")
+    oversized_issue_number = client.get(f"/bounties?issue_number={SQLITE_INTEGER_MAX + 1}")
+
+    assert max_issue_number.status_code == 200
+    assert oversized_issue_number.status_code == 422
 
 
 def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary

Bounty #655
Source live report / verification bounty: #656

This PR fixes a public HTML bounty-page validation gap: `/bounties?issue_number=<oversized integer>` currently returns HTTP 500 because the page route validates `issue_number >= 1` but does not cap the value before it reaches the SQLite-backed bounty filtering path.

- Bounds the `/bounties` page `issue_number` query parameter with the shared `SQLITE_INTEGER_MAX` limit.
- Keeps `issue_number=SQLITE_INTEGER_MAX` valid while rejecting `SQLITE_INTEGER_MAX + 1` with FastAPI validation.
- Adds focused regression coverage for the public HTML route.

## Live report

Reported on #656: https://github.com/ramimbo/mergework/issues/656#issuecomment-4592450978

Read-only live reproduction on 2026-06-01 UTC:

```text
500 https://mrwk.online/bounties?issue_number=999999999999999999999999999999999999999999999999
422 https://mrwk.online/bounties?issue_number=0
```

This is distinct from the API-only oversized issue-number report/fix for `/api/v1/bounties`; this PR covers the public HTML `/bounties` route and its own query parameter declaration.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/Scripts/python -m pytest tests/test_bounty_pages.py::test_bounties_page_rejects_sqlite_overflow_issue_number tests/test_bounty_pages.py::test_bounties_page_and_api_search_by_text_and_issue_number -q` -> 2 passed, 1 warning
- `.venv/Scripts/python -m pytest tests/test_bounty_pages.py -q` -> 17 passed, 1 warning
- `.venv/Scripts/ruff.exe check app/public_routes.py tests/test_bounty_pages.py` -> passed
- `.venv/Scripts/ruff.exe format --check app/public_routes.py tests/test_bounty_pages.py` -> 2 files already formatted
- `.venv/Scripts/python.exe scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `69cf2a295f205d761797170b4deaa4cbc3e21f15`

## Safety

Public page query validation only. No private data, credentials, wallet material, signatures, transfers, proposal execution, ledger mutation, payout execution, exchange, bridge, cash-out behavior, price claims, or private vulnerability details changed or used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for issue numbers on the bounties page to prevent edge-case errors.

* **Tests**
  * Added test coverage for bounties page validation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->