### PR TITLE
Add automated bounty board refresh

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -50,8 +50,8 @@ def _optional_positive_int_env(name: str) -> int | None:
         return None
     try:
         value = int(raw_value)
-    except ValueError:
-        return 0
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
     return value
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -19,6 +19,7 @@ class Settings:
     admin_token: str
     cookie_secret: str
     github_accepted_labelers: tuple[str, ...]
+    bounty_board_issue_number: int | None
 
 
 WEAK_SECRET_VALUES = {
@@ -41,6 +42,17 @@ def _csv_env(name: str, default: str = "") -> tuple[str, ...]:
     if not raw_value.strip():
         return ()
     return tuple(item.strip().lower() for item in raw_value.split(","))
+
+
+def _optional_positive_int_env(name: str) -> int | None:
+    raw_value = os.environ.get(name, "").strip()
+    if not raw_value:
+        return None
+    try:
+        value = int(raw_value)
+    except ValueError:
+        return 0
+    return value
 
 
 def _secret_errors(name: str, value: str) -> list[str]:
@@ -197,6 +209,8 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
             errors.append(
                 "MERGEWORK_GITHUB_ACCEPTED_LABELERS must be included in MERGEWORK_ADMIN_LOGINS"
             )
+    if settings.bounty_board_issue_number is not None and settings.bounty_board_issue_number <= 0:
+        errors.append("MERGEWORK_BOUNTY_BOARD_ISSUE_NUMBER must be a positive integer")
     errors.extend(_required_env_value_errors("MERGEWORK_PUBLIC_BASE_URL", settings.public_base_url))
     try:
         parsed_base_url = urlparse(settings.public_base_url)
@@ -260,4 +274,5 @@ def get_settings() -> Settings:
         admin_token=os.environ.get("MERGEWORK_ADMIN_TOKEN", ""),
         cookie_secret=os.environ.get("MERGEWORK_COOKIE_SECRET", ""),
         github_accepted_labelers=_csv_env("MERGEWORK_GITHUB_ACCEPTED_LABELERS"),
+        bounty_board_issue_number=_optional_positive_int_env("MERGEWORK_BOUNTY_BOARD_ISSUE_NUMBER"),
     )

