### PR TITLE
Reject uppercase proof hash aliases

### DIFF
--- a/app/path_params.py
+++ b/app/path_params.py
@@ -52,8 +52,11 @@ def positive_proposal_id(proposal_id: int | str) -> int:
 
 def proof_hash_from_path(proof_hash: str) -> str:
     if proof_hash != proof_hash.strip():
-        raise HTTPException(status_code=400, detail="proof hash must be 64 hex characters")
-    clean = proof_hash.lower()
-    if not HEX_HASH_RE.fullmatch(clean):
-        raise HTTPException(status_code=400, detail="proof hash must be 64 hex characters")
-    return clean
+        raise HTTPException(
+            status_code=400, detail="proof hash must be lowercase 64 hex characters"
+        )
+    if not HEX_HASH_RE.fullmatch(proof_hash):
+        raise HTTPException(
+            status_code=400, detail="proof hash must be lowercase 64 hex characters"
+        )
+    return proof_hash

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -989,10 +989,13 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert f'href="/activity?q={bounty.id}"' in proof_page.text
     assert 'href="/activity?q=https%3A//github.com/ramimbo/mergework/pull/99"' in proof_page.text
 
+    uppercase_api_proof = client.get(f"/api/v1/proofs/{proof_hash.upper()}")
     uppercase_proof_page = client.get(f"/proofs/{proof_hash.upper()}")
-    assert uppercase_proof_page.status_code == 200
-    assert f'<code class="hash">{proof_hash}</code>' in uppercase_proof_page.text
-    assert f'<code class="hash">{proof_hash.upper()}</code>' not in uppercase_proof_page.text
+    assert uppercase_api_proof.status_code == 400
+    assert uppercase_api_proof.json()["detail"] == (
+        "proof hash must be lowercase 64 hex characters"
+    )
+    assert uppercase_proof_page.status_code == 400
 
     missing_proof = client.get(f"/api/v1/proofs/{'0' * 64}")
     assert missing_proof.status_code == 404

--- a/tests/test_path_params.py
+++ b/tests/test_path_params.py
@@ -64,12 +64,13 @@ def test_positive_bounty_id_and_ledger_sequence_validate_bounds():
     assert_bad_request(positive_proposal_id, oversized_digit_string)
 
 
-def test_proof_hash_from_path_normalizes_hex_hash():
-    raw_hash = "A" * 64
-    assert proof_hash_from_path(raw_hash) == "a" * 64
+def test_proof_hash_from_path_accepts_canonical_lowercase_hash():
+    raw_hash = "a" * 64
+    assert proof_hash_from_path(raw_hash) == raw_hash
 
 
-def test_proof_hash_from_path_rejects_whitespace_or_non_hex():
+def test_proof_hash_from_path_rejects_whitespace_uppercase_or_non_hex():
     assert_bad_request(proof_hash_from_path, " " + "a" * 64)
+    assert_bad_request(proof_hash_from_path, "A" * 64)
     assert_bad_request(proof_hash_from_path, "g" * 64)
     assert_bad_request(proof_hash_from_path, "a" * 63)


### PR DESCRIPTION
/claim #656

## Summary
- reject uppercase proof-hash path aliases instead of silently lowercasing them
- keep canonical lowercase 64-hex proof hashes working unchanged
- update API/page regression coverage and the shared path-param unit test

## Live evidence before the fix
The current public deployment accepts uppercase proof hashes and resolves them to the canonical lowercase proof:

```text
GET https://mrwk.online/proofs/D1C64A6AEEFFF35A04B0EAAE8D589FA889A40597D031D9C2AF4DA5B3EEB1D511 -> 200
GET https://mrwk.online/api/v1/proofs/D1C64A6AEEFFF35A04B0EAAE8D589FA889A40597D031D9C2AF4DA5B3EEB1D511 -> 200
```

Expected: proof hashes are content-addressed public identifiers already emitted as lowercase 64-hex values, so non-canonical uppercase aliases should fail closed with the same validation boundary used for malformed hashes.

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/test_path_params.py tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable -q` → `6 passed, 1 warning`
- `.venv/bin/python -m ruff check app/path_params.py tests/test_path_params.py tests/test_bounty_pages.py`
- `.venv/bin/python -m ruff format --check app/path_params.py tests/test_path_params.py tests/test_bounty_pages.py`
- `git diff --check`

## Scope
No payout, treasury, wallet, ledger, proof generation, private data, price, bridge, exchange, liquidity, or cash-out behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Proof hash validation is now stricter, rejecting inputs with leading/trailing whitespace, uppercase characters, or incorrect formatting. Invalid submissions return HTTP 400 with the message "proof hash must be lowercase 64 hex characters."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->