### PR TITLE
Reject boolean query aliases for bounty attempts

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -15,7 +15,7 @@ from app.ledger.service import CONTROL_CHAR_RE, LedgerError, validate_public_url
 from app.models import Bounty, BountyAttempt
 from app.openapi_request_bodies import OPTIONAL_ATTEMPT_BODY, OPTIONAL_ATTEMPT_RELEASE_BODY
 from app.query_validation import (
-    reject_control_char_query_param,
+    reject_noncanonical_bool_query_param,
     reject_noncanonical_int_query_param,
     reject_repeated_query_param,
 )
@@ -165,7 +165,7 @@ def register_bounty_attempt_routes(
     ) -> dict[str, Any]:
         for name in ("include_expired", "limit"):
             reject_repeated_query_param(request, name)
-        reject_control_char_query_param(request, "include_expired")
+        reject_noncanonical_bool_query_param(request, "include_expired")
         reject_noncanonical_int_query_param(request, "limit")
         bounty_id_int = positive_bounty_id(bounty_id)
         now = _utc_now()

--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -160,7 +160,7 @@ def register_bounty_attempt_routes(
     def api_bounty_attempts(
         request: Request,
         bounty_id: str,
-        include_expired: bool = Query(False),
+        include_expired: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=100)] = None,
     ) -> dict[str, Any]:
         for name in ("include_expired", "limit"):
@@ -174,7 +174,11 @@ def register_bounty_attempt_routes(
             if bounty is None:
                 raise HTTPException(status_code=404, detail="bounty not found")
             listing = list_bounty_attempts(
-                session, bounty, include_expired=include_expired, limit=limit, now=now
+                session,
+                bounty,
+                include_expired=include_expired == "true",
+                limit=limit,
+                now=now,
             )
             return {
                 "bounty_id": bounty_id_int,

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -9,6 +9,7 @@ from app.control_chars import contains_control_character
 # Keep zero syntactically canonical so existing typed range validators own range errors,
 # while rejecting aliases like +1, 1.0, and 01 before integer coercion.
 CANONICAL_INTEGER_QUERY_RE = re.compile(r"^(?:0|[1-9][0-9]*)$")
+CANONICAL_BOOLEAN_QUERY_VALUES = {"true", "false"}
 
 
 def reject_control_char_query_param(request: Request, name: str) -> None:
@@ -33,6 +34,21 @@ def reject_noncanonical_int_query_param(request: Request, name: str) -> None:
             raise HTTPException(
                 status_code=400,
                 detail=f"{name} must be a canonical positive integer",
+            )
+
+
+def reject_noncanonical_bool_query_param(request: Request, name: str) -> None:
+    """Reject boolean query aliases before application code trusts coerced values."""
+    for value in request.query_params.getlist(name):
+        if contains_control_character(value):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} must not contain control characters",
+            )
+        if value not in CANONICAL_BOOLEAN_QUERY_VALUES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} must be true or false",
             )
 
 

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -150,6 +150,14 @@ def test_bounty_attempts_register_list_duplicate_and_release(sqlite_url: str, mo
         assert response.status_code == 400
         assert response.json()["detail"] == "include_expired must be true or false"
 
+    control_char_bool = client.get(
+        f"/api/v1/bounties/{bounty.id}/attempts?include_expired=%C2%85true"
+    )
+    assert control_char_bool.status_code == 400
+    assert (
+        control_char_bool.json()["detail"] == "include_expired must not contain control characters"
+    )
+
     wrong_submitter = client.post(
         f"/api/v1/bounty-attempts/{first_attempt['id']}/release",
         json={"submitter_account": "github:bob"},

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -143,6 +143,13 @@ def test_bounty_attempts_register_list_duplicate_and_release(sqlite_url: str, mo
         repeated_include_expired.json()["detail"] == "include_expired must be provided at most once"
     )
 
+    for noncanonical_bool in ("1", "0", "yes", "no", "on", "off", "t", "f", "True"):
+        response = client.get(
+            f"/api/v1/bounties/{bounty.id}/attempts?include_expired={noncanonical_bool}"
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"] == "include_expired must be true or false"
+
     wrong_submitter = client.post(
         f"/api/v1/bounty-attempts/{first_attempt['id']}/release",
         json={"submitter_account": "github:bob"},


### PR DESCRIPTION
Refs #656
Related report: https://github.com/ramimbo/mergework/issues/656#issuecomment-4596321943
Related proposed work: #780

## Summary
- Add a shared raw boolean query validator that only accepts canonical `true` / `false` query values.
- Apply it to `/api/v1/bounties/{bounty_id}/attempts?include_expired=...` before trusting the coerced boolean argument.
- Cover common aliases (`1`, `0`, `yes`, `no`, `on`, `off`, `t`, `f`, `True`) with bounded 400 responses.

## Why
Live public checks showed `include_expired` accepted multiple Pydantic boolean aliases as successful requests. This aligns boolean filters with the recent canonical numeric and repeated scalar query validation behavior.

## Verification
- `.venv/bin/python -m pytest tests/test_bounty_attempts.py -q` -> 11 passed, 1 warning
- `.venv/bin/python -m pytest -q` -> 674 passed, 1 warning
- `.venv/bin/python -m ruff format --check .` -> 104 files already formatted
- `.venv/bin/python -m ruff check .` -> All checks passed
- `git diff --check` -> clean

No secrets, wallet material, private vulnerability details, deployment credentials, payout details, MRWK price/exchange, or bridge/liquidity claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation for boolean query parameters: only the literal "true" or "false" are accepted. Invalid values return HTTP 400 with a clear error.
  * The include_expired query now enables expired items only when set to "true" (other values are rejected).

* **Tests**
  * Updated tests to cover non-canonical and control-character boolean inputs and expected 400 responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->