### PR TITLE
Reject whitespace-padded account and wallet paths

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -13,7 +13,7 @@ from app.db import session_scope
 from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
 from app.ledger_views import account_ledger_transactions
 from app.models import Account
-from app.path_params import SQLITE_INTEGER_MAX
+from app.path_params import SQLITE_INTEGER_MAX, reject_path_whitespace_padding
 from app.query_validation import reject_repeated_query_param
 from app.serializers import (
     accepted_work_for_account,
@@ -176,11 +176,13 @@ def account_page_context(
 def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
     @app.get("/api/v1/accounts/{account}")
     def api_account(account: str) -> dict[str, Any]:
+        reject_path_whitespace_padding(account, "account")
         with session_scope(db_url) as session:
             return account_api_context(session, account)
 
     @app.get("/api/v1/accounts/{account}/accepted-work")
     def api_account_accepted_work(account: str) -> dict[str, Any]:
+        reject_path_whitespace_padding(account, "account")
         with session_scope(db_url) as session:
             return account_accepted_work_context(session, account)
 
@@ -188,6 +190,7 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
     def account_page(
         request: Request, account: str, tx_type: str | None = Query(None)
     ) -> HTMLResponse:
+        reject_path_whitespace_padding(account, "account")
         for value in request.query_params.getlist("tx_type"):
             if contains_control_character(value):
                 raise HTTPException(

--- a/app/path_params.py
+++ b/app/path_params.py
@@ -9,6 +9,17 @@ HEX_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 POSITIVE_INTEGER_RE = re.compile(r"^[0-9]+$")
 
 
+def reject_path_whitespace_padding(value: str, field: str) -> None:
+    """Reject leading or trailing path whitespace before identifier normalization."""
+    if any(ord(char) < 32 or 127 <= ord(char) < 160 for char in value):
+        return
+    if value.strip() and value != value.strip():
+        raise HTTPException(
+            status_code=400,
+            detail=f"{field} must not contain leading or trailing whitespace",
+        )
+
+
 def issue_number_search_value(query: str) -> int | None:
     """Return a bounded GitHub issue number from a plain numeric search query."""
     clean = query.removeprefix("#")

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -21,7 +21,7 @@ from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger_views import account_ledger_transaction_types, account_ledger_transactions
 from app.models import Wallet
-from app.path_params import SQLITE_INTEGER_MAX, proof_hash_from_path
+from app.path_params import SQLITE_INTEGER_MAX, proof_hash_from_path, reject_path_whitespace_padding
 from app.query_validation import (
     reject_control_char_query_param,
     reject_noncanonical_int_query_param,
@@ -337,6 +337,7 @@ def register_public_routes(
         address: str,
         type: str | None = Query(None),  # noqa: A002
     ) -> HTMLResponse:
+        reject_path_whitespace_padding(address, "MRWK wallet address")
         for value in request.query_params.getlist("type"):
             if contains_control_character(value):
                 raise HTTPException(

--- a/app/wallet_api.py
+++ b/app/wallet_api.py
@@ -19,6 +19,7 @@ from app.openapi_request_bodies import (
     WALLET_REGISTER_BODY,
     WALLET_TRANSFER_BODY,
 )
+from app.path_params import reject_path_whitespace_padding
 from app.serializers import ledger_to_dict, wallet_to_dict, wallet_transfer_to_dict
 
 JsonObjectLoader = Callable[[Request], Awaitable[dict[str, Any]]]
@@ -66,6 +67,7 @@ def register_wallet_api_routes(
 
     @app.get("/api/v1/wallets/{address}")
     def api_wallet(address: str) -> dict[str, Any]:
+        reject_path_whitespace_padding(address, "MRWK wallet address")
         address = normalized_wallet_address(address)
         with session_scope(db_url) as session:
             wallet = session.get(Wallet, address)

--- a/tests/test_account_validation.py
+++ b/tests/test_account_validation.py
@@ -57,6 +57,26 @@ def test_account_views_reject_c1_controls_before_normalizing(
     assert resp.json()["detail"] == "account must not contain control characters"
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/accounts/%20github:alice",
+        "/api/v1/accounts/github:alice%20",
+        "/api/v1/accounts/%20github:alice/accepted-work",
+        "/api/v1/accounts/github:alice%20/accepted-work",
+        "/accounts/%20github:alice",
+        "/accounts/github:alice%20",
+    ],
+)
+def test_account_views_reject_path_whitespace_padding(sqlite_url: str, path: str) -> None:
+    client = _setup_app(sqlite_url)
+
+    resp = client.get(path)
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "account must not contain leading or trailing whitespace"
+
+
 def test_api_account_accepts_valid(sqlite_url: str) -> None:
     client = _setup_app(sqlite_url)
     resp = client.get("/api/v1/accounts/github:alice")
@@ -68,7 +88,7 @@ def test_api_account_rejects_empty_github_login(sqlite_url: str) -> None:
     client = _setup_app(sqlite_url)
     resp = client.get("/api/v1/accounts/github:%20")
     assert resp.status_code == 400
-    assert "github login" in resp.json()["detail"].lower()
+    assert resp.json()["detail"] == "account must not contain leading or trailing whitespace"
 
 
 def test_mcp_get_balance_rejects_empty_account(sqlite_url: str) -> None:
@@ -150,6 +170,7 @@ def test_account_page_rejects_empty_github_login(sqlite_url: str) -> None:
     client = _setup_app(sqlite_url)
     resp = client.get("/accounts/github:%20")
     assert resp.status_code == 400
+    assert resp.json()["detail"] == "account must not contain leading or trailing whitespace"
 
 
 def test_account_views_normalize_treasury_account(sqlite_url: str) -> None:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -2141,7 +2141,6 @@ def test_github_account_views_normalize_mixed_case_logins(sqlite_url: str) -> No
     account_cases = (
         ("github:Alice", "/api/v1/accounts/github:Alice", "/accounts/github:Alice"),
         ("GitHub:Alice", "/api/v1/accounts/GitHub:Alice", "/accounts/GitHub:Alice"),
-        (" GitHub:Alice ", "/api/v1/accounts/%20GitHub:Alice%20", "/accounts/%20GitHub:Alice%20"),
     )
     for mcp_account, api_path, page_path in account_cases:
         account_api = client.get(api_path).json()
@@ -2164,6 +2163,24 @@ def test_github_account_views_normalize_mixed_case_logins(sqlite_url: str) -> No
         assert f"/proofs/{proof.hash}" in account
         assert 'href="https://github.com/alice">@alice</a>' in account
         assert "github:alice: 50 MRWK" in balance["result"]["content"][0]["text"]
+
+    padded_api = client.get("/api/v1/accounts/%20GitHub:Alice%20")
+    padded_page = client.get("/accounts/%20GitHub:Alice%20")
+    padded_mcp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "get_balance", "arguments": {"account": " GitHub:Alice "}},
+        },
+    ).json()
+
+    assert padded_api.status_code == 400
+    assert padded_api.json()["detail"] == "account must not contain leading or trailing whitespace"
+    assert padded_page.status_code == 400
+    assert padded_page.json()["detail"] == "account must not contain leading or trailing whitespace"
+    assert "github:alice: 50 MRWK" in padded_mcp["result"]["content"][0]["text"]
 
 
 def test_ledger_page_highlights_bounty_payment_and_release(sqlite_url: str) -> None:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -373,6 +373,30 @@ def test_wallet_api_malformed_register_requests_return_4xx(sqlite_url: str) -> N
     assert non_object.json()["detail"] == "json body must be an object"
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/wallets/%20{address}",
+        "/api/v1/wallets/{address}%20",
+        "/wallets/%20{address}",
+        "/wallets/{address}%20",
+    ],
+)
+def test_wallet_lookup_rejects_path_whitespace_padding(sqlite_url: str, path: str) -> None:
+    create_schema(sqlite_url)
+    _, public_hex, address = _keypair()
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _register_wallet(client, public_hex)
+
+    response = client.get(path.format(address=address))
+
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "MRWK wallet address must not contain leading or trailing whitespace"
+    )
+
+
 def test_wallet_lookup_rejects_invalid_addresses_before_lookup(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))


