### PR TITLE
Bound bounty attempts list limit

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -10,6 +10,7 @@ from sqlalchemy import func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import CONTROL_CHAR_RE, LedgerError, validate_public_url
 from app.models import Bounty, BountyAttempt
@@ -36,6 +37,15 @@ def _as_utc(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value.replace(tzinfo=UTC)
     return value.astimezone(UTC)
+
+
+def _reject_control_char_query_param(request: Request, name: str) -> None:
+    for value in request.query_params.getlist(name):
+        if contains_control_character(value):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} must not contain control characters",
+            )
 
 
 def _attempt_effective_status(attempt: BountyAttempt, now: datetime) -> str:
@@ -153,10 +163,12 @@ def register_bounty_attempt_routes(
 
     @app.get("/api/v1/bounties/{bounty_id}/attempts")
     def api_bounty_attempts(
+        request: Request,
         bounty_id: int,
         include_expired: bool = Query(False),
         limit: Annotated[int | None, Query(ge=1, le=100)] = None,
     ) -> dict[str, Any]:
+        _reject_control_char_query_param(request, "limit")
         bounty_id = positive_bounty_id(bounty_id)
         now = _utc_now()
         with session_scope(db_url) as session:

--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
@@ -152,7 +152,11 @@ def register_bounty_attempt_routes(
         return submitter_account
 
     @app.get("/api/v1/bounties/{bounty_id}/attempts")
-    def api_bounty_attempts(bounty_id: int, include_expired: bool = Query(False)) -> dict[str, Any]:
+    def api_bounty_attempts(
+        bounty_id: int,
+        include_expired: bool = Query(False),
+        limit: Annotated[int | None, Query(ge=1, le=100)] = None,
+    ) -> dict[str, Any]:
         bounty_id = positive_bounty_id(bounty_id)
         now = _utc_now()
         with session_scope(db_url) as session:
@@ -160,7 +164,7 @@ def register_bounty_attempt_routes(
             if bounty is None:
                 raise HTTPException(status_code=404, detail="bounty not found")
             listing = list_bounty_attempts(
-                session, bounty, include_expired=include_expired, now=now
+                session, bounty, include_expired=include_expired, limit=limit, now=now
             )
             return {
                 "bounty_id": bounty_id,

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -180,7 +180,7 @@ work.
 List active attempts for a bounty:
 
 ```bash
-curl -s "$API_HOST/api/v1/bounties/<bounty_id>/attempts"
+curl -s "$API_HOST/api/v1/bounties/<bounty_id>/attempts?limit=25"
 ```
 
 The list response returns the bounty id, advisory warnings, and active attempt reservations:

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -108,6 +108,15 @@ def test_bounty_attempts_register_list_duplicate_and_release(sqlite_url: str, mo
         "github:alice",
     ]
 
+    limited = client.get(f"/api/v1/bounties/{bounty.id}/attempts?limit=1")
+    assert limited.status_code == 200
+    assert [attempt["submitter_account"] for attempt in limited.json()["attempts"]] == [
+        "github:bob"
+    ]
+
+    assert client.get(f"/api/v1/bounties/{bounty.id}/attempts?limit=0").status_code == 422
+    assert client.get(f"/api/v1/bounties/{bounty.id}/attempts?limit=101").status_code == 422
+
     wrong_submitter = client.post(
         f"/api/v1/bounty-attempts/{first_attempt['id']}/release",
         json={"submitter_account": "github:bob"},

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -116,6 +116,9 @@ def test_bounty_attempts_register_list_duplicate_and_release(sqlite_url: str, mo
 
     assert client.get(f"/api/v1/bounties/{bounty.id}/attempts?limit=0").status_code == 422
     assert client.get(f"/api/v1/bounties/{bounty.id}/attempts?limit=101").status_code == 422
+    control_padded_limit = client.get(f"/api/v1/bounties/{bounty.id}/attempts?limit=%C2%851")
+    assert control_padded_limit.status_code == 400
+    assert control_padded_limit.json()["detail"] == "limit must not contain control characters"
 
     wrong_submitter = client.post(
         f"/api/v1/bounty-attempts/{first_attempt['id']}/release",


### PR DESCRIPTION
﻿## Summary

Bounty #655
Refs #656

- Adds a bounded `limit` query parameter to `GET /api/v1/bounties/{bounty_id}/attempts`.
- Applies the existing `list_bounty_attempts()` limit path to the public HTTP endpoint.
- Documents the bounded attempts-list call in the public API examples.

## Evidence

- Live bug report: https://github.com/ramimbo/mergework/issues/656#issuecomment-4592752455
- Confusion, missing step, stale example, or bug this addresses: the live attempts endpoint silently accepts ignored `limit` values, including oversized integers, while related public list endpoints reject invalid limits.
- Bounty capacity and active attempts/open PRs checked: Bounty #655 is open with effective awards available; the attempts endpoint for bounty #99 was checked read-only; open PRs were checked for overlap before this focused branch.
- Intended files or surfaces: `app/bounty_attempts.py`, `tests/test_bounty_attempts.py`, `docs/api-examples.md`.
- Expected PR size: small API validation/docs/test fix.
- Out of scope: payout execution, treasury mutation, wallet behavior, proof payloads, balances, exchange/bridge/cash-out behavior, or private data.

## Test Evidence

- [ ] `ruff format --check .`
- [ ] `ruff check .`
- [ ] `mypy app`
- [ ] `pytest`
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_bounty_attempts.py -q` -> 11 passed, 1 warning
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_docs_public_urls.py::test_api_examples_document_attempt_list_response_shape -q` -> 1 passed
- [x] `ruff check app/bounty_attempts.py tests/test_bounty_attempts.py docs/api-examples.md` -> passed
- [x] `ruff format --check app/bounty_attempts.py tests/test_bounty_attempts.py` -> passed
- [x] `python -m mypy app/bounty_attempts.py` -> passed
- [x] `python scripts/docs_smoke.py` -> docs smoke ok
- [x] `git diff --check` -> passed
- [x] `git merge-tree --write-tree origin/main HEAD` -> clean tree `69cf2a295f205d761797170b4deaa4cbc3e21f15`

## MRWK

Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties): Bounty #655, Refs #656

Claim-window check for MRWK bounty work:

- [x] GitHub issue has the `mrwk:bounty` label.
- [x] GitHub issue has the `Reserved on MergeWork` claims-open comment.
- [x] Public bounty API row is `open`.
- [x] Awards remain after checking accepted, pending, or paid work.
- [x] Active attempts and open PRs do not already cover this exact scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Listing for bounty attempts accepts an optional `limit` query parameter (1–100) to control result count.

* **Bug Fixes**
  * Requests with control characters in `limit` are now rejected with a clear error.

* **Documentation**
  * API examples updated to show `limit` usage.

* **Tests**
  * Added/updated tests covering valid limits, out-of-range rejections, and control-character rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->