### PR TITLE
fix(mcp): enforce exact submit_work_proof format enum

### DIFF
--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -92,15 +92,14 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
         return clean or None
 
     def output_format_arg() -> str:
-        value = args.get("format", "text")
-        if value is None:
+        if "format" not in args:
             return "text"
+        value = args["format"]
         if not isinstance(value, str):
             raise ValueError("format must be a string")
-        normalized = value.strip().lower()
-        if normalized not in {"text", "json"}:
+        if value not in {"text", "json"}:
             raise ValueError("format must be text or json")
-        return normalized
+        return value
 
     def optional_repo_selector_arg() -> str | None:
         repo = optional_clean_str_arg("repo")

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1810,10 +1810,13 @@ def test_mcp_submit_work_proof_scopes_issue_number_by_repo(sqlite_url: str) -> N
         ({"bounty_id": 1, "issue_number": 1}, 25),
         ({"format": "xml"}, 26),
         ({"format": 1}, 27),
+        ({"format": None}, 28),
         ({"repo": "ramimbo/mergework"}, 29),
         ({"bounty_id": 1, "repo": "ramimbo/mergework"}, 30),
         ({"issue_number": 1, "repo": 1}, 31),
         ({"issue_number": 1, "repo": "a" * 201}, 32),
+        ({"format": "JSON"}, 33),
+        ({"format": " json "}, 34),
     ],
 )
 def test_mcp_submit_work_proof_rejects_invalid_bounty_selectors(


### PR DESCRIPTION
## Summary

- make `submit_work_proof` use the default `format` only when the field is omitted
- require provided `format` values to match the advertised MCP enum exactly: `text` or `json`
- add regression coverage for uppercase, padded, and explicit-null `format` values

Refs #656
Report: https://github.com/ramimbo/mergework/issues/656#issuecomment-4601544504

## Validation

- `python -m pytest tests/test_api_mcp.py -q` -> 104 passed, 1 warning
- `python -m pytest -q` -> 677 passed, 1 warning
- `python -m mypy app` -> success
- `ruff check app/mcp_tools.py tests/test_api_mcp.py`
- `ruff format --check app/mcp_tools.py tests/test_api_mcp.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced format argument validation for MCP tools. The format parameter now requires exact case-sensitive values ("text" or "json") only, with null values explicitly rejected and whitespace trimming removed for stricter input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->