### PR TITLE
Add proposed-work intake triage report

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -282,6 +282,28 @@ post comments. It reports missing bounty references, closed or exhausted bounty
 references, dirty or unknown merge state, `mrwk:needs-info`, and likely duplicate
 PR scope within the same bounty issue.
 
+### Proposed Work Triage
+
+Use the read-only proposed-work triage report when maintainers need to review
+the intake queue before creating, rejecting, or consolidating future bounties:
+
+```bash
+python scripts/proposed_work_triage.py --repo ramimbo/mergework --format markdown
+```
+
+For deterministic review or incident write-ups, use an offline fixture instead:
+
+```bash
+python scripts/proposed_work_triage.py --input proposed-work-fixture.json --format json
+```
+
+The report lists proposed-work issues, missing `proposed-work` labels, missing
+template sections, vague or rejected proposals, already-routed items, likely
+related groups, and #649 pending-versus-proof-backed payment status when that
+public data is present in the input or available from the public API. Use
+`--api-host` only for another public MergeWork API host. It does not label,
+comment, edit issues, create bounties, accept work, or pay claims.
+
 For reviewer-specific review-bounty preflight, generate a candidate report with
 the reviewer login:
 

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -331,16 +331,23 @@ def format_markdown(report: dict[str, Any]) -> str:
 
 
 def _run_gh(args: list[str]) -> Any:
