### PR TITLE
Document OpenAPI auth requirements

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -26,6 +26,7 @@ from app.ledger.service import (
     validate_public_url,
 )
 from app.models import Bounty, Proof, Submission
+from app.openapi_request_bodies import ADMIN_TOKEN_AUTH, with_openapi_auth
 from app.path_params import SQLITE_INTEGER_MAX, issue_number_search_value, positive_bounty_id
 from app.query_validation import (
     reject_control_char_query_param,
@@ -242,7 +243,10 @@ def register_bounty_api_routes(
             )
         )
 
-    @app.get("/api/v1/admin/webhook-events")
+    @app.get(
+        "/api/v1/admin/webhook-events",
+        openapi_extra=with_openapi_auth(None, ADMIN_TOKEN_AUTH),
+    )
     def api_admin_webhook_events(
         status: str | None = Query(None),
         limit: Annotated[int, Query(ge=1, le=200)] = 50,
@@ -255,7 +259,7 @@ def register_bounty_api_routes(
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    @app.post("/api/v1/bounties")
+    @app.post("/api/v1/bounties", openapi_extra=with_openapi_auth(None, ADMIN_TOKEN_AUTH))
     async def api_create_bounty(
         request: Request, admin_login: str = Depends(require_admin_token)
     ) -> dict[str, Any]:
@@ -293,7 +297,10 @@ def register_bounty_api_routes(
             result["accepted_awards"] = bounty_awards_to_dict(session, bounty.id)
             return result
 
-    @app.get("/api/v1/reconciliation/payouts")
+    @app.get(
+        "/api/v1/reconciliation/payouts",
+        openapi_extra=with_openapi_auth(None, ADMIN_TOKEN_AUTH),
+    )
     def api_payout_reconciliation(
         admin_login: str = Depends(require_admin_token),
     ) -> dict[str, Any]:
@@ -305,7 +312,10 @@ def register_bounty_api_routes(
                 "checks": [payout_reconciliation_to_dict(check) for check in checks],
             }
 
-    @app.post("/api/v1/bounties/{bounty_id}/pay")
+    @app.post(
+        "/api/v1/bounties/{bounty_id}/pay",
+        openapi_extra=with_openapi_auth(None, ADMIN_TOKEN_AUTH),
+    )
     async def api_pay_bounty(
         bounty_id: str,
         request: Request,
@@ -366,7 +376,10 @@ def register_bounty_api_routes(
                 raise _ledger_http_error(exc) from exc
             return proposal_to_dict(proposal)
 
-    @app.post("/api/v1/bounties/{bounty_id}/close")
+    @app.post(
+        "/api/v1/bounties/{bounty_id}/close",
+        openapi_extra=with_openapi_auth(None, ADMIN_TOKEN_AUTH),
+    )
     async def api_close_bounty(
         bounty_id: str,
         request: Request,

--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -13,7 +13,12 @@ from sqlalchemy.orm import Session
 from app.db import session_scope
 from app.ledger.service import CONTROL_CHAR_RE, LedgerError, validate_public_url
 from app.models import Bounty, BountyAttempt
-from app.openapi_request_bodies import OPTIONAL_ATTEMPT_BODY, OPTIONAL_ATTEMPT_RELEASE_BODY
+from app.openapi_request_bodies import (
+    GITHUB_SESSION_AUTH,
+    OPTIONAL_ATTEMPT_BODY,
+    OPTIONAL_ATTEMPT_RELEASE_BODY,
+    with_openapi_auth,
+)
 from app.query_validation import (
     reject_control_char_query_param,
     reject_noncanonical_int_query_param,
@@ -182,7 +187,10 @@ def register_bounty_attempt_routes(
                 "attempts": listing["attempts"],
             }
 
-    @app.post("/api/v1/bounties/{bounty_id}/attempts", openapi_extra=OPTIONAL_ATTEMPT_BODY)
+    @app.post(
+        "/api/v1/bounties/{bounty_id}/attempts",
+        openapi_extra=with_openapi_auth(OPTIONAL_ATTEMPT_BODY, GITHUB_SESSION_AUTH),
+    )
     async def api_create_bounty_attempt(
         bounty_id: str,
         request: Request,
@@ -292,7 +300,7 @@ def register_bounty_attempt_routes(
 
     @app.post(
         "/api/v1/bounty-attempts/{attempt_id}/release",
-        openapi_extra=OPTIONAL_ATTEMPT_RELEASE_BODY,
+        openapi_extra=with_openapi_auth(OPTIONAL_ATTEMPT_RELEASE_BODY, GITHUB_SESSION_AUTH),
     )
     async def api_release_bounty_attempt(
         attempt_id: int,

--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.me import me_page_context
 from app.models import (
     Proof,
 )
+from app.openapi_request_bodies import OPENAPI_SECURITY_SCHEMES
 from app.path_params import (
     SQLITE_INTEGER_MAX,
     positive_bounty_id,
@@ -91,6 +92,23 @@ API_DOCS_CSP = (
     "worker-src 'self' blob:"
 )
 API_DOCS_PATHS = {"/api/docs", "/api/redoc"}
+
+
+def _install_openapi_security_schemes(app: FastAPI) -> None:
+    default_openapi = app.openapi
+
+    def custom_openapi() -> dict[str, Any]:
+        if app.openapi_schema:
+            return app.openapi_schema
+        schema = default_openapi()
+        components = schema.setdefault("components", {})
+        security_schemes = components.setdefault("securitySchemes", {})
+        for name, scheme in OPENAPI_SECURITY_SCHEMES.items():
+            security_schemes.setdefault(name, scheme)
+        app.openapi_schema = schema
+        return schema
+
+    app.openapi = custom_openapi  # type: ignore[method-assign]
 
 
 def _request_was_forwarded_https(request: Request) -> bool:
@@ -413,6 +431,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         verify_csrf_token=_verify_csrf_token,
     )
 
+    _install_openapi_security_schemes(app)
     return app
 
 

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -2,6 +2,59 @@ from __future__ import annotations
 
 from typing import Any
 
+OPENAPI_SECURITY_SCHEMES = {
+    "MergeWorkAdminToken": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-mergework-admin-token",
+        "description": "Admin API token required for protected admin and treasury operations.",
+    },
+    "MergeWorkGitHubSession": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "mrwk_user",
+        "description": (
+            "GitHub login session cookie from /auth/github/login required for "
+            "authenticated contributor operations."
+        ),
+    },
+}
+
+
+AUTH_ERROR_RESPONSE = {
+    "description": "Authentication required.",
+    "content": {
+        "application/json": {
+            "schema": {
+                "type": "object",
+                "properties": {"detail": {"type": "string"}},
+                "required": ["detail"],
+            },
+        },
+    },
+}
+
+
+ADMIN_TOKEN_AUTH = {
+    "security": [{"MergeWorkAdminToken": []}],
+    "responses": {"401": AUTH_ERROR_RESPONSE},
+}
+
+
+GITHUB_SESSION_AUTH = {
+    "security": [{"MergeWorkGitHubSession": []}],
+    "responses": {"401": AUTH_ERROR_RESPONSE},
+}
+
+
+def with_openapi_auth(extra: dict[str, Any] | None, auth: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(extra or {})
+    responses = dict(merged.get("responses", {}))
+    responses.update(auth["responses"])
+    merged["responses"] = responses
+    merged["security"] = auth["security"]
+    return merged
+
 
 def _request_body(schema: dict[str, Any], *, required: bool = True) -> dict[str, Any]:
     body: dict[str, Any] = {

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -11,7 +11,13 @@ from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import LedgerError
 from app.models import TreasuryProposal
-from app.openapi_request_bodies import TREASURY_CHALLENGE_BODY, TREASURY_PROPOSAL_BODY
+from app.openapi_request_bodies import (
+    ADMIN_TOKEN_AUTH,
+    GITHUB_SESSION_AUTH,
+    TREASURY_CHALLENGE_BODY,
+    TREASURY_PROPOSAL_BODY,
+    with_openapi_auth,
+)
 from app.path_params import SQLITE_INTEGER_MAX, positive_proposal_id
 from app.query_validation import (
     reject_control_char_query_param,
@@ -184,7 +190,10 @@ def register_treasury_routes(
                 raise HTTPException(status_code=404, detail="proposal not found")
             return proposal_to_dict(proposal)
 
-    @app.post("/api/v1/treasury/proposals", openapi_extra=TREASURY_PROPOSAL_BODY)
+    @app.post(
+        "/api/v1/treasury/proposals",
+        openapi_extra=with_openapi_auth(TREASURY_PROPOSAL_BODY, ADMIN_TOKEN_AUTH),
+    )
     async def api_create_treasury_proposal(
         request: Request,
         admin_login: str = Depends(require_admin_token),
@@ -208,7 +217,10 @@ def register_treasury_routes(
             except LedgerError as exc:
                 raise _proposal_error(exc) from exc
 
-    @app.post("/api/v1/treasury/proposals/{proposal_id}/execute")
+    @app.post(
+        "/api/v1/treasury/proposals/{proposal_id}/execute",
+        openapi_extra=with_openapi_auth(None, ADMIN_TOKEN_AUTH),
+    )
     def api_execute_treasury_proposal(
         proposal_id: str,
         admin_login: str = Depends(require_admin_token),
@@ -227,7 +239,7 @@ def register_treasury_routes(
 
     @app.post(
         "/api/v1/treasury/proposals/{proposal_id}/challenges",
-        openapi_extra=TREASURY_CHALLENGE_BODY,
+        openapi_extra=with_openapi_auth(TREASURY_CHALLENGE_BODY, GITHUB_SESSION_AUTH),
     )
     async def api_create_treasury_challenge(
         proposal_id: str,

--- a/app/wallet_api.py
+++ b/app/wallet_api.py
@@ -15,9 +15,11 @@ from app.ledger.service import (
 )
 from app.models import Wallet
 from app.openapi_request_bodies import (
+    GITHUB_SESSION_AUTH,
     SIGNED_WALLET_ACTION_BODY,
     WALLET_REGISTER_BODY,
     WALLET_TRANSFER_BODY,
+    with_openapi_auth,
 )
 from app.serializers import ledger_to_dict, wallet_to_dict, wallet_transfer_to_dict
 
@@ -73,7 +75,10 @@ def register_wallet_api_routes(
                 raise HTTPException(status_code=404, detail="wallet not found")
             return wallet_to_dict(session, wallet)
 
-    @app.post("/api/v1/wallets/link-github", openapi_extra=SIGNED_WALLET_ACTION_BODY)
+    @app.post(
+        "/api/v1/wallets/link-github",
+        openapi_extra=with_openapi_auth(SIGNED_WALLET_ACTION_BODY, GITHUB_SESSION_AUTH),
+    )
     async def api_link_wallet_github(
         request: Request, github_login: str = Depends(require_github_login)
     ) -> dict[str, Any]:
@@ -91,7 +96,10 @@ def register_wallet_api_routes(
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             return wallet_to_dict(session, wallet)
 
-    @app.post("/api/v1/github/claim", openapi_extra=SIGNED_WALLET_ACTION_BODY)
+    @app.post(
+        "/api/v1/github/claim",
+        openapi_extra=with_openapi_auth(SIGNED_WALLET_ACTION_BODY, GITHUB_SESSION_AUTH),
+    )
     async def api_github_claim(
         request: Request, github_login: str = Depends(require_github_login)
     ) -> dict[str, Any]:

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -118,3 +118,48 @@ def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None
 
     assert attempt_body.get("required") is not True
     assert release_body.get("required") is not True
+
+
+def test_openapi_documents_auth_for_protected_routes(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    security_schemes = openapi["components"]["securitySchemes"]
+    assert security_schemes["MergeWorkAdminToken"] == {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-mergework-admin-token",
+        "description": "Admin API token required for protected admin and treasury operations.",
+    }
+    assert security_schemes["MergeWorkGitHubSession"]["type"] == "apiKey"
+    assert security_schemes["MergeWorkGitHubSession"]["in"] == "cookie"
+    assert security_schemes["MergeWorkGitHubSession"]["name"] == "mrwk_user"
+
+    admin_routes = [
+        ("/api/v1/admin/webhook-events", "get"),
+        ("/api/v1/bounties", "post"),
+        ("/api/v1/reconciliation/payouts", "get"),
+        ("/api/v1/bounties/{bounty_id}/pay", "post"),
+        ("/api/v1/bounties/{bounty_id}/close", "post"),
+        ("/api/v1/treasury/proposals", "post"),
+        ("/api/v1/treasury/proposals/{proposal_id}/execute", "post"),
+    ]
+    for path, method in admin_routes:
+        operation = openapi["paths"][path][method]
+        assert operation["security"] == [{"MergeWorkAdminToken": []}]
+        assert "401" in operation["responses"]
+
+    github_session_routes = [
+        ("/api/v1/bounties/{bounty_id}/attempts", "post"),
+        ("/api/v1/bounty-attempts/{attempt_id}/release", "post"),
+        ("/api/v1/wallets/link-github", "post"),
+        ("/api/v1/github/claim", "post"),
+        ("/api/v1/treasury/proposals/{proposal_id}/challenges", "post"),
+    ]
+    for path, method in github_session_routes:
+        operation = openapi["paths"][path][method]
+        assert operation["security"] == [{"MergeWorkGitHubSession": []}]
+        assert "401" in operation["responses"]
+
+    public_operation = openapi["paths"]["/api/v1/bounties"]["get"]
+    assert "security" not in public_operation

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -131,9 +131,28 @@ def test_openapi_documents_auth_for_protected_routes(sqlite_url: str) -> None:
         "name": "x-mergework-admin-token",
         "description": "Admin API token required for protected admin and treasury operations.",
     }
-    assert security_schemes["MergeWorkGitHubSession"]["type"] == "apiKey"
-    assert security_schemes["MergeWorkGitHubSession"]["in"] == "cookie"
-    assert security_schemes["MergeWorkGitHubSession"]["name"] == "mrwk_user"
+    assert security_schemes["MergeWorkGitHubSession"] == {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "mrwk_user",
+        "description": (
+            "GitHub login session cookie from /auth/github/login required for "
+            "authenticated contributor operations."
+        ),
+    }
+
+    expected_auth_error = {
+        "description": "Authentication required.",
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {"detail": {"type": "string"}},
+                    "required": ["detail"],
+                },
+            },
+        },
+    }
 
     admin_routes = [
         ("/api/v1/admin/webhook-events", "get"),
@@ -147,7 +166,7 @@ def test_openapi_documents_auth_for_protected_routes(sqlite_url: str) -> None:
     for path, method in admin_routes:
         operation = openapi["paths"][path][method]
         assert operation["security"] == [{"MergeWorkAdminToken": []}]
-        assert "401" in operation["responses"]
+        assert operation["responses"]["401"] == expected_auth_error
 
     github_session_routes = [
         ("/api/v1/bounties/{bounty_id}/attempts", "post"),
@@ -159,7 +178,7 @@ def test_openapi_documents_auth_for_protected_routes(sqlite_url: str) -> None:
     for path, method in github_session_routes:
         operation = openapi["paths"][path][method]
         assert operation["security"] == [{"MergeWorkGitHubSession": []}]
-        assert "401" in operation["responses"]
+        assert operation["responses"]["401"] == expected_auth_error
 
     public_operation = openapi["paths"]["/api/v1/bounties"]["get"]
     assert "security" not in public_operation


### PR DESCRIPTION
## Summary

Bounty #656
Refs #656

Fixes the OpenAPI contract mismatch reported in https://github.com/ramimbo/mergework/issues/656#issuecomment-4600342640.

Protected routes already reject anonymous requests at runtime, but the public OpenAPI document currently publishes those routes without auth/security metadata or documented `401` responses. This adds explicit OpenAPI auth metadata without changing runtime authorization behavior.

## Implementation

- Adds `MergeWorkAdminToken` and `MergeWorkGitHubSession` OpenAPI security schemes.
- Adds per-operation `security` and `401` response metadata for admin-token routes:
  - `/api/v1/admin/webhook-events`
  - `/api/v1/bounties` creation
  - `/api/v1/reconciliation/payouts`
  - bounty pay/close routes
  - treasury proposal create/execute routes
- Adds per-operation `security` and `401` response metadata for GitHub-session routes:
  - bounty attempt create/release routes
  - wallet link and GitHub claim routes
  - treasury proposal challenge route
- Keeps public read-only routes unauthenticated in OpenAPI.

## Validation

```text
.\.venv\Scripts\python.exe -m pytest tests/test_openapi_request_bodies.py tests/test_bounty_api.py tests/test_treasury_proposals.py tests/test_wallet_api.py tests/test_bounty_attempts.py -q
# 133 passed, 1 warning

.\.venv\Scripts\python.exe -m pytest -q
# 675 passed, 1 warning

.\.venv\Scripts\python.exe scripts\docs_smoke.py
# docs smoke ok

.\.venv\Scripts\python.exe -m mypy app
# Success: no issues found in 38 source files

.\.venv\Scripts\python.exe scripts\check_agents.py
# AGENTS.md ok

.\.venv\Scripts\python.exe -m ruff check app/openapi_request_bodies.py app/main.py app/bounty_api.py app/bounty_attempts.py app/treasury_routes.py app/wallet_api.py tests/test_openapi_request_bodies.py
# All checks passed

.\.venv\Scripts\python.exe -m ruff format --check app/openapi_request_bodies.py app/main.py app/bounty_api.py app/bounty_attempts.py app/treasury_routes.py app/wallet_api.py tests/test_openapi_request_bodies.py
# 7 files already formatted

git merge-tree --write-tree origin/main HEAD
# clean tree 2c8ce39bec9cde781fd26355b8ac8abafe3addc1

git diff --check origin/main...HEAD
# clean
```

## Scope

No admin token handling, GitHub session handling, wallet signing, ledger mutation, proposal execution, payout execution, challenge submission, private data, bridge/exchange/cash-out behavior, or MRWK price behavior is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * API docs now include explicit security schemes for admin-token and GitHub-session auth, show which protected endpoints require authentication, and include a standardized 401 error response.

* **Tests**
  * Added tests that validate the generated OpenAPI spec documents auth requirements and 401 responses for protected routes, and confirm public endpoints remain unauthenticated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->