### PR TITLE
Bounty #694: Add proposed-work triage report

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -111,8 +111,11 @@ python scripts/proposed_work_triage.py \
 ```
 
 The live mode uses read-only `gh issue list` and `gh issue view --comments`
-commands. It must not add labels, post comments, create bounties, execute
-treasury proposals, or mutate payout state.
+commands plus read-only public `GET /api/v1/bounties` and `GET /api/v1/activity`
+requests so #649 accepted proposed-work intake can be shown as proof-backed paid
+or pending payout when those public rows are available. Use `--no-public-api`
+for an offline GitHub-only report. The report must not add labels, post
+comments, create bounties, execute treasury proposals, or mutate payout state.
 
 Review the report in this order:
 

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -112,10 +112,10 @@ python scripts/proposed_work_triage.py \
 
 The live mode uses read-only `gh issue list` and `gh issue view --comments`
 commands plus read-only public `GET /api/v1/bounties` and `GET /api/v1/activity`
-requests so #649 accepted proposed-work intake can be shown as proof-backed paid
-or pending payout when those public rows are available. Use `--no-public-api`
-for an offline GitHub-only report. The report must not add labels, post
-comments, create bounties, execute treasury proposals, or mutate payout state.
+requests so accepted proposed-work intake can be shown as proof-backed paid or
+pending payout when those public rows are available. Use `--no-public-api` for
+an offline GitHub-only report. The report must not add labels, post comments,
+create bounties, execute treasury proposals, or mutate payout state.
 
 Review the report in this order:
 

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -93,6 +93,43 @@ enter the public queue, including mismatched GitHub issue URLs, missing or
 non-open bounties, duplicate pending proposals, and pending reserve-cap
 overcommit.
 
+### Proposed-work Intake Triage
+
+Proposed-work issues are maintainer intake only. They are not live bounties,
+even when the author included acceptance criteria or suggested a reference tier.
+Use the read-only triage report when the queue needs a quick review before
+opening, routing, rejecting, or consolidating possible bounty scopes:
+
+```bash
+python scripts/proposed_work_triage.py \
+  --input tests/fixtures/proposed_work_triage.json \
+  --format markdown
+
+python scripts/proposed_work_triage.py \
+  --repo ramimbo/mergework \
+  --format markdown
+```
+
+The live mode uses read-only `gh issue list` and `gh issue view --comments`
+commands. It must not add labels, post comments, create bounties, execute
+treasury proposals, or mutate payout state.
+
+Review the report in this order:
+
+1. Fix incomplete template sections first: problem, evidence, proposed work,
+   expected value, possible acceptance criteria, evidence/tests, duplicate
+   search, and out-of-scope notes.
+2. Add the `proposed-work` label only when an issue clearly matches the intake
+   template but was opened without the label.
+3. Keep routed proposals separate from live bounties; follow the linked bounty
+   only after it has `mrwk:bounty`, remaining award capacity, and the
+   `Reserved on MergeWork` claims-open comment.
+4. Keep pending payout proposals separate from proof-backed paid work. A
+   pending `pay_bounty` proposal is accepted-for-review, not paid, until the
+   public proof or ledger entry exists.
+5. Consolidate likely duplicate proposals before creating a new bounty so
+   contributors do not claim overlapping scopes.
+
 When `MERGEWORK_GITHUB_ISSUE_TOKEN` is set, successful `create_bounty`
 execution also finalizes the GitHub issue. The token needs permission to add
 labels and comments on `ramimbo/mergework` issues. Treasury execution still

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -1,0 +1,793 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.bounty_refs import BOUNTY_REF_RE
+
+GH_TIMEOUT_SECONDS = 30
+GH_ISSUE_SAFETY_CAP = 201
+DEFAULT_API_HOST = "https://api.mrwk.online"
+PROPOSED_WORK_LABEL = "proposed-work"
+
+GITHUB_URL_RE = re.compile(
+    r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/"
+    r"(?:issues|pull)/\d+(?:#[A-Za-z0-9_.-]+)?"
+)
+HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(.+?)\s*$", re.MULTILINE)
+ROUTED_REF_RE = re.compile(
+    r"\b(?:routed|accepted|converted|promoted|reserved|opened|created)\b[^#\n]{0,100}#(\d+)",
+    re.IGNORECASE,
+)
+PROPOSED_TITLE_RE = re.compile(r"^\s*proposed\s+work\s*:\s*", re.IGNORECASE)
+PLACEHOLDER_RE = re.compile(
+    r"^(?:n/?a|none|no response|todo|tbd|unknown|not sure|\.|-|_no response_)$",
+    re.IGNORECASE,
+)
+
+SECTION_ALIASES = {
+    "problem": "problem",
+    "evidence": "evidence",
+    "proposed work": "proposed_work",
+    "expected value": "expected_value",
+    "possible acceptance criteria": "acceptance",
+    "acceptance criteria": "acceptance",
+    "acceptance": "acceptance",
+    "evidence or tests required": "tests_required",
+    "tests required": "tests_required",
+    "tests": "tests_required",
+    "duplicate search": "duplicate_search",
+    "related work": "duplicate_search",
+    "out of scope": "out_of_scope",
+}
+REQUIRED_SECTIONS = (
+    "problem",
+    "evidence",
+    "proposed_work",
+    "expected_value",
+    "acceptance",
+    "tests_required",
+    "duplicate_search",
+    "out_of_scope",
+)
+SECTION_LABELS = {
+    "problem": "Problem",
+    "evidence": "Evidence",
+    "proposed_work": "Proposed work",
+    "expected_value": "Expected value",
+    "acceptance": "Possible acceptance criteria",
+    "tests_required": "Evidence or tests required",
+    "duplicate_search": "Duplicate search",
+    "out_of_scope": "Out of scope",
+}
+WEAK_SECTION_MIN_WORDS = {
+    "problem": 4,
+    "evidence": 4,
+    "proposed_work": 4,
+    "expected_value": 4,
+    "acceptance": 4,
+    "tests_required": 3,
+    "duplicate_search": 3,
+    "out_of_scope": 3,
+}
+REJECTED_LABELS = {"duplicate", "invalid", "rejected", "wontfix", "not planned"}
+REJECTED_STATE_REASONS = {"not_planned", "duplicate"}
+STOPWORDS = {
+    "and",
+    "for",
+    "from",
+    "into",
+    "live",
+    "mrwk",
+    "proposed",
+    "read",
+    "only",
+    "report",
+    "the",
+    "triage",
+    "with",
+    "work",
+}
+MUTATING_GH_WORDS = {
+    "comment",
+    "create",
+    "delete",
+    "edit",
+    "close",
+    "reopen",
+    "merge",
+    "review",
+    "lock",
+    "unlock",
+    "pin",
+    "unpin",
+    "transfer",
+}
+
+
+@dataclass(frozen=True)
+class ProposedWorkRow:
+    number: int
+    title: str
+    url: str | None
+    state: str
+    state_reason: str | None
+    labels: list[str]
+    author: str
+    classification: str
+    readiness: str
+    missing_sections: list[str]
+    weak_sections: list[str]
+    warnings: list[str]
+    routed_refs: list[int]
+    payment_status: str
+    payment_url: str | None
+    pending_proposal_url: str | None
+    suggested_action: str
+
+
+def _single_line(value: Any) -> str:
+    return " ".join(str(value or "").split())
+
+
+def _author_login(raw: Any) -> str:
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, dict):
+        login = raw.get("login")
+        if isinstance(login, str) and login:
+            return login
+    return "unknown"
+
+
+def _labels(raw: dict[str, Any]) -> list[str]:
+    labels = raw.get("labels", [])
+    names: list[str] = []
+    if not isinstance(labels, list):
+        return names
+    for label in labels:
+        if isinstance(label, str):
+            names.append(label)
+        elif isinstance(label, dict) and isinstance(label.get("name"), str):
+            names.append(label["name"])
+    return names
+
+
+def _comments(raw: dict[str, Any]) -> list[dict[str, str]]:
+    comments = raw.get("comments", [])
+    normalized: list[dict[str, str]] = []
+    if not isinstance(comments, list):
+        return normalized
+    for comment in comments:
+        if isinstance(comment, str):
+            normalized.append({"body": comment, "url": ""})
+        elif isinstance(comment, dict):
+            normalized.append(
+                {
+                    "body": str(comment.get("body") or ""),
+                    "url": str(comment.get("url") or ""),
+                }
+            )
+    return normalized
+
+
+def _state(raw: dict[str, Any]) -> str:
+    return str(raw.get("state") or "").lower()
+
+
+def _state_reason(raw: dict[str, Any]) -> str | None:
+    for key in ("stateReason", "state_reason"):
+        value = raw.get(key)
+        if isinstance(value, str) and value:
+            return value.lower()
+    return None
+
+
+def _normalize_section_title(title: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", " ", title.lower()).strip()
+    return SECTION_ALIASES.get(normalized, normalized)
+
+
+def _section_map(body: str) -> dict[str, str]:
+    matches = list(HEADING_RE.finditer(body or ""))
+    sections: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        title = _normalize_section_title(match.group(1))
+        if title not in REQUIRED_SECTIONS:
+            continue
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
+        sections[title] = body[start:end].strip()
+    return sections
+
+
+def _word_count(value: str) -> int:
+    return len(re.findall(r"[A-Za-z0-9_]+", value or ""))
+
+
+def _is_weak_section(section: str, content: str) -> bool:
+    cleaned = _single_line(content).strip(" -*_`\t\r\n")
+    if not cleaned:
+        return True
+    if PLACEHOLDER_RE.fullmatch(cleaned):
+        return True
+    return _word_count(cleaned) < WEAK_SECTION_MIN_WORDS[section]
+
+
+def _looks_like_proposed_work(raw: dict[str, Any], labels: list[str]) -> bool:
+    label_set = {label.lower() for label in labels}
+    title = str(raw.get("title") or "")
+    body = str(raw.get("body") or "")
+    return (
+        PROPOSED_WORK_LABEL in label_set
+        or bool(PROPOSED_TITLE_RE.match(title))
+        or "proposed work" in body.lower()
+    )
+
+
+def _issue_text(raw: dict[str, Any]) -> str:
+    comment_text = "\n".join(comment["body"] for comment in _comments(raw))
+    return "\n".join([str(raw.get("title") or ""), str(raw.get("body") or ""), comment_text])
+
+
+def _github_urls(text: str) -> list[str]:
+    seen: set[str] = set()
+    urls: list[str] = []
+    for match in GITHUB_URL_RE.findall(text or ""):
+        url = match.rstrip(".,)")
+        if url and url not in seen:
+            seen.add(url)
+            urls.append(url)
+    return urls
+
+
+def _issue_surface_urls(raw: dict[str, Any]) -> set[str]:
+    surfaces: set[str] = set()
+    url = str(raw.get("url") or "").strip()
+    if url:
+        surfaces.add(url.rstrip(".,)"))
+    for comment in _comments(raw):
+        if comment["url"]:
+            surfaces.add(comment["url"].rstrip(".,)"))
+        surfaces.update(_github_urls(comment["body"]))
+    surfaces.update(_github_urls(str(raw.get("body") or "")))
+    return {surface for surface in surfaces if surface}
+
+
+def _bounty_refs(text: str) -> list[int]:
+    refs: set[int] = set()
+    for match in BOUNTY_REF_RE.findall(text or ""):
+        try:
+            refs.add(int(match))
+        except ValueError:
+            continue
+    for match in ROUTED_REF_RE.findall(text or ""):
+        try:
+            refs.add(int(match))
+        except ValueError:
+            continue
+    return sorted(refs)
+
+
+def _is_routed(text: str, labels: list[str]) -> tuple[bool, list[int]]:
+    lowered = text.lower()
+    refs = _bounty_refs(text)
+    label_set = {label.lower() for label in labels}
+    routed = (
+        bool(refs)
+        and any(word in lowered for word in ("routed", "accepted", "converted", "promoted"))
+    ) or "reserved on mergework" in lowered
+    if PROPOSED_WORK_LABEL in label_set and "mrwk:bounty" in label_set:
+        routed = True
+    return routed, refs
+
+
+def _is_rejected(raw: dict[str, Any], labels: list[str], text: str) -> bool:
+    label_set = {label.lower() for label in labels}
+    if label_set & REJECTED_LABELS:
+        return True
+    reason = _state_reason(raw)
+    if _state(raw) == "closed" and reason in REJECTED_STATE_REASONS:
+        return True
+    lowered = text.lower()
+    return any(
+        phrase in lowered
+        for phrase in (
+            "closed as not planned",
+            "maintainer rejected",
+            "rejected by maintainer",
+            "will not be accepted",
+        )
+    )
+
+
+def _source_matches_issue(source: str, surfaces: set[str]) -> bool:
+    clean_source = source.rstrip(".,)")
+    for surface in surfaces:
+        if clean_source == surface or clean_source.startswith(f"{surface}#"):
+            return True
+    return False
+
+
+def _proof_sources(data: dict[str, Any]) -> dict[str, str]:
+    proof_by_source: dict[str, str] = {}
+    proof_rows: list[Any] = []
+    for key in ("proofs", "accepted_awards", "activity", "recent", "contributors"):
+        raw = data.get(key)
+        if isinstance(raw, list):
+            proof_rows.extend(raw)
+        elif isinstance(raw, dict):
+            for nested_key in ("contributors", "recent"):
+                nested = raw.get(nested_key)
+                if isinstance(nested, list):
+                    proof_rows.extend(nested)
+    for item in proof_rows:
+        if not isinstance(item, dict):
+            continue
+        source = str(
+            item.get("source_url")
+            or item.get("submission_url")
+            or item.get("latest_submission_url")
+            or ""
+        ).rstrip(".,)")
+        proof = str(item.get("proof_url") or item.get("latest_proof_url") or "").strip()
+        if source and proof:
+            proof_by_source[source] = proof
+    return proof_by_source
+
+
+def _pending_sources(data: dict[str, Any], api_host: str) -> dict[str, dict[str, Any]]:
+    pending_by_source: dict[str, dict[str, Any]] = {}
+    for bounty in data.get("bounties", []):
+        if not isinstance(bounty, dict):
+            continue
+        proposals = bounty.get("pending_payout_proposals", [])
+        if not isinstance(proposals, list):
+            continue
+        for proposal in proposals:
+            if not isinstance(proposal, dict):
+                continue
+            source = str(proposal.get("submission_url") or "").rstrip(".,)")
+            if not source:
+                continue
+            proposal_id = proposal.get("proposal_id", proposal.get("id"))
+            proposal_url = str(proposal.get("proposal_url") or "")
+            if not proposal_url and proposal_id is not None:
+                proposal_url = f"{api_host.rstrip('/')}/api/v1/treasury/proposals/{proposal_id}"
+            pending_by_source[source] = {
+                "proposal_id": proposal_id,
+                "proposal_url": proposal_url or None,
+                "executes_after": proposal.get("executes_after"),
+            }
+    return pending_by_source
+
+
+def _payment_status(
+    raw: dict[str, Any],
+    proof_by_source: dict[str, str],
+    pending_by_source: dict[str, dict[str, Any]],
+) -> tuple[str, str | None, str | None]:
+    surfaces = _issue_surface_urls(raw)
+    for source, proof in sorted(proof_by_source.items()):
+        if _source_matches_issue(source, surfaces):
+            return "proof_backed_paid", proof, None
+    for source, pending in sorted(pending_by_source.items()):
+        if _source_matches_issue(source, surfaces):
+            return "pending_payout", None, pending.get("proposal_url")
+    return "none", None, None
+
+
+def _suggested_action(
+    classification: str,
+    readiness: str,
+    labels: list[str],
+    payment_status: str,
+) -> str:
+    if payment_status == "proof_backed_paid":
+        return "Do not relabel as pending; keep separate as proof-backed paid work."
+    if payment_status == "pending_payout":
+        return "Keep separate as accepted pending payout until a public proof exists."
+    if classification == "rejected":
+        return "Leave closed/rejected unless a maintainer explicitly reopens the scope."
+    if classification == "routed":
+        return "No duplicate bounty needed; follow the linked live bounty or routed issue."
+    if PROPOSED_WORK_LABEL not in {label.lower() for label in labels}:
+        return "Add the proposed-work label or ask the author to reopen with the template."
+    if readiness == "incomplete":
+        return "Ask for missing template evidence before considering a bounty proposal."
+    return "Ready for maintainer intake review; still not claimable until a bounty is reserved."
+
+
+def _row_for_issue(
+    raw: dict[str, Any],
+    proof_by_source: dict[str, str],
+    pending_by_source: dict[str, dict[str, Any]],
+) -> ProposedWorkRow | None:
+    labels = _labels(raw)
+    if not _looks_like_proposed_work(raw, labels):
+        return None
+    body = str(raw.get("body") or "")
+    sections = _section_map(body)
+    missing = [section for section in REQUIRED_SECTIONS if section not in sections]
+    weak = [
+        section
+        for section in REQUIRED_SECTIONS
+        if section in sections and _is_weak_section(section, sections[section])
+    ]
+    text = _issue_text(raw)
+    routed, refs = _is_routed(text, labels)
+    rejected = _is_rejected(raw, labels, text)
+    if rejected:
+        classification = "rejected"
+    elif routed:
+        classification = "routed"
+    else:
+        classification = "active"
+    warnings: list[str] = []
+    if PROPOSED_WORK_LABEL not in {label.lower() for label in labels}:
+        warnings.append("missing proposed-work label")
+    if _word_count(body) < 35:
+        warnings.append("body is short for maintainer intake")
+    readiness = "complete" if not missing and not weak else "incomplete"
+    payment_status, payment_url, pending_url = _payment_status(
+        raw, proof_by_source, pending_by_source
+    )
+    return ProposedWorkRow(
+        number=int(raw["number"]),
+        title=str(raw.get("title") or ""),
+        url=str(raw.get("url") or "") or None,
+        state=_state(raw),
+        state_reason=_state_reason(raw),
+        labels=labels,
+        author=_author_login(raw.get("author")),
+        classification=classification,
+        readiness=readiness,
+        missing_sections=[SECTION_LABELS[section] for section in missing],
+        weak_sections=[SECTION_LABELS[section] for section in weak],
+        warnings=warnings,
+        routed_refs=refs,
+        payment_status=payment_status,
+        payment_url=payment_url,
+        pending_proposal_url=pending_url,
+        suggested_action=_suggested_action(classification, readiness, labels, payment_status),
+    )
+
+
+def _scope_tokens(title: str) -> set[str]:
+    clean = PROPOSED_TITLE_RE.sub("", title or "")
+    words = re.findall(r"[a-z0-9]+", clean.lower())
+    return {word for word in words if len(word) >= 3 and word not in STOPWORDS}
+
+
+def _related_groups(rows: list[ProposedWorkRow]) -> list[dict[str, Any]]:
+    clusters: list[dict[str, Any]] = []
+    for row in rows:
+        if row.classification == "rejected":
+            continue
+        tokens = _scope_tokens(row.title)
+        if len(tokens) < 2:
+            continue
+        matched_cluster: dict[str, Any] | None = None
+        for cluster in clusters:
+            cluster_tokens: set[str] = cluster["tokens"]
+            common = tokens & cluster_tokens
+            union = tokens | cluster_tokens
+            if len(common) >= 2 and len(common) / len(union) >= 0.45:
+                matched_cluster = cluster
+                break
+        if matched_cluster is None:
+            clusters.append({"tokens": set(tokens), "rows": [row]})
+        else:
+            matched_cluster["tokens"] |= tokens
+            matched_cluster["rows"].append(row)
+    groups: list[dict[str, Any]] = []
+    for cluster in clusters:
+        cluster_rows: list[ProposedWorkRow] = cluster["rows"]
+        if len(cluster_rows) < 2:
+            continue
+        common = set.intersection(*[_scope_tokens(row.title) for row in cluster_rows])
+        scope_words = sorted(common or cluster["tokens"])
+        groups.append(
+            {
+                "scope": " ".join(scope_words),
+                "issues": [
+                    {"number": row.number, "title": row.title, "url": row.url}
+                    for row in sorted(cluster_rows, key=lambda item: item.number)
+                ],
+                "suggested_consolidation": (
+                    "Consider one maintainer decision/bounty covering "
+                    f"{', '.join(scope_words[:6]) or 'the shared scope'}."
+                ),
+            }
+        )
+    return groups
+
+
+def analyze_proposed_work(
+    data: dict[str, Any], *, api_host: str = DEFAULT_API_HOST
+) -> dict[str, Any]:
+    proof_by_source = _proof_sources(data)
+    pending_by_source = _pending_sources(data, api_host)
+    rows: list[ProposedWorkRow] = []
+    for issue in data.get("issues", []):
+        if not isinstance(issue, dict) or not isinstance(issue.get("number"), int):
+            continue
+        row = _row_for_issue(issue, proof_by_source, pending_by_source)
+        if row is not None:
+            rows.append(row)
+    rows.sort(key=lambda item: item.number)
+    related = _related_groups(rows)
+    row_dicts = [asdict(row) for row in rows]
+
+    def count_where(key: str, value: str) -> int:
+        return sum(1 for row in row_dicts if row[key] == value)
+
+    report = {
+        "summary": {
+            "issues_scanned": len(
+                [item for item in data.get("issues", []) if isinstance(item, dict)]
+            ),
+            "proposed_work_issues": len(row_dicts),
+            "active": count_where("classification", "active"),
+            "routed": count_where("classification", "routed"),
+            "rejected": count_where("classification", "rejected"),
+            "complete": count_where("readiness", "complete"),
+            "incomplete": count_where("readiness", "incomplete"),
+            "label_missing": sum(
+                1 for row in row_dicts if "missing proposed-work label" in row["warnings"]
+            ),
+            "proof_backed_paid": count_where("payment_status", "proof_backed_paid"),
+            "pending_payout": count_where("payment_status", "pending_payout"),
+            "related_groups": len(related),
+        },
+        "issues": row_dicts,
+        "complete": [row for row in row_dicts if row["readiness"] == "complete"],
+        "incomplete": [row for row in row_dicts if row["readiness"] == "incomplete"],
+        "missing_label": [
+            row for row in row_dicts if "missing proposed-work label" in row["warnings"]
+        ],
+        "routed": [row for row in row_dicts if row["classification"] == "routed"],
+        "rejected": [row for row in row_dicts if row["classification"] == "rejected"],
+        "proof_backed_paid": [
+            row for row in row_dicts if row["payment_status"] == "proof_backed_paid"
+        ],
+        "pending_payout": [row for row in row_dicts if row["payment_status"] == "pending_payout"],
+        "related_groups": related,
+    }
+    return report
+
+
+def has_triage_warnings(report: dict[str, Any]) -> bool:
+    summary = report["summary"]
+    return any(
+        int(summary[key]) > 0
+        for key in ("incomplete", "label_missing", "rejected", "related_groups")
+    )
+
+
+def _markdown_issue_link(row: dict[str, Any]) -> str:
+    label = f"#{row['number']}"
+    if row.get("url"):
+        return f"[{label}]({row['url']})"
+    return label
+
+
+def _row_detail(row: dict[str, Any]) -> str:
+    details: list[str] = []
+    if row.get("missing_sections"):
+        details.append("missing: " + ", ".join(row["missing_sections"]))
+    if row.get("weak_sections"):
+        details.append("weak: " + ", ".join(row["weak_sections"]))
+    if row.get("warnings"):
+        details.append("warnings: " + ", ".join(row["warnings"]))
+    if row.get("routed_refs"):
+        details.append("refs: " + ", ".join(f"#{ref}" for ref in row["routed_refs"]))
+    if row.get("payment_url"):
+        details.append(f"proof: {row['payment_url']}")
+    if row.get("pending_proposal_url"):
+        details.append(f"pending: {row['pending_proposal_url']}")
+    return "; ".join(details) or "no issues found"
+
+
+def format_markdown_report(report: dict[str, Any]) -> str:
+    lines = ["## Proposed Work Intake Triage", ""]
+    for key, value in report["summary"].items():
+        lines.append(f"- **{key.replace('_', ' ')}**: {value}")
+    lines.append("")
+    lines.append("| Issue | State | Status | Payment | Action |")
+    lines.append("| --- | --- | --- | --- | --- |")
+    for row in report["issues"]:
+        status = f"{row['classification']} / {row['readiness']}"
+        payment = row["payment_status"]
+        lines.append(
+            f"| {_markdown_issue_link(row)} | `{row['state'] or 'unknown'}` | "
+            f"`{status}` | `{payment}` | {_single_line(row['suggested_action'])} |"
+        )
+        detail = _row_detail(row)
+        if detail != "no issues found":
+            lines.append(f"|  |  |  |  | {_single_line(detail)} |")
+    if report["related_groups"]:
+        lines.append("")
+        lines.append("### Likely related or duplicate scopes")
+        for group in report["related_groups"]:
+            issue_refs = ", ".join(
+                f"[#{issue['number']}]({issue['url']})"
+                if issue.get("url")
+                else f"#{issue['number']}"
+                for issue in group["issues"]
+            )
+            lines.append(
+                f"- **{_single_line(group['scope'])}**: {issue_refs}. "
+                f"{_single_line(group['suggested_consolidation'])}"
+            )
+    return "\n".join(lines)
+
+
+def format_text_report(report: dict[str, Any]) -> str:
+    lines = ["Proposed Work Intake Triage"]
+    for key, value in report["summary"].items():
+        lines.append(f"- {key.replace('_', ' ')}: {value}")
+    for row in report["issues"]:
+        lines.append(
+            f"- #{row['number']} {row['title']}: {row['classification']} / "
+            f"{row['readiness']} / {row['payment_status']}"
+        )
+        detail = _row_detail(row)
+        if detail != "no issues found":
+            lines.append(f"  - {detail}")
+        lines.append(f"  - action: {row['suggested_action']}")
+    if report["related_groups"]:
+        lines.append("Likely related or duplicate scopes")
+        for group in report["related_groups"]:
+            issues = ", ".join(f"#{issue['number']}" for issue in group["issues"])
+            lines.append(f"- {group['scope']}: {issues}")
+    return "\n".join(lines)
+
+
+def _assert_read_only_gh(args: list[str]) -> None:
+    if not args or args[0] != "gh":
+        raise RuntimeError(f"expected gh command, got: {' '.join(args)}")
+    if any(word in MUTATING_GH_WORDS for word in args):
+        raise RuntimeError(f"refusing non-read-only gh command: {' '.join(args)}")
+    if args[:2] == ["gh", "api"]:
+        for flag in ("--method", "-X"):
+            if flag in args:
+                index = args.index(flag)
+                if index + 1 >= len(args) or args[index + 1].upper() not in {"GET", "HEAD"}:
+                    raise RuntimeError(f"refusing non-read-only gh api command: {' '.join(args)}")
+
+
+def _run_gh_json(args: list[str]) -> Any:
+    _assert_read_only_gh(args)
+    command = " ".join(args)
+    try:
+        completed = subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s: {command}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            "gh command failed "
+            f"(exit {exc.returncode}): {command}\n"
+            f"stdout:\n{exc.stdout or exc.output or ''}\n"
+            f"stderr:\n{exc.stderr or ''}"
+        ) from exc
+    return json.loads(completed.stdout)
+
+
+def load_live_triage(repo: str) -> dict[str, Any]:
+    candidate_issues: dict[int, dict[str, Any]] = {}
+    list_commands = [
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "all",
+            "--label",
+            PROPOSED_WORK_LABEL,
+            "--limit",
+            str(GH_ISSUE_SAFETY_CAP),
+            "--json",
+            "number,title,url,state,stateReason,labels,author",
+        ],
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "all",
+            "--search",
+            '"Proposed work" in:title',
+            "--limit",
+            str(GH_ISSUE_SAFETY_CAP),
+            "--json",
+            "number,title,url,state,stateReason,labels,author",
+        ],
+    ]
+    for command in list_commands:
+        issues = _run_gh_json(command)
+        if len(issues) >= GH_ISSUE_SAFETY_CAP:
+            raise RuntimeError(
+                f"gh issue list reached the {GH_ISSUE_SAFETY_CAP} item safety cap; "
+                "use an API-paginated collector before trusting this live report"
+            )
+        for issue in issues:
+            if isinstance(issue, dict) and isinstance(issue.get("number"), int):
+                candidate_issues[int(issue["number"])] = issue
+    detailed: list[dict[str, Any]] = []
+    for number in sorted(candidate_issues):
+        detailed.append(
+            _run_gh_json(
+                [
+                    "gh",
+                    "issue",
+                    "view",
+                    str(number),
+                    "--repo",
+                    repo,
+                    "--comments",
+                    "--json",
+                    "number,title,url,body,state,stateReason,labels,author,comments",
+                ]
+            )
+        )
+    return {"issues": detailed}
+
+
+def _load_input(path: str) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("proposed-work triage input must be a JSON object")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Summarize MergeWork proposed-work intake without mutating GitHub."
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--input", help="Read proposed-work data from a JSON fixture file.")
+    source.add_argument(
+        "--repo",
+        help="Collect live proposed-work data with read-only gh commands, e.g. ramimbo/mergework.",
+    )
+    parser.add_argument("--format", choices=["json", "markdown", "text"], default="text")
+    parser.add_argument("--api-host", default=DEFAULT_API_HOST)
+    parser.add_argument("--fail-on-warnings", action="store_true")
+    args = parser.parse_args(argv)
+
+    data = _load_input(args.input) if args.input else load_live_triage(args.repo)
+    report = analyze_proposed_work(data, api_host=args.api_host)
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif args.format == "markdown":
+        print(format_markdown_report(report))
+    else:
+        print(format_text_report(report))
+    return 1 if args.fail_on_warnings and has_triage_warnings(report) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -101,20 +101,26 @@ STOPWORDS = {
     "work",
 }
 MUTATING_GH_WORDS = {
+    "assign",
     "comment",
     "create",
     "delete",
+    "develop",
     "edit",
     "close",
+    "label",
     "reopen",
     "merge",
+    "mark",
     "review",
     "lock",
     "unlock",
     "pin",
     "unpin",
     "transfer",
+    "unassign",
 }
