### PR TITLE
Make proposed-work payment source selectable

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -301,8 +301,15 @@ Use the read-only proposed-work triage report when maintainers need to review
 the intake queue before creating, rejecting, or consolidating future bounties:
 
 ```bash
-python scripts/proposed_work_triage.py --repo ramimbo/mergework --format markdown
+python scripts/proposed_work_triage.py \
+  --repo ramimbo/mergework \
+  --payment-bounty-issue 722 \
+  --format markdown
 ```
+
+During accepted-proposed-work round transitions, repeat
+`--payment-bounty-issue` for each intake bounty whose payment state should be
+included, such as `--payment-bounty-issue 649 --payment-bounty-issue 722`.
 
 For deterministic review or incident write-ups, use an offline fixture instead:
 
@@ -312,10 +319,11 @@ python scripts/proposed_work_triage.py --input proposed-work-fixture.json --form
 
 The report lists proposed-work issues, missing `proposed-work` labels, missing
 template sections, vague or rejected proposals, already-routed items, likely
-related groups, and #649 pending-versus-proof-backed payment status when that
-public data is present in the input or available from the public API. Use
-`--api-host` only for another public MergeWork API host. It does not label,
-comment, edit issues, create bounties, accept work, or pay claims.
+related groups, and pending-versus-proof-backed payment status for the selected
+payment bounty issue numbers when that public data is present in the input or
+available from the public API. Use `--api-host` only for another public
+MergeWork API host. It does not label, comment, edit issues, create bounties,
+accept work, or pay claims.
 
 For reviewer-specific review-bounty preflight, generate a candidate report with
 the reviewer login:

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -57,7 +57,7 @@ STOPWORDS = {
 GH_TIMEOUT_SECONDS = 30
 HTTP_TIMEOUT_SECONDS = 30
 DEFAULT_API_HOST = "https://api.mrwk.online"
-INTAKE_BOUNTY_ISSUE_NUMBER = 649
+DEFAULT_PAYMENT_BOUNTY_ISSUE_NUMBERS = (649,)
 LIVE_ISSUE_SEARCHES = (
     "label:proposed-work",
     '"proposed work"',
@@ -421,7 +421,36 @@ def _load_public_bounty_issue(
     return bounties, warnings
 
 
-def load_live_issues(repo: str, limit: int, api_host: str = DEFAULT_API_HOST) -> dict[str, Any]:
+def _load_public_bounty_issues(
+    api_host: str, issue_numbers: list[int] | tuple[int, ...]
+) -> tuple[list[dict[str, Any]], list[str]]:
+    bounties: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for issue_number in issue_numbers:
+        issue_bounties, issue_warnings = _load_public_bounty_issue(api_host, issue_number)
+        bounties.extend(issue_bounties)
+        warnings.extend(issue_warnings)
+    return bounties, warnings
+
+
+def _positive_issue_number(value: str) -> int:
+    try:
+        issue_number = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("payment bounty issue must be an integer") from exc
+    if issue_number <= 0:
+        raise argparse.ArgumentTypeError("payment bounty issue must be positive")
+    return issue_number
+
+
+def load_live_issues(
+    repo: str,
+    limit: int,
+    api_host: str = DEFAULT_API_HOST,
+    payment_bounty_issue_numbers: list[int] | tuple[int, ...] = (
+        DEFAULT_PAYMENT_BOUNTY_ISSUE_NUMBERS
+    ),
+) -> dict[str, Any]:
     rows_by_number: dict[int, dict[str, Any]] = {}
     per_search_limit = max(1, limit)
     for query in LIVE_ISSUE_SEARCHES:
@@ -444,7 +473,7 @@ def load_live_issues(repo: str, limit: int, api_host: str = DEFAULT_API_HOST) ->
             ]
         )
         issues.append(issue)
-    bounties, data_warnings = _load_public_bounty_issue(api_host, INTAKE_BOUNTY_ISSUE_NUMBER)
+    bounties, data_warnings = _load_public_bounty_issues(api_host, payment_bounty_issue_numbers)
     return {
         "issues": issues,
         "bounties": bounties,
@@ -460,12 +489,29 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--limit", type=int, default=50)
     parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
     parser.add_argument("--api-host", default=DEFAULT_API_HOST)
+    parser.add_argument(
+        "--payment-bounty-issue",
+        action="append",
+        default=None,
+        type=_positive_issue_number,
+        help=(
+            "GitHub issue number for an accepted-proposed-work bounty whose public "
+            "payment state should be loaded. Repeat during round transitions."
+        ),
+    )
     args = parser.parse_args(argv)
 
     data = (
         json.loads(args.input.read_text(encoding="utf-8"))
         if args.input
-        else load_live_issues(args.repo, args.limit, api_host=args.api_host)
+        else load_live_issues(
+            args.repo,
+            args.limit,
+            api_host=args.api_host,
+            payment_bounty_issue_numbers=(
+                args.payment_bounty_issue or list(DEFAULT_PAYMENT_BOUNTY_ISSUE_NUMBERS)
+            ),
+        )
     )
     report = analyze_proposed_work(data)
     if args.format == "json":

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -513,6 +513,8 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     args = parser.parse_args(argv)
+    if args.input and args.payment_bounty_issue:
+        parser.error("--payment-bounty-issue is only valid in live --repo mode")
 
     data = (
         json.loads(args.input.read_text(encoding="utf-8"))

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -387,6 +387,75 @@ def test_proposed_work_triage_live_mode_uses_read_only_gh(monkeypatch, capsys) -
     assert not any("comment" in call or "edit" in call for call in calls)
 
 
+def test_proposed_work_triage_live_mode_uses_selected_payment_bounty_issue(
+    monkeypatch, capsys
+) -> None:
+    def fake_run(args, **kwargs):  # noqa: ANN001, ANN202
+        if args[:3] == ["gh", "issue", "list"]:
+            stdout = json.dumps([{"number": 791}])
+        else:
+            stdout = json.dumps(
+                {
+                    "number": 791,
+                    "title": "Expose bounty board data as public JSON",
+                    "url": "https://github.com/ramimbo/mergework/issues/791",
+                    "body": _complete_body("bounty board JSON"),
+                    "labels": [{"name": "proposed-work"}],
+                    "comments": [],
+                }
+            )
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+    def fake_urlopen(request, timeout):  # noqa: ANN001, ANN202, ARG001
+        url = request.full_url
+        if url.endswith("/api/v1/bounties?issue_number=722&limit=5"):
+            return FakeResponse([{"id": 101}])
+        if url.endswith("/api/v1/bounties/101"):
+            return FakeResponse(
+                {
+                    "id": 101,
+                    "issue_number": 722,
+                    "pending_payout_proposals": [
+                        {
+                            "proposal_id": 124,
+                            "submission_url": "https://github.com/ramimbo/mergework/issues/791",
+                            "accepted_by": "ramimbo",
+                            "executes_after": "2026-06-03T10:58:13Z",
+                        }
+                    ],
+                    "accepted_awards": [],
+                }
+            )
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr("scripts.proposed_work_triage.subprocess.run", fake_run)
+    monkeypatch.setattr("scripts.proposed_work_triage.urllib.request.urlopen", fake_urlopen)
+
+    assert (
+        main(
+            [
+                "--repo",
+                "ramimbo/mergework",
+                "--payment-bounty-issue",
+                "722",
+                "--format",
+                "json",
+                "--limit",
+                "1",
+            ]
+        )
+        == 0
+    )
+    output = json.loads(capsys.readouterr().out)
+    proposal = output["proposals"][0]
+
+    assert output["summary"]["payment_counts"] == {"pending": 1}
+    assert proposal["number"] == 791
+    assert proposal["payment_status"]["state"] == "pending"
+    assert proposal["payment_status"]["proposal_id"] == 124
+    assert "accepted_pending_payout" in proposal["warnings"]
+
+
 def test_proposed_work_triage_live_mode_warns_when_payment_state_is_incomplete(
     monkeypatch, capsys
 ) -> None:

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -5,6 +5,8 @@ import subprocess
 import urllib.error
 from typing import Any
 
+import pytest
+
 from scripts.proposed_work_triage import _run_gh, analyze_proposed_work, format_markdown, main
 
 
@@ -386,6 +388,19 @@ def test_proposed_work_triage_markdown_and_json_cli(tmp_path, capsys) -> None:
     markdown = format_markdown(output)
     assert "# Proposed Work Triage" in markdown
     assert "#672 Read-only proposed-work intake triage report" in markdown
+
+
+def test_proposed_work_triage_rejects_payment_bounty_issue_in_offline_mode(
+    tmp_path, capsys
+) -> None:
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps({"issues": []}), encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--input", str(fixture), "--payment-bounty-issue", "722"])
+
+    assert excinfo.value.code == 2
+    assert "--payment-bounty-issue is only valid in live --repo mode" in capsys.readouterr().err
 
 
 def test_proposed_work_triage_live_mode_uses_read_only_gh(monkeypatch, capsys) -> None:

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -456,6 +456,93 @@ def test_proposed_work_triage_live_mode_uses_selected_payment_bounty_issue(
     assert "accepted_pending_payout" in proposal["warnings"]
 
 
+def test_proposed_work_triage_live_mode_aggregates_selected_payment_bounty_issues(
+    monkeypatch, capsys
+) -> None:
+    def fake_run(args, **kwargs):  # noqa: ANN001, ANN202
+        if args[:3] == ["gh", "issue", "list"]:
+            stdout = json.dumps([{"number": 672}, {"number": 791}])
+        else:
+            number = int(args[3])
+            stdout = json.dumps(
+                {
+                    "number": number,
+                    "title": f"Proposed work: issue {number}",
+                    "url": f"https://github.com/ramimbo/mergework/issues/{number}",
+                    "body": _complete_body(f"issue {number}"),
+                    "labels": [{"name": "proposed-work"}],
+                    "comments": [],
+                }
+            )
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+    def fake_urlopen(request, timeout):  # noqa: ANN001, ANN202, ARG001
+        url = request.full_url
+        if url.endswith("/api/v1/bounties?issue_number=649&limit=5"):
+            return FakeResponse([{"id": 96}])
+        if url.endswith("/api/v1/bounties/96"):
+            return FakeResponse(
+                {
+                    "id": 96,
+                    "issue_number": 649,
+                    "accepted_awards": [
+                        {
+                            "submission_url": "https://github.com/ramimbo/mergework/issues/672",
+                            "proof_url": "https://mrwk.online/proofs/old-round",
+                            "ledger_sequence": 99,
+                        }
+                    ],
+                }
+            )
+        if url.endswith("/api/v1/bounties?issue_number=722&limit=5"):
+            return FakeResponse([{"id": 101}])
+        if url.endswith("/api/v1/bounties/101"):
+            return FakeResponse(
+                {
+                    "id": 101,
+                    "issue_number": 722,
+                    "pending_payout_proposals": [
+                        {
+                            "proposal_id": 124,
+                            "submission_url": "https://github.com/ramimbo/mergework/issues/791",
+                            "accepted_by": "ramimbo",
+                            "executes_after": "2026-06-03T10:58:13Z",
+                        }
+                    ],
+                }
+            )
+        raise AssertionError(f"unexpected URL {url}")
+
+    monkeypatch.setattr("scripts.proposed_work_triage.subprocess.run", fake_run)
+    monkeypatch.setattr("scripts.proposed_work_triage.urllib.request.urlopen", fake_urlopen)
+
+    assert (
+        main(
+            [
+                "--repo",
+                "ramimbo/mergework",
+                "--payment-bounty-issue",
+                "649",
+                "--payment-bounty-issue",
+                "722",
+                "--format",
+                "json",
+                "--limit",
+                "2",
+            ]
+        )
+        == 0
+    )
+    output = json.loads(capsys.readouterr().out)
+    by_number = {item["number"]: item for item in output["proposals"]}
+
+    assert output["summary"]["payment_counts"] == {"paid": 1, "pending": 1}
+    assert by_number[672]["payment_status"]["state"] == "paid"
+    assert by_number[672]["payment_status"]["proof_url"] == "https://mrwk.online/proofs/old-round"
+    assert by_number[791]["payment_status"]["state"] == "pending"
+    assert by_number[791]["payment_status"]["proposal_id"] == 124
+
+
 def test_proposed_work_triage_live_mode_warns_when_payment_state_is_incomplete(
     monkeypatch, capsys
 ) -> None:


### PR DESCRIPTION
## Summary

- Add a repeatable `--payment-bounty-issue` option to `scripts/proposed_work_triage.py` so live reports can load payment state from the current accepted-proposed-work round.
- Keep the historical default source intact, while allowing maintainers to include #722 or multiple rounds during transitions.
- Update the admin runbook with the current #722 example and transition guidance.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: live proposed-work triage was still tied to the old #649 intake payment source, so current #722 accepted proposals could appear as unpaid or unaccepted.
- Bounty capacity and active attempts/open PRs checked: maintainer infrastructure PR; no bounty requested.
- Intended files or surfaces: `scripts/proposed_work_triage.py`, `tests/test_proposed_work_triage.py`, `docs/admin-runbook.md`.
- Expected PR size: small, focused CLI/report fix.
- Out of scope: no labels, comments, issue edits, bounty creation, claim acceptance, payout proposals, proposal execution, wallet behavior, ledger writes, or MRWK price/exchange/bridge/cash-out claims.

Live read-only smoke:

```text
./.venv/bin/python scripts/proposed_work_triage.py --repo ramimbo/mergework --payment-bounty-issue 722 --format json --limit 20 | jq ...
# payment_counts: {"none": 16, "pending": 4}
# #772, #774, #786, and #791 classify as pending from current #722 public bounty data.
```

## Test Evidence

- [x] `./.venv/bin/python scripts/check_agents.py`
- [x] `./.venv/bin/python -m pytest`
- [x] `./.venv/bin/python -m ruff format --check .`
- [x] `./.venv/bin/python -m ruff check .`
- [x] `./.venv/bin/python -m mypy app`
- [x] `./.venv/bin/python scripts/docs_smoke.py`
- [x] `git diff --check`

## MRWK

Maintainer infrastructure PR; no bounty requested. Related issue: #802.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The triage script now accepts repeated flags to specify multiple payment-bounty issues instead of a single hard-coded issue.

* **Documentation**
  * Admin runbook updated with multi-issue usage examples and clearer explanations of report scope and payment-status behavior.

* **Tests**
  * Added CLI validation and live-mode tests covering single-issue selection, multi-issue aggregation, and rejection of the flag in offline mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->