### PR TITLE
Reject non-canonical MCP integer arguments

### DIFF
--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 from sqlalchemy import func, or_, select
@@ -31,6 +32,8 @@ from app.serializers import (
     wallet_transfer_to_dict,
 )
 
+MCP_INTEGER_RE = re.compile(r"^(?:0|-?[1-9][0-9]*)$")
+
 
 def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | dict[str, Any]:
     def int_arg(field: str) -> int:
@@ -42,10 +45,9 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
         elif isinstance(value, str):
             if contains_control_character(value):
                 raise ValueError(f"{field} must not contain control characters")
-            clean = value.strip()
-            if clean and clean.lstrip("+-").isdigit():
+            if MCP_INTEGER_RE.fullmatch(value):
                 try:
-                    parsed = int(clean)
+                    parsed = int(value)
                 except ValueError as exc:
                     raise ValueError(f"{field} must be an integer") from exc
             else:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1013,6 +1013,77 @@ def test_mcp_rejects_oversized_integer_arguments_without_500(
 @pytest.mark.parametrize(
     ("tool_name", "arguments", "request_id"),
     [
+        ("list_bounties", {"limit": "03"}, 21),
+        ("list_bounties", {"limit": "+3"}, 22),
+        ("list_bounties", {"limit": " 3"}, 23),
+        ("get_bounty", {"id": "099"}, 24),
+        ("get_bounty", {"id": "+99"}, 25),
+        ("get_ledger_entry", {"sequence": "01"}, 26),
+        ("submit_work_proof", {"bounty_id": "099"}, 27),
+        ("submit_work_proof", {"issue_number": "0656"}, 28),
+    ],
+)
+def test_mcp_rejects_noncanonical_integer_string_arguments(
+    sqlite_url: str, tool_name: str, arguments: dict[str, object], request_id: int
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
+def test_mcp_accepts_canonical_integer_string_arguments(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=656,
+            issue_url="https://github.com/ramimbo/mergework/issues/656",
+            title="MCP canonical integer args",
+            reward_mrwk="75",
+            acceptance="MCP should keep canonical numeric string compatibility.",
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 29,
+            "method": "tools/call",
+            "params": {"name": "get_bounty", "arguments": {"id": str(bounty_id)}},
+        },
+    )
+
+    payload = json.loads(response.json()["result"]["content"][0]["text"])
+    assert payload["id"] == bounty_id
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments", "request_id"),
+    [
         ("get_balance", {"account": True}, 13),
         ("get_balance", {"account": 123}, 14),
         ("get_balance", {"account": ""}, 15),

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1016,11 +1016,13 @@ def test_mcp_rejects_oversized_integer_arguments_without_500(
         ("list_bounties", {"limit": "03"}, 21),
         ("list_bounties", {"limit": "+3"}, 22),
         ("list_bounties", {"limit": " 3"}, 23),
-        ("get_bounty", {"id": "099"}, 24),
-        ("get_bounty", {"id": "+99"}, 25),
-        ("get_ledger_entry", {"sequence": "01"}, 26),
-        ("submit_work_proof", {"bounty_id": "099"}, 27),
-        ("submit_work_proof", {"issue_number": "0656"}, 28),
+        ("list_bounties", {"limit": "3 "}, 24),
+        ("get_bounty", {"id": "099"}, 25),
+        ("get_bounty", {"id": "+99"}, 26),
+        ("get_bounty", {"id": "99 "}, 27),
+        ("get_ledger_entry", {"sequence": "01"}, 28),
+        ("submit_work_proof", {"bounty_id": "099"}, 29),
+        ("submit_work_proof", {"issue_number": "0656"}, 30),
     ],
 )
 def test_mcp_rejects_noncanonical_integer_string_arguments(


### PR DESCRIPTION
Bounty #656

## Summary
- Reject non-canonical numeric string arguments in public MCP tool calls, such as `099`, `+99`, `03`, and whitespace-padded values.
- Preserve compatibility for real JSON integers and canonical numeric strings such as `"99"`.
- Add MCP regressions across `list_bounties.limit`, `get_bounty.id`, `get_ledger_entry.sequence`, and `submit_work_proof` bounty/issue selectors.

## Live evidence before fix
Read-only calls to `https://api.mrwk.online/mcp` returned successful resources for non-canonical aliases:
- `get_bounty {"id": "099"}` -> result for bounty id 99.
- `get_bounty {"id": "+99"}` -> result for bounty id 99.
- `get_ledger_entry {"sequence": "01"}` -> result for ledger sequence 1.
- `submit_work_proof {"bounty_id": "099", "format": "json"}` -> guidance for bounty id 99.
- `submit_work_proof {"issue_number": "0656", "repo": "ramimbo/mergework", "format": "json"}` -> guidance for issue 656.
- `list_bounties {"limit": "03"}` and `{"limit": "+3"}` -> normal three-row result.

`99.0` / `3.0` already failed, so this PR narrows the accepted string form to canonical integer spellings instead of changing all numeric-string compatibility.

## Validation
- `.venv/bin/python -m pytest tests/test_api_mcp.py::test_mcp_rejects_noncanonical_integer_string_arguments tests/test_api_mcp.py::test_mcp_accepts_canonical_integer_string_arguments tests/test_api_mcp.py::test_mcp_get_bounty_rejects_fractional_id tests/test_api_mcp.py::test_mcp_rejects_oversized_integer_arguments_without_500 -q` -> 15 passed, 1 warning.
- `.venv/bin/python -m pytest tests/test_api_mcp.py -q` -> 94 passed, 1 warning.
- `.venv/bin/python -m pytest -q` -> 633 passed, 1 warning.
- `.venv/bin/python -m mypy app/mcp_tools.py` -> success.
- `.venv/bin/ruff check app/mcp_tools.py tests/test_api_mcp.py` -> passed.
- `.venv/bin/ruff format --check app/mcp_tools.py tests/test_api_mcp.py` -> 2 files already formatted.
- `git diff --check` and `git diff --check origin/main...HEAD` -> passed.

## Safety
Live verification was read-only against the public MCP endpoint. No private data, credentials, wallet material, signatures, transfers, proposal execution, ledger mutation, scanners, rate-limit bypass, exchange/bridge/cash-out behavior, or private vulnerability details were used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened integer argument validation in API requests: non-canonical integer strings (leading zeros, explicit `+`, or surrounding whitespace) are rejected; properly formatted integers are accepted.

* **Tests**
  * Added tests covering integer argument canonicalization across multiple MCP endpoints to assert correct acceptance and rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->