### PR TITLE
Filter bounty issues from proposed-work triage

### DIFF
--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -39,6 +39,8 @@ NON_LIVE_CONFUSION_RE = re.compile(
     r"(claimable now|already paid|guaranteed payout|cash[- ]?out|off[- ]?ramp)",
     re.IGNORECASE,
 )
+BOUNTY_TITLE_RE = re.compile(r"^\s*MRWK bounty\s*:", re.IGNORECASE)
+BOUNTY_TEMPLATE_HEADING_RE = re.compile(r"(^|\n)\s*#+\s*MRWK bounty\b", re.IGNORECASE)
 WORD_RE = re.compile(r"[a-z0-9]+")
 STOPWORDS = {
     "add",
@@ -94,6 +96,17 @@ def _combined_text(issue: dict[str, Any]) -> str:
     parts = [str(issue.get("title") or ""), str(issue.get("body") or "")]
     parts.extend(_comments(issue))
     return "\n".join(parts)
+
+
+def _is_non_intake_bounty_issue(issue: dict[str, Any]) -> bool:
+    labels = {label.lower() for label in _labels(issue)}
+    if "mrwk:bounty" in labels:
+        return True
+    title = str(issue.get("title") or "")
+    if BOUNTY_TITLE_RE.search(title):
+        return True
+    body = str(issue.get("body") or "")
+    return bool(BOUNTY_TEMPLATE_HEADING_RE.search(body))
 
 
 def _has_section(body: str, aliases: tuple[str, ...]) -> bool:
@@ -285,7 +298,7 @@ def analyze_proposed_work(data: dict[str, Any]) -> dict[str, Any]:
     proposals = [
         proposal
         for raw in data.get("issues", [])
-        if isinstance(raw, dict)
+        if isinstance(raw, dict) and not _is_non_intake_bounty_issue(raw)
         for proposal in [_normalize_issue(raw, payments)]
         if proposal is not None
     ]

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -71,6 +71,67 @@ def test_proposed_work_triage_accepts_complete_issue() -> None:
     assert report["proposals"][0]["missing_sections"] == []
 
 
+def test_proposed_work_triage_excludes_bounty_issues_from_broad_search() -> None:
+    report = analyze_proposed_work(
+        {
+            "issues": [
+                {
+                    "number": 722,
+                    "title": "MRWK bounty: 50 MRWK - accepted proposed-work requests, round 2",
+                    "url": "https://github.com/ramimbo/mergework/issues/722",
+                    "body": """
+## MRWK Bounty
+
+Reward: `50 MRWK per accepted award`
+Max awards: `10`
+
+Do not submit implementation work for proposed work unless a separate bounty is live.
+""",
+                    "labels": ["mrwk:bounty"],
+                    "comments": [
+                        {"body": "Reserved on MergeWork: https://mrwk.online/bounties/101"}
+                    ],
+                },
+                {
+                    "number": 800,
+                    "title": "MRWK bounty: 600 MRWK - public work discovery",
+                    "url": "https://github.com/ramimbo/mergework/issues/800",
+                    "body": """
+## MRWK Bounty
+
+Status: proposed bounty. This issue is not claimable yet.
+
+Do not submit implementation work for proposed work until finalization.
+""",
+                    "labels": [],
+                    "comments": [],
+                },
+                {
+                    "number": 803,
+                    "title": "Proposed work: filter bounty issues from proposed-work triage",
+                    "url": "https://github.com/ramimbo/mergework/issues/803",
+                    "body": _complete_body("filtering bounty issues from proposed-work triage"),
+                    "labels": ["proposed-work"],
+                    "comments": [],
+                },
+                {
+                    "number": 762,
+                    "title": "Proposed work: reject control-padded numeric path IDs",
+                    "url": "https://github.com/ramimbo/mergework/issues/762",
+                    "body": _complete_body("unlabeled CLI proposed-work intake"),
+                    "labels": [],
+                    "comments": [],
+                },
+            ]
+        }
+    )
+
+    assert [proposal["number"] for proposal in report["proposals"]] == [803, 762]
+    assert report["summary"]["proposed_work_issues"] == 2
+    unlabeled = next(item for item in report["proposals"] if item["number"] == 762)
+    assert "missing_proposed_work_label" in unlabeled["warnings"]
+
+
 def test_proposed_work_triage_flags_missing_label_and_template_sections() -> None:
     report = analyze_proposed_work(
         {


### PR DESCRIPTION
## Summary

- Exclude maintainer bounty issues from `scripts/proposed_work_triage.py` results when broad `"proposed work"` search finds normal bounty text.
- Keep labeled proposed-work intake and unlabeled template-shaped intake visible.
- Add fixture coverage for live/pending `MRWK bounty:` issues alongside real intake issues.

## Evidence

Root cause: live mode searches both `label:proposed-work` and the broad phrase `"proposed work"`. Normal bounty issues can contain that phrase in lifecycle guardrails, causing them to be reported as malformed proposed-work intake.

Related issue: #803.

## Verification

- `./.venv/bin/python -m pytest tests/test_proposed_work_triage.py -q`
- `./.venv/bin/python -m ruff format --check scripts/proposed_work_triage.py tests/test_proposed_work_triage.py`
- `./.venv/bin/python -m ruff check scripts/proposed_work_triage.py tests/test_proposed_work_triage.py`
- `git diff --check`
- Live read-only smoke showed no known bounty issue numbers (`649`, `694`, `722`, `761`, `799`, `800`) in the proposed-work output.

## MRWK

Maintainer infrastructure PR; no bounty requested.

## Out of scope

No labels, comments, issue edits, bounty creation, claim acceptance, payout proposals, proposal execution, wallet behavior, ledger writes, or public value claims.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue triage to properly exclude bounty-related issues from proposed work analysis.

* **Tests**
  * Added test coverage to verify bounty issues are correctly filtered out during triage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->