### PR TITLE
Reject uppercase wallet path aliases

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -48,6 +48,16 @@ def normalized_wallet_address(address: str) -> str:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
+def normalized_wallet_path_address(address: str) -> str:
+    normalized = normalized_wallet_address(address)
+    if address != normalized:
+        raise HTTPException(
+            status_code=400,
+            detail="wallet address must be lowercase canonical MRWK address",
+        )
+    return normalized
+
+
 def normalized_account(account: str) -> str:
     if not account or not account.strip():
         raise HTTPException(status_code=400, detail="account must not be empty")

--- a/app/main.py
+++ b/app/main.py
@@ -13,7 +13,6 @@ from fastapi.templating import Jinja2Templates
 from app import auth as auth_module
 from app.accounts import (
     normalized_account,
-    normalized_wallet_address,
     normalized_wallet_path_address,
     register_account_routes,
 )
@@ -307,7 +306,6 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         required_str=_required_str,
         required_int=_required_int,
         optional_str=_optional_str,
-        normalized_wallet_address=normalized_wallet_address,
         normalized_wallet_path_address=normalized_wallet_path_address,
         post_only_route=post_only_route,
     )

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,12 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from app import auth as auth_module
-from app.accounts import normalized_account, normalized_wallet_address, register_account_routes
+from app.accounts import (
+    normalized_account,
+    normalized_wallet_address,
+    normalized_wallet_path_address,
+    register_account_routes,
+)
 from app.activity import register_activity_routes
 from app.admin_routes import register_admin_routes
 from app.bounty_api import register_bounty_api_routes
@@ -303,6 +308,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         required_int=_required_int,
         optional_str=_optional_str,
         normalized_wallet_address=normalized_wallet_address,
+        normalized_wallet_path_address=normalized_wallet_path_address,
         post_only_route=post_only_route,
     )
 

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 from app.accounts import (
     ACCOUNT_TRANSACTION_TYPE_OPTIONS,
     ACCOUNT_TRANSACTION_TYPES,
-    normalized_wallet_address,
+    normalized_wallet_path_address,
 )
 from app.bounty_availability import normalize_bounty_availability_filter
 from app.bounty_sorting import BOUNTY_SORT_LABELS, normalize_bounty_sort
