### PR TITLE
fix(mcp): reject invalid jsonrpc versions

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -112,6 +112,9 @@ async def handle_mcp_request(
         return JSONResponse(_jsonrpc_error(None, -32600, "invalid request"), status_code=400)
 
     response_id = payload.get("id")
+    if payload.get("jsonrpc") != "2.0":
+        return JSONResponse(_jsonrpc_error(response_id, -32600, "invalid request"), status_code=400)
+
     method = payload.get("method")
     if method == "tools/list":
         return {"jsonrpc": "2.0", "id": response_id, "result": {"tools": MCP_TOOLS}}

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -711,6 +711,42 @@ def test_mcp_rejects_malformed_requests_without_500(sqlite_url: str) -> None:
 
 
 @pytest.mark.parametrize(
+    ("payload", "expected_id"),
+    [
+        ({"id": 1, "method": "tools/list"}, 1),
+        ({"jsonrpc": "1.0", "id": 2, "method": "tools/list"}, 2),
+        ({"jsonrpc": None, "id": 3, "method": "tools/list"}, 3),
+        ({"jsonrpc": 2.0, "id": 4, "method": "tools/list"}, 4),
+        (
+            {
+                "id": 5,
+                "method": "tools/call",
+                "params": {
+                    "name": "get_balance",
+                    "arguments": {"account": "treasury:mrwk"},
+                },
+            },
+            5,
+        ),
+        ({"method": "tools/list"}, None),
+    ],
+)
+def test_mcp_rejects_missing_or_invalid_jsonrpc_version(
+    sqlite_url: str, payload: dict[str, object], expected_id: object
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post("/mcp", json=payload)
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": expected_id,
+        "error": {"code": -32600, "message": "invalid request"},
+    }
+
+
+@pytest.mark.parametrize(
     ("arguments", "request_id"),
     [
         ([], 8),


### PR DESCRIPTION
## Summary

- Reject `/mcp` JSON-RPC request objects that omit `jsonrpc` or provide a value other than exact `"2.0"`.
- Keep valid `jsonrpc: "2.0"` requests, parse-error handling, non-object handling, and tool-call validation behavior unchanged.
- Add regression coverage for missing, wrong, null, and numeric JSON-RPC version values before method dispatch.

## Evidence

Bounty #656.

Live production checks before this fix showed `tools/list` and `tools/call` succeeding even when the request omitted `jsonrpc` or used `"jsonrpc":"1.0"` / `null` / numeric `2.0`. Those malformed request objects returned normal JSON-RPC 2.0 result bodies instead of top-level `invalid request`.

Validation on this branch:

- MCP endpoint tests: `107 passed, 1 warning`
- full pytest suite: `680 passed, 1 warning`
- `python -m mypy app`
- targeted Ruff check/format
- `git diff --check`

## Out Of Scope

This does not change tool schemas, tool-specific argument validation, ledger behavior, wallet behavior, payout/proposal execution, auth, or MCP notification response handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced MCP JSON-RPC request validation for stricter protocol compliance.
  * Invalid requests now receive proper error responses with HTTP 400 status.

* **Tests**
  * Added validation tests for JSON-RPC protocol compliance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->