--- a/app/github_bounty_board.py
+++ b/app/github_bounty_board.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+from datetime import UTC, datetime
+from typing import Any
+from urllib.error import HTTPError
+from urllib.request import urlopen
+
+from sqlalchemy import select
+
+from app.db import session_scope
+from app.github_issue_finalization import (
+    _get_json,
+    _github_issue_api_base,
+    _patch_json,
+)
+from app.models import Bounty
+from app.serializers import bounties_to_dict, public_utc_timestamp
+from app.treasury import treasury_status
+
+BOUNTY_BOARD_REPO = "ramimbo/mergework"
+BOUNTY_BOARD_BLOCK_START = "<!-- mergework:bounty-board:start -->"
+BOUNTY_BOARD_BLOCK_END = "<!-- mergework:bounty-board:end -->"
+BOUNTY_TITLE_PREFIX_RE = re.compile(r"^MRWK bounty:\s*(?:[^-]+-\s*)?", re.IGNORECASE)
+STATE_UPDATED_RE = re.compile(r"^Displayed state updated: .*$", re.MULTILINE)
+
+
+def _markdown_cell(value: object) -> str:
+    return str(value or "").replace("|", "\\|").replace("\n", " ").strip()
+
+
+def _issue_link(issue_number: object, issue_url: object) -> str:
+    return f"[#{_markdown_cell(issue_number)}]({_markdown_cell(issue_url)})"
+
+
+def _work_lane(title: object) -> str:
+    return _markdown_cell(BOUNTY_TITLE_PREFIX_RE.sub("", str(title or "")).strip())
+
+
+def _int_value(value: object) -> int:
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _claimable_bounties(open_bounties: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        bounty
+        for bounty in open_bounties
+        if _int_value(bounty.get("effective_awards_remaining")) > 0
+    ]
+
+
+def _unavailable_bounties(open_bounties: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        bounty
+        for bounty in open_bounties
+        if _int_value(bounty.get("effective_awards_remaining")) <= 0
+    ]
+
+
+def _claimable_table(open_bounties: Sequence[dict[str, Any]]) -> list[str]:
+    rows = [
+        "| Issue | Work lane | Reward | Effective slots | Status |",
+        "| --- | --- | ---: | ---: | --- |",
+    ]
+    for bounty in sorted(
+        _claimable_bounties(open_bounties),
+        key=lambda item: (
+            -_int_value(item.get("effective_awards_remaining")),
+            _int_value(item.get("issue_number")),
+        ),
+    ):
+        rows.append(
+            " | ".join(
+                [
+                    f"| {_issue_link(bounty.get('issue_number'), bounty.get('issue_url'))}",
+                    _work_lane(bounty.get("title")),
+                    f"{_markdown_cell(bounty.get('reward_mrwk'))} MRWK",
+                    str(_int_value(bounty.get("effective_awards_remaining"))),
+                    f"{_markdown_cell(bounty.get('availability_note'))} |",
+                ]
+            )
+        )
+    if len(rows) == 2:
+        rows.append(
+            "| - | No live bounty currently has effective capacity. | - | 0 | Check opening soon. |"
+        )
+    return rows
+
+
+def _unavailable_table(open_bounties: Sequence[dict[str, Any]]) -> list[str]:
+    unavailable = _unavailable_bounties(open_bounties)
+    if not unavailable:
+        return []
+    rows = [
+        "## Open But Not Currently Claimable",
+        "",
+        "| Issue | Work lane | Reward | Effective slots | Status |",
+        "| --- | --- | ---: | ---: | --- |",
+    ]
+    for bounty in sorted(unavailable, key=lambda item: _int_value(item.get("issue_number"))):
+        rows.append(
+            " | ".join(
+                [
+                    f"| {_issue_link(bounty.get('issue_number'), bounty.get('issue_url'))}",
+                    _work_lane(bounty.get("title")),
+                    f"{_markdown_cell(bounty.get('reward_mrwk'))} MRWK",
+                    str(_int_value(bounty.get("effective_awards_remaining"))),
+                    f"{_markdown_cell(bounty.get('availability_note'))} |",
+                ]
+            )
+        )
+    return rows
+
+
+def _pending_create_table(treasury_data: dict[str, Any]) -> list[str]:
+    pending = treasury_data.get("pending_create_bounties")
+    pending_rows = (
+        [item for item in pending if isinstance(item, dict)] if isinstance(pending, list) else []
+    )
+    rows = [
+        "## Opening Soon",
+        "",
+        (
+            "These are pending `create_bounty` proposals. They are not claimable "
+            "until execution creates the public bounty row and the GitHub issue "
+            "gets both `mrwk:bounty` and `Reserved on MergeWork`."
+        ),
+        "",
+        "| Issue | Work lane | Proposal | Opens after | Reserve |",
+        "| --- | --- | ---: | --- | ---: |",
+    ]
+    for proposal in sorted(pending_rows, key=lambda item: str(item.get("executes_after") or "")):
+        rows.append(
+            " | ".join(
+                [
+                    f"| {_issue_link(proposal.get('issue_number'), proposal.get('issue_url'))}",
+                    _work_lane(proposal.get("title")),
+                    _markdown_cell(proposal.get("proposal_id")),
+                    _markdown_cell(proposal.get("executes_after")),
+                    f"{_markdown_cell(proposal.get('reserve_mrwk'))} MRWK |",
+                ]
+            )
+        )
+    if len(rows) == 6:
+        rows.append("| - | No pending create-bounty proposals. | - | - | - |")
+    return rows
+
+
+def _treasury_capacity_lines(treasury_data: dict[str, Any]) -> list[str]:
+    available = treasury_data.get("available_create_reserve_mrwk")
+    next_release = treasury_data.get("next_projected_capacity_release_at")
+    lines = ["## Treasury Capacity", ""]
+    if available is not None:
+        lines.append(f"Available create reserve: {_markdown_cell(available)} MRWK.")
+    if next_release:
+        lines.append(f"Next projected capacity release: {_markdown_cell(next_release)}.")
+    if len(lines) == 2:
+        lines.append("Treasury capacity is unavailable in the current public status payload.")
+    return lines
+
+
+def render_bounty_board(
+    *,
+    open_bounties: Sequence[dict[str, Any]],
+    treasury_status: dict[str, Any],
+    checked_at: str,
+) -> str:
+    sections = [
+        BOUNTY_BOARD_BLOCK_START,
+        f"Displayed state updated: {_markdown_cell(checked_at)}",
+        "",
+        "This board issue itself is not a bounty. Do not submit `/claim` here.",
+        "",
+        "## Claimable Now",
+        "",
+        *_claimable_table(open_bounties),
+        "",
+    ]
+    unavailable = _unavailable_table(open_bounties)
+    if unavailable:
+        sections.extend([*unavailable, ""])
+    sections.extend(
+        [
+            *_pending_create_table(treasury_status),
+            "",
+            *_treasury_capacity_lines(treasury_status),
+            "",
+            "## Not Claimable Here",
+            "",
+            "- This board issue itself is not a bounty.",
+            (
+                "- Proposed-work issues are intake only unless maintainers later make a "
+                "separate live bounty."
+            ),
+            "- Pending `create_bounty` proposals are not live bounties.",
+            (
+                "- Pending `pay_bounty` proposals are accepted for proposal review, not "
+                "paid, until a proof exists."
+            ),
+            (
+                "- Closed, paid, exhausted, duplicate, stale, or superseded rounds are "
+                "not claimable for new work."
+            ),
+            "",
+            BOUNTY_BOARD_BLOCK_END,
+        ]
+    )
+    return "\n".join(sections)
+
+
+def _replace_board_block(existing_body: str, board_body: str) -> str:
+    start = existing_body.find(BOUNTY_BOARD_BLOCK_START)
+    end = existing_body.find(BOUNTY_BOARD_BLOCK_END)
+    if start != -1 and end != -1 and start < end:
+        end += len(BOUNTY_BOARD_BLOCK_END)
+        return f"{existing_body[:start]}{board_body}{existing_body[end:]}"
+    if not existing_body.strip():
+        return board_body
+    return f"{existing_body.rstrip()}\n\n{board_body}"
+
+
+def _normalized_board_body(body: str) -> str:
+    return STATE_UPDATED_RE.sub("Displayed state updated: <state timestamp>", body)
+
+
+def update_bounty_board_issue(
+    *,
+    github_token: str,
+    repo: str,
+    issue_number: int | None,
+    board_body: str,
+    opener: Callable[..., Any] = urlopen,
+) -> dict[str, Any]:
+    clean_token = github_token.strip()
+    if not clean_token:
+        return {"status": "skipped", "reason": "github issue token not configured"}
+    if issue_number is None:
+        return {"status": "skipped", "reason": "bounty board issue number not configured"}
+    issue_api_base = _github_issue_api_base(repo, issue_number)
+    try:
+        issue = _get_json(opener=opener, url=issue_api_base, github_token=clean_token)
+        current_body = issue.get("body")
+        existing_body = current_body if isinstance(current_body, str) else ""
+        updated_body = _replace_board_block(existing_body, board_body)
+        if _normalized_board_body(updated_body) == _normalized_board_body(existing_body):
+            return {"status": "already_current", "issue_number": issue_number}
+        _patch_json(
+            opener=opener,
+            url=issue_api_base,
+            github_token=clean_token,
+            payload={"body": updated_body},
+        )
+    except HTTPError as exc:
+        return {"status": "failed", "reason": f"github bounty board update failed: HTTP {exc.code}"}
+    except (OSError, ValueError) as exc:
+        return {
+            "status": "failed",
+            "reason": f"github bounty board update failed: {type(exc).__name__}",
+        }
+    return {"status": "updated", "issue_number": issue_number}
+
+
+def refresh_bounty_board_issue(
+    db_url: str,
+    *,
+    github_token: str,
+    public_base_url: str,
+    issue_number: int | None,
+    opener: Callable[..., Any] = urlopen,
+) -> dict[str, Any]:
+    if issue_number is None:
+        return {"status": "skipped", "reason": "bounty board issue number not configured"}
+    with session_scope(db_url) as session:
+        bounties = session.scalars(
+            select(Bounty)
+            .where(Bounty.repo == BOUNTY_BOARD_REPO, Bounty.status == "open")
+            .order_by(Bounty.created_at.desc(), Bounty.id.desc())
+        ).all()
+        open_bounties = bounties_to_dict(bounties, session=session)
+        treasury_data = treasury_status(session)
+    board_body = render_bounty_board(
+        open_bounties=open_bounties,
+        treasury_status=treasury_data,
+        checked_at=public_utc_timestamp(datetime.now(UTC)),
+    )
+    return update_bounty_board_issue(
+        github_token=github_token,
+        repo=BOUNTY_BOARD_REPO,
+        issue_number=issue_number,
+        board_body=board_body,
+        opener=opener,
+    )

