### PR TITLE
Refresh live bounty issue body on finalization

### DIFF
--- a/app/github_issue_finalization.py
+++ b/app/github_issue_finalization.py
@@ -11,6 +11,8 @@ GITHUB_LABEL = "mrwk:bounty"
 GITHUB_PAID_LABEL = "mrwk:paid"
 USER_AGENT = "MergeWork"
 API_VERSION = "2022-11-28"
+LIVE_BOUNTY_STATUS_BLOCK_START = "<!-- mergework:mrwk:live-bounty-status:start -->"
+LIVE_BOUNTY_STATUS_BLOCK_END = "<!-- mergework:mrwk:live-bounty-status:end -->"
 PAID_BOUNTY_FINALIZATION_COMMENT_MARKER = "<!-- mergework:mrwk:paid-bounty-finalized -->"
 
 
@@ -152,6 +154,56 @@ def _existing_paid_finalization_comment_url(comments: list[dict[str, Any]]) -> s
     return None
 
 
+def _live_bounty_status_block(bounty_url: str) -> str:
+    return "\n".join(
+        [
+            LIVE_BOUNTY_STATUS_BLOCK_START,
+            "**MergeWork status:** live bounty",
+            "",
+            f"Reserved on MergeWork: {bounty_url}",
+            "",
+            (
+                "Claims are open only while the public bounty row remains open "
+                "and effective award capacity remains. Use the public bounty "
+                "page or API as the authoritative current status."
+            ),
+            LIVE_BOUNTY_STATUS_BLOCK_END,
+        ]
+    )
+
+
+def _issue_body_with_live_bounty_status(body: str, bounty_url: str) -> str:
+    block = _live_bounty_status_block(bounty_url)
+    start = body.find(LIVE_BOUNTY_STATUS_BLOCK_START)
+    end = body.find(LIVE_BOUNTY_STATUS_BLOCK_END)
+    if start != -1 and end != -1 and start < end:
+        end += len(LIVE_BOUNTY_STATUS_BLOCK_END)
+        return f"{body[:start]}{block}{body[end:]}"
+    return f"{block}\n\n{body}" if body else block
+
+
+def _refresh_live_bounty_issue_body(
+    *,
+    opener: Callable[..., Any],
+    issue_api_base: str,
+    github_token: str,
+    bounty_url: str,
+) -> dict[str, str]:
+    issue = _get_json(opener=opener, url=issue_api_base, github_token=github_token)
+    body = issue.get("body")
+    clean_body = body if isinstance(body, str) else ""
+    updated_body = _issue_body_with_live_bounty_status(clean_body, bounty_url)
+    if updated_body == clean_body:
+        return {"status": "already_current"}
+    _patch_json(
+        opener=opener,
+        url=issue_api_base,
+        github_token=github_token,
+        payload={"body": updated_body},
+    )
+    return {"status": "updated"}
+
+
 def finalize_created_bounty_issue(
     *,
     github_token: str,
@@ -185,16 +237,37 @@ def finalize_created_bounty_issue(
             github_token=clean_token,
             payload={"body": comment},
         )
+        try:
+            body_update = _refresh_live_bounty_issue_body(
+                opener=opener,
+                issue_api_base=issue_api_base,
+                github_token=clean_token,
+                bounty_url=bounty_url,
+            )
+        except HTTPError as exc:
+            body_update = {
+                "status": "failed",
+                "reason": f"github issue body update failed: HTTP {exc.code}",
+            }
+        except (OSError, ValueError) as exc:
+            body_update = {
+                "status": "failed",
+                "reason": f"github issue body update failed: {type(exc).__name__}",
+            }
     except HTTPError as exc:
         return {"status": "failed", "reason": f"github issue update failed: HTTP {exc.code}"}
     except (OSError, ValueError) as exc:
         return {"status": "failed", "reason": f"github issue update failed: {type(exc).__name__}"}
-    return {
+    result = {
         "status": "updated",
         "label": GITHUB_LABEL,
         "bounty_url": bounty_url,
         "comment_url": comment_response.get("html_url"),
+        "issue_body_status": body_update["status"],
     }
+    if "reason" in body_update:
+        result["issue_body_reason"] = body_update["reason"]
+    return result
 
 
 def finalize_paid_bounty_issue(

--- a/app/github_issue_finalization.py
+++ b/app/github_issue_finalization.py
@@ -13,6 +13,14 @@ USER_AGENT = "MergeWork"
 API_VERSION = "2022-11-28"
 LIVE_BOUNTY_STATUS_BLOCK_START = "<!-- mergework:mrwk:live-bounty-status:start -->"
 LIVE_BOUNTY_STATUS_BLOCK_END = "<!-- mergework:mrwk:live-bounty-status:end -->"
+STALE_PENDING_BOUNTY_STATUS_TEXT = (
+    (
+        "Status: proposed bounty. This issue is not claimable until the treasury proposal "
+        "executes, the public bounty page exists, and the `Reserved on MergeWork` "
+        "claims-open comment is posted."
+    ),
+    "Status: proposed bounty. This issue is not claimable yet.",
+)
 PAID_BOUNTY_FINALIZATION_COMMENT_MARKER = "<!-- mergework:mrwk:paid-bounty-finalized -->"
 
 
@@ -172,14 +180,26 @@ def _live_bounty_status_block(bounty_url: str) -> str:
     )
 
 
+def _without_stale_pending_bounty_status_text(body: str) -> str:
+    paragraphs = body.split("\n\n")
+    filtered = [
+        paragraph
+        for paragraph in paragraphs
+        if paragraph.strip() not in STALE_PENDING_BOUNTY_STATUS_TEXT
+    ]
+    return "\n\n".join(filtered).strip("\n")
+
+
 def _issue_body_with_live_bounty_status(body: str, bounty_url: str) -> str:
     block = _live_bounty_status_block(bounty_url)
     start = body.find(LIVE_BOUNTY_STATUS_BLOCK_START)
     end = body.find(LIVE_BOUNTY_STATUS_BLOCK_END)
     if start != -1 and end != -1 and start < end:
         end += len(LIVE_BOUNTY_STATUS_BLOCK_END)
-        return f"{body[:start]}{block}{body[end:]}"
-    return f"{block}\n\n{body}" if body else block
+        updated = f"{body[:start]}{block}{body[end:]}"
+    else:
+        updated = f"{block}\n\n{body}" if body else block
+    return _without_stale_pending_bounty_status_text(updated)
 
 
 def _refresh_live_bounty_issue_body(

--- a/tests/test_github_issue_finalization.py
+++ b/tests/test_github_issue_finalization.py
@@ -29,6 +29,11 @@ class _FakeResponse:
 
 def test_finalize_created_bounty_issue_adds_label_and_claims_open_comment() -> None:
     requests: list[Request] = []
+    stale_status = (
+        "Status: proposed bounty. This issue is not claimable until the treasury proposal "
+        "executes, the public bounty page exists, and the `Reserved on MergeWork` "
+        "claims-open comment is posted."
+    )
 
     def fake_opener(request: Request, timeout: float) -> _FakeResponse:
         requests.append(request)
@@ -37,7 +42,11 @@ def test_finalize_created_bounty_issue_adds_label_and_claims_open_comment() -> N
                 {
                     "body": (
                         "## MRWK Bounty\n\n"
-                        "Status: proposed bounty. This issue is not claimable yet."
+                        f"{stale_status}\n\n"
+                        "Reward: `50 MRWK per accepted award`\n"
+                        "Max awards: `10`\n\n"
+                        "## Work Needed\n\n"
+                        "Normal bounty details stay here."
                     )
                 }
             )
@@ -82,7 +91,10 @@ def test_finalize_created_bounty_issue_adds_label_and_claims_open_comment() -> N
     issue_body = json.loads((requests[3].data or b"").decode())["body"]
     assert issue_body.startswith(LIVE_BOUNTY_STATUS_BLOCK_START)
     assert "Reserved on MergeWork: https://mrwk.example/bounties/123" in issue_body
-    assert "Status: proposed bounty. This issue is not claimable yet." in issue_body
+    assert stale_status not in issue_body
+    assert "Reward: `50 MRWK per accepted award`" in issue_body
+    assert "Max awards: `10`" in issue_body
+    assert "Normal bounty details stay here." in issue_body
 
 
 def test_finalize_created_bounty_issue_replaces_existing_live_status_block() -> None:
@@ -98,7 +110,15 @@ def test_finalize_created_bounty_issue_replaces_existing_live_status_block() -> 
     def fake_opener(request: Request, timeout: float) -> _FakeResponse:
         requests.append(request)
         if request.get_method() == "GET":
-            return _FakeResponse({"body": f"Intro\n\n{stale_block}\n\nOriginal details"})
+            return _FakeResponse(
+                {
+                    "body": (
+                        f"Intro\n\n{stale_block}\n\n"
+                        "Status: proposed bounty. This issue is not claimable yet.\n\n"
+                        "Original details"
+                    )
+                }
+            )
         if request.full_url.endswith("/comments"):
             return _FakeResponse(
                 {"html_url": "https://github.com/ramimbo/mergework/issues/77#issuecomment-1"}
@@ -119,6 +139,7 @@ def test_finalize_created_bounty_issue_replaces_existing_live_status_block() -> 
     assert issue_body.count(LIVE_BOUNTY_STATUS_BLOCK_START) == 1
     assert issue_body.count(LIVE_BOUNTY_STATUS_BLOCK_END) == 1
     assert "old status" not in issue_body
+    assert "Status: proposed bounty. This issue is not claimable yet." not in issue_body
     assert issue_body.startswith("Intro\n\n")
     assert issue_body.endswith("\n\nOriginal details")
 

--- a/tests/test_github_issue_finalization.py
+++ b/tests/test_github_issue_finalization.py
@@ -5,7 +5,12 @@ from typing import Any
 from urllib.error import HTTPError
 from urllib.request import Request
 
-from app.github_issue_finalization import finalize_created_bounty_issue, finalize_paid_bounty_issue
+from app.github_issue_finalization import (
+    LIVE_BOUNTY_STATUS_BLOCK_END,
+    LIVE_BOUNTY_STATUS_BLOCK_START,
+    finalize_created_bounty_issue,
+    finalize_paid_bounty_issue,
+)
 
 
 class _FakeResponse:
@@ -27,6 +32,15 @@ def test_finalize_created_bounty_issue_adds_label_and_claims_open_comment() -> N
 
     def fake_opener(request: Request, timeout: float) -> _FakeResponse:
         requests.append(request)
+        if request.get_method() == "GET":
+            return _FakeResponse(
+                {
+                    "body": (
+                        "## MRWK Bounty\n\n"
+                        "Status: proposed bounty. This issue is not claimable yet."
+                    )
+                }
+            )
         if request.full_url.endswith("/comments"):
             return _FakeResponse(
                 {"html_url": "https://github.com/ramimbo/mergework/issues/77#issuecomment-1"}
@@ -49,8 +63,9 @@ def test_finalize_created_bounty_issue_adds_label_and_claims_open_comment() -> N
         "label": "mrwk:bounty",
         "bounty_url": "https://mrwk.example/bounties/123",
         "comment_url": "https://github.com/ramimbo/mergework/issues/77#issuecomment-1",
+        "issue_body_status": "updated",
     }
-    assert [request.get_method() for request in requests] == ["POST", "POST"]
+    assert [request.get_method() for request in requests] == ["POST", "POST", "GET", "PATCH"]
     assert requests[0].full_url == (
         "https://api.github.com/repos/ramimbo/mergework/issues/77/labels"
     )
@@ -62,6 +77,81 @@ def test_finalize_created_bounty_issue_adds_label_and_claims_open_comment() -> N
     comment_body = json.loads((requests[1].data or b"").decode())["body"]
     assert "Reserved on MergeWork: https://mrwk.example/bounties/123" in comment_body
     assert "Claims are now open" in comment_body
+    assert requests[2].full_url == "https://api.github.com/repos/ramimbo/mergework/issues/77"
+    assert requests[3].full_url == "https://api.github.com/repos/ramimbo/mergework/issues/77"
+    issue_body = json.loads((requests[3].data or b"").decode())["body"]
+    assert issue_body.startswith(LIVE_BOUNTY_STATUS_BLOCK_START)
+    assert "Reserved on MergeWork: https://mrwk.example/bounties/123" in issue_body
+    assert "Status: proposed bounty. This issue is not claimable yet." in issue_body
+
+
+def test_finalize_created_bounty_issue_replaces_existing_live_status_block() -> None:
+    requests: list[Request] = []
+    stale_block = "\n".join(
+        [
+            LIVE_BOUNTY_STATUS_BLOCK_START,
+            "old status",
+            LIVE_BOUNTY_STATUS_BLOCK_END,
+        ]
+    )
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        requests.append(request)
+        if request.get_method() == "GET":
+            return _FakeResponse({"body": f"Intro\n\n{stale_block}\n\nOriginal details"})
+        if request.full_url.endswith("/comments"):
+            return _FakeResponse(
+                {"html_url": "https://github.com/ramimbo/mergework/issues/77#issuecomment-1"}
+            )
+        return _FakeResponse({})
+
+    result = finalize_created_bounty_issue(
+        github_token="github-token",
+        public_base_url="https://mrwk.example",
+        bounty={"id": 123, "repo": "ramimbo/mergework", "issue_number": 77},
+        opener=fake_opener,
+    )
+
+    assert result["issue_body_status"] == "updated"
+    patch_requests = [request for request in requests if request.get_method() == "PATCH"]
+    assert len(patch_requests) == 1
+    issue_body = json.loads((patch_requests[0].data or b"").decode())["body"]
+    assert issue_body.count(LIVE_BOUNTY_STATUS_BLOCK_START) == 1
+    assert issue_body.count(LIVE_BOUNTY_STATUS_BLOCK_END) == 1
+    assert "old status" not in issue_body
+    assert issue_body.startswith("Intro\n\n")
+    assert issue_body.endswith("\n\nOriginal details")
+
+
+def test_finalize_created_bounty_issue_reports_body_refresh_failure_without_blocking() -> None:
+    requests: list[Request] = []
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        requests.append(request)
+        if request.get_method() == "GET":
+            raise HTTPError(url=request.full_url, code=503, msg="unavailable", hdrs=None, fp=None)
+        if request.full_url.endswith("/comments"):
+            return _FakeResponse(
+                {"html_url": "https://github.com/ramimbo/mergework/issues/77#issuecomment-1"}
+            )
+        return _FakeResponse({})
+
+    result = finalize_created_bounty_issue(
+        github_token="github-token",
+        public_base_url="https://mrwk.example",
+        bounty={"id": 123, "repo": "ramimbo/mergework", "issue_number": 77},
+        opener=fake_opener,
+    )
+
+    assert result == {
+        "status": "updated",
+        "label": "mrwk:bounty",
+        "bounty_url": "https://mrwk.example/bounties/123",
+        "comment_url": "https://github.com/ramimbo/mergework/issues/77#issuecomment-1",
+        "issue_body_status": "failed",
+        "issue_body_reason": "github issue body update failed: HTTP 503",
+    }
+    assert [request.get_method() for request in requests] == ["POST", "POST", "GET"]
 
 
 def test_finalize_created_bounty_issue_skips_without_token() -> None:


### PR DESCRIPTION
Bounty #656

## Summary

Fixes a live bounty-lifecycle inconsistency found after proposal 105 finalized #722: GitHub finalization adds `mrwk:bounty` and posts the `Reserved on MergeWork` comment, but the original issue body can still say the bounty is proposed and not claimable.

This PR makes `finalize_created_bounty_issue()` also refresh the GitHub issue body with a bounded MergeWork live-status block.

## Changes

- Adds a generated `mergework:mrwk:live-bounty-status` block with the public bounty URL and current-status guidance.
- Preserves the existing issue body below the generated block.
- Replaces an existing generated block on rerun instead of duplicating it.
- Keeps label/comment finalization behavior unchanged.
- Treats body-refresh failures as non-blocking and records `issue_body_status` / `issue_body_reason` in the finalization result.

## Live Evidence

Observed on 2026-06-01:

- #722 has `mrwk:bounty`, `Reserved on MergeWork`, and public bounty row `https://mrwk.online/bounties/101`.
- Treasury proposal 105 executed at `2026-06-01T18:49:00.753586Z` with `github_issue_finalization.status: updated`.
- #722 issue body still says `Status: proposed bounty` and `not claimable`.
- #649 shows the same stale-body pattern after completion/paid finalization.

Related proposed-work intake: #772.

## Validation

- `../mergework/.venv/bin/python -m pytest tests/test_github_issue_finalization.py -q` -> 11 passed
- `../mergework/.venv/bin/python -m pytest tests/test_github_issue_finalization.py tests/test_treasury_executor.py tests/test_treasury_proposals.py -q` -> 64 passed, 1 warning
- `../mergework/.venv/bin/python -m pytest -q` -> 626 passed, 1 warning
- `../mergework/.venv/bin/python -m mypy app` -> success, no issues in 38 source files
- `../mergework/.venv/bin/ruff check app/github_issue_finalization.py tests/test_github_issue_finalization.py` -> passed
- `../mergework/.venv/bin/ruff format --check app/github_issue_finalization.py tests/test_github_issue_finalization.py` -> 2 files already formatted
- `git diff --check` -> passed

## Safety / Scope

No payout, wallet, bridge, exchange, liquidity, cash-out, or private security behavior is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display and automatically update a "live bounty" status block in GitHub issue bodies during bounty finalization; outdated content is replaced or prepended as needed.
  * Issue-body update failures are reported (with reason) without aborting the finalization flow.
* **Tests**
  * Expanded tests cover status-block replacement, preservation of other content, and handling of update failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->