### PR TITLE
fix: reject control-padded numeric queries

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -191,6 +191,7 @@ def register_bounty_api_routes(
         availability: str | None = Query(None),
     ) -> list[dict[str, Any]]:
         reject_control_char_query_param(request, "limit")
+        reject_control_char_query_param(request, "issue_number")
         return _list_bounties_by_status(
             status,
             q,
@@ -213,6 +214,7 @@ def register_bounty_api_routes(
         availability: str | None = Query(None),
     ) -> dict[str, Any]:
         reject_control_char_query_param(request, "limit")
+        reject_control_char_query_param(request, "issue_number")
         return bounty_list_summary(
             _list_bounties_by_status(
                 status,

--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -28,6 +28,7 @@ from app.ledger.service import (
 )
 from app.models import Bounty, Proof, Submission
 from app.path_params import issue_number_search_value, positive_bounty_id
+from app.query_validation import reject_control_char_query_param
 from app.serializers import (
     bounties_to_dict,
     bounty_awards_to_dict,
@@ -180,6 +181,7 @@ def register_bounty_api_routes(
 
     @app.get("/api/v1/bounties")
     def api_bounties(
+        request: Request,
         status: str | None = Query(None),
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
@@ -188,6 +190,7 @@ def register_bounty_api_routes(
         issue_number: Annotated[int | None, Query(ge=1)] = None,
         availability: str | None = Query(None),
     ) -> list[dict[str, Any]]:
+        reject_control_char_query_param(request, "limit")
         return _list_bounties_by_status(
             status,
             q,
@@ -200,6 +203,7 @@ def register_bounty_api_routes(
 
     @app.get("/api/v1/bounties/summary")
     def api_bounties_summary(
+        request: Request,
         status: str | None = Query(None),
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
@@ -208,6 +212,7 @@ def register_bounty_api_routes(
         issue_number: Annotated[int | None, Query(ge=1)] = None,
         availability: str | None = Query(None),
     ) -> dict[str, Any]:
+        reject_control_char_query_param(request, "limit")
         return bounty_list_summary(
             _list_bounties_by_status(
                 status,

--- a/app/main.py
+++ b/app/main.py
@@ -37,6 +37,7 @@ from app.path_params import (
     proof_hash_from_path,
 )
 from app.public_routes import register_public_routes
+from app.query_validation import reject_control_char_query_param
 from app.status import health_status, system_status
 from app.treasury_routes import register_treasury_routes
 from app.wallet_api import register_wallet_api_routes
@@ -305,10 +306,17 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         post_only_route=post_only_route,
     )
 
-    @app.get("/api/v1/ledger")
-    def api_ledger(limit: Annotated[int, Query(ge=1, le=200)] = 50) -> list[dict[str, Any]]:
+    def ledger_rows(limit: int = 50) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
             return recent_ledger_entries(session, limit)
+
+    @app.get("/api/v1/ledger")
+    def api_ledger(
+        request: Request,
+        limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    ) -> list[dict[str, Any]]:
+        reject_control_char_query_param(request, "limit")
+        return ledger_rows(limit)
 
     @app.get("/api/v1/ledger/{sequence}")
     def api_ledger_entry(sequence: int) -> dict[str, Any]:
@@ -376,7 +384,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         templates=templates,
         list_bounties_by_status=list_bounties_by_status,
         api_bounty=api_bounty,
-        api_ledger=api_ledger,
+        api_ledger=ledger_rows,
         api_ledger_entry=api_ledger_entry,
         api_proof=api_proof,
     )

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -254,6 +254,7 @@ def register_public_routes(
         availability: str | None = Query(None),
     ) -> HTMLResponse:
         reject_control_char_query_param(request, "limit")
+        reject_control_char_query_param(request, "issue_number")
         bounties = list_bounties_by_status(status, q, sort, limit, repo, issue_number, availability)
         return templates.TemplateResponse(
             request,

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -17,6 +17,7 @@ from app.db import session_scope
 from app.ledger_views import account_ledger_transaction_types, account_ledger_transactions
 from app.models import Wallet
 from app.path_params import proof_hash_from_path
+from app.query_validation import reject_control_char_query_param
 from app.serializers import bounty_list_summary, wallet_to_dict
 from app.status import (
     CURRENT_TRANSFER_PATHS,
@@ -252,6 +253,7 @@ def register_public_routes(
         issue_number: int | None = Query(None, ge=1),
         availability: str | None = Query(None),
     ) -> HTMLResponse:
+        reject_control_char_query_param(request, "limit")
         bounties = list_bounties_by_status(status, q, sort, limit, repo, issue_number, availability)
         return templates.TemplateResponse(
             request,

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from fastapi import HTTPException, Request
+
+from app.control_chars import contains_control_character
+
+
+def reject_control_char_query_param(request: Request, name: str) -> None:
+    """Reject raw control characters before FastAPI coerces query values."""
+    for value in request.query_params.getlist(name):
+        if contains_control_character(value):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} must not contain control characters",
+            )

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -13,6 +13,7 @@ from app.ledger.service import LedgerError
 from app.models import TreasuryProposal
 from app.openapi_request_bodies import TREASURY_CHALLENGE_BODY, TREASURY_PROPOSAL_BODY
 from app.path_params import SQLITE_INTEGER_MAX
+from app.query_validation import reject_control_char_query_param
 from app.treasury import (
     TREASURY_ACTIONS,
     challenge_to_dict,
@@ -116,12 +117,14 @@ def register_treasury_routes(
 ) -> None:
     @app.get("/api/v1/treasury/proposals")
     def api_treasury_proposals(
+        request: Request,
         limit: Annotated[int, Query(ge=1, le=200)] = 100,
         action: Annotated[str | None, Query(max_length=40)] = None,
         status: Annotated[str | None, Query(max_length=40)] = None,
         to_account: Annotated[str | None, Query(max_length=128)] = None,
         bounty_id: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
     ) -> list[dict[str, Any]]:
+        reject_control_char_query_param(request, "limit")
         action_filter = _optional_query_filter(
             action,
             "action",

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -125,6 +125,7 @@ def register_treasury_routes(
         bounty_id: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
     ) -> list[dict[str, Any]]:
         reject_control_char_query_param(request, "limit")
+        reject_control_char_query_param(request, "bounty_id")
         action_filter = _optional_query_filter(
             action,
             "action",

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -52,6 +52,19 @@ def test_ledger_api_rejects_out_of_range_limits(sqlite_url: str, limit: str) -> 
     assert response.status_code == 422
 
 
+def test_ledger_api_rejects_control_character_limit(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/api/v1/ledger?limit=%C2%8550")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "limit must not contain control characters"
+
+
 def test_head_requests_match_get_routes_without_body(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -409,6 +409,14 @@ def test_bounty_api_limit_rejects_out_of_range_values(sqlite_url: str) -> None:
     assert client.get("/api/v1/bounties/summary?limit=0").status_code == 422
     assert client.get("/api/v1/bounties/summary?limit=201").status_code == 422
 
+    controlled_list = client.get("/api/v1/bounties?limit=%C2%8550")
+    controlled_summary = client.get("/api/v1/bounties/summary?limit=50%C2%85")
+
+    assert controlled_list.status_code == 400
+    assert controlled_list.json()["detail"] == "limit must not contain control characters"
+    assert controlled_summary.status_code == 400
+    assert controlled_summary.json()["detail"] == "limit must not contain control characters"
+
 
 def test_bounty_api_filters_by_exact_repo_and_issue_number(sqlite_url: str) -> None:
     create_schema(sqlite_url)

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -458,6 +458,8 @@ def test_bounty_api_filters_by_exact_repo_and_issue_number(sqlite_url: str) -> N
     by_issue = client.get("/api/v1/bounties?issue_number=649")
     summary = client.get("/api/v1/bounties/summary?repo=ramimbo%2Fmergework")
     composed = client.get("/api/v1/bounties?repo=ramimbo%2Fmergework&q=proposed-work")
+    controlled_issue = client.get("/api/v1/bounties?issue_number=%C2%85649")
+    controlled_summary_issue = client.get("/api/v1/bounties/summary?issue_number=649%C2%85")
 
     assert [row["id"] for row in by_repo.json()] == [other_mergework.id, mergework_649.id]
     assert [row["id"] for row in exact.json()] == [mergework_649.id]
@@ -472,3 +474,10 @@ def test_bounty_api_filters_by_exact_repo_and_issue_number(sqlite_url: str) -> N
     invalid_repo = client.get("/api/v1/bounties?repo=ramimbo%C2%85mergework")
     assert invalid_repo.status_code == 400
     assert invalid_repo.json()["detail"] == "repo must not contain control characters"
+    assert controlled_issue.status_code == 400
+    assert controlled_issue.json()["detail"] == "issue_number must not contain control characters"
+    assert controlled_summary_issue.status_code == 400
+    assert (
+        controlled_summary_issue.json()["detail"]
+        == "issue_number must not contain control characters"
+    )

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -294,6 +294,10 @@ def test_bounties_page_honors_limit_filter(sqlite_url: str) -> None:
     too_large_limit = client.get("/bounties?limit=201")
     assert too_large_limit.status_code == 422
 
+    controlled_limit = client.get("/bounties?limit=%C2%8550")
+    assert controlled_limit.status_code == 400
+    assert controlled_limit.json()["detail"] == "limit must not contain control characters"
+
 
 def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) -> None:
     create_schema(sqlite_url)

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -391,6 +391,9 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     assert [row["issue_number"] for row in underscore_search.json()] == [66]
 
     source_filter_page = client.get("/bounties?repo=ramimbo%2Fmergework&issue_number=64")
+    controlled_source_filter_page = client.get(
+        "/bounties?repo=ramimbo%2Fmergework&issue_number=%C2%8564"
+    )
     assert source_filter_page.status_code == 200
     assert "Source filter: ramimbo/mergework #64." in source_filter_page.text
     assert "Improve public bounty discovery" in source_filter_page.text
@@ -411,6 +414,11 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     backslash_search = client.get("/api/v1/bounties", params={"q": "\\"})
     assert backslash_search.status_code == 200
     assert [row["issue_number"] for row in backslash_search.json()] == [66]
+    assert controlled_source_filter_page.status_code == 400
+    assert (
+        controlled_source_filter_page.json()["detail"]
+        == "issue_number must not contain control characters"
+    )
 
 
 def test_bounties_page_and_api_sort_public_rows(sqlite_url: str) -> None:

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -409,12 +409,15 @@ def test_treasury_proposals_list_honors_limit(
     limited = client.get("/api/v1/treasury/proposals?limit=1")
     too_small = client.get("/api/v1/treasury/proposals?limit=0")
     too_large = client.get("/api/v1/treasury/proposals?limit=201")
+    controlled_limit = client.get("/api/v1/treasury/proposals?limit=%C2%8550")
 
     assert limited.status_code == 200
     assert [proposal["id"] for proposal in limited.json()] == [second["id"]]
     assert first["id"] not in [proposal["id"] for proposal in limited.json()]
     assert too_small.status_code == 422
     assert too_large.status_code == 422
+    assert controlled_limit.status_code == 400
+    assert controlled_limit.json()["detail"] == "limit must not contain control characters"
 
 
 def test_treasury_proposals_list_filters_by_recipient_before_limit(

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -607,6 +607,7 @@ def test_treasury_proposals_list_filters_by_action_status_and_bounty_id(
     ("field", "value", "expected_detail"),
     (
         ("action", "\tpay_bounty", "action must not contain control characters"),
+        ("bounty_id", "\x8599", "bounty_id must not contain control characters"),
         ("status", " ", "status is required"),
         ("action", "paybounty", "action must be one of: close_bounty, create_bounty, pay_bounty"),
         ("status", "complete", "status must be one of: pending, executed, blocked"),


### PR DESCRIPTION
## Summary

Bounty #655
Source report: https://github.com/ramimbo/mergework/issues/656#issuecomment-4592773607

This PR rejects raw C0/C1 control characters in public numeric `limit` query parameters before FastAPI/Pydantic coerces them to integers.

## Root cause

Some public `limit` parameters are declared as `int` with FastAPI bounds. A raw query value such as `%C2%8550` is decoded with a C1 control/whitespace prefix and then coerced to `50`, so the request silently succeeds instead of failing closed.

Live examples observed before this fix:

- `https://api.mrwk.online/api/v1/ledger?limit=%C2%8550` returned `200`
- `https://api.mrwk.online/api/v1/bounties?limit=%C2%8550` returned `200`
- `https://api.mrwk.online/api/v1/bounties/summary?limit=%C2%8550` returned `200`
- `https://api.mrwk.online/api/v1/treasury/proposals?limit=%C2%8550` returned `200`
- `https://api.mrwk.online/bounties?limit=%C2%8550` returned `200`

## What changed

- Added `reject_control_char_query_param()` to validate raw query strings before integer coercion.
- Applied it to public `limit` parameters on:
  - `/api/v1/ledger`
  - `/api/v1/bounties`
  - `/api/v1/bounties/summary`
  - `/bounties`
  - `/api/v1/treasury/proposals`
- Kept the existing numeric range behavior unchanged for valid integers and out-of-range values.

## Verification

- `PYTHONPATH=. /Users/jonas/Documents/Playground 2/mergework/.venv/bin/python -m pytest tests/test_api_mcp.py tests/test_bounty_api_routes.py tests/test_bounty_pages.py tests/test_treasury_proposals.py -q` -> `157 passed, 1 warning`
- `/Users/jonas/Documents/Playground 2/mergework/.venv/bin/python -m ruff check app/query_validation.py app/main.py app/bounty_api.py app/public_routes.py app/treasury_routes.py tests/test_api_mcp.py tests/test_bounty_api_routes.py tests/test_bounty_pages.py tests/test_treasury_proposals.py` -> passed
- `/Users/jonas/Documents/Playground 2/mergework/.venv/bin/python -m ruff format --check app/query_validation.py app/main.py app/bounty_api.py app/public_routes.py app/treasury_routes.py tests/test_api_mcp.py tests/test_bounty_api_routes.py tests/test_bounty_pages.py tests/test_treasury_proposals.py` -> passed
- `git diff --check` -> clean

## Out of scope

No auth, payments, treasury mutation, wallet signing, exchange/liquidity, or deployment changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API endpoints and public pages now reject query parameters containing control characters (e.g., limit, issue_number, bounty_id), returning HTTP 400 with a clear validation error.

* **Tests**
  * Added/updated tests to cover control-character validation across bounties, ledger, treasury proposals, and related pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->