### PR TITLE
Accept value heading for proposed-work labels

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -39,7 +39,7 @@ GITHUB_ISSUE_URL_RE = re.compile(
 PROPOSED_WORK_HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+(?P<heading>.+?)\s*#*\s*$", re.MULTILINE)
 PROPOSED_WORK_REQUIRED_HEADINGS = (
     ("problem",),
-    ("expected value",),
+    ("expected value", "value"),
     ("duplicate search",),
     ("out of scope",),
 )

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -69,6 +69,20 @@ def _proposed_work_issue_form_body() -> str:
     )
 
 
+def _proposed_work_value_body() -> str:
+    return "\n\n".join(
+        [
+            "## Problem\n\nStaging webhook dry-run checks need explicit identity validation.",
+            "## Evidence\n\nRecent dry-run setup issues used this heading shape.",
+            "## Proposed Work\n\nValidate the dry-run identity environment variables.",
+            "## Value\n\nMaintainers can catch misconfigured webhook identity before staging.",
+            "## Acceptance / Verification Notes\n\nWebhook tests cover the behavior.",
+            "## Duplicate Search\n\nNo existing proposed-work issue covers this exact validation.",
+            "## Out Of Scope\n\nNo production webhook execution or payout changes.",
+        ]
+    )
+
+
 def test_issue_webhook_adds_proposed_work_label_for_template_shaped_issue(
     sqlite_url: str,
 ) -> None:
@@ -164,6 +178,53 @@ def test_issue_webhook_adds_proposed_work_label_for_issue_form_headings(
     assert len(requests) == 1
     with session_scope(sqlite_url) as session:
         event = session.get(WebhookEvent, "delivery-proposed-work-issue-form")
+        assert event is not None
+        assert event.processed_status == "proposed_work_labeled"
+
+
+def test_issue_webhook_adds_proposed_work_label_for_value_heading(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    body = json.dumps(
+        {
+            "action": "opened",
+            "issue": {
+                "number": 813,
+                "title": "Proposed work: validate staging webhook dry-run identity env vars",
+                "body": _proposed_work_value_body(),
+                "html_url": "https://github.com/ramimbo/mergework/issues/813",
+                "labels": [],
+                "user": {"login": "contributor"},
+            },
+            "repository": {"full_name": "ramimbo/mergework"},
+            "sender": {"login": "contributor"},
+        },
+        separators=(",", ":"),
+    ).encode()
+    requests: list[Request] = []
+
+    def fake_opener(request: Request, timeout: float) -> _FakeResponse:
+        requests.append(request)
+        return _FakeResponse({})
+
+    result = handle_github_webhook(
+        sqlite_url,
+        {
+            "X-GitHub-Delivery": "delivery-proposed-work-value-heading",
+            "X-GitHub-Event": "issues",
+            "X-Hub-Signature-256": _signature("secret", body),
+        },
+        body,
+        "secret",
+        github_issue_token="github-issue-token",
+        opener=fake_opener,
+    )
+
+    assert result == {"status": "proposed_work_labeled", "label": "proposed-work"}
+    assert len(requests) == 1
+    with session_scope(sqlite_url) as session:
+        event = session.get(WebhookEvent, "delivery-proposed-work-value-heading")
         assert event is not None
         assert event.processed_status == "proposed_work_labeled"
 


### PR DESCRIPTION
## Summary

- Accept `Value` as an alias for `Expected value` when the GitHub webhook detects proposed-work issue headings.
- Add a regression test for the heading shape used by recent proposed-work intake issues.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: Proposed-work issues with `## Value` were valid intake but missed the automated `proposed-work` label.
- Bounty capacity and active attempts/open PRs checked: This is a maintainer infrastructure PR; no bounty requested and no bounty, claim, payout, or reserve state changes.
- Intended files or surfaces: `app/webhooks/github.py`, `tests/test_webhooks.py`.
- Expected PR size: Small.
- Out of scope: Bounty creation, payout proposals, paid labels, and manual claim handling.

## Test Evidence

- [x] `ruff format --check .`
- [x] `ruff check .`
- [x] `mypy app`
- [x] `pytest`
- [ ] `python scripts/docs_smoke.py` (not run; no docs, template, example, or onboarding changes)

## MRWK

Refs #813 and #814. Maintainer PR; no bounty requested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proposed-work issue detection now accepts "value" as an alternative heading alongside "expected value" in issue templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->