### PR TITLE
Reject unknown wallet transaction filters

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -10,7 +10,11 @@ from fastapi.templating import Jinja2Templates
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
-from app.accounts import normalized_wallet_address
+from app.accounts import (
+    ACCOUNT_TRANSACTION_TYPE_OPTIONS,
+    ACCOUNT_TRANSACTION_TYPES,
+    normalized_wallet_address,
+)
 from app.bounty_availability import normalize_bounty_availability_filter
 from app.bounty_sorting import BOUNTY_SORT_LABELS, normalize_bounty_sort
 from app.control_chars import contains_control_character
@@ -208,12 +212,27 @@ def wallet_page_context(
     selected_transaction_type = transaction_type.strip() if transaction_type is not None else ""
     if selected_transaction_type.lower() == "all":
         selected_transaction_type = ""
+    available_transaction_types = account_ledger_transaction_types(session, wallet.address)
+    selected_transaction_type = selected_transaction_type.lower()
+    allowed_transaction_types = ACCOUNT_TRANSACTION_TYPES | set(available_transaction_types)
+    if selected_transaction_type and selected_transaction_type not in allowed_transaction_types:
+        static_options = [str(option["value"]) for option in ACCOUNT_TRANSACTION_TYPE_OPTIONS]
+        custom_options = [
+            entry_type
+            for entry_type in available_transaction_types
+            if entry_type not in ACCOUNT_TRANSACTION_TYPES and entry_type != "all"
+        ]
+        allowed = ", ".join([*static_options, *custom_options])
+        raise HTTPException(
+            status_code=400,
+            detail=f"transaction type must be one of: {allowed}",
+        )
     return {
         "wallet": wallet_to_dict(session, wallet),
         "transactions": account_ledger_transactions(
             session, wallet.address, entry_type=selected_transaction_type or None
         ),
-        "transaction_types": account_ledger_transaction_types(session, wallet.address),
+        "transaction_types": available_transaction_types,
         "selected_transaction_type": selected_transaction_type,
     }
 

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -648,6 +648,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     funded_all_type_filter_upper = client.get(f"/wallets/{funded_address}?type=ALL").text
     funded_all_type_filter_spaced = client.get(f"/wallets/{funded_address}?type=%20all%20").text
     funded_missing_type = client.get(f"/wallets/{funded_address}?type=bounty_payment").text
+    funded_unknown_type = client.get(f"/wallets/{funded_address}?type=not_a_real_type")
     transfer = client.get("/transfer").text
     me = client.get("/me").text
 
@@ -691,6 +692,11 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "wallet_transfer" in funded_all_type_filter_spaced
     assert "test_funding" in funded_all_type_filter_spaced
     assert "No wallet transactions match this type." in funded_missing_type
+    assert funded_unknown_type.status_code == 400
+    assert funded_unknown_type.json()["detail"] == (
+        "transaction type must be one of: all, bounty_payment, bounty_reserve, "
+        "bounty_release, github_claim, wallet_transfer, genesis, test_funding"
+    )
     assert "Signed transfer" in transfer
     assert "both wallets are registered" in transfer
     assert "/static/wallet.js" in transfer


### PR DESCRIPTION
Bounty #656

## Summary
- reject unknown wallet detail `type=` filters instead of rendering arbitrary transaction type names as if they were valid;
- keep `type=all` / blank as unfiltered;
- keep known account transaction types valid even when a specific wallet has no matching rows;
- keep wallet-specific custom ledger types such as `test_funding` valid when they exist for that wallet.

## Live Evidence
Observed on 2026-06-01 against the public wallet/account pages:

```text
GET /wallets/mrwk17849a6031ac8bc203a6a1a915b55e6a40d9769cd?type=not_a_real_type
-> 200 HTML, "Showing not_a_real_type transactions." and "No wallet transactions match this type."

GET /accounts/github:attaboy11?tx_type=not_a_real_type
-> 400 {"detail":"transaction type must be one of: all, bounty_payment, bounty_reserve, bounty_release, github_claim, wallet_transfer, genesis"}
```

The wallet page already rejects control-character `type` values and now treats `type=all` as unfiltered; this patch covers the remaining single-value unknown-type case.

## Why it matters
Wallet detail pages are public reconciliation surfaces for balances, linked GitHub accounts, and transaction history. Silently accepting impossible transaction types makes malformed contributor or monitor URLs look like valid empty filtered views.

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/mycomputo/Documents/Codex/2026-05-31/goal-goal-find-and-execute-legitimate/work/repos/mergework/.venv/bin/python -m pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows tests/test_wallet_api.py::test_wallet_pages_reject_control_character_filters -q` -> 2 passed, 1 warning
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/mycomputo/Documents/Codex/2026-05-31/goal-goal-find-and-execute-legitimate/work/repos/mergework/.venv/bin/python -m pytest tests/test_wallet_api.py tests/test_account_routes.py tests/test_public_routes.py -q` -> 54 passed, 1 warning
- `/Users/mycomputo/Documents/Codex/2026-05-31/goal-goal-find-and-execute-legitimate/work/repos/mergework/.venv/bin/python -m ruff check app/public_routes.py tests/test_wallet_api.py` -> passed
- `/Users/mycomputo/Documents/Codex/2026-05-31/goal-goal-find-and-execute-legitimate/work/repos/mergework/.venv/bin/python -m ruff format --check app/public_routes.py tests/test_wallet_api.py` -> 2 files already formatted
- `/Users/mycomputo/Documents/Codex/2026-05-31/goal-goal-find-and-execute-legitimate/work/repos/mergework/.venv/bin/python -m mypy app/public_routes.py` -> success
- `git diff --check` -> passed
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `6b54b95c59e309e75a920767d703aacd2125a944`

No private data, credentials, wallet material, production mutation, payout/proof/ledger execution, exchange, bridge, cash-out, price behavior, or fabricated payout claims were used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction type query parameters are now validated; invalid types return HTTP 400 with allowed values enumerated.

* **Tests**
  * Added test coverage for invalid transaction type query parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->