### PR TITLE
Reject padded public string query filters

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -14,7 +14,10 @@ from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
 from app.ledger_views import account_ledger_transactions
 from app.models import Account
 from app.path_params import SQLITE_INTEGER_MAX
-from app.query_validation import reject_repeated_query_param
+from app.query_validation import (
+    reject_padded_query_param,
+    reject_repeated_query_param,
+)
 from app.serializers import (
     accepted_work_for_account,
     account_accepted_summary,
@@ -141,6 +144,13 @@ def _transaction_type_filter(tx_type: str | None) -> tuple[str, str | None]:
         raise HTTPException(
             status_code=400, detail="transaction type must not contain control characters"
         )
+    if tx_type is not None:
+        stripped = tx_type.strip()
+        if stripped and stripped != tx_type:
+            raise HTTPException(
+                status_code=400,
+                detail="transaction type must not include leading or trailing whitespace",
+            )
     selected = (tx_type or "all").strip().lower()
     if selected in {"", "all"}:
         return "all", None
@@ -194,6 +204,7 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
                     status_code=400, detail="transaction type must not contain control characters"
                 )
         reject_repeated_query_param(request, "tx_type")
+        reject_padded_query_param(request, "tx_type")
         with session_scope(db_url) as session:
             context = account_page_context(session, account, tx_type)
         return templates.TemplateResponse(request, "account.html", context)

--- a/app/activity.py
+++ b/app/activity.py
@@ -9,7 +9,11 @@ from sqlalchemy.orm import Session
 
 from app.control_chars import contains_control_character
 from app.db import session_scope
-from app.query_validation import reject_control_char_query_param, reject_repeated_query_param
+from app.query_validation import (
+    reject_control_char_query_param,
+    reject_padded_query_param,
+    reject_repeated_query_param,
+)
 from app.serializers import activity_to_dict
 
 
@@ -23,6 +27,7 @@ def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Temp
     @app.get("/api/v1/activity")
     def api_activity(request: Request, q: str | None = Query(None)) -> dict[str, Any]:
         reject_control_char_query_param(request, "q")
+        reject_padded_query_param(request, "q")
         reject_repeated_query_param(request, "q")
         with session_scope(db_url) as session:
             return activity_context(session, q)

