### PR TITLE
Reject repeated scalar query filters

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -14,6 +14,7 @@ from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
 from app.ledger_views import account_ledger_transactions
 from app.models import Account
 from app.path_params import SQLITE_INTEGER_MAX
+from app.query_validation import reject_repeated_query_param
 from app.serializers import (
     accepted_work_for_account,
     account_accepted_summary,
@@ -187,6 +188,12 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
     def account_page(
         request: Request, account: str, tx_type: str | None = Query(None)
     ) -> HTMLResponse:
+        for value in request.query_params.getlist("tx_type"):
+            if contains_control_character(value):
+                raise HTTPException(
+                    status_code=400, detail="transaction type must not contain control characters"
+                )
+        reject_repeated_query_param(request, "tx_type")
         with session_scope(db_url) as session:
             context = account_page_context(session, account, tx_type)
         return templates.TemplateResponse(request, "account.html", context)

--- a/app/activity.py
+++ b/app/activity.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.control_chars import contains_control_character
 from app.db import session_scope
+from app.query_validation import reject_control_char_query_param, reject_repeated_query_param
 from app.serializers import activity_to_dict
 
 
@@ -20,12 +21,16 @@ def activity_context(session: Session, query: str | None = None) -> dict[str, An
 
 def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
     @app.get("/api/v1/activity")
-    def api_activity(q: str | None = Query(None)) -> dict[str, Any]:
+    def api_activity(request: Request, q: str | None = Query(None)) -> dict[str, Any]:
+        reject_control_char_query_param(request, "q")
+        reject_repeated_query_param(request, "q")
         with session_scope(db_url) as session:
             return activity_context(session, q)
 
     @app.get("/activity", response_class=HTMLResponse)
     def activity_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:
+        reject_control_char_query_param(request, "q")
+        reject_repeated_query_param(request, "q")
         with session_scope(db_url) as session:
             context = activity_context(session, q)
         return templates.TemplateResponse(request, "activity.html", context)

--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -27,7 +27,7 @@ from app.ledger.service import (
 )
 from app.models import Bounty, Proof, Submission
 from app.path_params import SQLITE_INTEGER_MAX, issue_number_search_value, positive_bounty_id
-from app.query_validation import reject_control_char_query_param
+from app.query_validation import reject_control_char_query_param, reject_repeated_query_param
 from app.serializers import (
     bounties_to_dict,
     bounty_awards_to_dict,
@@ -193,8 +193,9 @@ def register_bounty_api_routes(
         issue_number: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
         availability: str | None = Query(None),
     ) -> list[dict[str, Any]]:
-        reject_control_char_query_param(request, "limit")
-        reject_control_char_query_param(request, "issue_number")
+        for name in ("status", "q", "limit", "sort", "repo", "issue_number", "availability"):
+            reject_control_char_query_param(request, name)
+            reject_repeated_query_param(request, name)
         return _list_bounties_by_status(
             status,
             q,
@@ -216,8 +217,9 @@ def register_bounty_api_routes(
         issue_number: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
         availability: str | None = Query(None),
     ) -> dict[str, Any]:
-        reject_control_char_query_param(request, "limit")
-        reject_control_char_query_param(request, "issue_number")
+        for name in ("status", "q", "limit", "sort", "repo", "issue_number", "availability"):
+            reject_control_char_query_param(request, name)
+            reject_repeated_query_param(request, name)
         return bounty_list_summary(
             _list_bounties_by_status(
                 status,

--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -10,11 +10,11 @@ from sqlalchemy import func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import CONTROL_CHAR_RE, LedgerError, validate_public_url
 from app.models import Bounty, BountyAttempt
 from app.openapi_request_bodies import OPTIONAL_ATTEMPT_BODY, OPTIONAL_ATTEMPT_RELEASE_BODY
+from app.query_validation import reject_control_char_query_param, reject_repeated_query_param
 from app.serializers import bounty_to_dict
 
 DEFAULT_ATTEMPT_TTL_SECONDS = 24 * 60 * 60
@@ -37,15 +37,6 @@ def _as_utc(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value.replace(tzinfo=UTC)
     return value.astimezone(UTC)
-
-
-def _reject_control_char_query_param(request: Request, name: str) -> None:
-    for value in request.query_params.getlist(name):
-        if contains_control_character(value):
-            raise HTTPException(
-                status_code=400,
-                detail=f"{name} must not contain control characters",
-            )
 
 
 def _attempt_effective_status(attempt: BountyAttempt, now: datetime) -> str:
@@ -168,7 +159,9 @@ def register_bounty_attempt_routes(
         include_expired: bool = Query(False),
         limit: Annotated[int | None, Query(ge=1, le=100)] = None,
     ) -> dict[str, Any]:
-        _reject_control_char_query_param(request, "limit")
+        for name in ("include_expired", "limit"):
+            reject_control_char_query_param(request, name)
+            reject_repeated_query_param(request, name)
         bounty_id_int = positive_bounty_id(bounty_id)
         now = _utc_now()
         with session_scope(db_url) as session:

--- a/app/main.py
+++ b/app/main.py
@@ -37,7 +37,7 @@ from app.path_params import (
     proof_hash_from_path,
 )
 from app.public_routes import register_public_routes
-from app.query_validation import reject_control_char_query_param
+from app.query_validation import reject_control_char_query_param, reject_repeated_query_param
 from app.status import health_status, system_status
 from app.treasury_routes import register_treasury_routes
 from app.wallet_api import register_wallet_api_routes
@@ -316,6 +316,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         limit: Annotated[int, Query(ge=1, le=200)] = 50,
     ) -> list[dict[str, Any]]:
         reject_control_char_query_param(request, "limit")
+        reject_repeated_query_param(request, "limit")
         return ledger_rows(limit)
 
     @app.get("/api/v1/ledger/{sequence}")

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -299,6 +299,8 @@ def register_public_routes(
 
     @app.get("/wallets", response_class=HTMLResponse)
     def wallets_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:
+        reject_control_char_query_param(request, "q")
+        reject_repeated_query_param(request, "q")
         with session_scope(db_url) as session:
             context = wallets_page_context(session, q)
         return templates.TemplateResponse(request, "wallets.html", context)
@@ -309,6 +311,12 @@ def register_public_routes(
         address: str,
         type: str | None = Query(None),  # noqa: A002
     ) -> HTMLResponse:
+        for value in request.query_params.getlist("type"):
+            if contains_control_character(value):
+                raise HTTPException(
+                    status_code=400, detail="transaction type must not contain control characters"
+                )
+        reject_repeated_query_param(request, "type")
         with session_scope(db_url) as session:
             context = wallet_page_context(session, address, type)
         return templates.TemplateResponse(request, "wallet_detail.html", context)

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -18,7 +18,7 @@ from app.db import session_scope
 from app.ledger_views import account_ledger_transaction_types, account_ledger_transactions
 from app.models import Wallet
 from app.path_params import SQLITE_INTEGER_MAX, proof_hash_from_path
-from app.query_validation import reject_control_char_query_param
+from app.query_validation import reject_control_char_query_param, reject_repeated_query_param
 from app.serializers import bounty_list_summary, wallet_to_dict
 from app.status import (
     CURRENT_TRANSFER_PATHS,
@@ -262,8 +262,9 @@ def register_public_routes(
         issue_number: int | None = Query(None, ge=1, le=SQLITE_INTEGER_MAX),
         availability: str | None = Query(None),
     ) -> HTMLResponse:
-        reject_control_char_query_param(request, "limit")
-        reject_control_char_query_param(request, "issue_number")
+        for name in ("status", "q", "limit", "sort", "repo", "issue_number", "availability"):
+            reject_control_char_query_param(request, name)
+            reject_repeated_query_param(request, name)
         bounties = list_bounties_by_status(status, q, sort, limit, repo, issue_number, availability)
         return templates.TemplateResponse(
             request,

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -13,3 +13,12 @@ def reject_control_char_query_param(request: Request, name: str) -> None:
                 status_code=400,
                 detail=f"{name} must not contain control characters",
             )
+
+
+def reject_repeated_query_param(request: Request, name: str) -> None:
+    """Reject ambiguous scalar query parameters before FastAPI chooses one value."""
+    if len(request.query_params.getlist(name)) > 1:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{name} must be provided at most once",
+        )

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -13,7 +13,7 @@ from app.ledger.service import LedgerError
 from app.models import TreasuryProposal
 from app.openapi_request_bodies import TREASURY_CHALLENGE_BODY, TREASURY_PROPOSAL_BODY
 from app.path_params import SQLITE_INTEGER_MAX, positive_proposal_id
-from app.query_validation import reject_control_char_query_param
+from app.query_validation import reject_control_char_query_param, reject_repeated_query_param
 from app.treasury import (
     TREASURY_ACTIONS,
     challenge_to_dict,
@@ -116,8 +116,9 @@ def register_treasury_routes(
         to_account: Annotated[str | None, Query(max_length=128)] = None,
         bounty_id: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
     ) -> list[dict[str, Any]]:
-        reject_control_char_query_param(request, "limit")
-        reject_control_char_query_param(request, "bounty_id")
+        for name in ("limit", "action", "status", "to_account", "bounty_id"):
+            reject_control_char_query_param(request, name)
+            reject_repeated_query_param(request, name)
         action_filter = _optional_query_filter(
             action,
             "action",

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -265,6 +265,8 @@ def test_account_page_filters_transactions_by_type(sqlite_url: str) -> None:
     claims = client.get("/accounts/github:alice?tx_type=github_claim")
     invalid = client.get("/accounts/github:alice?tx_type=bogus")
     control = client.get("/accounts/github:alice?tx_type=%C2%85bounty_payment")
+    masked_control = client.get("/accounts/github:alice?tx_type=%C2%85bounty_payment&tx_type=all")
+    repeated = client.get("/accounts/github:alice?tx_type=bounty_payment&tx_type=all")
 
     assert all_rows.status_code == 200
     assert "Transaction type filters" in all_rows.text
@@ -287,6 +289,10 @@ def test_account_page_filters_transactions_by_type(sqlite_url: str) -> None:
 
     assert control.status_code == 400
     assert control.json()["detail"] == "transaction type must not contain control characters"
+    assert masked_control.status_code == 400
+    assert masked_control.json()["detail"] == "transaction type must not contain control characters"
+    assert repeated.status_code == 400
+    assert repeated.json()["detail"] == "tx_type must be provided at most once"
 
 
 def test_account_api_does_not_advertise_wallet_transfers_for_plain_accounts(

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -209,11 +209,20 @@ def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
 
     api_response = client.get("/api/v1/activity?q=%C2%85github")
     page_response = client.get("/activity?q=github%09")
+    masked_api_response = client.get("/api/v1/activity?q=%C2%85github&q=alice")
+    repeated_api_response = client.get("/api/v1/activity?q=github&q=alice")
+    repeated_page_response = client.get("/activity?q=github&q=alice")
 
     assert api_response.status_code == 400
     assert api_response.json()["detail"] == "q must not contain control characters"
     assert page_response.status_code == 400
     assert page_response.json()["detail"] == "q must not contain control characters"
+    assert masked_api_response.status_code == 400
+    assert masked_api_response.json()["detail"] == "q must not contain control characters"
+    assert repeated_api_response.status_code == 400
+    assert repeated_api_response.json()["detail"] == "q must be provided at most once"
+    assert repeated_page_response.status_code == 400
+    assert repeated_page_response.json()["detail"] == "q must be provided at most once"
 
 
 def test_activity_api_exposes_pending_payouts_separately_from_paid_work(

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -65,6 +65,19 @@ def test_ledger_api_rejects_control_character_limit(sqlite_url: str) -> None:
     assert response.json()["detail"] == "limit must not contain control characters"
 
 
+def test_ledger_api_rejects_repeated_limit_before_using_later_value(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/api/v1/ledger?limit=not-an-int&limit=1")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "limit must be provided at most once"
+
+
 def test_head_requests_match_get_routes_without_body(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -376,6 +376,11 @@ def test_bounty_api_search_query_rejects_control_characters(sqlite_url: str) -> 
     ("path", "detail"),
     [
         ("/api/v1/bounties?limit=not-an-int&limit=1", "limit must be provided at most once"),
+        ("/api/v1/bounties?sort=bogus&sort=newest", "sort must be provided at most once"),
+        (
+            "/api/v1/bounties/summary?repo=a%2Fb&repo=c%2Fd",
+            "repo must be provided at most once",
+        ),
         (
             "/api/v1/bounties/summary?issue_number=abc&issue_number=1",
             "issue_number must be provided at most once",

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
@@ -369,6 +370,40 @@ def test_bounty_api_search_query_rejects_control_characters(sqlite_url: str) -> 
     assert list_response.json()["detail"] == "q must not contain control characters"
     assert summary_response.status_code == 400
     assert summary_response.json()["detail"] == "q must not contain control characters"
+
+
+@pytest.mark.parametrize(
+    ("path", "detail"),
+    [
+        ("/api/v1/bounties?limit=not-an-int&limit=1", "limit must be provided at most once"),
+        (
+            "/api/v1/bounties/summary?issue_number=abc&issue_number=1",
+            "issue_number must be provided at most once",
+        ),
+        ("/api/v1/bounties?status=bogus&status=open", "status must be provided at most once"),
+        (
+            "/api/v1/bounties/summary?q=first&q=second",
+            "q must be provided at most once",
+        ),
+        (
+            "/api/v1/bounties?availability=bad&availability=all",
+            "availability must be provided at most once",
+        ),
+    ],
+)
+def test_bounty_api_rejects_repeated_scalar_filters(
+    sqlite_url: str, path: str, detail: str
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(path)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == detail
 
 
 def test_bounty_api_limit_caps_filtered_rows(sqlite_url: str) -> None:

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -124,6 +124,18 @@ def test_bounty_attempts_register_list_duplicate_and_release(sqlite_url: str, mo
     assert control_padded_limit.status_code == 400
     assert control_padded_limit.json()["detail"] == "limit must not contain control characters"
 
+    repeated_limit = client.get(f"/api/v1/bounties/{bounty.id}/attempts?limit=bad&limit=1")
+    assert repeated_limit.status_code == 400
+    assert repeated_limit.json()["detail"] == "limit must be provided at most once"
+
+    repeated_include_expired = client.get(
+        f"/api/v1/bounties/{bounty.id}/attempts?include_expired=bad&include_expired=false"
+    )
+    assert repeated_include_expired.status_code == 400
+    assert (
+        repeated_include_expired.json()["detail"] == "include_expired must be provided at most once"
+    )
+
     wrong_submitter = client.post(
         f"/api/v1/bounty-attempts/{first_attempt['id']}/release",
         json={"submitter_account": "github:bob"},

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -300,6 +300,25 @@ def test_bounties_page_honors_limit_filter(sqlite_url: str) -> None:
     assert controlled_limit.json()["detail"] == "limit must not contain control characters"
 
 
+def test_bounties_page_rejects_repeated_scalar_filters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    cases = {
+        "/bounties?limit=not-an-int&limit=10": "limit must be provided at most once",
+        "/bounties?issue_number=bad&issue_number=64": "issue_number must be provided at most once",
+        "/bounties?status=bogus&status=open": "status must be provided at most once",
+    }
+
+    for path, detail in cases.items():
+        response = client.get(path)
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == detail
+
+
 def test_bounties_page_rejects_sqlite_overflow_issue_number(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -310,6 +310,14 @@ def test_bounties_page_rejects_repeated_scalar_filters(sqlite_url: str) -> None:
         "/bounties?limit=not-an-int&limit=10": "limit must be provided at most once",
         "/bounties?issue_number=bad&issue_number=64": "issue_number must be provided at most once",
         "/bounties?status=bogus&status=open": "status must be provided at most once",
+        "/bounties?q=first&q=second": "q must be provided at most once",
+        "/bounties?sort=reward&sort=newest": "sort must be provided at most once",
+        "/bounties?repo=ramimbo%2Fmergework&repo=example%2Fother": (
+            "repo must be provided at most once"
+        ),
+        "/bounties?availability=all&availability=effectively_open": (
+            "availability must be provided at most once"
+        ),
     }
 
     for path, detail in cases.items():

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -632,6 +632,28 @@ def test_treasury_proposals_list_rejects_invalid_filters(
     assert response.json()["detail"] == expected_detail
 
 
+@pytest.mark.parametrize(
+    ("query", "detail"),
+    [
+        ("limit=not-an-int&limit=2", "limit must be provided at most once"),
+        ("status=invalid&status=pending", "status must be provided at most once"),
+        ("action=invalid&action=pay_bounty", "action must be provided at most once"),
+        ("to_account=bad&to_account=github%3Aalice", "to_account must be provided at most once"),
+        ("bounty_id=not-an-int&bounty_id=1", "bounty_id must be provided at most once"),
+    ],
+)
+def test_treasury_proposals_list_rejects_repeated_scalar_filters(
+    sqlite_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+    query: str,
+    detail: str,
+) -> None:
+    response = _client(sqlite_url, monkeypatch).get(f"/api/v1/treasury/proposals?{query}")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == detail
+
+
 def test_direct_proposal_creation_requires_admin_token(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -706,11 +706,26 @@ def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
 
     search_response = client.get("/wallets", params={"q": "\u0085Main"})
     type_response = client.get(f"/wallets/{address}", params={"type": "test_funding\t"})
+    masked_search_response = client.get("/wallets?q=%C2%85Main&q=Main")
+    repeated_search_response = client.get("/wallets?q=Main&q=smoke")
+    masked_type_response = client.get(f"/wallets/{address}?type=%C2%85test_funding&type=all")
+    repeated_type_response = client.get(f"/wallets/{address}?type=test_funding&type=all")
 
     assert search_response.status_code == 400
     assert search_response.json()["detail"] == "q must not contain control characters"
     assert type_response.status_code == 400
     assert type_response.json()["detail"] == "transaction type must not contain control characters"
+    assert masked_search_response.status_code == 400
+    assert masked_search_response.json()["detail"] == "q must not contain control characters"
+    assert repeated_search_response.status_code == 400
+    assert repeated_search_response.json()["detail"] == "q must be provided at most once"
+    assert masked_type_response.status_code == 400
+    assert (
+        masked_type_response.json()["detail"]
+        == "transaction type must not contain control characters"
+    )
+    assert repeated_type_response.status_code == 400
+    assert repeated_type_response.json()["detail"] == "type must be provided at most once"
 
 
 def test_me_page_shows_signed_in_github_claim_balance(sqlite_url: str, monkeypatch) -> None:


### PR DESCRIPTION
Refs #656.

## Summary
- add a shared raw query helper that rejects repeated scalar parameters before FastAPI chooses the later value
- apply it to public bounty API/page filters, ledger limit, and treasury proposal filters
- add regressions for the live invalid-first/valid-second duplicate-query pattern

## Live read-only bug evidence
Observed on 2026-06-01 before this fix:
- `/api/v1/bounties?limit=notanint&limit=1` returned HTTP 200
- `/api/v1/bounties/summary?limit=abc&limit=1` returned HTTP 200
- `/api/v1/ledger?limit=abc&limit=1` returned HTTP 200
- `/api/v1/treasury/proposals?status=not-a-status&status=pending&limit=2` returned HTTP 200
- `/api/v1/treasury/proposals?bounty_id=abc&bounty_id=99` returned HTTP 200

Expected behavior is to fail closed on repeated scalar filters so malformed earlier values cannot be hidden by a later valid duplicate.

## Validation
- `../mergework/.venv/bin/python -m pytest tests/test_api_mcp.py tests/test_bounty_api_routes.py tests/test_bounty_pages.py tests/test_treasury_proposals.py` -> 173 passed, 1 warning
- `../mergework/.venv/bin/python -m pytest` -> 636 passed, 1 warning
- `../mergework/.venv/bin/python -m mypy app` -> success
- `../mergework/.venv/bin/python -m ruff check app/query_validation.py app/bounty_api.py app/main.py app/public_routes.py app/treasury_routes.py tests/test_api_mcp.py tests/test_bounty_api_routes.py tests/test_bounty_pages.py tests/test_treasury_proposals.py` -> passed
- `../mergework/.venv/bin/python -m ruff format --check app/query_validation.py app/bounty_api.py app/main.py app/public_routes.py app/treasury_routes.py tests/test_api_mcp.py tests/test_bounty_api_routes.py tests/test_bounty_pages.py tests/test_treasury_proposals.py` -> 9 files already formatted
- `git diff --check` -> passed

## Safety
Live verification was read-only against public MRWK endpoints. No private data, credentials, wallet material, signatures, transfers, proposal execution, ledger mutation, scanners, rate-limit bypass, exchange/bridge/cash-out behavior, or private vulnerability details were used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened query-parameter validation sitewide and in APIs: duplicated scalar query parameters are now rejected with HTTP 400 and a clear "must be provided at most once" message across bounties, ledger, treasury proposals, wallets, accounts, activity, and related pages/endpoints.

* **Tests**
  * Added and expanded tests to verify repeated-query rejection and exact error messages for affected endpoints and pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->