### PR DESCRIPTION
Refs #656
Related report: https://github.com/ramimbo/mergework/issues/656#issuecomment-4596087917
Related proposed work: #778

## Summary
- Add a small path-parameter guard for leading/trailing ordinary whitespace before identifier normalization.
- Apply it to public account API/page routes, account accepted-work route, wallet API route, and wallet detail page.
- Preserve clean mixed-case account/wallet normalization and MCP text-argument behavior, while failing closed for `%20`-padded HTTP path identifiers.

## Why
Live public checks showed `/api/v1/accounts/%20github:...`, `/accounts/...%20`, `/api/v1/wallets/%20mrwk1...`, and `/wallets/...%20` normalized to canonical resources with HTTP 200. That makes malformed generated URLs look canonical. This PR keeps normal clean values working and rejects whitespace-padded path aliases with bounded 400 responses.

## Verification
- `.venv/bin/python -m pytest tests/test_account_validation.py tests/test_wallet_api.py::test_wallet_lookup_rejects_path_whitespace_padding tests/test_wallet_api.py::test_wallet_lookup_rejects_invalid_addresses_before_lookup -q` -> 49 passed, 1 warning
- `.venv/bin/python -m pytest tests/test_api_mcp.py::test_github_account_views_normalize_mixed_case_logins tests/test_account_validation.py tests/test_wallet_api.py::test_wallet_lookup_rejects_path_whitespace_padding -q` -> 49 passed, 1 warning
- `.venv/bin/python -m pytest -q` -> 684 passed, 1 warning
- `.venv/bin/python -m ruff format --check .` -> 104 files already formatted
- `.venv/bin/python -m ruff check .` -> All checks passed
- `git diff --check` -> clean

No secrets, wallet material, private vulnerability details, deployment credentials, payout details, MRWK price/exchange, or bridge/liquidity claims are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Stricter validation for account identifiers and wallet addresses in URLs; requests with leading or trailing whitespace in these path parameters are now rejected with HTTP 400 and a clear error message.

* **Tests**
  * Added comprehensive test coverage for whitespace validation across account and wallet endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->