### PR TITLE
Reject control-padded treasury bounty ids

### DIFF
--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -71,6 +71,14 @@ def _optional_query_filter(
     return clean
 
 
+def _reject_control_char_query_param(request: Request, field: str) -> None:
+    for value in request.query_params.getlist(field):
+        if contains_control_character(value):
+            raise HTTPException(
+                status_code=400, detail=f"{field} must not contain control characters"
+            )
+
+
 def _proposal_payload_object(proposal: TreasuryProposal) -> dict[str, Any] | None:
     try:
         payload = json.loads(proposal.payload_json)
@@ -116,12 +124,14 @@ def register_treasury_routes(
 ) -> None:
     @app.get("/api/v1/treasury/proposals")
     def api_treasury_proposals(
+        request: Request,
         limit: Annotated[int, Query(ge=1, le=200)] = 100,
         action: Annotated[str | None, Query(max_length=40)] = None,
         status: Annotated[str | None, Query(max_length=40)] = None,
         to_account: Annotated[str | None, Query(max_length=128)] = None,
         bounty_id: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
     ) -> list[dict[str, Any]]:
+        _reject_control_char_query_param(request, "bounty_id")
         action_filter = _optional_query_filter(
             action,
             "action",

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -568,6 +568,9 @@ def test_treasury_proposals_list_filters_by_action_status_and_bounty_id(
     pending_filtered = client.get("/api/v1/treasury/proposals?status=pending")
     uppercase_pending_filtered = client.get("/api/v1/treasury/proposals?status=PENDING")
     bounty_filtered = client.get(f"/api/v1/treasury/proposals?bounty_id={first_bounty_id}")
+    control_padded_bounty_filter = client.get(
+        f"/api/v1/treasury/proposals?bounty_id=%C2%85{first_bounty_id}"
+    )
     composed_filtered = client.get(
         "/api/v1/treasury/proposals",
         params={
@@ -594,6 +597,11 @@ def test_treasury_proposals_list_filters_by_action_status_and_bounty_id(
     assert uppercase_pending_filtered.json() == pending_filtered.json()
     assert bounty_filtered.status_code == 200
     assert [proposal["id"] for proposal in bounty_filtered.json()] == [first_payout["id"]]
+    assert control_padded_bounty_filter.status_code == 400
+    assert (
+        control_padded_bounty_filter.json()["detail"]
+        == "bounty_id must not contain control characters"
+    )
     assert composed_filtered.status_code == 200
     assert [proposal["id"] for proposal in composed_filtered.json()] == [second_payout["id"]]
     assert limited_after_filter.status_code == 200


### PR DESCRIPTION
## Summary

Bounty #655
Refs #656

- Rejects raw control characters in the `/api/v1/treasury/proposals` `bounty_id` query parameter before FastAPI/Pydantic integer coercion.
- Keeps clean numeric `bounty_id` filtering and existing oversized-integer validation behavior unchanged.
- Adds regression coverage that `bounty_id=%C2%85<id>` returns `400` with `bounty_id must not contain control characters`.

## Evidence

- Live bug report: https://github.com/ramimbo/mergework/issues/656#issuecomment-4593045610
- Confusion, missing step, stale example, or bug this addresses: sibling treasury filters (`action`, `status`, `to_account`) already reject raw control characters, but `bounty_id=%C2%8597` is accepted and applied as clean bounty id `97`.
- Bounty capacity and active attempts/open PRs checked: Bounty #655 is open with 7 effective awards available; duplicate searches for `treasury proposals bounty_id control` found no matching existing issue/PR.
- Intended files or surfaces: `app/treasury_routes.py`, `tests/test_treasury_proposals.py`.
- Expected PR size: small public API validation/test fix.
- Out of scope: proposal creation, proposal execution, payout execution, ledger mutation, wallet behavior, proof payloads, balances, exchange/bridge/cash-out behavior, or private data.

## Test Evidence

- [ ] `ruff format --check .`
- [ ] `ruff check .`
- [ ] `mypy app`
- [ ] `pytest`
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests\test_treasury_proposals.py::test_treasury_proposals_list_filters_by_action_status_and_bounty_id -q` -> 1 passed, 1 warning
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .\.venv\Scripts\python.exe -m pytest tests\test_treasury_proposals.py -q` -> 46 passed, 1 warning
- [x] `.\.venv\Scripts\python.exe -m ruff check app\treasury_routes.py tests\test_treasury_proposals.py` -> passed
- [x] `.\.venv\Scripts\python.exe -m ruff format --check app\treasury_routes.py tests\test_treasury_proposals.py` -> 2 files already formatted
- [x] `.\.venv\Scripts\python.exe -m mypy app\treasury_routes.py` -> success
- [x] `git diff --check` -> clean

## MRWK

Related bounty or issue (`Bounty #N` or `Refs #N` for multi-award bounties): Bounty #655, Refs #656

Claim-window check for MRWK bounty work:

- [x] GitHub issue has the `mrwk:bounty` label.
- [x] GitHub issue has the `Reserved on MergeWork` claims-open comment.
- [x] Public bounty API row is `open`.
- [x] Awards remain after checking accepted, pending, or paid work.
- [x] Active attempts and open PRs do not already cover this exact scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The treasury proposals endpoint now validates the `bounty_id` query parameter and rejects requests containing control characters with a 400 error response.

* **Tests**
  * Added test coverage for query parameter validation against control characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->