### PR TITLE
fix(mcp): suppress JSON-RPC notification responses

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from typing import Any
 
 from fastapi import HTTPException, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 
 from app.ledger.service import LedgerError
 
@@ -102,7 +102,7 @@ def _tool_result_response(response_id: Any, tool_result: str | dict[str, Any]) -
 
 async def handle_mcp_request(
     request: Request, database_url: str, call_tool: MCPToolHandler
-) -> dict[str, Any] | JSONResponse:
+) -> dict[str, Any] | JSONResponse | Response:
     try:
         payload = await request.json()
     except ValueError:
@@ -111,18 +111,25 @@ async def handle_mcp_request(
     if not isinstance(payload, dict):
         return JSONResponse(_jsonrpc_error(None, -32600, "invalid request"), status_code=400)
 
+    has_response_id = "id" in payload
     response_id = payload.get("id")
     method = payload.get("method")
     if method == "tools/list":
+        if not has_response_id:
+            return Response(status_code=202)
         return {"jsonrpc": "2.0", "id": response_id, "result": {"tools": MCP_TOOLS}}
 
     if method != "tools/call":
+        if not has_response_id:
+            return Response(status_code=202)
         return _jsonrpc_error(response_id, -32601, "unknown method")
 
     params = payload.get("params")
     if params is None:
         params = {}
     if not isinstance(params, dict):
+        if not has_response_id:
+            return Response(status_code=202)
         return _jsonrpc_error(response_id, -32602, "invalid params")
 
     name = params.get("name")
@@ -130,13 +137,21 @@ async def handle_mcp_request(
     if args is None:
         args = {}
     if not isinstance(args, dict):
+        if not has_response_id:
+            return Response(status_code=202)
         return _jsonrpc_error(response_id, -32602, "invalid params")
     if not isinstance(name, str):
+        if not has_response_id:
+            return Response(status_code=202)
         return _jsonrpc_error(response_id, -32602, "tool name is required")
 
     try:
         tool_result = call_tool(database_url, name, args)
     except (KeyError, TypeError, ValueError, LedgerError, HTTPException):
+        if not has_response_id:
+            return Response(status_code=202)
         return _jsonrpc_error(response_id, -32602, "invalid tool arguments")
 
+    if not has_response_id:
+        return Response(status_code=202)
     return _tool_result_response(response_id, tool_result)

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -282,6 +282,39 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert "100000000" in balance["result"]["content"][0]["text"]
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"jsonrpc": "2.0", "method": "tools/list"},
+        {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": "get_balance", "arguments": {"account": "treasury:mrwk"}},
+        },
+        {"jsonrpc": "2.0", "method": "definitely_unknown"},
+        {"jsonrpc": "2.0", "method": "tools/call", "params": []},
+        {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": "get_balance", "arguments": {"account": ""}},
+        },
+    ],
+)
+def test_mcp_notifications_do_not_return_jsonrpc_responses(
+    sqlite_url: str, payload: dict[str, object]
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post("/mcp", json=payload)
+
+    assert response.status_code == 202
+    assert response.content == b""
+
+
 def test_mcp_list_bounty_attempts_reports_active_and_expired(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     now = datetime.now(UTC)


### PR DESCRIPTION
## Summary

- distinguish JSON-RPC requests from notifications by checking whether the `id` member is present
- process MCP notifications without returning JSON-RPC result/error bodies
- add regression coverage for successful, unknown-method, invalid-param, and invalid-tool-argument notifications

Refs #656
Report: https://github.com/ramimbo/mergework/issues/656#issuecomment-4601635088

## Validation

- `python -m pytest tests/test_api_mcp.py -q` -> 106 passed, 1 warning
- `python -m pytest -q` -> 679 passed, 1 warning
- `python -m mypy app` -> success
- `ruff check app/mcp.py tests/test_api_mcp.py`
- `ruff format --check app/mcp.py tests/test_api_mcp.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MCP notification-style requests (missing ID) now return HTTP 202 with an empty body for applicable operations; JSON-RPC responses remain for requests that include an ID.

* **Tests**
  * Added parametrized tests to verify notification requests receive HTTP 202 empty responses instead of JSON-RPC error objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->