--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -30,6 +30,7 @@ from app.path_params import SQLITE_INTEGER_MAX, issue_number_search_value, posit
 from app.query_validation import (
     reject_control_char_query_param,
     reject_noncanonical_int_query_param,
+    reject_padded_query_param,
     reject_repeated_query_param,
 )
 from app.serializers import (
@@ -201,6 +202,7 @@ def register_bounty_api_routes(
             reject_repeated_query_param(request, name)
         for name in ("status", "q", "sort", "repo", "availability"):
             reject_control_char_query_param(request, name)
+            reject_padded_query_param(request, name)
         for name in ("limit", "issue_number"):
             reject_noncanonical_int_query_param(request, name)
         return _list_bounties_by_status(
@@ -228,6 +230,7 @@ def register_bounty_api_routes(
             reject_repeated_query_param(request, name)
         for name in ("status", "q", "sort", "repo", "availability"):
             reject_control_char_query_param(request, name)
+            reject_padded_query_param(request, name)
         for name in ("limit", "issue_number"):
             reject_noncanonical_int_query_param(request, name)
         return bounty_list_summary(

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -26,6 +26,7 @@ from app.query_validation import (
     reject_control_char_query_param,
     reject_noncanonical_int_query_param,
     reject_padded_query_param,
+    reject_padded_value,
     reject_repeated_query_param,
 )
 from app.serializers import bounty_list_summary, wallet_to_dict
@@ -182,10 +183,7 @@ def public_bounties_context(
 def wallets_page_context(session: Session, q: str | None = None) -> dict[str, Any]:
     if q is not None and contains_control_character(q):
         raise HTTPException(status_code=400, detail="q must not contain control characters")
-    if q is not None and q.strip() and q.strip() != q:
-        raise HTTPException(
-            status_code=400, detail="q must not include leading or trailing whitespace"
-        )
+    reject_padded_value("q", q)
     query_text = q.strip() if q is not None else ""
     query = select(Wallet)
     if query_text:
@@ -218,14 +216,7 @@ def wallet_page_context(
         raise HTTPException(
             status_code=400, detail="transaction type must not contain control characters"
         )
-    if (
-        transaction_type is not None
-        and transaction_type.strip()
-        and transaction_type.strip() != transaction_type
-    ):
-        raise HTTPException(
-            status_code=400, detail="type must not include leading or trailing whitespace"
-        )
+    reject_padded_value("type", transaction_type)
     selected_transaction_type = transaction_type.strip() if transaction_type is not None else ""
     if selected_transaction_type.lower() == "all":
         selected_transaction_type = ""

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -25,6 +25,7 @@ from app.path_params import SQLITE_INTEGER_MAX, proof_hash_from_path
 from app.query_validation import (
     reject_control_char_query_param,
     reject_noncanonical_int_query_param,
+    reject_padded_query_param,
     reject_repeated_query_param,
 )
 from app.serializers import bounty_list_summary, wallet_to_dict
@@ -181,6 +182,10 @@ def public_bounties_context(
 def wallets_page_context(session: Session, q: str | None = None) -> dict[str, Any]:
     if q is not None and contains_control_character(q):
         raise HTTPException(status_code=400, detail="q must not contain control characters")
+    if q is not None and q.strip() and q.strip() != q:
+        raise HTTPException(
+            status_code=400, detail="q must not include leading or trailing whitespace"
+        )
     query_text = q.strip() if q is not None else ""
     query = select(Wallet)
     if query_text:
@@ -212,6 +217,14 @@ def wallet_page_context(
     if transaction_type is not None and contains_control_character(transaction_type):
         raise HTTPException(
             status_code=400, detail="transaction type must not contain control characters"
+        )
+    if (
+        transaction_type is not None
+        and transaction_type.strip()
+        and transaction_type.strip() != transaction_type
+    ):
+        raise HTTPException(
+            status_code=400, detail="type must not include leading or trailing whitespace"
         )
     selected_transaction_type = transaction_type.strip() if transaction_type is not None else ""
     if selected_transaction_type.lower() == "all":
@@ -327,6 +340,7 @@ def register_public_routes(
     def wallets_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:
         reject_control_char_query_param(request, "q")
         reject_repeated_query_param(request, "q")
+        reject_padded_query_param(request, "q")
         with session_scope(db_url) as session:
             context = wallets_page_context(session, q)
         return templates.TemplateResponse(request, "wallets.html", context)
@@ -343,6 +357,7 @@ def register_public_routes(
                     status_code=400, detail="transaction type must not contain control characters"
                 )
         reject_repeated_query_param(request, "type")
+        reject_padded_query_param(request, "type")
         with session_scope(db_url) as session:
             context = wallet_page_context(session, address, type)
         return templates.TemplateResponse(request, "wallet_detail.html", context)

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -36,6 +36,17 @@ def reject_noncanonical_int_query_param(request: Request, name: str) -> None:
             )
 
 
+def reject_padded_query_param(request: Request, name: str) -> None:
+    """Reject non-empty string query values with raw leading/trailing whitespace."""
+    for value in request.query_params.getlist(name):
+        stripped = value.strip()
+        if stripped and stripped != value:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} must not include leading or trailing whitespace",
+            )
+
+
 def reject_repeated_query_param(request: Request, name: str) -> None:
     """Reject ambiguous scalar query parameters before FastAPI chooses one value."""
     if len(request.query_params.getlist(name)) > 1:

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -36,15 +36,22 @@ def reject_noncanonical_int_query_param(request: Request, name: str) -> None:
             )
 
 
+def reject_padded_value(name: str, value: str | None) -> None:
+    """Reject non-empty string values with raw leading/trailing whitespace."""
+    if value is None:
+        return
+    stripped = value.strip()
+    if stripped and stripped != value:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{name} must not include leading or trailing whitespace",
+        )
+
+
 def reject_padded_query_param(request: Request, name: str) -> None:
     """Reject non-empty string query values with raw leading/trailing whitespace."""
     for value in request.query_params.getlist(name):
-        stripped = value.strip()
-        if stripped and stripped != value:
-            raise HTTPException(
-                status_code=400,
-                detail=f"{name} must not include leading or trailing whitespace",
-            )
+        reject_padded_value(name, value)
 
 
 def reject_repeated_query_param(request: Request, name: str) -> None:

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -16,6 +16,7 @@ from app.path_params import SQLITE_INTEGER_MAX, positive_proposal_id
 from app.query_validation import (
     reject_control_char_query_param,
     reject_noncanonical_int_query_param,
+    reject_padded_query_param,
     reject_repeated_query_param,
 )
 from app.treasury import (
@@ -124,6 +125,7 @@ def register_treasury_routes(
             reject_repeated_query_param(request, name)
         for name in ("action", "status", "to_account"):
             reject_control_char_query_param(request, name)
+            reject_padded_query_param(request, name)
         for name in ("limit", "bounty_id"):
             reject_noncanonical_int_query_param(request, name)
         action_filter = _optional_query_filter(

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 import app.serializers as serializers_module
@@ -296,6 +298,18 @@ def test_account_page_filters_transactions_by_type(sqlite_url: str) -> None:
     assert padded.json()["detail"] == "tx_type must not include leading or trailing whitespace"
     assert repeated.status_code == 400
     assert repeated.json()["detail"] == "tx_type must be provided at most once"
+
+
+def test_account_page_context_rejects_padded_transaction_type(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+        with pytest.raises(HTTPException) as exc:
+            account_page_context(session, "github:alice", " bounty_payment ")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "transaction type must not include leading or trailing whitespace"
 
 
 def test_account_api_does_not_advertise_wallet_transfers_for_plain_accounts(

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -266,6 +266,7 @@ def test_account_page_filters_transactions_by_type(sqlite_url: str) -> None:
     invalid = client.get("/accounts/github:alice?tx_type=bogus")
     control = client.get("/accounts/github:alice?tx_type=%C2%85bounty_payment")
     masked_control = client.get("/accounts/github:alice?tx_type=%C2%85bounty_payment&tx_type=all")
+    padded = client.get("/accounts/github:alice?tx_type=%20bounty_payment%20")
     repeated = client.get("/accounts/github:alice?tx_type=bounty_payment&tx_type=all")
 
     assert all_rows.status_code == 200
@@ -291,6 +292,8 @@ def test_account_page_filters_transactions_by_type(sqlite_url: str) -> None:
     assert control.json()["detail"] == "transaction type must not contain control characters"
     assert masked_control.status_code == 400
     assert masked_control.json()["detail"] == "transaction type must not contain control characters"
+    assert padded.status_code == 400
+    assert padded.json()["detail"] == "tx_type must not include leading or trailing whitespace"
     assert repeated.status_code == 400
     assert repeated.json()["detail"] == "tx_type must be provided at most once"
 

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -225,6 +225,19 @@ def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
     assert repeated_page_response.json()["detail"] == "q must be provided at most once"
 
 
+def test_activity_api_rejects_padded_query_filter(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/api/v1/activity?q=%20github%20")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "q must not include leading or trailing whitespace"
+
+
 def test_activity_api_exposes_pending_payouts_separately_from_paid_work(
     sqlite_url: str,
 ) -> None:

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -348,7 +348,7 @@ def test_bounty_api_filters_by_status(sqlite_url: str) -> None:
     assert [item["id"] for item in client.get("/api/v1/bounties?status=OPEN").json()] == [
         open_bounty.id
     ]
-    assert [item["id"] for item in client.get("/api/v1/bounties?status= Paid ").json()] == [
+    assert [item["id"] for item in client.get("/api/v1/bounties?status=Paid").json()] == [
         paid_bounty.id
     ]
     invalid = client.get("/api/v1/bounties?status=bogus")
@@ -370,6 +370,44 @@ def test_bounty_api_search_query_rejects_control_characters(sqlite_url: str) -> 
     assert list_response.json()["detail"] == "q must not contain control characters"
     assert summary_response.status_code == 400
     assert summary_response.json()["detail"] == "q must not contain control characters"
+
+
+@pytest.mark.parametrize(
+    ("path", "detail"),
+    [
+        (
+            "/api/v1/bounties?status=%20open%20",
+            "status must not include leading or trailing whitespace",
+        ),
+        (
+            "/api/v1/bounties/summary?q=%20open%20",
+            "q must not include leading or trailing whitespace",
+        ),
+        (
+            "/api/v1/bounties?sort=%20reward%20",
+            "sort must not include leading or trailing whitespace",
+        ),
+        (
+            "/api/v1/bounties/summary?repo=%20ramimbo%2Fmergework%20",
+            "repo must not include leading or trailing whitespace",
+        ),
+        (
+            "/api/v1/bounties?availability=%20effectively_open%20",
+            "availability must not include leading or trailing whitespace",
+        ),
+    ],
+)
+def test_bounty_api_rejects_padded_string_filters(sqlite_url: str, path: str, detail: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(path)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == detail
 
 
 @pytest.mark.parametrize(

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -470,7 +470,7 @@ def test_treasury_proposals_list_filters_by_recipient_before_limit(
         params={
             "status": "pending",
             "action": "pay_bounty",
-            "to_account": " GitHub:Alice ",
+            "to_account": "GitHub:Alice",
             "limit": "1",
         },
     )
@@ -498,7 +498,10 @@ def test_treasury_proposals_list_filters_by_recipient_before_limit(
             "to_account=github%3Aalice%0Abad",
             "to_account must not contain control characters",
         ),
-        ("to_account=github%3A%20", "github login must be valid"),
+        (
+            "to_account=github%3A%20",
+            "to_account must not include leading or trailing whitespace",
+        ),
     ],
 )
 def test_treasury_proposals_list_rejects_invalid_recipient_filter(
@@ -619,6 +622,21 @@ def test_treasury_proposals_list_filters_by_action_status_and_bounty_id(
         ("limit", "+1", "limit must be a canonical positive integer"),
         ("limit", "01", "limit must be a canonical positive integer"),
         ("status", " ", "status is required"),
+        (
+            "action",
+            " pay_bounty ",
+            "action must not include leading or trailing whitespace",
+        ),
+        (
+            "status",
+            " pending ",
+            "status must not include leading or trailing whitespace",
+        ),
+        (
+            "to_account",
+            " github:alice ",
+            "to_account must not include leading or trailing whitespace",
+        ),
         ("action", "paybounty", "action must be one of: close_bounty, create_bounty, pay_bounty"),
         ("status", "complete", "status must be one of: pending, executed, blocked"),
     ),

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -890,6 +890,16 @@ def test_prelinked_wallet_creates_github_account_row(sqlite_url: str) -> None:
     assert account.json()["exists"] is True
 
 
+def test_wallets_page_allows_whitespace_only_query(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/wallets?q=%20%20%20")
+
+    assert response.status_code == 200
+    assert "Search wallets" in response.text
+
+
 def test_wallet_page_context_rejects_padded_transaction_type(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     _, public_hex, address = _keypair()

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -6,6 +6,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
@@ -22,6 +23,7 @@ from app.ledger.service import (
 )
 from app.main import _safe_next_path, _signed_value, _verified_value, create_app
 from app.models import Wallet
+from app.public_routes import wallet_page_context
 from app.wallets import address_from_public_key_hex, canonical_wallet_json
 
 
@@ -646,7 +648,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     funded_type_filter = client.get(f"/wallets/{funded_address}?type=test_funding").text
     funded_all_type_filter = client.get(f"/wallets/{funded_address}?type=all").text
     funded_all_type_filter_upper = client.get(f"/wallets/{funded_address}?type=ALL").text
-    funded_all_type_filter_spaced = client.get(f"/wallets/{funded_address}?type=%20all%20").text
+    funded_all_type_filter_spaced = client.get(f"/wallets/{funded_address}?type=%20all%20")
     funded_missing_type = client.get(f"/wallets/{funded_address}?type=bounty_payment").text
     funded_unknown_type = client.get(f"/wallets/{funded_address}?type=not_a_real_type")
     transfer = client.get("/transfer").text
@@ -689,8 +691,10 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "No wallet transactions match this type." not in funded_all_type_filter
     assert "wallet_transfer" in funded_all_type_filter_upper
     assert "test_funding" in funded_all_type_filter_upper
-    assert "wallet_transfer" in funded_all_type_filter_spaced
-    assert "test_funding" in funded_all_type_filter_spaced
+    assert funded_all_type_filter_spaced.status_code == 400
+    assert funded_all_type_filter_spaced.json()["detail"] == (
+        "type must not include leading or trailing whitespace"
+    )
     assert "No wallet transactions match this type." in funded_missing_type
     assert funded_unknown_type.status_code == 400
     assert funded_unknown_type.json()["detail"] == (
@@ -714,6 +718,7 @@ def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
     type_response = client.get(f"/wallets/{address}", params={"type": "test_funding\t"})
     masked_search_response = client.get("/wallets?q=%C2%85Main&q=Main")
     repeated_search_response = client.get("/wallets?q=Main&q=smoke")
+    padded_search_response = client.get("/wallets?q=%20Main%20")
     masked_type_response = client.get(f"/wallets/{address}?type=%C2%85test_funding&type=all")
     repeated_type_response = client.get(f"/wallets/{address}?type=test_funding&type=all")
 
@@ -725,6 +730,10 @@ def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
     assert masked_search_response.json()["detail"] == "q must not contain control characters"
     assert repeated_search_response.status_code == 400
     assert repeated_search_response.json()["detail"] == "q must be provided at most once"
+    assert padded_search_response.status_code == 400
+    assert padded_search_response.json()["detail"] == (
+        "q must not include leading or trailing whitespace"
+    )
     assert masked_type_response.status_code == 400
     assert (
         masked_type_response.json()["detail"]
@@ -879,3 +888,16 @@ def test_prelinked_wallet_creates_github_account_row(sqlite_url: str) -> None:
 
     assert account.status_code == 200
     assert account.json()["exists"] is True
+
+
+def test_wallet_page_context_rejects_padded_transaction_type(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    _, public_hex, address = _keypair()
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _register_wallet(client, public_hex, "Context smoke wallet")
+
+    with session_scope(sqlite_url) as session, pytest.raises(HTTPException) as exc_info:
+        wallet_page_context(session, address, " all ")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "type must not include leading or trailing whitespace"


### PR DESCRIPTION
## Summary
- add a shared public-query guard that rejects non-empty string filter values with raw leading/trailing whitespace
- apply it to API bounty list/summary filters, treasury proposal filters, and the activity API query filter
- preserve clean uppercase normalization and blank UI/default behavior while making padded generated API URLs fail closed with bounded 400 responses

## Related
- Follow-up implementation for proposed work #779
- Related to live validation bounty #656 and proposed-work bounty #722

## Verification
- `.venv/bin/pytest tests/test_bounty_api.py tests/test_bounty_api_routes.py tests/test_bounty_pages.py tests/test_treasury_proposals.py tests/test_activity.py tests/test_public_routes.py -q` -> 134 passed
- `.venv/bin/pytest -q` -> 683 passed
- `.venv/bin/ruff format --check app tests` -> passed
- `.venv/bin/ruff check app tests` -> passed
- `git diff --check` -> clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API and page routes now reject query parameters with leading/trailing whitespace for activity API (q), bounties (and summary), treasury proposals, account transaction type, and public wallet filters — returning HTTP 400 with clear error details.
  * The HTML activity page retains previous, less-strict validation (no padded-value rejection).

* **Tests**
  * Added and updated tests to cover padded-value rejection across activity, bounties, treasury, accounts, and wallet routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->