+MUTATING_GH_API_FIELD_FLAGS = {"-f", "--field", "-F", "--raw-field"}
 
 
 @dataclass(frozen=True)
@@ -664,6 +670,8 @@ def _assert_read_only_gh(args: list[str]) -> None:
     if any(word in MUTATING_GH_WORDS for word in args):
         raise RuntimeError(f"refusing non-read-only gh command: {' '.join(args)}")
     if args[:2] == ["gh", "api"]:
+        if any(arg in MUTATING_GH_API_FIELD_FLAGS for arg in args):
+            raise RuntimeError(f"refusing gh api field mutation flags: {' '.join(args)}")
         for flag in ("--method", "-X"):
             if flag in args:
                 index = args.index(flag)

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -723,14 +723,15 @@ def load_public_payment_state(api_host: str = DEFAULT_API_HOST) -> dict[str, Any
     host = api_host.rstrip("/")
     bounties = _get_json(f"{host}/api/v1/bounties?limit={PUBLIC_API_LIMIT}")
     activity = _get_json(f"{host}/api/v1/activity?limit={PUBLIC_API_LIMIT}")
-    data: dict[str, Any] = {}
-    if isinstance(bounties, list):
-        data["bounties"] = bounties
-    if isinstance(activity, dict):
-        for key in ("contributors", "recent"):
-            value = activity.get(key)
-            if isinstance(value, list):
-                data[key] = value
+    if not isinstance(bounties, list):
+        raise RuntimeError("unexpected /api/v1/bounties response shape: expected list")
+    if not isinstance(activity, dict):
+        raise RuntimeError("unexpected /api/v1/activity response shape: expected object")
+    data: dict[str, Any] = {"bounties": bounties}
+    for key in ("contributors", "recent"):
+        value = activity.get(key)
+        if isinstance(value, list):
+            data[key] = value
     return data
 
 

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -670,13 +670,32 @@ def _assert_read_only_gh(args: list[str]) -> None:
     if any(word in MUTATING_GH_WORDS for word in args):
         raise RuntimeError(f"refusing non-read-only gh command: {' '.join(args)}")
     if args[:2] == ["gh", "api"]:
-        if any(arg in MUTATING_GH_API_FIELD_FLAGS for arg in args):
+        if any(_matches_gh_api_field_flag(arg) for arg in args):
             raise RuntimeError(f"refusing gh api field mutation flags: {' '.join(args)}")
-        for flag in ("--method", "-X"):
-            if flag in args:
-                index = args.index(flag)
-                if index + 1 >= len(args) or args[index + 1].upper() not in {"GET", "HEAD"}:
-                    raise RuntimeError(f"refusing non-read-only gh api command: {' '.join(args)}")
+        for method in _gh_api_methods(args):
+            if method.upper() not in {"GET", "HEAD"}:
+                raise RuntimeError(f"refusing non-read-only gh api command: {' '.join(args)}")
+
+
+def _matches_gh_api_field_flag(arg: str) -> bool:
+    if arg in MUTATING_GH_API_FIELD_FLAGS:
+        return True
+    for flag in MUTATING_GH_API_FIELD_FLAGS:
+        if arg.startswith(f"{flag}="):
+            return True
+    return any(arg.startswith(flag) for flag in ("-f", "-F") if len(arg) > len(flag))
+
+
+def _gh_api_methods(args: list[str]) -> list[str]:
+    methods: list[str] = []
+    for index, arg in enumerate(args):
+        if arg in {"--method", "-X"}:
+            methods.append(args[index + 1] if index + 1 < len(args) else "")
+        elif arg.startswith("--method="):
+            methods.append(arg.split("=", 1)[1])
+        elif arg.startswith("-X") and len(arg) > len("-X"):
+            methods.append(arg[len("-X") :])
+    return methods
 
 
 def _run_gh_json(args: list[str]) -> Any:

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -5,6 +5,8 @@ import json
 import re
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -16,6 +18,7 @@ from scripts.bounty_refs import BOUNTY_REF_RE
 
 GH_TIMEOUT_SECONDS = 30
 GH_ISSUE_SAFETY_CAP = 201
+PUBLIC_API_LIMIT = 200
 DEFAULT_API_HOST = "https://api.mrwk.online"
 PROPOSED_WORK_LABEL = "proposed-work"
 
@@ -318,7 +321,7 @@ def _source_matches_issue(source: str, surfaces: set[str]) -> bool:
     return False
 
 
-def _proof_sources(data: dict[str, Any]) -> dict[str, str]:
+def _proof_sources(data: dict[str, Any], api_host: str) -> dict[str, str]:
     proof_by_source: dict[str, str] = {}
     proof_rows: list[Any] = []
     for key in ("proofs", "accepted_awards", "activity", "recent", "contributors"):
@@ -340,6 +343,8 @@ def _proof_sources(data: dict[str, Any]) -> dict[str, str]:
             or ""
         ).rstrip(".,)")
         proof = str(item.get("proof_url") or item.get("latest_proof_url") or "").strip()