-    result = subprocess.run(
-        ["gh", *args],
-        capture_output=True,
-        text=True,
-        timeout=GH_TIMEOUT_SECONDS,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=GH_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s") from exc
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or result.stdout.strip())
-    return json.loads(result.stdout)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        excerpt = result.stdout[:200].strip()
+        raise RuntimeError(f"gh returned invalid JSON: {excerpt}") from exc
 
 
 def _gh_issue_search(repo: str, query: str, limit: int) -> list[dict[str, Any]]:

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+REQUIRED_TEMPLATE_SECTIONS = {
+    "problem": ("problem", "current problem"),
+    "evidence": ("evidence", "current evidence"),
+    "proposed_work": ("proposed work", "proposal"),
+    "value": ("value", "expected value"),
+    "acceptance": ("acceptance", "acceptance criteria", "possible acceptance criteria"),
+    "tests": (
+        "tests",
+        "evidence or tests required",
+        "tests required",
+        "test notes",
+        "verification",
+    ),
+    "duplicate_search": ("duplicate search", "duplicates"),
+    "out_of_scope": ("out of scope",),
+}
+ROUTED_RE = re.compile(
+    r"\b(accepted by|accepted and|routed|created bounty|create_bounty|"
+    r"treasury proposal|reserved on mergework)\b",
+    re.IGNORECASE,
+)
+REJECTED_RE = re.compile(
+    r"\b(rejected|declined|not accepted|outside accepted scope)\b", re.IGNORECASE
+)
+NON_LIVE_CONFUSION_RE = re.compile(
+    r"(claimable now|already paid|guaranteed payout|cash[- ]?out|off[- ]?ramp)",
+    re.IGNORECASE,
+)
+WORD_RE = re.compile(r"[a-z0-9]+")
+STOPWORDS = {
+    "add",
+    "and",
+    "bounty",
+    "for",
+    "from",
+    "issue",
+    "mrwk",
+    "proposed",
+    "request",
+    "the",
+    "to",
+    "work",
+}
+GH_TIMEOUT_SECONDS = 30
+HTTP_TIMEOUT_SECONDS = 30
+DEFAULT_API_HOST = "https://api.mrwk.online"
+INTAKE_BOUNTY_ISSUE_NUMBER = 649
+LIVE_ISSUE_SEARCHES = (
+    "label:proposed-work",
+    '"proposed work"',
+)
+
+
+def _labels(raw: dict[str, Any]) -> list[str]:
+    labels = raw.get("labels", [])
+    names: list[str] = []
+    for label in labels:
+        if isinstance(label, str):
+            names.append(label)
+        elif isinstance(label, dict) and isinstance(label.get("name"), str):
+            names.append(label["name"])
+    return names
+
+
+def _comments(raw: dict[str, Any]) -> list[str]:
+    comments = raw.get("comments", [])
+    bodies: list[str] = []
+    for comment in comments:
+        if isinstance(comment, str):
+            bodies.append(comment)
+        elif isinstance(comment, dict) and isinstance(comment.get("body"), str):
+            bodies.append(comment["body"])
+    return bodies
+
+
+def _combined_text(issue: dict[str, Any]) -> str:
+    parts = [str(issue.get("title") or ""), str(issue.get("body") or "")]
+    parts.extend(_comments(issue))
+    return "\n".join(parts)
+
+
+def _has_section(body: str, aliases: tuple[str, ...]) -> bool:
+    lowered = body.lower()
+    for alias in aliases:
+        if re.search(rf"(^|\n)\s*#+\s*{re.escape(alias)}\b", lowered):
+            return True
+        if re.search(rf"(^|\n)\s*(?:-\s*)?\*\*{re.escape(alias)}\*\*", lowered):
+            return True
+    return False
+
+
+def _missing_sections(body: str) -> list[str]:
+    return [
+        key
+        for key, aliases in REQUIRED_TEMPLATE_SECTIONS.items()
+        if not _has_section(body, aliases)
+    ]
+
+
+def _token_set(issue: dict[str, Any]) -> set[str]:
+    text = str(issue.get("title") or "").lower()
+    return {word for word in WORD_RE.findall(text) if len(word) > 3 and word not in STOPWORDS}
+
+
+def _is_vague(body: str, missing_sections: list[str]) -> bool:
+    return len(body.split()) < 45 or len(missing_sections) >= 4
+
+
+def _has_non_live_confusion(text: str) -> bool:
+    for line in text.splitlines():
+        lowered = line.lower()
+        is_guardrail = (
+            "do not" in lowered or "don't" in lowered or lowered.lstrip().startswith("- no ")
+        )
+        if "/claim" in lowered and not is_guardrail:
+            return True
+        if NON_LIVE_CONFUSION_RE.search(lowered) and not is_guardrail:
+            return True
+    return False
+
+
+def _payment_index(data: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+    for item in data.get("payments", []):
+        if not isinstance(item, dict):
+            continue
+        submission_url = item.get("submission_url")
+        if isinstance(submission_url, str) and submission_url:
+            index[submission_url.rstrip("/")] = item
+    for bounty in data.get("bounties", []):
+        if not isinstance(bounty, dict):
+            continue
+        for proposal in bounty.get("pending_payout_proposals", []) or []:
+            if not isinstance(proposal, dict):
+                continue
+            submission_url = proposal.get("submission_url")
+            if isinstance(submission_url, str) and submission_url:
+                index[submission_url.rstrip("/")] = {
+                    "state": "pending",
+                    "source": "pending_payout_proposal",
+                    "proposal_id": proposal.get("proposal_id"),
+                    "accepted_by": proposal.get("accepted_by"),
+                    "executes_after": proposal.get("executes_after"),
+                }
+        awards: list[Any] = []
+        for award_key in ("awards", "accepted_awards"):
+            raw_awards = bounty.get(award_key) or []
+            if isinstance(raw_awards, list):
+                awards.extend(raw_awards)
+        for award in awards:
+            if not isinstance(award, dict):
+                continue
+            submission_url = award.get("submission_url")
+            if isinstance(submission_url, str) and submission_url:
+                index[submission_url.rstrip("/")] = {
+                    "state": "paid",
+                    "source": "proof_backed_award",
+                    "proof_url": award.get("proof_url"),
+                    "ledger_sequence": award.get("ledger_sequence"),
+                }
+    return index
+
+
+def _payment_status(issue: dict[str, Any], payments: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    issue_url = str(issue.get("url") or "").rstrip("/")
+    payment = payments.get(issue_url)
+    if payment:
+        return payment
+    for comment in _comments(issue):
+        for url in re.findall(r"https://github\.com/[^\s)]+", comment):
+            payment = payments.get(url.rstrip("/"))
+            if payment:
+                return payment
+    return {"state": "none"}
+
+
+def _normalize_issue(
+    raw: dict[str, Any], payments: dict[str, dict[str, Any]]
+) -> dict[str, Any] | None:
+    number = raw.get("number")
+    if not isinstance(number, int):
+        return None
+    body = str(raw.get("body") or "")
+    labels = _labels(raw)
+    missing = _missing_sections(body)
+    text = _combined_text(raw)
+    warnings: list[str] = []
+    if "proposed-work" not in {label.lower() for label in labels}:
+        warnings.append("missing_proposed_work_label")
+    if missing:
+        warnings.append("missing_template_sections")
+    if _is_vague(body, missing):
+        warnings.append("vague_or_under_specified")
+    if ROUTED_RE.search(text):
+        warnings.append("already_routed_or_accepted")
+    if REJECTED_RE.search(text):
+        warnings.append("rejected_or_out_of_scope")
+    if _has_non_live_confusion(text):
+        warnings.append("non_live_bounty_confusion")
+    payment = _payment_status(raw, payments)
+    if payment.get("state") == "pending":
+        warnings.append("accepted_pending_payout")
+    elif payment.get("state") == "paid":
+        warnings.append("proof_backed_paid")
+    return {
+        "number": number,
+        "title": str(raw.get("title") or ""),
+        "url": raw.get("url"),
+        "state": str(raw.get("state") or ""),
+        "labels": labels,
+        "missing_sections": missing,
+        "warnings": warnings,
+        "payment_status": payment,
+        "tokens": sorted(_token_set(raw)),
+    }
+
+
+def _related_groups(proposals: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: dict[tuple[str, ...], set[int]] = defaultdict(set)
+    for index, left in enumerate(proposals):
+        left_tokens = set(left["tokens"])
+        if len(left_tokens) < 3:
+            continue
+        for right in proposals[index + 1 :]:
+            right_tokens = set(right["tokens"])
+            common = left_tokens & right_tokens
+            if len(common) < 3:
+                continue
+            if len(common) / min(len(left_tokens), len(right_tokens)) < 0.6:
+                continue
+            grouped[tuple(sorted(common))].update({left["number"], right["number"]})
+    groups: list[dict[str, Any]] = []
+    for tokens, numbers in grouped.items():
+        if len(numbers) < 2:
+            continue
+        groups.append(
+            {
+                "issues": sorted(numbers),
+                "evidence_tokens": list(tokens),
+                "suggested_scope": " / ".join(tokens[:6]),
+            }
+        )
+    return sorted(groups, key=lambda item: (-len(item["issues"]), item["issues"]))
+
+
+def _mark_duplicate_warnings(
+    proposals: list[dict[str, Any]], related_groups: list[dict[str, Any]]
+) -> None:
+    grouped_numbers = {
+        number
+        for group in related_groups
+        for number in group.get("issues", [])
+        if isinstance(number, int)
+    }
+    for proposal in proposals:
+        if (
+            proposal["number"] in grouped_numbers
+            and "duplicate_looking_related_proposal" not in proposal["warnings"]
+        ):
+            proposal["warnings"].append("duplicate_looking_related_proposal")
+
+
+def analyze_proposed_work(data: dict[str, Any]) -> dict[str, Any]:
+    payments = _payment_index(data)
+    proposals = [
+        proposal
+        for raw in data.get("issues", [])
+        if isinstance(raw, dict)
+        for proposal in [_normalize_issue(raw, payments)]
+        if proposal is not None
+    ]
+    related_groups = _related_groups(proposals)
+    _mark_duplicate_warnings(proposals, related_groups)
+    warning_counts: dict[str, int] = defaultdict(int)
+    payment_counts: dict[str, int] = defaultdict(int)
+    for proposal in proposals:
+        payment_counts[str(proposal["payment_status"].get("state") or "none")] += 1
+        for warning in proposal["warnings"]:
+            warning_counts[warning] += 1
+    return {
+        "summary": {
+            "proposed_work_issues": len(proposals),
+            "warning_counts": dict(sorted(warning_counts.items())),
+            "payment_counts": dict(sorted(payment_counts.items())),
+            "related_groups": len(related_groups),
+        },
+        "proposals": proposals,
+        "related_groups": related_groups,
+    }
+
+
+def format_markdown(report: dict[str, Any]) -> str:
+    lines = ["# Proposed Work Triage", ""]
+    summary = report["summary"]
+    lines.append(f"- proposed work issues: {summary['proposed_work_issues']}")
+    lines.append(f"- related groups: {summary['related_groups']}")
+    for state, count in summary["payment_counts"].items():
+        lines.append(f"- {state} payment status: {count}")
+    lines.append("")
+    lines.append("## Issues")
+    for item in report["proposals"]:
+        warnings = ", ".join(item["warnings"]) if item["warnings"] else "none"
+        missing = ", ".join(item["missing_sections"]) if item["missing_sections"] else "none"
+        payment = item["payment_status"].get("state", "none")
+        lines.append(f"- #{item['number']} {item['title']} ({payment})")
+        lines.append(f"  - warnings: {warnings}")
+        lines.append(f"  - missing sections: {missing}")
+        if item.get("url"):
+            lines.append(f"  - url: {item['url']}")
+    if report["related_groups"]:
+        lines.append("")
+        lines.append("## Related Groups")
+        for group in report["related_groups"]:
+            issues = ", ".join(f"#{number}" for number in group["issues"])
+            evidence = ", ".join(group["evidence_tokens"])
+            lines.append(f"- {issues}: {group['suggested_scope']} ({evidence})")
+    return "\n".join(lines)
+
+
+def _run_gh(args: list[str]) -> Any:
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        timeout=GH_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip())
+    return json.loads(result.stdout)
+
+
+def _gh_issue_search(repo: str, query: str, limit: int) -> list[dict[str, Any]]:
+    return _run_gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "all",
+            "--limit",
+            str(limit),
+            "--search",
+            query,
+            "--json",
+            "number",
+        ]
+    )
+
+
+def _load_public_json(url: str) -> Any:
+    request = urllib.request.Request(url, headers={"User-Agent": "mergework-proposed-work-triage"})
+    with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+        return json.load(response)
+
+
+def _load_public_bounty_issue(api_host: str, issue_number: int) -> list[dict[str, Any]]:
+    query = urllib.parse.urlencode({"issue_number": str(issue_number), "limit": "5"})
+    try:
+        rows = _load_public_json(f"{api_host.rstrip('/')}/api/v1/bounties?{query}")
+    except (OSError, urllib.error.URLError, json.JSONDecodeError):
+        return []
+    bounties: list[dict[str, Any]] = []
+    for row in rows if isinstance(rows, list) else []:
+        if not isinstance(row, dict):
+            continue
+        bounty_id = row.get("id")
+        if not isinstance(bounty_id, int):
+            continue
+        try:
+            detail = _load_public_json(f"{api_host.rstrip('/')}/api/v1/bounties/{bounty_id}")
+        except (OSError, urllib.error.URLError, json.JSONDecodeError):
+            detail = row
+        if isinstance(detail, dict):
+            bounties.append(detail)
+    return bounties
+
+
+def load_live_issues(repo: str, limit: int, api_host: str = DEFAULT_API_HOST) -> dict[str, Any]:
+    rows_by_number: dict[int, dict[str, Any]] = {}
+    per_search_limit = max(1, limit)
+    for query in LIVE_ISSUE_SEARCHES:
+        for row in _gh_issue_search(repo, query, per_search_limit):
+            number = row.get("number")
+            if isinstance(number, int):
+                rows_by_number[number] = row
+    issues: list[dict[str, Any]] = []
+    for number in sorted(rows_by_number, reverse=True)[:limit]:
+        issue = _run_gh(
+            [
+                "issue",
+                "view",
+                str(number),
+                "--repo",
+                repo,
+                "--comments",
+                "--json",
+                "number,title,url,body,labels,state,comments,author,createdAt,updatedAt",
+            ]
+        )
+        issues.append(issue)
+    return {
+        "issues": issues,
+        "bounties": _load_public_bounty_issue(api_host, INTAKE_BOUNTY_ISSUE_NUMBER),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Read-only proposed-work intake triage report")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--input", type=Path, help="Offline JSON fixture with issues/payments")
+    source.add_argument("--repo", help="GitHub repo for read-only gh live mode")
+    parser.add_argument("--limit", type=int, default=50)
+    parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
+    parser.add_argument("--api-host", default=DEFAULT_API_HOST)
+    args = parser.parse_args(argv)
+
+    data = (
+        json.loads(args.input.read_text(encoding="utf-8"))
+        if args.input
+        else load_live_issues(args.repo, args.limit, api_host=args.api_host)
+    )
+    report = analyze_proposed_work(data)
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(format_markdown(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -62,6 +62,10 @@ LIVE_ISSUE_SEARCHES = (
     "label:proposed-work",
     '"proposed work"',
 )
+READ_ONLY_GH_COMMANDS = {
+    ("issue", "list"),
+    ("issue", "view"),
+}
 
 
 def _labels(raw: dict[str, Any]) -> list[str]:
@@ -337,6 +341,9 @@ def format_markdown(report: dict[str, Any]) -> str:
 
 
 def _run_gh(args: list[str]) -> Any:
+    if len(args) < 2 or tuple(args[:2]) not in READ_ONLY_GH_COMMANDS:
+        allowed = ", ".join(" ".join(command) for command in sorted(READ_ONLY_GH_COMMANDS))
+        raise RuntimeError(f"live mode only permits read-only gh commands: {allowed}")
     try:
         result = subprocess.run(
             ["gh", *args],

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -275,6 +275,9 @@ def _mark_duplicate_warnings(
 
 def analyze_proposed_work(data: dict[str, Any]) -> dict[str, Any]:
     payments = _payment_index(data)
+    data_warnings = [
+        warning for warning in data.get("data_warnings", []) if isinstance(warning, str)
+    ]
     proposals = [
         proposal
         for raw in data.get("issues", [])
@@ -296,6 +299,7 @@ def analyze_proposed_work(data: dict[str, Any]) -> dict[str, Any]:
             "warning_counts": dict(sorted(warning_counts.items())),
             "payment_counts": dict(sorted(payment_counts.items())),
             "related_groups": len(related_groups),
+            "data_warnings": data_warnings,
         },
         "proposals": proposals,
         "related_groups": related_groups,
@@ -309,6 +313,8 @@ def format_markdown(report: dict[str, Any]) -> str:
     lines.append(f"- related groups: {summary['related_groups']}")
     for state, count in summary["payment_counts"].items():
         lines.append(f"- {state} payment status: {count}")
+    for warning in summary.get("data_warnings", []):
+        lines.append(f"- data warning: {warning}")
     lines.append("")
     lines.append("## Issues")
     for item in report["proposals"]:
@@ -375,12 +381,19 @@ def _load_public_json(url: str) -> Any:
         return json.load(response)
 
 
-def _load_public_bounty_issue(api_host: str, issue_number: int) -> list[dict[str, Any]]:
+def _load_public_bounty_issue(
+    api_host: str, issue_number: int
+) -> tuple[list[dict[str, Any]], list[str]]:
     query = urllib.parse.urlencode({"issue_number": str(issue_number), "limit": "5"})
+    warnings: list[str] = []
     try:
         rows = _load_public_json(f"{api_host.rstrip('/')}/api/v1/bounties?{query}")
-    except (OSError, urllib.error.URLError, json.JSONDecodeError):
-        return []
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        warnings.append(
+            "payment_state_incomplete: failed to load public bounty list "
+            f"for issue #{issue_number} ({type(exc).__name__})"
+        )
+        return [], warnings
     bounties: list[dict[str, Any]] = []
     for row in rows if isinstance(rows, list) else []:
         if not isinstance(row, dict):
@@ -390,11 +403,15 @@ def _load_public_bounty_issue(api_host: str, issue_number: int) -> list[dict[str
             continue
         try:
             detail = _load_public_json(f"{api_host.rstrip('/')}/api/v1/bounties/{bounty_id}")
-        except (OSError, urllib.error.URLError, json.JSONDecodeError):
+        except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+            warnings.append(
+                "payment_state_incomplete: failed to load public bounty "
+                f"detail for bounty {bounty_id}; using list row only ({type(exc).__name__})"
+            )
             detail = row
         if isinstance(detail, dict):
             bounties.append(detail)
-    return bounties
+    return bounties, warnings
 
 
 def load_live_issues(repo: str, limit: int, api_host: str = DEFAULT_API_HOST) -> dict[str, Any]:
@@ -420,9 +437,11 @@ def load_live_issues(repo: str, limit: int, api_host: str = DEFAULT_API_HOST) ->
             ]
         )
         issues.append(issue)
+    bounties, data_warnings = _load_public_bounty_issue(api_host, INTAKE_BOUNTY_ISSUE_NUMBER)
     return {
         "issues": issues,
-        "bounties": _load_public_bounty_issue(api_host, INTAKE_BOUNTY_ISSUE_NUMBER),
+        "bounties": bounties,
+        "data_warnings": data_warnings,
     }
 
 

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -8,6 +8,20 @@ from typing import Any
 from scripts.proposed_work_triage import _run_gh, analyze_proposed_work, format_markdown, main
 
 
+class FakeResponse:
+    def __init__(self, payload: Any) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode()
+
+
 def _complete_body(topic: str = "queue review") -> str:
     return f"""
 ## Problem
@@ -316,19 +330,6 @@ def test_proposed_work_triage_markdown_and_json_cli(tmp_path, capsys) -> None:
 def test_proposed_work_triage_live_mode_uses_read_only_gh(monkeypatch, capsys) -> None:
     calls: list[list[str]] = []
 
-    class FakeResponse:
-        def __init__(self, payload: Any) -> None:
-            self.payload = payload
-
-        def __enter__(self) -> FakeResponse:
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            return None
-
-        def read(self) -> bytes:
-            return json.dumps(self.payload).encode()
-
     def fake_run(args, **kwargs):  # noqa: ANN001, ANN202
         calls.append(args)
         if args[:3] == ["gh", "issue", "list"]:
@@ -417,6 +418,45 @@ def test_proposed_work_triage_live_mode_warns_when_payment_state_is_incomplete(
     assert output["summary"]["payment_counts"] == {"none": 1}
     assert output["summary"]["data_warnings"] == [
         "payment_state_incomplete: failed to load public bounty list for issue #649 (URLError)"
+    ]
+    markdown = format_markdown(output)
+    assert "data warning: payment_state_incomplete" in markdown
+
+
+def test_proposed_work_triage_live_mode_warns_when_bounty_detail_fetch_fails(
+    monkeypatch, capsys
+) -> None:
+    def fake_run(args, **kwargs):  # noqa: ANN001, ANN202
+        if args[:3] == ["gh", "issue", "list"]:
+            stdout = json.dumps([{"number": 672}])
+        else:
+            stdout = json.dumps(
+                {
+                    "number": 672,
+                    "title": "Read-only proposed-work intake triage report",
+                    "url": "https://github.com/ramimbo/mergework/issues/672",
+                    "body": _complete_body(),
+                    "labels": [{"name": "proposed-work"}],
+                    "comments": [],
+                }
+            )
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+    def fake_urlopen(request, timeout):  # noqa: ANN001, ANN202, ARG001
+        if request.full_url.endswith("/api/v1/bounties?issue_number=649&limit=5"):
+            return FakeResponse([{"id": 96}])
+        raise urllib.error.URLError("offline")
+
+    monkeypatch.setattr("scripts.proposed_work_triage.subprocess.run", fake_run)
+    monkeypatch.setattr("scripts.proposed_work_triage.urllib.request.urlopen", fake_urlopen)
+
+    assert main(["--repo", "ramimbo/mergework", "--format", "json", "--limit", "1"]) == 0
+    output = json.loads(capsys.readouterr().out)
+
+    assert output["summary"]["payment_counts"] == {"none": 1}
+    assert output["summary"]["data_warnings"] == [
+        "payment_state_incomplete: failed to load public bounty "
+        "detail for bounty 96; using list row only (URLError)"
     ]
     markdown = format_markdown(output)
     assert "data warning: payment_state_incomplete" in markdown

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -485,3 +485,23 @@ def test_run_gh_reports_timeout_and_invalid_json(monkeypatch) -> None:
         assert "not-json" in str(exc)
     else:  # pragma: no cover - defensive assertion
         raise AssertionError("expected invalid JSON RuntimeError")
+
+
+def test_run_gh_rejects_mutating_commands_before_subprocess(monkeypatch) -> None:
+    def fail_if_called(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
+        raise AssertionError("mutating gh command should be rejected before subprocess.run")
+
+    monkeypatch.setattr("scripts.proposed_work_triage.subprocess.run", fail_if_called)
+
+    for args in (
+        ["issue", "comment", "672", "--body", "mutation"],
+        ["issue", "edit", "672", "--add-label", "proposed-work"],
+        ["pr", "review", "763", "--approve"],
+        ["api", "repos/ramimbo/mergework/issues/672"],
+    ):
+        try:
+            _run_gh(args)
+        except RuntimeError as exc:
+            assert "only permits read-only gh commands" in str(exc)
+        else:  # pragma: no cover - defensive assertion
+            raise AssertionError(f"expected read-only guard for {args}")

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+from scripts.proposed_work_triage import analyze_proposed_work, format_markdown, main
+
+
+def _complete_body(topic: str = "queue review") -> str:
+    return f"""
+## Problem
+Maintainers need a clearer read-only view of {topic}.
+
+## Evidence
+Issue comments show repeated confusion around {topic}.
+
+## Proposed work
+Add a fixture-tested read-only report for {topic}.
+
+## Expected value
+Maintainers can route work without guessing.
+
+## Acceptance
+Focused tests and docs pass.
+
+## Evidence or tests required
+Run the proposed-work triage tests.
+
+## Duplicate search
+Searched open issues and did not find a duplicate.
+
+## Out of scope
+No labels, comments, payments, or bounty creation.
+"""
+
+
+def test_proposed_work_triage_accepts_complete_issue() -> None:
+    report = analyze_proposed_work(
+        {
+            "issues": [
+                {
+                    "number": 672,
+                    "title": "Read-only proposed-work intake triage report",
+                    "url": "https://github.com/ramimbo/mergework/issues/672",
+                    "body": _complete_body(),
+                    "labels": [{"name": "proposed-work"}],
+                    "comments": [],
+                }
+            ]
+        }
+    )
+
+    assert report["summary"]["proposed_work_issues"] == 1
+    assert report["proposals"][0]["warnings"] == []
+    assert report["proposals"][0]["missing_sections"] == []
+
+
+def test_proposed_work_triage_flags_missing_label_and_template_sections() -> None:
+    report = analyze_proposed_work(
+        {
+            "issues": [
+                {
+                    "number": 673,
+                    "title": "Maybe improve things",
+                    "body": "Could be useful.",
+                    "labels": [],
+                    "comments": [],
+                }
+            ]
+        }
+    )
+
+    proposal = report["proposals"][0]
+    assert "missing_proposed_work_label" in proposal["warnings"]
+    assert "missing_template_sections" in proposal["warnings"]
+    assert "vague_or_under_specified" in proposal["warnings"]
+    assert set(proposal["missing_sections"]) == {
+        "problem",
+        "evidence",
+        "proposed_work",
+        "value",
+        "acceptance",
+        "tests",
+        "duplicate_search",
+        "out_of_scope",
+    }
+
+
+def test_proposed_work_triage_accepts_current_template_section_labels() -> None:
+    body = """
+## Problem
+Maintainers need a clearer read-only view.
+
+## Evidence
+Issue comments show repeated confusion.
+
+## Proposed work
+Add a fixture-tested read-only report.
+
+## Expected value
+Maintainers can route work without guessing.
+
+## Possible acceptance criteria
+Focused tests and docs pass.
+
+## Evidence or tests required
+Run the proposed-work triage tests.
+
+## Duplicate search
+Searched open issues and did not find a duplicate.
+
+## Out of scope
+No labels, comments, payments, or bounty creation.
+"""
+    report = analyze_proposed_work(
+        {
+            "issues": [
+                {
+                    "number": 674,
+                    "title": "Current template labels",
+                    "body": body,
+                    "labels": ["proposed-work"],
+                    "comments": [],
+                }
+            ]
+        }
+    )
+
+    assert report["proposals"][0]["missing_sections"] == []
+    assert "missing_template_sections" not in report["proposals"][0]["warnings"]
+
+
+def test_proposed_work_triage_accepts_short_tests_heading() -> None:
+    body = """
+## Problem
+Maintainers need a clearer read-only view.
+
+## Evidence
+Issue comments show repeated confusion.
+
+## Proposed work
+Add a fixture-tested read-only report.
+
+## Expected value
+Maintainers can route work without guessing.
+
+## Acceptance
+Focused tests and docs pass.
+
+## Tests
+Run the proposed-work triage tests.
+
+## Duplicate search
+Searched open issues and did not find a duplicate.
+
+## Out of scope
+No labels, comments, payments, or bounty creation.
+"""
+    report = analyze_proposed_work(
+        {
+            "issues": [
+                {
+                    "number": 675,
+                    "title": "Short tests heading",
+                    "body": body,
+                    "labels": ["proposed-work"],
+                    "comments": [],
+                }
+            ]
+        }
+    )
+
+    assert report["proposals"][0]["missing_sections"] == []
+    assert "missing_template_sections" not in report["proposals"][0]["warnings"]
+
+
+def test_proposed_work_triage_groups_likely_related_proposals_conservatively() -> None:
+    report = analyze_proposed_work(
+        {
+            "issues": [
+                {
+                    "number": 680,
+                    "title": "Queue duplicate stale bounty triage report",
+                    "body": _complete_body("queue duplicate stale bounty triage"),
+                    "labels": ["proposed-work"],
+                },
+                {
+                    "number": 681,
+                    "title": "Queue duplicate stale bounty report",
+                    "body": _complete_body("queue duplicate stale bounty report"),
+                    "labels": ["proposed-work"],
+                },
+                {
+                    "number": 682,
+                    "title": "Wallet transfer nonce parser",
+                    "body": _complete_body("wallet transfer nonce parsing"),
+                    "labels": ["proposed-work"],
+                },
+            ]
+        }
+    )
+
+    assert report["summary"]["related_groups"] == 1
+    assert report["related_groups"][0]["issues"] == [680, 681]
+    related_warnings = {
+        item["number"]: item["warnings"]
+        for item in report["proposals"]
+        if item["number"] in {680, 681}
+    }
+    assert all(
+        "duplicate_looking_related_proposal" in warnings for warnings in related_warnings.values()
+    )
+
+
+def test_proposed_work_triage_separates_pending_and_paid_payment_status() -> None:
+    report = analyze_proposed_work(
+        {
+            "issues": [
+                {
+                    "number": 687,
+                    "title": "Accepted pending intake",
+                    "url": "https://github.com/ramimbo/mergework/issues/687",
+                    "body": _complete_body("accepted pending intake"),
+                    "labels": ["proposed-work"],
+                    "comments": [{"body": "Accepted and routed for maintainer review."}],
+                },
+                {
+                    "number": 688,
+                    "title": "Proof backed intake",
+                    "url": "https://github.com/ramimbo/mergework/issues/688",
+                    "body": _complete_body("proof backed intake"),
+                    "labels": ["proposed-work"],
+                },
+            ],
+            "bounties": [
+                {
+                    "issue_number": 649,
+                    "pending_payout_proposals": [
+                        {
+                            "proposal_id": 96,
+                            "submission_url": "https://github.com/ramimbo/mergework/issues/687",
+                            "accepted_by": "ramimbo",
+                            "executes_after": "2026-06-01T15:01:35Z",
+                        }
+                    ],
+                    "accepted_awards": [
+                        {
+                            "submission_url": "https://github.com/ramimbo/mergework/issues/688",
+                            "proof_url": "https://mrwk.online/proofs/example",
+                            "ledger_sequence": 99,
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+    assert report["summary"]["payment_counts"] == {"paid": 1, "pending": 1}
+    pending = next(item for item in report["proposals"] if item["number"] == 687)
+    paid = next(item for item in report["proposals"] if item["number"] == 688)
+    assert "accepted_pending_payout" in pending["warnings"]
+    assert "proof_backed_paid" in paid["warnings"]
+    assert "already_routed_or_accepted" in pending["warnings"]
+
+
+def test_proposed_work_triage_flags_rejected_and_non_live_confused_proposals() -> None:
+    report = analyze_proposed_work(
+        {
+            "issues": [
+                {
+                    "number": 690,
+                    "title": "Confused claim proposal",
+                    "body": _complete_body("confused claim proposal") + "\n/claim #694 now paid",
+                    "labels": ["proposed-work"],
+                    "comments": [{"body": "Rejected as out of scope."}],
+                }
+            ]
+        }
+    )
+
+    warnings = set(report["proposals"][0]["warnings"])
+    assert "rejected_or_out_of_scope" in warnings
+    assert "non_live_bounty_confusion" in warnings
+
+
+def test_proposed_work_triage_markdown_and_json_cli(tmp_path, capsys) -> None:
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(
+        json.dumps(
+            {
+                "issues": [
+                    {
+                        "number": 672,
+                        "title": "Read-only proposed-work intake triage report",
+                        "url": "https://github.com/ramimbo/mergework/issues/672",
+                        "body": _complete_body(),
+                        "labels": ["proposed-work"],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert main(["--input", str(fixture), "--format", "json"]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["summary"]["proposed_work_issues"] == 1
+
+    markdown = format_markdown(output)
+    assert "# Proposed Work Triage" in markdown
+    assert "#672 Read-only proposed-work intake triage report" in markdown
+
+
+def test_proposed_work_triage_live_mode_uses_read_only_gh(monkeypatch, capsys) -> None:
+    calls: list[list[str]] = []
+
+    class FakeResponse:
+        def __init__(self, payload: Any) -> None:
+            self.payload = payload
+
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(self.payload).encode()
+
+    def fake_run(args, **kwargs):  # noqa: ANN001, ANN202
+        calls.append(args)
+        if args[:3] == ["gh", "issue", "list"]:
+            stdout = json.dumps([{"number": 672}, {"number": 673}])
+        else:
+            number = int(args[3])
+            labels = [{"name": "proposed-work"}] if number == 672 else []
+            stdout = json.dumps(
+                {
+                    "number": number,
+                    "title": "Read-only proposed-work intake triage report",
+                    "url": f"https://github.com/ramimbo/mergework/issues/{number}",
+                    "body": _complete_body(),
+                    "labels": labels,
+                    "comments": [],
+                }
+            )
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+    def fake_urlopen(request, timeout):  # noqa: ANN001, ANN202, ARG001
+        url = request.full_url
+        if url.endswith("/api/v1/bounties?issue_number=649&limit=5"):
+            return FakeResponse([{"id": 96}])
+        if url.endswith("/api/v1/bounties/96"):
+            return FakeResponse(
+                {
+                    "id": 96,
+                    "pending_payout_proposals": [
+                        {
+                            "proposal_id": 100,
+                            "submission_url": "https://github.com/ramimbo/mergework/issues/672",
+                            "accepted_by": "ramimbo",
+                            "executes_after": "2026-06-01T18:44:46Z",
+                        }
+                    ],
+                    "accepted_awards": [],
+                }
+            )
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr("scripts.proposed_work_triage.subprocess.run", fake_run)
+    monkeypatch.setattr("scripts.proposed_work_triage.urllib.request.urlopen", fake_urlopen)
+
+    assert main(["--repo", "ramimbo/mergework", "--format", "json", "--limit", "2"]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["summary"]["proposed_work_issues"] == 2
+    assert output["summary"]["payment_counts"] == {"none": 1, "pending": 1}
+    pending = next(item for item in output["proposals"] if item["number"] == 672)
+    unlabeled = next(item for item in output["proposals"] if item["number"] == 673)
+    assert "accepted_pending_payout" in pending["warnings"]
+    assert "missing_proposed_work_label" in unlabeled["warnings"]
+    assert all(
+        call[:3] == ["gh", "issue", "list"] or call[:3] == ["gh", "issue", "view"] for call in calls
+    )
+    assert not any("comment" in call or "edit" in call for call in calls)

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -4,7 +4,7 @@ import json
 import subprocess
 from typing import Any
 
-from scripts.proposed_work_triage import analyze_proposed_work, format_markdown, main
+from scripts.proposed_work_triage import _run_gh, analyze_proposed_work, format_markdown, main
 
 
 def _complete_body(topic: str = "queue review") -> str:
@@ -383,3 +383,28 @@ def test_proposed_work_triage_live_mode_uses_read_only_gh(monkeypatch, capsys) -
         call[:3] == ["gh", "issue", "list"] or call[:3] == ["gh", "issue", "view"] for call in calls
     )
     assert not any("comment" in call or "edit" in call for call in calls)
+
+
+def test_run_gh_reports_timeout_and_invalid_json(monkeypatch) -> None:
+    def fake_timeout(args, **kwargs):  # noqa: ANN001, ANN202, ARG001
+        raise subprocess.TimeoutExpired(args, timeout=15)
+
+    monkeypatch.setattr("scripts.proposed_work_triage.subprocess.run", fake_timeout)
+    try:
+        _run_gh(["issue", "list"])
+    except RuntimeError as exc:
+        assert "timed out" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("expected timeout RuntimeError")
+
+    def fake_invalid_json(args, **kwargs):  # noqa: ANN001, ANN202
+        return subprocess.CompletedProcess(args, 0, stdout="not-json", stderr="")
+
+    monkeypatch.setattr("scripts.proposed_work_triage.subprocess.run", fake_invalid_json)
+    try:
+        _run_gh(["issue", "list"])
+    except RuntimeError as exc:
+        assert "invalid JSON" in str(exc)
+        assert "not-json" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("expected invalid JSON RuntimeError")

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import urllib.error
 from typing import Any
 
 from scripts.proposed_work_triage import _run_gh, analyze_proposed_work, format_markdown, main
@@ -383,6 +384,42 @@ def test_proposed_work_triage_live_mode_uses_read_only_gh(monkeypatch, capsys) -
         call[:3] == ["gh", "issue", "list"] or call[:3] == ["gh", "issue", "view"] for call in calls
     )
     assert not any("comment" in call or "edit" in call for call in calls)
+
+
+def test_proposed_work_triage_live_mode_warns_when_payment_state_is_incomplete(
+    monkeypatch, capsys
+) -> None:
+    def fake_run(args, **kwargs):  # noqa: ANN001, ANN202
+        if args[:3] == ["gh", "issue", "list"]:
+            stdout = json.dumps([{"number": 672}])
+        else:
+            stdout = json.dumps(
+                {
+                    "number": 672,
+                    "title": "Read-only proposed-work intake triage report",
+                    "url": "https://github.com/ramimbo/mergework/issues/672",
+                    "body": _complete_body(),
+                    "labels": [{"name": "proposed-work"}],
+                    "comments": [],
+                }
+            )
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+    def fake_urlopen(request, timeout):  # noqa: ANN001, ANN202, ARG001
+        raise urllib.error.URLError("offline")
+
+    monkeypatch.setattr("scripts.proposed_work_triage.subprocess.run", fake_run)
+    monkeypatch.setattr("scripts.proposed_work_triage.urllib.request.urlopen", fake_urlopen)
+
+    assert main(["--repo", "ramimbo/mergework", "--format", "json", "--limit", "1"]) == 0
+    output = json.loads(capsys.readouterr().out)
+
+    assert output["summary"]["payment_counts"] == {"none": 1}
+    assert output["summary"]["data_warnings"] == [
+        "payment_state_incomplete: failed to load public bounty list for issue #649 (URLError)"
+    ]
+    markdown = format_markdown(output)
+    assert "data warning: payment_state_incomplete" in markdown
 
 
 def test_run_gh_reports_timeout_and_invalid_json(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Bounty #694
Source proposed-work intake: #672

Adds a focused read-only proposed-work intake triage report for maintainers:

- `scripts/proposed_work_triage.py` supports offline JSON fixtures and live read-only `gh issue list/view` mode.
- Output can be Markdown or JSON.
- The report detects missing `proposed-work` labels, missing template sections, vague/rejected/already-routed/non-live-confused proposals, and duplicate-looking related proposal groups with evidence tokens and suggested consolidated scopes.
- Live mode also reads public MergeWork API bounty #649 data so accepted proposed-work intake remains separated into pending payout proposals vs proof-backed paid awards.
- Runbook docs explain usage and the read-only boundary.

## Verification

- `PYTHONPATH=. ../mergework/.venv/bin/python -m pytest tests/test_proposed_work_triage.py -q` -> `9 passed`
- `../mergework/.venv/bin/ruff check scripts/proposed_work_triage.py tests/test_proposed_work_triage.py docs/admin-runbook.md` -> `All checks passed!`
- `../mergework/.venv/bin/ruff format --check scripts/proposed_work_triage.py tests/test_proposed_work_triage.py` -> `2 files already formatted`
- `PYTHONPATH=. ../mergework/.venv/bin/python scripts/docs_smoke.py` -> `docs smoke ok`
- `git diff --check origin/main...HEAD` -> passed
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `330be44236be542e2dc3f07f403b1ae29400e203`

Live read-only smoke:

- `PYTHONPATH=. ../mergework/.venv/bin/python scripts/proposed_work_triage.py --repo ramimbo/mergework --format json --limit 10`
- Summary from the smoke: `10` proposed-work issues, payment counts `none=8`, `pending=2`, warning counts included `accepted_pending_payout=2`, `missing_proposed_work_label=1`, `missing_template_sections=1`, `already_routed_or_accepted=5`.
- The section-heading hardening keeps current template labels such as `Possible acceptance criteria`, `Evidence or tests required`, and `Tests` from producing false missing-section warnings.

## Duplicate Check

- Bounty #100 is live/open with `400 MRWK`, `effective_awards_remaining=1`, and no active attempts at submission time.
- Existing PR #720 is the narrower #684/#647 proposed-work fallback report for unlabeled CLI/API-created intake. This PR targets #694/#672's broader intake triage scope, including #649 pending-vs-paid status, duplicate-looking related groups, suggested consolidated scopes, and the accepted #694 test matrix.
- Existing PR #723 changes the proposed-work template source-context field only; it does not add the triage report.

## Out of Scope

No automatic labels, comments, issue edits, bounty creation, claim submission, acceptance decisions, payments, admin-token APIs, production database access, private state, secrets, wallet behavior, price/exchange/bridge/cash-out claims, or private security details.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an admin runbook subsection "Proposed Work Triage" describing usage, modes, outputs, API host option, and read-only behavior.

* **New Features**
  * Added a triage tool that analyzes proposed-work intake, flags missing template sections/labels, vagueness/rejections, related/duplicate proposals, and payment state; produces JSON or Markdown; supports live GitHub or offline fixture modes and reports data-warnings for incomplete payment info.

* **Tests**
  * Added comprehensive tests covering analysis, grouping, payment-state handling, CLI output, and live-mode read-only/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->