--- a/app/treasury_executor.py
+++ b/app/treasury_executor.py
@@ -8,6 +8,7 @@ from typing import Any
 from sqlalchemy import select
 
 from app.db import session_scope
+from app.github_bounty_board import refresh_bounty_board_issue
 from app.github_issue_finalization import finalize_created_bounty_issue, finalize_paid_bounty_issue
 from app.ledger.service import LedgerError
 from app.models import Bounty, TreasuryProposal, utc_now
@@ -19,6 +20,7 @@ from app.treasury import (
 
 Finalizer = Callable[..., dict[str, Any]]
 PaidIssueFinalizer = Callable[..., dict[str, Any]]
+BountyBoardRefresher = Callable[..., dict[str, Any]]
 PAID_ISSUE_FINALIZED_STATUSES = {"updated", "closed", "already_finalized"}
 
 
@@ -189,8 +191,10 @@ def execute_due_treasury_proposals(
     public_base_url: str,
     executed_by: str = "treasury-executor",
     limit: int = 25,
+    bounty_board_issue_number: int | None = None,
     finalizer: Finalizer | None = None,
     paid_issue_finalizer: PaidIssueFinalizer | None = None,
+    bounty_board_refresher: BountyBoardRefresher | None = None,
 ) -> dict[str, Any]:
     proposal_ids = due_treasury_proposal_ids(db_url, limit=limit)
     results: list[dict[str, Any]] = []
@@ -240,6 +244,25 @@ def execute_due_treasury_proposals(
         limit=limit,
         finalizer=paid_issue_finalizer,
     )
+    if bounty_board_issue_number is None:
+        bounty_board_report = {
+            "status": "skipped",
+            "reason": "bounty board issue number not configured",
+        }
+    else:
+        issue_refresher = bounty_board_refresher or refresh_bounty_board_issue
+        try:
+            bounty_board_report = issue_refresher(
+                db_url,
+                github_token=github_issue_token,
+                public_base_url=public_base_url,
+                issue_number=bounty_board_issue_number,
+            )
+        except Exception as exc:
+            bounty_board_report = {
+                "status": "failed",
+                "reason": f"github bounty board refresh failed: {type(exc).__name__}",
+            }
     return {
         "type": "treasury_executor_run",
         "attempted": len(proposal_ids),
@@ -247,4 +270,5 @@ def execute_due_treasury_proposals(
         "failed": failed,
         "results": results,
         "paid_issue_finalization": paid_issue_report,
+        "bounty_board": bounty_board_report,
     }

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -120,6 +120,8 @@ Enable it only in the production `.env`:
 MERGEWORK_TREASURY_EXECUTOR_ENABLED=1
 MERGEWORK_TREASURY_EXECUTOR_INTERVAL_SECONDS=300
 MERGEWORK_TREASURY_EXECUTOR_BATCH_LIMIT=25
+MERGEWORK_BOUNTY_BOARD_ISSUE_NUMBER=785
+MERGEWORK_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS=60
 ```
 
 Deploy or restart the service with Docker Compose after editing production
@@ -148,6 +150,17 @@ that are merely full because pending payout proposals consume effective
 capacity. Successful paid-issue finalization adds `mrwk:paid`, posts a concise
 filled-and-paid comment when needed, closes the GitHub issue, and records a
 local finalization marker so later executor passes do not repeat the comment.
+
+When `MERGEWORK_BOUNTY_BOARD_ISSUE_NUMBER` is set, each executor pass also
+refreshes that issue's bounty-board marker block. The board is an index only:
+it must not use a `MRWK bounty:` title, must not receive `mrwk:bounty`, and must
+separate claimable live bounties from pending `create_bounty` proposals.
+The service also runs a board-only refresh on
+`MERGEWORK_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS`, defaulting to 60 seconds with
+a 30-second minimum. That path reads current bounty and treasury state and only
+patches GitHub when the marker block changes, so the board stays fresh without
+requiring the full treasury proposal executor to run every minute. The displayed
+state timestamp changes only when the displayed state changes.
 
 ## Accept Work
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -102,6 +102,14 @@ Use proposal-list filters when you need one queue slice, such as pending
 Use [docs/bounty-lifecycle.md](bounty-lifecycle.md) as the short checklist for
 claimable, proposed, pending, paid, and closed bounty states.
 
+The GitHub bounty board at
+https://github.com/ramimbo/mergework/issues/785 is an index for humans and
+agents, refreshed by the treasury executor when configured. Do not submit
+`/claim` on the board issue. Use it to find live claimable bounty issues and
+pending `create_bounty` proposals, then verify the target issue's `mrwk:bounty`
+label, `Reserved on MergeWork` comment, public bounty row, and effective award
+capacity before opening work.
+
 Proposal challenges require a GitHub-authenticated session and at least one
 accepted MRWK award. Use machine-checkable challenge types only when the rule is
 objectively true; use `subjective_note` for review concerns that should be

--- a/scripts/treasury_executor.py
+++ b/scripts/treasury_executor.py
@@ -9,11 +9,14 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 from app.config import get_settings
+from app.github_bounty_board import refresh_bounty_board_issue
 from app.treasury_executor import execute_due_treasury_proposals
 
 DEFAULT_INTERVAL_SECONDS = 300
 DEFAULT_BATCH_LIMIT = 25
+DEFAULT_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS = 60
 MIN_INTERVAL_SECONDS = 15
+MIN_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS = 30
 MAX_BATCH_LIMIT = 200
 TRUE_VALUES = {"1", "true", "yes", "on"}
 FALSE_VALUES = {"", "0", "false", "no", "off"}
@@ -24,6 +27,7 @@ class ExecutorConfig:
     enabled: bool
     interval_seconds: int
     batch_limit: int
+    bounty_board_refresh_interval_seconds: int
 
 
 def _enabled_from_env(value: str | None) -> bool:
@@ -67,6 +71,12 @@ def executor_config_from_env(env: Mapping[str, str] | None = None) -> ExecutorCo
             minimum=1,
             maximum=MAX_BATCH_LIMIT,
         ),
+        bounty_board_refresh_interval_seconds=_positive_int_from_env(
+            source,
+            "MERGEWORK_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS",
+            DEFAULT_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS,
+            minimum=MIN_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS,
+        ),
     )
 
 
@@ -78,7 +88,57 @@ def run_once(config: ExecutorConfig) -> dict[str, object]:
         public_base_url=settings.public_base_url,
         executed_by="treasury-executor",
         limit=config.batch_limit,
+        bounty_board_issue_number=settings.bounty_board_issue_number,
     )
+
+
+def run_bounty_board_refresh_once() -> dict[str, object]:
+    settings = get_settings()
+    return refresh_bounty_board_issue(
+        settings.database_url,
+        github_token=settings.github_issue_token,
+        public_base_url=settings.public_base_url,
+        issue_number=settings.bounty_board_issue_number,
+    )
+
+
+def _sleep_until(next_run_at: float) -> None:
+    delay = max(1.0, next_run_at - time.monotonic())
+    time.sleep(delay)
+
+
+def run_enabled_loop(config: ExecutorConfig, *, once: bool) -> int:
+    next_executor_at = 0.0
+    next_board_refresh_at = 0.0
+
+    while True:
+        now = time.monotonic()
+        if now >= next_executor_at:
+            try:
+                report = run_once(config)
+                logging.info("treasury executor report %s", json.dumps(report, sort_keys=True))
+            except Exception:
+                logging.exception("treasury executor pass failed")
+                if once:
+                    return 1
+            if once:
+                return 0
+            now = time.monotonic()
+            next_executor_at = now + config.interval_seconds
+            next_board_refresh_at = now + config.bounty_board_refresh_interval_seconds
+            _sleep_until(min(next_executor_at, next_board_refresh_at))
+            continue
+
+        if now >= next_board_refresh_at:
+            try:
+                report = run_bounty_board_refresh_once()
+                logging.info("bounty board refresh report %s", json.dumps(report, sort_keys=True))
+            except Exception:
+                logging.exception("bounty board refresh failed")
+            now = time.monotonic()
+            next_board_refresh_at = now + config.bounty_board_refresh_interval_seconds
+
+        _sleep_until(min(next_executor_at, next_board_refresh_at))
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -93,17 +153,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
         while True:
             time.sleep(config.interval_seconds)
-    while True:
-        try:
-            report = run_once(config)
-            logging.info("treasury executor report %s", json.dumps(report, sort_keys=True))
-        except Exception:
-            logging.exception("treasury executor pass failed")
-            if args.once:
-                return 1
-        if args.once:
-            return 0
-        time.sleep(config.interval_seconds)
+    return run_enabled_loop(config, once=args.once)
 
 
 if __name__ == "__main__":

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -19,6 +19,7 @@ def _settings(**overrides: object) -> Settings:
         "admin_token": "admin-14dcaab83bb245f2bfb5d5c21a9bb55b",
         "cookie_secret": "cookie-27fd1c41324a4bdcb2e4014adc3a6108",
         "github_accepted_labelers": ("alice",),
+        "bounty_board_issue_number": None,
     }
     values.update(overrides)
     return Settings(**values)  # type: ignore[arg-type]
@@ -26,6 +27,18 @@ def _settings(**overrides: object) -> Settings:
 
 def test_deploy_readiness_accepts_strong_configuration() -> None:
     assert validate_deploy_settings(_settings()) == []
+
+
+def test_get_settings_parses_bounty_board_issue_number(monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_BOUNTY_BOARD_ISSUE_NUMBER", "785")
+
+    assert get_settings().bounty_board_issue_number == 785
+
+
+def test_deploy_readiness_rejects_invalid_bounty_board_issue_number() -> None:
+    errors = validate_deploy_settings(_settings(bounty_board_issue_number=0))
+
+    assert "MERGEWORK_BOUNTY_BOARD_ISSUE_NUMBER must be a positive integer" in errors
 
 
 def test_deploy_readiness_rejects_missing_or_placeholder_secrets() -> None:

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -41,6 +41,17 @@ def test_deploy_readiness_rejects_invalid_bounty_board_issue_number() -> None:
     assert "MERGEWORK_BOUNTY_BOARD_ISSUE_NUMBER must be a positive integer" in errors
 
 
+def test_get_settings_rejects_malformed_bounty_board_issue_number(monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_BOUNTY_BOARD_ISSUE_NUMBER", "notanumber")
+
+    try:
+        get_settings()
+    except ValueError as exc:
+        assert str(exc) == "MERGEWORK_BOUNTY_BOARD_ISSUE_NUMBER must be an integer"
+    else:
+        raise AssertionError("expected malformed bounty board issue number to fail")
+
+
 def test_deploy_readiness_rejects_missing_or_placeholder_secrets() -> None:
     errors = validate_deploy_settings(
         _settings(

--- a/tests/test_github_bounty_board.py
+++ b/tests/test_github_bounty_board.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.request import Request
+
+from app.db import create_schema, session_scope
+from app.github_bounty_board import (
+    BOUNTY_BOARD_BLOCK_END,
+    BOUNTY_BOARD_BLOCK_START,
+    refresh_bounty_board_issue,
+    render_bounty_board,
+    update_bounty_board_issue,
+)
+from app.ledger.service import create_bounty, ensure_genesis
+from app.treasury import propose_treasury_action
+
+
+class _FakeResponse:
+    def __init__(self, body: Any) -> None:
+        self._body = body
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._body).encode()
+
+
+def test_render_bounty_board_separates_claimable_pending_and_unavailable() -> None:
+    body = render_bounty_board(
+        open_bounties=[
+            {
+                "id": 1,
+                "issue_number": 10,
+                "issue_url": "https://github.com/ramimbo/mergework/issues/10",
+                "title": "MRWK bounty: 75 MRWK - useful verification",
+                "reward_mrwk": "75",
+                "effective_awards_remaining": 3,
+                "availability_note": "3 awards effectively available.",
+                "availability_state": "open",
+            },
+            {
+                "id": 2,
+                "issue_number": 11,
+                "issue_url": "https://github.com/ramimbo/mergework/issues/11",
+                "title": "MRWK bounty: 40 MRWK - full review round",
+                "reward_mrwk": "40",
+                "effective_awards_remaining": 0,
+                "availability_note": "No awards remain available for new submissions.",
+                "availability_state": "full",
+            },
+        ],
+        treasury_status={
+            "pending_create_bounties": [
+                {
+                    "proposal_id": 44,
+                    "issue_number": 12,
+                    "issue_url": "https://github.com/ramimbo/mergework/issues/12",
+                    "title": "MRWK bounty: 150 MRWK - focused fixes",
+                    "reward_mrwk": "150",
+                    "max_awards": 2,
+                    "reserve_mrwk": "300",
+                    "executes_after": "2026-06-02T14:48:17Z",
+                }
+            ],
+            "available_create_reserve_mrwk": "2550",
+            "next_projected_capacity_release_at": "2026-06-02T07:42:42Z",
+        },
+        checked_at="2026-06-02T05:38:44Z",
+    )
+
+    assert body.startswith(BOUNTY_BOARD_BLOCK_START)
+    assert body.rstrip().endswith(BOUNTY_BOARD_BLOCK_END)
+    assert "This board issue itself is not a bounty." in body
+    assert "| [#10](https://github.com/ramimbo/mergework/issues/10) | useful verification |" in body
+    assert "| [#11](https://github.com/ramimbo/mergework/issues/11) | full review round |" in body
+    assert "## Claimable Now" in body
+    assert "## Open But Not Currently Claimable" in body
+    assert "## Opening Soon" in body
+    assert "These are pending `create_bounty` proposals. They are not claimable" in body
+    assert "| [#12](https://github.com/ramimbo/mergework/issues/12) | focused fixes |" in body
+    assert "Available create reserve: 2550 MRWK." in body
+    assert "Next projected capacity release: 2026-06-02T07:42:42Z." in body
+
+
+def test_update_bounty_board_issue_replaces_marker_block() -> None:
+    requests: list[Request] = []
+    existing_body = "\n".join(
+        [
+            "Intro stays.",
+            "",
+            BOUNTY_BOARD_BLOCK_START,
+            "old board",
+            BOUNTY_BOARD_BLOCK_END,
+            "",
+            "Footer stays.",
+        ]
+    )
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        requests.append(request)
+        if request.get_method() == "GET":
+            return _FakeResponse({"body": existing_body})
+        return _FakeResponse({})
+
+    result = update_bounty_board_issue(
+        github_token="github-token",
+        repo="ramimbo/mergework",
+        issue_number=785,
+        board_body=f"{BOUNTY_BOARD_BLOCK_START}\nnew board\n{BOUNTY_BOARD_BLOCK_END}",
+        opener=fake_opener,
+    )
+
+    assert result == {"status": "updated", "issue_number": 785}
+    assert [request.get_method() for request in requests] == ["GET", "PATCH"]
+    payload = json.loads((requests[1].data or b"").decode())
+    assert payload["body"] == "\n".join(
+        [
+            "Intro stays.",
+            "",
+            BOUNTY_BOARD_BLOCK_START,
+            "new board",
+            BOUNTY_BOARD_BLOCK_END,
+            "",
+            "Footer stays.",
+        ]
+    )
+
+
+def test_update_bounty_board_issue_noops_when_current() -> None:
+    requests: list[Request] = []
+    board_body = f"{BOUNTY_BOARD_BLOCK_START}\ncurrent\n{BOUNTY_BOARD_BLOCK_END}"
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        requests.append(request)
+        return _FakeResponse({"body": board_body})
+
+    result = update_bounty_board_issue(
+        github_token="github-token",
+        repo="ramimbo/mergework",
+        issue_number=785,
+        board_body=board_body,
+        opener=fake_opener,
+    )
+
+    assert result == {"status": "already_current", "issue_number": 785}
+    assert [request.get_method() for request in requests] == ["GET"]
+
+
+def test_update_bounty_board_issue_noops_when_only_state_timestamp_changed() -> None:
+    requests: list[Request] = []
+    existing_body = "\n".join(
+        [
+            BOUNTY_BOARD_BLOCK_START,
+            "Displayed state updated: 2026-06-02T05:38:44Z",
+            "",
+            "same live rows",
+            BOUNTY_BOARD_BLOCK_END,
+        ]
+    )
+    board_body = "\n".join(
+        [
+            BOUNTY_BOARD_BLOCK_START,
+            "Displayed state updated: 2026-06-02T05:39:44Z",
+            "",
+            "same live rows",
+            BOUNTY_BOARD_BLOCK_END,
+        ]
+    )
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        requests.append(request)
+        return _FakeResponse({"body": existing_body})
+
+    result = update_bounty_board_issue(
+        github_token="github-token",
+        repo="ramimbo/mergework",
+        issue_number=785,
+        board_body=board_body,
+        opener=fake_opener,
+    )
+
+    assert result == {"status": "already_current", "issue_number": 785}
+    assert [request.get_method() for request in requests] == ["GET"]
+
+
+def test_update_bounty_board_issue_skips_without_token_or_issue() -> None:
+    calls = 0
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        nonlocal calls
+        calls += 1
+        return _FakeResponse({})
+
+    assert update_bounty_board_issue(
+        github_token="",
+        repo="ramimbo/mergework",
+        issue_number=785,
+        board_body=f"{BOUNTY_BOARD_BLOCK_START}\nboard\n{BOUNTY_BOARD_BLOCK_END}",
+        opener=fake_opener,
+    ) == {"status": "skipped", "reason": "github issue token not configured"}
+    assert update_bounty_board_issue(
+        github_token="github-token",
+        repo="ramimbo/mergework",
+        issue_number=None,
+        board_body=f"{BOUNTY_BOARD_BLOCK_START}\nboard\n{BOUNTY_BOARD_BLOCK_END}",
+        opener=fake_opener,
+    ) == {"status": "skipped", "reason": "bounty board issue number not configured"}
+    assert calls == 0
+
+
+def test_refresh_bounty_board_issue_uses_open_bounties_and_pending_creates(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    requests: list[Request] = []
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=10,
+            issue_url="https://github.com/ramimbo/mergework/issues/10",
+            title="MRWK bounty: 75 MRWK - useful verification",
+            reward_mrwk="75",
+            max_awards=2,
+            acceptance="Useful public verification reports.",
+        )
+        propose_treasury_action(
+            session,
+            action="create_bounty",
+            payload={
+                "repo": "ramimbo/mergework",
+                "issue_number": 11,
+                "issue_url": "https://github.com/ramimbo/mergework/issues/11",
+                "title": "MRWK bounty: 150 MRWK - focused fixes",
+                "reward_mrwk": "150",
+                "max_awards": 1,
+                "acceptance": "Focused fixes with tests.",
+            },
+            proposed_by="maintainer",
+        )
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        requests.append(request)
+        if request.get_method() == "GET":
+            return _FakeResponse({"body": "Board intro."})
+        return _FakeResponse({})
+
+    result = refresh_bounty_board_issue(
+        sqlite_url,
+        github_token="github-token",
+        public_base_url="https://mrwk.example",
+        issue_number=785,
+        opener=fake_opener,
+    )
+
+    assert result == {"status": "updated", "issue_number": 785}
+    patch_payload = json.loads((requests[1].data or b"").decode())
+    updated_body = patch_payload["body"]
+    assert "Board intro." in updated_body
+    assert "[#10](https://github.com/ramimbo/mergework/issues/10)" in updated_body
+    assert "useful verification" in updated_body
+    assert "[#11](https://github.com/ramimbo/mergework/issues/11)" in updated_body
+    assert "focused fixes" in updated_body

--- a/tests/test_treasury_executor.py
+++ b/tests/test_treasury_executor.py
@@ -426,3 +426,76 @@ def test_executor_continues_after_failed_due_proposal(sqlite_url: str) -> None:
         assert good_proposal is not None
         assert bad_proposal.status == "pending"
         assert good_proposal.status == "executed"
+
+
+def test_executor_refreshes_bounty_board_when_configured(sqlite_url: str) -> None:
+    _init_db(sqlite_url)
+    refresher_calls: list[dict[str, object]] = []
+
+    def fake_bounty_board_refresher(
+        db_url: str,
+        *,
+        github_token: str,
+        public_base_url: str,
+        issue_number: int | None,
+    ) -> dict[str, object]:
+        refresher_calls.append(
+            {
+                "db_url": db_url,
+                "github_token": github_token,
+                "public_base_url": public_base_url,
+                "issue_number": issue_number,
+            }
+        )
+        return {"status": "updated", "issue_number": issue_number}
+
+    report = execute_due_treasury_proposals(
+        sqlite_url,
+        github_issue_token="github-issue-token",
+        public_base_url="https://mrwk.example",
+        executed_by="treasury-executor",
+        bounty_board_issue_number=785,
+        bounty_board_refresher=fake_bounty_board_refresher,
+    )
+
+    assert report["attempted"] == 0
+    assert report["bounty_board"] == {"status": "updated", "issue_number": 785}
+    assert refresher_calls == [
+        {
+            "db_url": sqlite_url,
+            "github_token": "github-issue-token",
+            "public_base_url": "https://mrwk.example",
+            "issue_number": 785,
+        }
+    ]
+
+
+def test_executor_skips_bounty_board_refresh_without_issue_number(sqlite_url: str) -> None:
+    _init_db(sqlite_url)
+    refresher_calls = 0
+
+    def fake_bounty_board_refresher(
+        db_url: str,
+        *,
+        github_token: str,
+        public_base_url: str,
+        issue_number: int | None,
+    ) -> dict[str, object]:
+        nonlocal refresher_calls
+        refresher_calls += 1
+        return {"status": "updated", "issue_number": issue_number}
+
+    report = execute_due_treasury_proposals(
+        sqlite_url,
+        github_issue_token="github-issue-token",
+        public_base_url="https://mrwk.example",
+        executed_by="treasury-executor",
+        bounty_board_issue_number=None,
+        bounty_board_refresher=fake_bounty_board_refresher,
+    )
+
+    assert report["bounty_board"] == {
+        "status": "skipped",
+        "reason": "bounty board issue number not configured",
+    }
+    assert refresher_calls == 0

--- a/tests/test_treasury_executor_script.py
+++ b/tests/test_treasury_executor_script.py
@@ -12,6 +12,7 @@ def test_executor_config_defaults_to_disabled() -> None:
     assert config.enabled is False
     assert config.interval_seconds == 300
     assert config.batch_limit == 25
+    assert config.bounty_board_refresh_interval_seconds == 60
 
 
 def test_executor_config_reads_explicit_production_settings() -> None:
@@ -20,12 +21,14 @@ def test_executor_config_reads_explicit_production_settings() -> None:
             "MERGEWORK_TREASURY_EXECUTOR_ENABLED": "true",
             "MERGEWORK_TREASURY_EXECUTOR_INTERVAL_SECONDS": "60",
             "MERGEWORK_TREASURY_EXECUTOR_BATCH_LIMIT": "5",
+            "MERGEWORK_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS": "90",
         }
     )
 
     assert config.enabled is True
     assert config.interval_seconds == 60
     assert config.batch_limit == 5
+    assert config.bounty_board_refresh_interval_seconds == 90
 
 
 def test_executor_config_accepts_documented_enable_flag() -> None:
@@ -39,11 +42,13 @@ def test_executor_config_accepts_bounds() -> None:
         {
             "MERGEWORK_TREASURY_EXECUTOR_INTERVAL_SECONDS": "15",
             "MERGEWORK_TREASURY_EXECUTOR_BATCH_LIMIT": "200",
+            "MERGEWORK_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS": "30",
         }
     )
 
     assert config.interval_seconds == 15
     assert config.batch_limit == 200
+    assert config.bounty_board_refresh_interval_seconds == 30
 
 
 def test_executor_config_rejects_invalid_numbers() -> None:
@@ -59,6 +64,98 @@ def test_executor_config_rejects_invalid_numbers() -> None:
     with pytest.raises(ValueError, match="MERGEWORK_TREASURY_EXECUTOR_INTERVAL_SECONDS"):
         executor_config_from_env({"MERGEWORK_TREASURY_EXECUTOR_INTERVAL_SECONDS": "notanumber"})
 
+    with pytest.raises(ValueError, match="MERGEWORK_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS"):
+        executor_config_from_env({"MERGEWORK_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS": "29"})
+
+    with pytest.raises(ValueError, match="MERGEWORK_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS"):
+        executor_config_from_env({"MERGEWORK_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS": "notanumber"})
+
+
+def test_board_refresh_once_uses_lightweight_board_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, object]] = []
+
+    class Settings:
+        database_url = "sqlite:////srv/mergework/data/mergework.sqlite3"
+        github_issue_token = "github-issue-token"
+        public_base_url = "https://mrwk.example"
+        bounty_board_issue_number = 785
+
+    def fake_refresh(
+        db_url: str,
+        *,
+        github_token: str,
+        public_base_url: str,
+        issue_number: int | None,
+    ) -> dict[str, object]:
+        calls.append(
+            {
+                "db_url": db_url,
+                "github_token": github_token,
+                "public_base_url": public_base_url,
+                "issue_number": issue_number,
+            }
+        )
+        return {"status": "updated", "issue_number": issue_number}
+
+    monkeypatch.setattr(executor_script, "get_settings", lambda: Settings())
+    monkeypatch.setattr(executor_script, "refresh_bounty_board_issue", fake_refresh)
+
+    assert executor_script.run_bounty_board_refresh_once() == {
+        "status": "updated",
+        "issue_number": 785,
+    }
+    assert calls == [
+        {
+            "db_url": "sqlite:////srv/mergework/data/mergework.sqlite3",
+            "github_token": "github-issue-token",
+            "public_base_url": "https://mrwk.example",
+            "issue_number": 785,
+        }
+    ]
+
+
+def test_enabled_loop_refreshes_board_between_executor_passes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = ExecutorConfig(
+        enabled=True,
+        interval_seconds=300,
+        batch_limit=1,
+        bounty_board_refresh_interval_seconds=60,
+    )
+    now = 0.0
+    events: list[tuple[str, float]] = []
+
+    def fake_monotonic() -> float:
+        return now
+
+    def fake_sleep(seconds: float) -> None:
+        nonlocal now
+        now += seconds
+
+    def fake_run_once(config: ExecutorConfig) -> dict[str, object]:
+        events.append(("executor", now))
+        return {"status": "ok"}
+
+    def fake_board_refresh_once() -> dict[str, object]:
+        events.append(("board", now))
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(executor_script.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(executor_script.time, "sleep", fake_sleep)
+    monkeypatch.setattr(executor_script, "run_once", fake_run_once)
+    monkeypatch.setattr(
+        executor_script,
+        "run_bounty_board_refresh_once",
+        fake_board_refresh_once,
+        raising=False,
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        executor_script.run_enabled_loop(config, once=False)
+
+    assert events == [("executor", 0.0), ("board", 60.0)]
+
 
 def test_executor_once_returns_failure_when_pass_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_run_once(config: ExecutorConfig) -> dict[str, object]:
@@ -67,7 +164,12 @@ def test_executor_once_returns_failure_when_pass_fails(monkeypatch: pytest.Monke
     monkeypatch.setattr(
         executor_script,
         "executor_config_from_env",
-        lambda: ExecutorConfig(enabled=True, interval_seconds=15, batch_limit=1),
+        lambda: ExecutorConfig(
+            enabled=True,
+            interval_seconds=15,
+            batch_limit=1,
+            bounty_board_refresh_interval_seconds=60,
+        ),
     )
     monkeypatch.setattr(executor_script, "run_once", fake_run_once)
 


### PR DESCRIPTION
## Summary

- Adds automation for the public bounty board issue: https://github.com/ramimbo/mergework/issues/785
- Adds a GitHub bounty board renderer/updater that separates claimable live bounties, open-but-unavailable bounties, pending create-bounty proposals, treasury capacity, and non-claimable states.
- Wires the production treasury executor to refresh the board after normal proposal passes and through a lightweight board-only loop.
- Adds `MERGEWORK_BOUNTY_BOARD_ISSUE_NUMBER` and `MERGEWORK_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS`; the board-only refresh defaults to 60 seconds with a 30-second minimum.
- Keeps load bounded by comparing normalized board content and skipping GitHub PATCH calls when only the generated displayed-state timestamp changed.
- Documents the board in the admin runbook and agent guide.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: contributors and agents currently need to inspect multiple GitHub issues and API endpoints to know what is claimable now, what is pending, and what is non-claimable.
- Bounty capacity and active attempts/open PRs checked: not applicable; this is maintainer infrastructure and does not request a bounty.
- Intended files or surfaces: treasury executor refresh flow, GitHub bounty board renderer, production config, admin runbook, agent guide, and related tests.
- Expected PR size: medium maintainer infrastructure PR.
- Out of scope: no payout behavior changes, no treasury cap changes, no `mrwk:bounty` label changes, no bounty creation, and no contributor claim path changes.

## Test Evidence

- [x] `ruff format --check .`
- [x] `ruff check .`
- [x] `mypy app`
- [x] `pytest`
- [x] `python scripts/docs_smoke.py` (docs, template, example, or onboarding changes)
- [x] `python scripts/check_agents.py`

## MRWK

Refs #785.

Maintainer PR; no bounty requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a GitHub bounty board issue that automatically displays claimable and pending bounties, updated by the treasury executor on a configurable refresh interval.
  * Added environment variables to configure the bounty board issue number and refresh timing for administrators.

* **Documentation**
  * Added admin runbook guidance for bounty board configuration and behavior.
  * Added agent guide documentation for using the bounty board to discover live claimable bounties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->