+        if proof.startswith("/"):
+            proof = f"{api_host.rstrip('/')}{proof}"
         if source and proof:
             proof_by_source[source] = proof
     return proof_by_source
@@ -515,7 +520,7 @@ def _related_groups(rows: list[ProposedWorkRow]) -> list[dict[str, Any]]:
 def analyze_proposed_work(
     data: dict[str, Any], *, api_host: str = DEFAULT_API_HOST
 ) -> dict[str, Any]:
-    proof_by_source = _proof_sources(data)
+    proof_by_source = _proof_sources(data, api_host)
     pending_by_source = _pending_sources(data, api_host)
     rows: list[ProposedWorkRow] = []
     for issue in data.get("issues", []):
@@ -691,7 +696,42 @@ def _run_gh_json(args: list[str]) -> Any:
     return json.loads(completed.stdout)
 
 
-def load_live_triage(repo: str) -> dict[str, Any]:
+def _get_json(url: str) -> Any:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "accept": "application/json",
+            "user-agent": "mergework-proposed-work-triage",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=GH_TIMEOUT_SECONDS) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (TimeoutError, urllib.error.URLError) as exc:
+        raise RuntimeError(f"public API request failed: {url}") from exc
+
+
+def load_public_payment_state(api_host: str = DEFAULT_API_HOST) -> dict[str, Any]:
+    host = api_host.rstrip("/")
+    bounties = _get_json(f"{host}/api/v1/bounties?limit={PUBLIC_API_LIMIT}")
+    activity = _get_json(f"{host}/api/v1/activity?limit={PUBLIC_API_LIMIT}")
+    data: dict[str, Any] = {}
+    if isinstance(bounties, list):
+        data["bounties"] = bounties
+    if isinstance(activity, dict):
+        for key in ("contributors", "recent"):
+            value = activity.get(key)
+            if isinstance(value, list):
+                data[key] = value
+    return data
+
+
+def load_live_triage(
+    repo: str,
+    *,
+    api_host: str = DEFAULT_API_HOST,
+    include_public_api: bool = True,
+) -> dict[str, Any]:
     candidate_issues: dict[int, dict[str, Any]] = {}
     list_commands = [
         [
@@ -752,7 +792,10 @@ def load_live_triage(repo: str) -> dict[str, Any]:
                 ]
             )
         )
