### PR TITLE
Auto-label proposed-work intake issues

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -355,7 +355,12 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             "X-Hub-Signature-256": headers.get("x-hub-signature-256", ""),
         }
         result = handle_github_webhook(
-            db_url, normalized, body, secret, settings.github_accepted_labelers
+            db_url,
+            normalized,
+            body,
+            secret,
+            accepted_labelers=settings.github_accepted_labelers,
+            github_issue_token=settings.github_issue_token,
         )
         code = 401 if result["status"] == "unauthorized" else 200
         return JSONResponse(result, status_code=code)

--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -46,7 +46,7 @@ PROPOSED_WORK_REQUIRED_HEADINGS = (
 PROPOSED_WORK_HEADING_ALTERNATES = (
     ("evidence", "current evidence"),
     ("proposed work", "proposed scope"),
-    ("acceptance", "verification"),
+    ("acceptance", "verification", "possible acceptance criteria"),
 )
 
 

--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -4,7 +4,11 @@ import hashlib
 import hmac
 import json
 import re
+from collections.abc import Callable
 from typing import Any
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
 
 from app.db import session_scope
 from app.ledger.service import (
@@ -16,6 +20,8 @@ from app.ledger.service import (
 from app.models import Bounty, WebhookEvent
 
 ACCEPTED_LABEL = "mrwk:accepted"
+PROPOSED_WORK_LABEL = "proposed-work"
+PROPOSED_WORK_ACTIONS = {"opened", "edited", "reopened"}
 ISSUE_NUMBER_BOUNDARY = r"(?![A-Za-z0-9_-])"
 MAX_SQLITE_INTEGER = 2**63 - 1
 CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
@@ -29,6 +35,17 @@ LINKED_ISSUE_RE = re.compile(
 GITHUB_ISSUE_URL_RE = re.compile(
     rf"https://github\.com/(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/(?P<number>\d+){ISSUE_NUMBER_BOUNDARY}",
     re.IGNORECASE,
+)
+PROPOSED_WORK_REQUIRED_BODY_TEXT = (
+    "problem",
+    "expected value",
+    "duplicate search",
+    "out of scope",
+)
+PROPOSED_WORK_BODY_ALTERNATES = (
+    ("evidence", "current evidence"),
+    ("proposed work", "proposed scope"),
+    ("acceptance", "verification"),
 )
 
 
@@ -125,6 +142,156 @@ def _github_issue_number(value: Any) -> int | None:
     ):
         return None
     return value
+
+
+def _github_issue_api_base(repo: str, issue_number: int) -> str:
+    owner_part, name_part = repo.split("/", 1)
+    owner = quote(owner_part, safe="")
+    name = quote(name_part, safe="")
+    return f"https://api.github.com/repos/{owner}/{name}/issues/{issue_number}"
+
+
+def _github_request(url: str, github_token: str, payload: dict[str, Any]) -> Request:
+    return Request(
+        url,
+        data=json.dumps(payload, separators=(",", ":")).encode(),
+        method="POST",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {github_token}",
+            "Content-Type": "application/json",
+            "User-Agent": "MergeWork",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+
+
+def _post_github_json(
+    *,
+    opener: Callable[..., Any],
+    url: str,
+    github_token: str,
+    payload: dict[str, Any],
+) -> None:
+    request = _github_request(url, github_token, payload)
+    with opener(request, timeout=10) as response:
+        response.read()
+
+
+def _issue_has_label(issue: dict[str, Any], label: str) -> bool:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return False
+    for item in labels:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if isinstance(name, str) and name.lower() == label.lower():
+            return True
+    return False
+
+
+def _looks_like_proposed_work_issue(issue: dict[str, Any]) -> bool:
+    title = _clean_webhook_string(issue.get("title"))
+    if title is None or not title.lower().startswith("proposed work:"):
+        return False
+    body = issue.get("body")
+    if not isinstance(body, str):
+        return False
+    normalized = body.casefold()
+    return all(text in normalized for text in PROPOSED_WORK_REQUIRED_BODY_TEXT) and all(
+        any(text in normalized for text in alternatives)
+        for alternatives in PROPOSED_WORK_BODY_ALTERNATES
+    )
+
+
+def _handle_proposed_work_issue_label(
+    database_url: str,
+    payload: dict[str, Any],
+    event_type: str,
+    delivery_id: str,
+    payload_hash: str,
+    github_issue_token: str,
+    opener: Callable[..., Any],
+) -> dict[str, Any] | None:
+    if event_type != "issues" or payload.get("action") not in PROPOSED_WORK_ACTIONS:
+        return None
+    issue = _payload_object(payload, "issue")
+    if not issue or "pull_request" in issue or not _looks_like_proposed_work_issue(issue):
+        return None
+    if _issue_has_label(issue, PROPOSED_WORK_LABEL):
+        return _record_status(
+            database_url,
+            delivery_id,
+            event_type,
+            payload_hash,
+            "proposed_work_label_present",
+        )
+    repo_name = _payload_object(payload, "repository").get("full_name")
+    repo = _clean_webhook_string(repo_name)
+    issue_number = _github_issue_number(issue.get("number"))
+    if isinstance(repo_name, str) and CONTROL_CHAR_RE.search(repo_name):
+        return _record_status(
+            database_url,
+            delivery_id,
+            event_type,
+            payload_hash,
+            "malformed_repository",
+        )
+    if not repo or issue_number is None:
+        return _record_status(database_url, delivery_id, event_type, payload_hash, "missing_issue")
+    clean_token = github_issue_token.strip()
+    if not clean_token:
+        _record_event(
+            database_url,
+            delivery_id,
+            event_type,
+            payload_hash,
+            "proposed_work_label_skipped",
+        )
+        return {
+            "status": "proposed_work_label_skipped",
+            "reason": "github issue token not configured",
+        }
+    try:
+        _post_github_json(
+            opener=opener,
+            url=f"{_github_issue_api_base(repo, issue_number)}/labels",
+            github_token=clean_token,
+            payload={"labels": [PROPOSED_WORK_LABEL]},
+        )
+    except HTTPError as exc:
+        _record_event(
+            database_url,
+            delivery_id,
+            event_type,
+            payload_hash,
+            "proposed_work_label_failed",
+        )
+        return {
+            "status": "proposed_work_label_failed",
+            "reason": f"github label update failed: HTTP {exc.code}",
+        }
+    except (OSError, ValueError) as exc:
+        _record_event(
+            database_url,
+            delivery_id,
+            event_type,
+            payload_hash,
+            "proposed_work_label_failed",
+        )
+        return {
+            "status": "proposed_work_label_failed",
+            "reason": f"github label update failed: {type(exc).__name__}",
+        }
+    _record_event(
+        database_url,
+        delivery_id,
+        event_type,
+        payload_hash,
+        "proposed_work_labeled",
+    )
+    return {"status": "proposed_work_labeled", "label": PROPOSED_WORK_LABEL}
 
 
 def _bounty_accepts_awards(bounty: Bounty) -> bool:
@@ -288,6 +455,8 @@ def handle_github_webhook(
     body: bytes,
     webhook_secret: str,
     accepted_labelers: tuple[str, ...] = (),
+    github_issue_token: str = "",
+    opener: Callable[..., Any] = urlopen,
 ) -> dict[str, Any]:
     signature = headers.get("X-Hub-Signature-256")
     if not verify_github_signature(body, signature, webhook_secret):
@@ -313,6 +482,17 @@ def handle_github_webhook(
     if not isinstance(payload, dict):
         _record_event(database_url, delivery_id, event_type, hashed, "invalid_payload")
         return {"status": "invalid_payload"}
+    proposed_work_result = _handle_proposed_work_issue_label(
+        database_url,
+        payload,
+        event_type,
+        delivery_id,
+        hashed,
+        github_issue_token,
+        opener,
+    )
+    if proposed_work_result is not None:
+        return proposed_work_result
     if event_type in {"issues", "pull_request"}:
         return _handle_accepted_issue_label(
             database_url, payload, event_type, delivery_id, hashed, accepted_labelers

--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -36,13 +36,14 @@ GITHUB_ISSUE_URL_RE = re.compile(
     rf"https://github\.com/(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/(?P<number>\d+){ISSUE_NUMBER_BOUNDARY}",
     re.IGNORECASE,
 )
-PROPOSED_WORK_REQUIRED_BODY_TEXT = (
-    "problem",
-    "expected value",
-    "duplicate search",
-    "out of scope",
+PROPOSED_WORK_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(?P<heading>.+?)\s*#*\s*$", re.MULTILINE)
+PROPOSED_WORK_REQUIRED_HEADINGS = (
+    ("problem",),
+    ("expected value",),
+    ("duplicate search",),
+    ("out of scope",),
 )
-PROPOSED_WORK_BODY_ALTERNATES = (
+PROPOSED_WORK_HEADING_ALTERNATES = (
     ("evidence", "current evidence"),
     ("proposed work", "proposed scope"),
     ("acceptance", "verification"),
@@ -191,6 +192,24 @@ def _issue_has_label(issue: dict[str, Any], label: str) -> bool:
     return False
 
 
+def _normalized_markdown_headings(body: str) -> tuple[str, ...]:
+    headings: list[str] = []
+    for match in PROPOSED_WORK_HEADING_RE.finditer(body):
+        heading = match.group("heading").rstrip("#").strip()
+        normalized = re.sub(r"\s+", " ", heading).casefold().strip(" :")
+        if normalized:
+            headings.append(normalized)
+    return tuple(headings)
+
+
+def _has_markdown_heading(headings: tuple[str, ...], alternatives: tuple[str, ...]) -> bool:
+    for heading in headings:
+        for alternative in alternatives:
+            if heading == alternative or heading.startswith(f"{alternative} "):
+                return True
+    return False
+
+
 def _looks_like_proposed_work_issue(issue: dict[str, Any]) -> bool:
     title = _clean_webhook_string(issue.get("title"))
     if title is None or not title.lower().startswith("proposed work:"):
@@ -198,10 +217,13 @@ def _looks_like_proposed_work_issue(issue: dict[str, Any]) -> bool:
     body = issue.get("body")
     if not isinstance(body, str):
         return False
-    normalized = body.casefold()
-    return all(text in normalized for text in PROPOSED_WORK_REQUIRED_BODY_TEXT) and all(
-        any(text in normalized for text in alternatives)
-        for alternatives in PROPOSED_WORK_BODY_ALTERNATES
+    headings = _normalized_markdown_headings(body)
+    return all(
+        _has_markdown_heading(headings, alternatives)
+        for alternatives in PROPOSED_WORK_REQUIRED_HEADINGS
+    ) and all(
+        _has_markdown_heading(headings, alternatives)
+        for alternatives in PROPOSED_WORK_HEADING_ALTERNATES
     )
 
 
@@ -261,25 +283,11 @@ def _handle_proposed_work_issue_label(
             payload={"labels": [PROPOSED_WORK_LABEL]},
         )
     except HTTPError as exc:
-        _record_event(
-            database_url,
-            delivery_id,
-            event_type,
-            payload_hash,
-            "proposed_work_label_failed",
-        )
         return {
             "status": "proposed_work_label_failed",
             "reason": f"github label update failed: HTTP {exc.code}",
         }
     except (OSError, ValueError) as exc:
-        _record_event(
-            database_url,
-            delivery_id,
-            event_type,
-            payload_hash,
-            "proposed_work_label_failed",
-        )
         return {
             "status": "proposed_work_label_failed",
             "reason": f"github label update failed: {type(exc).__name__}",

--- a/docs/bounty-lifecycle.md
+++ b/docs/bounty-lifecycle.md
@@ -90,6 +90,9 @@ issue-comment work:
 ## Short Examples
 
 - A `proposed-work` issue with a suggested reward is not claimable.
+- CLI/API-created proposed-work issues may receive the `proposed-work` intake
+  label automatically when the title and body clearly match the proposed-work
+  template. That label still does not make the issue claimable.
 - An issue with a pending create_bounty proposal is not claimable.
 - An issue with `mrwk:bounty`, `Reserved on MergeWork`, and an open public
   bounty row is claimable while awards remain.

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -104,6 +104,128 @@ def test_issue_webhook_adds_proposed_work_label_for_template_shaped_issue(
         assert event.processed_status == "proposed_work_labeled"
 
 
+def test_issue_webhook_deduplicates_proposed_work_label_delivery(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "opened",
+            "issue": {
+                "number": 786,
+                "title": "Proposed work: handle activity account filter explicitly",
+                "body": _proposed_work_body(),
+                "html_url": "https://github.com/ramimbo/mergework/issues/786",
+                "labels": [],
+                "user": {"login": "contributor"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "contributor"},
+        },
+        separators=(",", ":"),
+    ).encode()
+    headers = {
+        "X-GitHub-Delivery": "delivery-proposed-work-replay",
+        "X-GitHub-Event": "issues",
+        "X-Hub-Signature-256": _signature("secret", body),
+    }
+    requests: list[Request] = []
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        requests.append(request)
+        return _FakeResponse({})
+
+    first = handle_github_webhook(
+        sqlite_url,
+        headers,
+        body,
+        "secret",
+        github_issue_token="github-issue-token",
+        opener=fake_opener,
+    )
+    replay = handle_github_webhook(
+        sqlite_url,
+        headers,
+        body,
+        "secret",
+        github_issue_token="github-issue-token",
+        opener=fake_opener,
+    )
+
+    assert first == {"status": "proposed_work_labeled", "label": "proposed-work"}
+    assert replay == {
+        "status": "duplicate",
+        "processed_status": "proposed_work_labeled",
+    }
+    assert len(requests) == 1
+    with session_scope(sqlite_url) as session:
+        assert session.query(WebhookEvent).count() == 1
+
+
+def test_issue_webhook_retries_proposed_work_label_after_post_failure(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "opened",
+            "issue": {
+                "number": 786,
+                "title": "Proposed work: handle activity account filter explicitly",
+                "body": _proposed_work_body(),
+                "html_url": "https://github.com/ramimbo/mergework/issues/786",
+                "labels": [],
+                "user": {"login": "contributor"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "contributor"},
+        },
+        separators=(",", ":"),
+    ).encode()
+    headers = {
+        "X-GitHub-Delivery": "delivery-proposed-work-failed-retry",
+        "X-GitHub-Event": "issues",
+        "X-Hub-Signature-256": _signature("secret", body),
+    }
+    calls = 0
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise OSError("temporary failure")
+        return _FakeResponse({})
+
+    first = handle_github_webhook(
+        sqlite_url,
+        headers,
+        body,
+        "secret",
+        github_issue_token="github-issue-token",
+        opener=fake_opener,
+    )
+    with session_scope(sqlite_url) as session:
+        assert session.get(WebhookEvent, "delivery-proposed-work-failed-retry") is None
+
+    retry = handle_github_webhook(
+        sqlite_url,
+        headers,
+        body,
+        "secret",
+        github_issue_token="github-issue-token",
+        opener=fake_opener,
+    )
+
+    assert first == {
+        "status": "proposed_work_label_failed",
+        "reason": "github label update failed: OSError",
+    }
+    assert retry == {"status": "proposed_work_labeled", "label": "proposed-work"}
+    assert calls == 2
+    with session_scope(sqlite_url) as session:
+        event = session.get(WebhookEvent, "delivery-proposed-work-failed-retry")
+        assert event is not None
+        assert event.processed_status == "proposed_work_labeled"
+
+
 def test_issue_webhook_skips_proposed_work_label_without_github_token(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     body = json.dumps(
@@ -182,6 +304,54 @@ def test_issue_webhook_does_not_label_non_template_issue(sqlite_url: str) -> Non
         sqlite_url,
         {
             "X-GitHub-Delivery": "delivery-non-proposed-work",
+            "X-GitHub-Event": "issues",
+            "X-Hub-Signature-256": _signature("secret", body),
+        },
+        body,
+        "secret",
+        github_issue_token="github-issue-token",
+        opener=fake_opener,
+    )
+
+    assert result == {"status": "ignored"}
+    assert calls == 0
+
+
+def test_issue_webhook_ignores_proposed_work_title_without_template_headings(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "opened",
+            "issue": {
+                "number": 787,
+                "title": "Proposed work: question about the intake flow",
+                "body": (
+                    "This asks about the problem, expected value, duplicate search, "
+                    "out of scope, evidence, proposed scope, and verification notes "
+                    "without using the proposed-work template headings."
+                ),
+                "html_url": "https://github.com/ramimbo/mergework/issues/787",
+                "labels": [],
+                "user": {"login": "contributor"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "contributor"},
+        },
+        separators=(",", ":"),
+    ).encode()
+    calls = 0
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        nonlocal calls
+        calls += 1
+        return _FakeResponse({})
+
+    result = handle_github_webhook(
+        sqlite_url,
+        {
+            "X-GitHub-Delivery": "delivery-proposed-work-prose-only",
             "X-GitHub-Event": "issues",
             "X-Hub-Signature-256": _signature("secret", body),
         },

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+from typing import Any
+from urllib.request import Request
 
 from app.db import create_schema, session_scope
 from app.ledger.service import (
@@ -19,6 +21,178 @@ from app.webhooks.github import handle_github_webhook, verify_github_signature
 def _signature(secret: str, body: bytes) -> str:
     digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
     return f"sha256={digest}"
+
+
+class _FakeResponse:
+    def __init__(self, body: dict[str, Any]) -> None:
+        self._body = body
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self._body).encode()
+
+
+def _proposed_work_body() -> str:
+    return "\n\n".join(
+        [
+            "## Proposed work\n\nHandle a focused contributor-flow problem.",
+            "## Problem\n\nCLI-created proposed-work issues miss the intake label.",
+            "## Current evidence\n\nIssue #786 had no label after creation.",
+            "## Proposed scope\n\nAdd the intake label when the issue is clearly proposed work.",
+            "## Expected value\n\nMaintainers and agents can find intake issues.",
+            "## Acceptance / verification notes\n\nWebhook tests cover the behavior.",
+            "## Duplicate search\n\nNo existing automation covers this.",
+            "## Out of scope\n\nNo bounty, payout, or mrwk:bounty label changes.",
+        ]
+    )
+
+
+def test_issue_webhook_adds_proposed_work_label_for_template_shaped_issue(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "opened",
+            "issue": {
+                "number": 786,
+                "title": "Proposed work: handle activity account filter explicitly",
+                "body": _proposed_work_body(),
+                "html_url": "https://github.com/ramimbo/mergework/issues/786",
+                "labels": [],
+                "user": {"login": "contributor"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "contributor"},
+        },
+        separators=(",", ":"),
+    ).encode()
+    requests: list[Request] = []
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        requests.append(request)
+        return _FakeResponse({})
+
+    result = handle_github_webhook(
+        sqlite_url,
+        {
+            "X-GitHub-Delivery": "delivery-proposed-work-opened",
+            "X-GitHub-Event": "issues",
+            "X-Hub-Signature-256": _signature("secret", body),
+        },
+        body,
+        "secret",
+        github_issue_token="github-issue-token",
+        opener=fake_opener,
+    )
+
+    assert result == {"status": "proposed_work_labeled", "label": "proposed-work"}
+    assert len(requests) == 1
+    assert requests[0].full_url == (
+        "https://api.github.com/repos/ramimbo/mergework/issues/786/labels"
+    )
+    assert requests[0].headers["Authorization"] == "Bearer github-issue-token"
+    assert json.loads((requests[0].data or b"").decode()) == {"labels": ["proposed-work"]}
+    with session_scope(sqlite_url) as session:
+        event = session.get(WebhookEvent, "delivery-proposed-work-opened")
+        assert event is not None
+        assert event.processed_status == "proposed_work_labeled"
+
+
+def test_issue_webhook_skips_proposed_work_label_without_github_token(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "opened",
+            "issue": {
+                "number": 786,
+                "title": "Proposed work: handle activity account filter explicitly",
+                "body": _proposed_work_body(),
+                "html_url": "https://github.com/ramimbo/mergework/issues/786",
+                "labels": [],
+                "user": {"login": "contributor"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "contributor"},
+        },
+        separators=(",", ":"),
+    ).encode()
+    calls = 0
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        nonlocal calls
+        calls += 1
+        return _FakeResponse({})
+
+    result = handle_github_webhook(
+        sqlite_url,
+        {
+            "X-GitHub-Delivery": "delivery-proposed-work-no-token",
+            "X-GitHub-Event": "issues",
+            "X-Hub-Signature-256": _signature("secret", body),
+        },
+        body,
+        "secret",
+        github_issue_token="",
+        opener=fake_opener,
+    )
+
+    assert result == {
+        "status": "proposed_work_label_skipped",
+        "reason": "github issue token not configured",
+    }
+    assert calls == 0
+    with session_scope(sqlite_url) as session:
+        event = session.get(WebhookEvent, "delivery-proposed-work-no-token")
+        assert event is not None
+        assert event.processed_status == "proposed_work_label_skipped"
+
+
+def test_issue_webhook_does_not_label_non_template_issue(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "opened",
+            "issue": {
+                "number": 787,
+                "title": "Question about claims",
+                "body": "Can I claim this?",
+                "html_url": "https://github.com/ramimbo/mergework/issues/787",
+                "labels": [],
+                "user": {"login": "contributor"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "contributor"},
+        },
+        separators=(",", ":"),
+    ).encode()
+    calls = 0
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        nonlocal calls
+        calls += 1
+        return _FakeResponse({})
+
+    result = handle_github_webhook(
+        sqlite_url,
+        {
+            "X-GitHub-Delivery": "delivery-non-proposed-work",
+            "X-GitHub-Event": "issues",
+            "X-Hub-Signature-256": _signature("secret", body),
+        },
+        body,
+        "secret",
+        github_issue_token="github-issue-token",
+        opener=fake_opener,
+    )
+
+    assert result == {"status": "ignored"}
+    assert calls == 0
 
 
 def test_github_signature_verification() -> None:

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -52,6 +52,23 @@ def _proposed_work_body() -> str:
     )
 
 
+def _proposed_work_issue_form_body() -> str:
+    return "\n\n".join(
+        [
+            "### Related bounty or source issue\n\nBounty #722",
+            "### Problem\n\nCLI-created proposed-work issues miss the intake label.",
+            "### Evidence\n\nIssue #786 had no label after creation.",
+            "### Proposed work\n\nAdd the intake label when the issue is clearly proposed work.",
+            "### Expected value\n\nMaintainers and agents can find intake issues.",
+            "### Reference tier\n\n100-500 MRWK: useful issue, test, docs page, small bugfix",
+            "### Possible acceptance criteria\n\nWebhook tests cover the behavior.",
+            "### Evidence or tests required\n\nRun the webhook tests.",
+            "### Duplicate search\n\nNo existing automation covers this.",
+            "### Out of scope\n\nNo bounty, payout, or mrwk:bounty label changes.",
+        ]
+    )
+
+
 def test_issue_webhook_adds_proposed_work_label_for_template_shaped_issue(
     sqlite_url: str,
 ) -> None:
@@ -100,6 +117,53 @@ def test_issue_webhook_adds_proposed_work_label_for_template_shaped_issue(
     assert json.loads((requests[0].data or b"").decode()) == {"labels": ["proposed-work"]}
     with session_scope(sqlite_url) as session:
         event = session.get(WebhookEvent, "delivery-proposed-work-opened")
+        assert event is not None
+        assert event.processed_status == "proposed_work_labeled"
+
+
+def test_issue_webhook_adds_proposed_work_label_for_issue_form_headings(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "opened",
+            "issue": {
+                "number": 786,
+                "title": "Proposed work: handle activity account filter explicitly",
+                "body": _proposed_work_issue_form_body(),
+                "html_url": "https://github.com/ramimbo/mergework/issues/786",
+                "labels": [],
+                "user": {"login": "contributor"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "contributor"},
+        },
+        separators=(",", ":"),
+    ).encode()
+    requests: list[Request] = []
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        requests.append(request)
+        return _FakeResponse({})
+
+    result = handle_github_webhook(
+        sqlite_url,
+        {
+            "X-GitHub-Delivery": "delivery-proposed-work-issue-form",
+            "X-GitHub-Event": "issues",
+            "X-Hub-Signature-256": _signature("secret", body),
+        },
+        body,
+        "secret",
+        github_issue_token="github-issue-token",
+        opener=fake_opener,
+    )
+
+    assert result == {"status": "proposed_work_labeled", "label": "proposed-work"}
+    assert len(requests) == 1
+    with session_scope(sqlite_url) as session:
+        event = session.get(WebhookEvent, "delivery-proposed-work-issue-form")
         assert event is not None
         assert event.processed_status == "proposed_work_labeled"
 


### PR DESCRIPTION
## Summary

Adds a narrow GitHub webhook path that auto-applies the `proposed-work` intake label to issue-open/edit/reopen events when the issue clearly matches the proposed-work template.

## Why

Most proposed-work intake is now coming from CLI/API-created issues rather than the GitHub issue form, so GitHub does not auto-apply the template label. Contributors cannot add labels themselves, and unlabeled proposed-work issues are harder for maintainers and agents to find.

## Behavior

- Only handles `issues` webhook events for `opened`, `edited`, and `reopened`.
- Requires the title to start with `Proposed work:` and the body to include the expected proposed-work sections.
- Adds only the `proposed-work` label.
- Does not add `mrwk:bounty`, does not post comments, does not create payouts, and does not make the issue claimable.
- Records webhook-event statuses for labeled/skipped/failed cases.
- Uses the existing `MERGEWORK_GITHUB_ISSUE_TOKEN` issue-permission token.

## Validation

- `python -m pytest tests/test_webhooks.py -q` -> 25 passed
- `python -m pytest tests/test_webhooks.py tests/test_docs_public_urls.py -q` -> 58 passed
- `python scripts/check_agents.py` -> passed
- `python -m pytest -q` -> 677 passed
- `python -m ruff format --check .` -> passed
- `python -m ruff check .` -> passed
- `python -m mypy app` -> passed
- `python scripts/docs_smoke.py` -> passed

## Bounty

Maintainer infrastructure PR; no bounty requested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Issues matching the proposed-work template are automatically labeled with the proposed-work intake label on creation (when configured).

* **Reliability**
  * Deduplication of repeated deliveries, retry behavior on transient failures, skips labeling when not configured, and proper handling of malformed or non-template submissions.

* **Tests**
  * Added comprehensive tests covering labeling, deduplication, retries, skips, and non-template cases.

* **Documentation**
  * Clarified that automatically-labeled proposed-work issues remain non-claimable and still require proper submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->