@@ -205,7 +205,7 @@ def wallets_page_context(session: Session, q: str | None = None) -> dict[str, An
 def wallet_page_context(
     session: Session, address: str, transaction_type: str | None = None
 ) -> dict[str, Any]:
-    normalized_address = normalized_wallet_address(address)
+    normalized_address = normalized_wallet_path_address(address)
     wallet = session.get(Wallet, normalized_address)
     if wallet is None:
         raise HTTPException(status_code=404, detail="wallet not found")

--- a/app/wallet_api.py
+++ b/app/wallet_api.py
@@ -39,7 +39,6 @@ def register_wallet_api_routes(
     required_str: RequiredString,
     required_int: RequiredInteger,
     optional_str: OptionalString,
-    normalized_wallet_address: NormalizeWalletAddress,
     normalized_wallet_path_address: NormalizeWalletAddress,
     post_only_route: PostOnlyRoute,
 ) -> None:

--- a/app/wallet_api.py
+++ b/app/wallet_api.py
@@ -40,6 +40,7 @@ def register_wallet_api_routes(
     required_int: RequiredInteger,
     optional_str: OptionalString,
     normalized_wallet_address: NormalizeWalletAddress,
+    normalized_wallet_path_address: NormalizeWalletAddress,
     post_only_route: PostOnlyRoute,
 ) -> None:
     @app.post("/api/v1/wallets/register", openapi_extra=WALLET_REGISTER_BODY)
@@ -66,13 +67,7 @@ def register_wallet_api_routes(
 
     @app.get("/api/v1/wallets/{address}")
     def api_wallet(address: str) -> dict[str, Any]:
-        normalized_address = normalized_wallet_address(address)
-        if address != normalized_address:
-            raise HTTPException(
-                status_code=400,
-                detail="wallet address must be lowercase canonical MRWK address",
-            )
-        address = normalized_address
+        address = normalized_wallet_path_address(address)
         with session_scope(db_url) as session:
             wallet = session.get(Wallet, address)
             if wallet is None:

--- a/app/wallet_api.py
+++ b/app/wallet_api.py
@@ -66,7 +66,13 @@ def register_wallet_api_routes(
 
     @app.get("/api/v1/wallets/{address}")
     def api_wallet(address: str) -> dict[str, Any]:
-        address = normalized_wallet_address(address)
+        normalized_address = normalized_wallet_address(address)
+        if address != normalized_address:
+            raise HTTPException(
+                status_code=400,
+                detail="wallet address must be lowercase canonical MRWK address",
+            )
+        address = normalized_address
         with session_scope(db_url) as session:
             wallet = session.get(Wallet, address)
             if wallet is None:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -380,6 +380,8 @@ def test_wallet_lookup_rejects_invalid_addresses_before_lookup(sqlite_url: str) 
     api_response = client.get("/api/v1/wallets/not-a-wallet")
     page_response = client.get("/wallets/%20%20%20")
     unknown_wallet = client.get("/api/v1/wallets/mrwk1" + ("0" * 40))
+    uppercase_wallet = client.get("/api/v1/wallets/MRWK1" + ("0" * 40))
+    uppercase_wallet_page = client.get("/wallets/MRWK1" + ("0" * 40))
 
     assert api_response.status_code == 400
     assert api_response.json()["detail"] == "invalid MRWK wallet address"
@@ -387,6 +389,12 @@ def test_wallet_lookup_rejects_invalid_addresses_before_lookup(sqlite_url: str) 
     assert "invalid MRWK wallet address" in page_response.text
     assert unknown_wallet.status_code == 404
     assert unknown_wallet.json()["detail"] == "wallet not found"
+    assert uppercase_wallet.status_code == 400
+    assert uppercase_wallet.json()["detail"] == (
+        "wallet address must be lowercase canonical MRWK address"
+    )
+    assert uppercase_wallet_page.status_code == 400
+    assert "wallet address must be lowercase canonical MRWK address" in uppercase_wallet_page.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Reject non-canonical uppercase MRWK wallet path aliases on the public wallet API and wallet detail page.

MRWK wallet addresses are emitted as lowercase `mrwk1[0-9a-f]{40}` values, but the public wallet paths currently accept uppercase aliases such as `MRWK1...` and silently normalize them to the canonical wallet. This change keeps existing wallet-address normalization for signed/action flows, while making public lookup paths fail closed unless the path is already the canonical lowercase address.

## Live evidence

Read-only production checks on 2026-06-02 UTC showed the uppercase alias resolving successfully:

```text
GET https://api.mrwk.online/api/v1/wallets/mrwk194973c55faef36256c62e11f390ed26bf801a99c -> 200
GET https://api.mrwk.online/api/v1/wallets/MRWK194973C55FAEF36256C62E11F390ED26BF801A99C -> 200
GET https://mrwk.online/wallets/mrwk194973c55faef36256c62e11f390ed26bf801a99c -> 200
GET https://mrwk.online/wallets/MRWK194973C55FAEF36256C62E11F390ED26BF801A99C -> 200
```

The uppercase API response returns the lowercase canonical `address`, and the uppercase page renders the lowercase canonical wallet title, so the path alias is currently accepted rather than rejected.

## Implementation

- Adds `normalized_wallet_path_address()` for public wallet path lookups.
- Keeps canonical lowercase wallet paths working.
- Keeps missing canonical wallets returning `404 wallet not found`.
- Rejects uppercase public wallet path aliases with `400`.
- Does not change wallet registration, linking, transfers, MCP account normalization, or signed wallet action normalization.

## Validation

```text
./.venv/bin/python -m pytest tests/test_wallet_api.py -q
# 41 passed, 1 warning

./.venv/bin/python -m ruff format --check app/accounts.py app/wallet_api.py app/public_routes.py tests/test_wallet_api.py
# 4 files already formatted

./.venv/bin/python -m ruff check app/accounts.py app/wallet_api.py app/public_routes.py tests/test_wallet_api.py
# All checks passed
```

## Safety / scope

No private data, wallet keys, signatures, balances, ledger mutation, payout execution, bridge/exchange behavior, or auth/payment logic is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet addresses must be provided in lowercase canonical format; non-lowercase addresses are rejected with a 400 error and clear message.
  * Wallet lookup endpoints (API and HTML) now enforce canonical-lowercase normalization for address path parameters.

* **Tests**
  * Updated tests to verify uppercase/non-canonical addresses are rejected with the expected error on both API and page lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->