-    return {"issues": detailed}
+    data: dict[str, Any] = {"issues": detailed}
+    if include_public_api:
+        data.update(load_public_payment_state(api_host))
+    return data
 
 
 def _load_input(path: str) -> dict[str, Any]:
@@ -775,10 +818,26 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--format", choices=["json", "markdown", "text"], default="text")
     parser.add_argument("--api-host", default=DEFAULT_API_HOST)
+    parser.add_argument(
+        "--no-public-api",
+        action="store_true",
+        help=(
+            "Skip read-only MergeWork public API reads. Live mode normally uses "
+            "public bounties/activity to classify #649 paid and pending intake."
+        ),
+    )
     parser.add_argument("--fail-on-warnings", action="store_true")
     args = parser.parse_args(argv)
 
-    data = _load_input(args.input) if args.input else load_live_triage(args.repo)
+    data = (
+        _load_input(args.input)
+        if args.input
+        else load_live_triage(
+            args.repo,
+            api_host=args.api_host,
+            include_public_api=not args.no_public_api,
+        )
+    )
     report = analyze_proposed_work(data, api_host=args.api_host)
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/tests/fixtures/proposed_work_triage.json
+++ b/tests/fixtures/proposed_work_triage.json
@@ -1,0 +1,58 @@
+{
+  "bounties": [
+    {
+      "id": 90,
+      "issue_number": 649,
+      "pending_payout_proposals": [
+        {
+          "proposal_id": 60,
+          "submission_url": "https://github.com/ramimbo/mergework/issues/101#issuecomment-1",
+          "executes_after": "2026-06-01T11:41:45Z"
+        }
+      ]
+    }
+  ],
+  "proofs": [
+    {
+      "source_url": "https://github.com/ramimbo/mergework/issues/102",
+      "proof_url": "https://api.mrwk.online/proofs/example-paid-proof"
+    }
+  ],
+  "issues": [
+    {
+      "number": 100,
+      "title": "Proposed work: complete intake example",
+      "url": "https://github.com/ramimbo/mergework/issues/100",
+      "state": "OPEN",
+      "labels": ["proposed-work"],
+      "author": {"login": "example-author"},
+      "body": "### Problem\nMaintainers need a safe read-only way to understand proposed-work intake quality.\n\n### Evidence\nThe proposed-work label can include complete, vague, routed, rejected, pending, and paid examples.\n\n### Proposed work\nGenerate a triage report without mutating GitHub labels, comments, bounties, or payouts.\n\n### Expected value\nMaintainers can decide what needs more evidence and what should not become a duplicate bounty.\n\n### Possible acceptance criteria\nThe report includes readiness gaps, routed bounty references, payment status separation, and next actions.\n\n### Evidence or tests required\nRun pytest for fixture coverage and a docs smoke check.\n\n### Duplicate search\nSearch related proposed-work issues before opening a new bounty.\n\n### Out of scope\nNo payout execution, label changes, bounty creation, private API mutation, or broad rewrite.\n",
+      "comments": []
+    },
+    {
+      "number": 101,
+      "title": "Proposed work: pending payout example",
+      "url": "https://github.com/ramimbo/mergework/issues/101",
+      "state": "OPEN",
+      "labels": ["proposed-work"],
+      "author": {"login": "example-author"},
+      "body": "### Problem\nAccepted work can be queued but not paid yet.\n\n### Evidence\nPending pay_bounty proposals are public but are not proof-backed payments.\n\n### Proposed work\nKeep pending payout proposals separate from paid rows.\n\n### Expected value\nContributors do not confuse queued review with received payment.\n\n### Possible acceptance criteria\nThe report marks this row as pending_payout, not proof_backed_paid.\n\n### Evidence or tests required\nFixture test with a pending proposal source URL.\n\n### Duplicate search\nThis covers a payment-state example only.\n\n### Out of scope\nNo payout execution or treasury mutation.\n",
+      "comments": [
+        {
+          "url": "https://github.com/ramimbo/mergework/issues/101#issuecomment-1",
+          "body": "Accepted for review; pending proposal only."
+        }
+      ]
+    },
+    {
+      "number": 102,
+      "title": "Proposed work: paid proof example",
+      "url": "https://github.com/ramimbo/mergework/issues/102",
+      "state": "OPEN",
+      "labels": ["proposed-work"],
+      "author": {"login": "example-author"},
+      "body": "### Problem\nProof-backed payments must not be mixed with pending payout proposals.\n\n### Evidence\nA public proof URL exists for this issue.\n\n### Proposed work\nMark this row as proof_backed_paid.\n\n### Expected value\nMaintainers can reconcile already-paid work without duplicate payout language.\n\n### Possible acceptance criteria\nThe report links the proof and avoids pending wording.\n\n### Evidence or tests required\nFixture test with a proof source URL.\n\n### Duplicate search\nThis covers a paid-state example only.\n\n### Out of scope\nNo duplicate claim or new bounty.\n",
+      "comments": []
+    }
+  ]
+}

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -302,7 +302,7 @@ def test_live_triage_uses_only_read_only_gh_commands(monkeypatch) -> None:
 
     monkeypatch.setattr(proposed_work_triage, "_run_gh_json", fake_run)
 
-    data = load_live_triage("ramimbo/mergework")
+    data = load_live_triage("ramimbo/mergework", include_public_api=False)
 
     assert data["issues"][0]["number"] == 22
     assert all(
@@ -310,6 +310,94 @@ def test_live_triage_uses_only_read_only_gh_commands(monkeypatch) -> None:
     )
     disallowed = {"comment", "create", "edit", "close", "reopen", "merge", "review"}
     assert not any(word in command for command in commands for word in disallowed)
+
+
+def test_live_triage_merges_public_paid_and_pending_state(monkeypatch) -> None:
+    def fake_run(args: list[str]) -> object:
+        if args[:3] == ["gh", "issue", "list"]:
+            if "--label" in args:
+                return [
+                    {
+                        "number": 23,
+                        "title": "Proposed work: pending public payment state",
+                        "url": "https://github.com/ramimbo/mergework/issues/23",
+                        "state": "OPEN",
+                        "labels": [{"name": "proposed-work"}],
+                        "author": {"login": "agent"},
+                    },
+                    {
+                        "number": 24,
+                        "title": "Proposed work: paid public payment state",
+                        "url": "https://github.com/ramimbo/mergework/issues/24",
+                        "state": "OPEN",
+                        "labels": [{"name": "proposed-work"}],
+                        "author": {"login": "agent"},
+                    },
+                ]
+            return []
+        if args[:3] == ["gh", "issue", "view"]:
+            number = int(args[3])
+            comments = []
+            if number == 23:
+                comments = [
+                    {
+                        "url": "https://github.com/ramimbo/mergework/issues/23#issuecomment-1",
+                        "body": "/claim #649 pending intake evidence",
+                    }
+                ]
+            return {
+                "number": number,
+                "title": f"Proposed work: live {number}",
+                "url": f"https://github.com/ramimbo/mergework/issues/{number}",
+                "state": "OPEN",
+                "labels": [{"name": "proposed-work"}],
+                "author": {"login": "agent"},
+                "body": _body(),
+                "comments": comments,
+            }
+        raise AssertionError(args)
+
+    def fake_get_json(url: str) -> object:
+        if url.endswith("/api/v1/bounties?limit=200"):
+            return [
+                {
+                    "id": 97,
+                    "issue_number": 649,
+                    "pending_payout_proposals": [
+                        {
+                            "proposal_id": 77,
+                            "submission_url": (
+                                "https://github.com/ramimbo/mergework/issues/23#issuecomment-1"
+                            ),
+                        }
+                    ],
+                }
+            ]
+        if url.endswith("/api/v1/activity?limit=200"):
+            return {
+                "recent": [
+                    {
+                        "submission_url": "https://github.com/ramimbo/mergework/issues/24",
+                        "proof_url": "/proofs/paid-24",
+                    }
+                ],
+                "contributors": [],
+            }
+        raise AssertionError(url)
+
+    monkeypatch.setattr(proposed_work_triage, "_run_gh_json", fake_run)
+    monkeypatch.setattr(proposed_work_triage, "_get_json", fake_get_json)
+
+    data = load_live_triage("ramimbo/mergework", api_host="https://api.example.test")
+    report = analyze_proposed_work(data, api_host="https://api.example.test")
+    rows = {row["number"]: row for row in report["issues"]}
+
+    assert rows[23]["payment_status"] == "pending_payout"
+    assert (
+        rows[23]["pending_proposal_url"] == "https://api.example.test/api/v1/treasury/proposals/77"
+    )
+    assert rows[24]["payment_status"] == "proof_backed_paid"
+    assert rows[24]["payment_url"] == "https://api.example.test/proofs/paid-24"
 
 
 def test_repo_fixture_offline_input(capsys) -> None:

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts import proposed_work_triage
 from scripts.proposed_work_triage import (
     analyze_proposed_work,
@@ -308,8 +310,16 @@ def test_live_triage_uses_only_read_only_gh_commands(monkeypatch) -> None:
     assert all(
         command[:3] in (["gh", "issue", "list"], ["gh", "issue", "view"]) for command in commands
     )
-    disallowed = {"comment", "create", "edit", "close", "reopen", "merge", "review"}
+    disallowed = proposed_work_triage.MUTATING_GH_WORDS
     assert not any(word in command for command in commands for word in disallowed)
+
+
+def test_read_only_gh_guard_rejects_api_field_flags() -> None:
+    for flag in proposed_work_triage.MUTATING_GH_API_FIELD_FLAGS:
+        with pytest.raises(RuntimeError, match="field mutation flags"):
+            proposed_work_triage._assert_read_only_gh(
+                ["gh", "api", "repos/ramimbo/mergework/issues", flag, "title=test"]
+            )
 
 
 def test_live_triage_merges_public_paid_and_pending_state(monkeypatch) -> None:

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -315,11 +315,38 @@ def test_live_triage_uses_only_read_only_gh_commands(monkeypatch) -> None:
 
 
 def test_read_only_gh_guard_rejects_api_field_flags() -> None:
-    for flag in proposed_work_triage.MUTATING_GH_API_FIELD_FLAGS:
+    for flag in (
+        *proposed_work_triage.MUTATING_GH_API_FIELD_FLAGS,
+        "--field=title=test",
+        "--raw-field=title=test",
+        "-ftitle=test",
+        "-Ftitle=test",
+    ):
         with pytest.raises(RuntimeError, match="field mutation flags"):
-            proposed_work_triage._assert_read_only_gh(
-                ["gh", "api", "repos/ramimbo/mergework/issues", flag, "title=test"]
-            )
+            args = ["gh", "api", "repos/ramimbo/mergework/issues", flag]
+            if "=" not in flag:
+                args.append("title=test")
+            proposed_work_triage._assert_read_only_gh(args)
+
+
+def test_read_only_gh_guard_rejects_non_get_methods() -> None:
+    for method in ("POST", "PATCH", "PUT", "DELETE"):
+        for args in (
+            ["gh", "api", "repos/ramimbo/mergework/issues", "-X", method],
+            ["gh", "api", "repos/ramimbo/mergework/issues", f"-X{method}"],
+            ["gh", "api", "repos/ramimbo/mergework/issues", f"--method={method}"],
+        ):
+            with pytest.raises(RuntimeError, match="non-read-only gh api"):
+                proposed_work_triage._assert_read_only_gh(args)
+
+
+def test_read_only_gh_guard_allows_get_and_head_methods() -> None:
+    for args in (
+        ["gh", "api", "repos/ramimbo/mergework/issues", "-X", "GET"],
+        ["gh", "api", "repos/ramimbo/mergework/issues", "-XHEAD"],
+        ["gh", "api", "repos/ramimbo/mergework/issues", "--method=GET"],
+    ):
+        proposed_work_triage._assert_read_only_gh(args)
 
 
 def test_live_triage_merges_public_paid_and_pending_state(monkeypatch) -> None:

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -410,6 +410,34 @@ def test_live_triage_merges_public_paid_and_pending_state(monkeypatch) -> None:
     assert rows[24]["payment_url"] == "https://api.example.test/proofs/paid-24"
 
 
+def test_public_payment_state_rejects_unexpected_bounties_shape(monkeypatch) -> None:
+    def fake_get_json(url: str) -> object:
+        if url.endswith("/api/v1/bounties?limit=200"):
+            return {"bounties": []}
+        if url.endswith("/api/v1/activity?limit=200"):
+            return {"recent": [], "contributors": []}
+        raise AssertionError(url)
+
+    monkeypatch.setattr(proposed_work_triage, "_get_json", fake_get_json)
+
+    with pytest.raises(RuntimeError, match="/api/v1/bounties response shape"):
+        proposed_work_triage.load_public_payment_state("https://api.example.test")
+
+
+def test_public_payment_state_rejects_unexpected_activity_shape(monkeypatch) -> None:
+    def fake_get_json(url: str) -> object:
+        if url.endswith("/api/v1/bounties?limit=200"):
+            return []
+        if url.endswith("/api/v1/activity?limit=200"):
+            return []
+        raise AssertionError(url)
+
+    monkeypatch.setattr(proposed_work_triage, "_get_json", fake_get_json)
+
+    with pytest.raises(RuntimeError, match="/api/v1/activity response shape"):
+        proposed_work_triage.load_public_payment_state("https://api.example.test")
+
+
 def test_repo_fixture_offline_input(capsys) -> None:
     fixture_path = ROOT / "tests" / "fixtures" / "proposed_work_triage.json"
     exit_code = main(["--input", str(fixture_path), "--format", "markdown"])

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts import proposed_work_triage
+from scripts.proposed_work_triage import (
+    analyze_proposed_work,
+    format_markdown_report,
+    load_live_triage,
+    main,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _body(
+    *,
+    problem: str = (
+        "The intake queue has multiple proposals and maintainers need a clear read-only summary."
+    ),
+    evidence: str = "See issue #649, issue #650, and the public proposed-work queue for examples.",
+    proposed: str = (
+        "Add a read-only report that classifies proposals without changing GitHub state."
+    ),
+    value: str = (
+        "Maintainers can see complete, incomplete, routed, rejected, pending, and paid work faster."
+    ),
+    acceptance: str = (
+        "The report lists each proposal, readiness gaps, routed bounties, and "
+        "recommended next action."
+    ),
+    tests: str = "Run pytest for fixture mode and a docs smoke check for the runbook entry.",
+    duplicate: str = (
+        "Searched related proposal issues and no live bounty currently covers this exact scope."
+    ),
+    out_of_scope: str = (
+        "No bounty creation, comments, labels, payout execution, or private API mutation."
+    ),
+) -> str:
+    return f"""### Problem
+{problem}
+
+### Evidence
+{evidence}
+
+### Proposed work
+{proposed}
+
+### Expected value
+{value}
+
+### Possible acceptance criteria
+{acceptance}
+
+### Evidence or tests required
+{tests}
+
+### Duplicate search
+{duplicate}
+
+### Out of scope
+{out_of_scope}
+"""
+
+
+def _fixture() -> dict[str, object]:
+    return {
+        "bounties": [
+            {
+                "id": 90,
+                "issue_number": 649,
+                "pending_payout_proposals": [
+                    {
+                        "proposal_id": 60,
+                        "submission_url": (
+                            "https://github.com/ramimbo/mergework/issues/15#issuecomment-1"
+                        ),
+                        "executes_after": "2026-06-01T11:41:45Z",
+                    }
+                ],
+            }
+        ],
+        "proofs": [
+            {
+                "source_url": "https://github.com/ramimbo/mergework/issues/16",
+                "proof_url": "https://api.example.test/proofs/paid-16",
+            }
+        ],
+        "issues": [
+            {
+                "number": 10,
+                "title": "Proposed work: intake queue summary",
+                "url": "https://github.com/ramimbo/mergework/issues/10",
+                "state": "OPEN",
+                "labels": ["proposed-work"],
+                "author": {"login": "alice"},
+                "body": _body(),
+                "comments": [],
+            },
+            {
+                "number": 11,
+                "title": "Proposed work: vague idea",
+                "url": "https://github.com/ramimbo/mergework/issues/11",
+                "state": "OPEN",
+                "labels": ["proposed-work"],
+                "author": {"login": "bob"},
+                "body": "### Problem\nBug\n\n### Evidence\nTBD\n",
+                "comments": [],
+            },
+            {
+                "number": 12,
+                "title": "Proposed work: missing label report",
+                "url": "https://github.com/ramimbo/mergework/issues/12",
+                "state": "OPEN",
+                "labels": [],
+                "author": {"login": "carol"},
+                "body": _body(),
+                "comments": [],
+            },
+            {
+                "number": 13,
+                "title": "Proposed work: routed report",
+                "url": "https://github.com/ramimbo/mergework/issues/13",
+                "state": "OPEN",
+                "labels": ["proposed-work"],
+                "author": {"login": "dave"},
+                "body": _body(),
+                "comments": [
+                    {
+                        "url": "https://github.com/ramimbo/mergework/issues/13#issuecomment-1",
+                        "body": "Routed to Bounty #694. Reserved on MergeWork once executed.",
+                    }
+                ],
+            },
+            {
+                "number": 14,
+                "title": "Proposed work: rejected bridge copy",
+                "url": "https://github.com/ramimbo/mergework/issues/14",
+                "state": "CLOSED",
+                "stateReason": "NOT_PLANNED",
+                "labels": ["proposed-work"],
+                "author": {"login": "erin"},
+                "body": _body(),
+                "comments": [],
+            },
+            {
+                "number": 15,
+                "title": "Proposed work: pending payout intake",
+                "url": "https://github.com/ramimbo/mergework/issues/15",
+                "state": "OPEN",
+                "labels": ["proposed-work"],
+                "author": {"login": "frank"},
+                "body": _body(),
+                "comments": [
+                    {
+                        "url": "https://github.com/ramimbo/mergework/issues/15#issuecomment-1",
+                        "body": "Accepted for review; pending proposal only, not paid yet.",
+                    }
+                ],
+            },
+            {
+                "number": 16,
+                "title": "Proposed work: paid proof intake",
+                "url": "https://github.com/ramimbo/mergework/issues/16",
+                "state": "OPEN",
+                "labels": ["proposed-work"],
+                "author": {"login": "grace"},
+                "body": _body(),
+                "comments": [],
+            },
+            {
+                "number": 17,
+                "title": "Proposed work: wallet payout reconciliation report",
+                "url": "https://github.com/ramimbo/mergework/issues/17",
+                "state": "OPEN",
+                "labels": ["proposed-work"],
+                "author": {"login": "heidi"},
+                "body": _body(),
+                "comments": [],
+            },
+            {
+                "number": 18,
+                "title": "Proposed work: wallet payout reconciliation checker",
+                "url": "https://github.com/ramimbo/mergework/issues/18",
+                "state": "OPEN",
+                "labels": ["proposed-work"],
+                "author": {"login": "ivy"},
+                "body": _body(),
+                "comments": [],
+            },
+        ],
+    }
+
+
+def test_proposed_work_triage_classifies_required_cases(tmp_path, capsys) -> None:
+    report = analyze_proposed_work(_fixture(), api_host="https://api.example.test")
+    rows = {row["number"]: row for row in report["issues"]}
+
+    assert report["summary"] == {
+        "issues_scanned": 9,
+        "proposed_work_issues": 9,
+        "active": 7,
+        "routed": 1,
+        "rejected": 1,
+        "complete": 8,
+        "incomplete": 1,
+        "label_missing": 1,
+        "proof_backed_paid": 1,
+        "pending_payout": 1,
+        "related_groups": 1,
+    }
+    assert rows[10]["readiness"] == "complete"
+    assert rows[11]["readiness"] == "incomplete"
+    assert "Evidence" in rows[11]["weak_sections"]
+    assert "Proposed work" in rows[11]["missing_sections"]
+    assert rows[12]["warnings"] == ["missing proposed-work label"]
+    assert rows[13]["classification"] == "routed"
+    assert rows[13]["routed_refs"] == [694]
+    assert rows[14]["classification"] == "rejected"
+    assert rows[15]["payment_status"] == "pending_payout"
+    assert (
+        rows[15]["pending_proposal_url"] == "https://api.example.test/api/v1/treasury/proposals/60"
+    )
+    assert rows[16]["payment_status"] == "proof_backed_paid"
+    assert rows[16]["payment_url"] == "https://api.example.test/proofs/paid-16"
+    assert report["related_groups"][0]["issues"] == [
+        {
+            "number": 17,
+            "title": "Proposed work: wallet payout reconciliation report",
+            "url": "https://github.com/ramimbo/mergework/issues/17",
+        },
+        {
+            "number": 18,
+            "title": "Proposed work: wallet payout reconciliation checker",
+            "url": "https://github.com/ramimbo/mergework/issues/18",
+        },
+    ]
+
+    input_path = tmp_path / "proposed-work.json"
+    input_path.write_text(json.dumps(_fixture()), encoding="utf-8")
+    exit_code = main(["--input", str(input_path), "--format", "json", "--fail-on-warnings"])
+    assert exit_code == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["summary"]["pending_payout"] == 1
+
+
+def test_proposed_work_triage_markdown_is_pasteable() -> None:
+    report = analyze_proposed_work({"issues": [_fixture()["issues"][0]]})
+    markdown = format_markdown_report(report)
+
+    assert "## Proposed Work Intake Triage" in markdown
+    assert "| Issue | State | Status | Payment | Action |" in markdown
+    assert "Ready for maintainer intake review" in markdown
+
+
+def test_proposed_work_triage_script_entrypoint_loads_shared_parser() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/proposed_work_triage.py", "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout
+
+
+def test_live_triage_uses_only_read_only_gh_commands(monkeypatch) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(args: list[str]) -> object:
+        commands.append(args)
+        if args[:3] == ["gh", "issue", "list"]:
+            if "--label" in args:
+                return [
+                    {
+                        "number": 22,
+                        "title": "Proposed work: live report",
+                        "url": "https://github.com/ramimbo/mergework/issues/22",
+                        "state": "OPEN",
+                        "labels": [{"name": "proposed-work"}],
+                        "author": {"login": "agent"},
+                    }
+                ]
+            return []
+        if args[:3] == ["gh", "issue", "view"]:
+            return {
+                "number": 22,
+                "title": "Proposed work: live report",
+                "url": "https://github.com/ramimbo/mergework/issues/22",
+                "state": "OPEN",
+                "labels": [{"name": "proposed-work"}],
+                "author": {"login": "agent"},
+                "body": _body(),
+                "comments": [],
+            }
+        raise AssertionError(args)
+
+    monkeypatch.setattr(proposed_work_triage, "_run_gh_json", fake_run)
+
+    data = load_live_triage("ramimbo/mergework")
+
+    assert data["issues"][0]["number"] == 22
+    assert all(
+        command[:3] in (["gh", "issue", "list"], ["gh", "issue", "view"]) for command in commands
+    )
+    disallowed = {"comment", "create", "edit", "close", "reopen", "merge", "review"}
+    assert not any(word in command for command in commands for word in disallowed)
+
+
+def test_repo_fixture_offline_input(capsys) -> None:
+    fixture_path = ROOT / "tests" / "fixtures" / "proposed_work_triage.json"
+    exit_code = main(["--input", str(fixture_path), "--format", "markdown"])
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "Proposed Work Intake Triage" in output
+    assert "pending payout" in output.lower()


### PR DESCRIPTION
## Summary

- Bounty #694
- Adds `scripts/proposed_work_triage.py`, a read-only proposed-work intake triage report with JSON/Markdown/text output.
- Live mode combines read-only `gh issue list/view` data with read-only public MergeWork `GET /api/v1/bounties` and `GET /api/v1/activity` data so accepted intake rows can be classified as `pending_payout` or `proof_backed_paid` when public evidence exists.
- Hardened live-mode command guards: mutating `gh` subcommands are refused; `gh api -f/-F/--field/--raw-field` (including attached-value forms) and non-GET/HEAD methods are rejected to avoid implicit write requests.
- Validates public API response shapes before merging payment-state rows so unexpected responses fail loudly instead of silently degrading the report.
- Adds offline fixture coverage, public-payment-state merge coverage, public API shape validation coverage, read-only guard coverage, and admin-runbook usage docs.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: proposed-work issues can be complete, incomplete, duplicate-looking, routed, rejected, pending payout, or proof-backed paid; maintainers need a pasteable read-only summary before opening or consolidating bounty scopes.
- Bounty capacity and active attempts/open PRs checked: this PR targets the live requested scope from Bounty #694 and does not mutate GitHub or treasury state.
- Intended files or surfaces: `scripts/proposed_work_triage.py`, `tests/test_proposed_work_triage.py`, `tests/fixtures/proposed_work_triage.json`, `docs/admin-runbook.md`.
- Expected PR size: medium; one script, one fixture, tests, and documentation.
- Out of scope: no labels, comments, bounty creation, payout execution, private API calls, admin-token APIs, or mutation automation.

## Test Evidence

- [x] `.venv/bin/python -m pytest` — 634 passed, 1 warning
- [x] `.venv/bin/python -m mypy app` — success, no issues in 38 source files
- [x] `.venv/bin/ruff check .` — passed
- [x] `.venv/bin/ruff format --check .` — 104 files already formatted
- [x] `.venv/bin/python scripts/docs_smoke.py` — docs smoke ok
- [x] `.venv/bin/python -m pytest tests/test_proposed_work_triage.py tests/test_pr_queue_health.py tests/test_claim_inventory.py` — 35 focused tests passed after guard/public-state changes
- [x] `python3 scripts/proposed_work_triage.py --input tests/fixtures/proposed_work_triage.json --format json` — fixture shows `none`, `pending_payout`, and `proof_backed_paid` rows

## MRWK

Bounty #694


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Proposed-work Intake Triage” section to the admin runbook with an ordered review checklist and explicit read-only triage guidance.

* **New Features**
  * Added a read-only triage tool that analyzes proposed-work issues, emits JSON/Markdown/text reports, flags readiness/warnings, detects duplicates and routing, and reports payment status with optional fail-on-warnings exit.

* **Tests**
  * Added fixtures and tests covering classification, reporting, live read-only safety, payment-state merging, and CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->