### PR TITLE
Add account filter to activity API

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -7,25 +7,35 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
+from app.accounts import normalized_account
 from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.query_validation import reject_control_char_query_param, reject_repeated_query_param
 from app.serializers import activity_to_dict
 
 
-def activity_context(session: Session, query: str | None = None) -> dict[str, Any]:
+def activity_context(
+    session: Session, query: str | None = None, account: str | None = None
+) -> dict[str, Any]:
     if query is not None and contains_control_character(query):
         raise HTTPException(status_code=400, detail="q must not contain control characters")
-    return activity_to_dict(session, query)
+    normalized = normalized_account(account) if account is not None else None
+    return activity_to_dict(session, query, account=normalized)
 
 
 def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
     @app.get("/api/v1/activity")
-    def api_activity(request: Request, q: str | None = Query(None)) -> dict[str, Any]:
+    def api_activity(
+        request: Request,
+        q: str | None = Query(None),
+        account: str | None = Query(None),
+    ) -> dict[str, Any]:
         reject_control_char_query_param(request, "q")
         reject_repeated_query_param(request, "q")
+        reject_control_char_query_param(request, "account")
+        reject_repeated_query_param(request, "account")
         with session_scope(db_url) as session:
-            return activity_context(session, q)
+            return activity_context(session, q, account)
 
     @app.get("/activity", response_class=HTMLResponse)
     def activity_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -496,7 +496,9 @@ def _pending_activity_row_matches(row: dict[str, Any], query: str) -> bool:
     }
 
 
-def pending_activity_rows(session: Session, query: str | None = None) -> list[dict[str, Any]]:
+def pending_activity_rows(
+    session: Session, query: str | None = None, *, account: str | None = None
+) -> list[dict[str, Any]]:
     """Return pending accepted work without treating it as proof-backed activity."""
     search_query = _activity_search_query(query)
     proposals = session.scalars(
@@ -528,13 +530,19 @@ def pending_activity_rows(session: Session, query: str | None = None) -> list[di
     for proposal, payload, bounty_id in parsed:
         bounty = bounty_by_id.get(bounty_id) if bounty_id is not None else None
         row = _pending_activity_row(proposal, payload, bounty)
-        if row["account"] is None or not _pending_activity_row_matches(row, search_query):
+        if row["account"] is None:
+            continue
+        if account is not None and row["account"] != account:
+            continue
+        if not _pending_activity_row_matches(row, search_query):
             continue
         pending.append(row)
     return pending
 
 
-def activity_to_dict(session: Session, query: str | None = None) -> dict[str, Any]:
+def activity_to_dict(
+    session: Session, query: str | None = None, *, account: str | None = None
+) -> dict[str, Any]:
     """Build the public activity feed and contributor totals."""
     search_query = _activity_search_query(query)
     rows = session.execute(
@@ -550,6 +558,8 @@ def activity_to_dict(session: Session, query: str | None = None) -> dict[str, An
             continue
         row = _activity_row(entry, proof)
         if row is None or row["account"] is None:
+            continue
+        if account is not None and row["account"] != account:
             continue
         if not _activity_row_matches(row, search_query):
             continue
@@ -589,12 +599,12 @@ def activity_to_dict(session: Session, query: str | None = None) -> dict[str, An
     for row in recent:
         del row["amount_microunits"]
 
-    pending_payouts = pending_activity_rows(session, search_query)
+    pending_payouts = pending_activity_rows(session, search_query, account=account)
     pending_microunits = sum(int(row["amount_microunits"]) for row in pending_payouts)
     for row in pending_payouts:
         del row["amount_microunits"]
 
-    return {
+    activity = {
         "totals": {
             "accepted_awards": len(recent),
             "accepted_mrwk": format_mrwk(total_microunits),
@@ -609,6 +619,9 @@ def activity_to_dict(session: Session, query: str | None = None) -> dict[str, An
         "pending_payouts": pending_payouts[:100],
         "recent": recent[:100],
     }
+    if account is not None:
+        activity["account"] = account
+    return activity
 
 
 def account_accepted_summary(session: Session, account: str) -> dict[str, Any]:

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -66,9 +66,14 @@ Inspect one bounty, accepted-work activity, a ledger page, and a proof:
 curl -s "$API_HOST/api/v1/bounties/<bounty_id>"
 curl -s "$API_HOST/api/v1/bounties/<bounty_id>/attempts"
 curl -s "$API_HOST/api/v1/activity"
+curl -s "$API_HOST/api/v1/activity?account=github%3A<login>"
 curl -s "$API_HOST/api/v1/ledger?limit=10"
 curl -s "$API_HOST/api/v1/proofs/<proof_hash>"
 ```
+
+Use `account=` for an exact account activity slice. Use `q=` when you need
+broader matching across proof hashes, proposal ids, bounty issues, repos, or
+submission URLs.
 
 Look up a single ledger entry by sequence number:
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -301,13 +301,17 @@ Read accepted-work activity summarized from proof-backed bounty payments:
 ```bash
 curl -s "$API_HOST/api/v1/activity"
 curl -s "$API_HOST/api/v1/activity?q=p3xill"
+curl -s "$API_HOST/api/v1/activity?account=github%3Ap3xill"
 ```
 
-The optional `q` parameter filters proof-backed and pending activity rows by
-account, amount, submission URL, proof hash, proposal id, bounty repo, bounty
-issue URL, internal bounty id, or GitHub issue number. In other words, the
-same search can match bounty repo, bounty issue URL, proposal, proof, or
-submission evidence. The response groups
+Use `account=github:<login>` or `account=mrwk1...` for an exact account-scoped
+activity view. The optional `q` parameter can still be used for broader
+free-text matching, or combined with `account` to search within one account's
+activity rows. `q` filters proof-backed and pending activity rows by account,
+amount, submission URL, proof hash, proposal id, bounty repo, bounty issue URL,
+internal bounty id, or GitHub issue number. In other words, the same search can
+match bounty repo, bounty issue URL, proposal, proof, or submission evidence.
+The response groups
 matching proof-backed bounty payments into `totals`, contributor rollups, and
 the most recent payment rows. Accepted-but-not-yet-executed `pay_bounty`
 proposals appear separately in `pending_totals` and `pending_payouts`; they are

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -200,6 +200,99 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
         assert invalid_hash_query["recent"] == []
 
 
+def test_activity_api_filters_by_exact_account(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        paid_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=166,
+            issue_url="https://github.com/ramimbo/mergework/issues/166",
+            title="Account scoped activity bounty",
+            reward_mrwk="25",
+            max_awards=2,
+            acceptance="Activity account filters should scope paid work.",
+        )
+        pending_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=167,
+            issue_url="https://github.com/ramimbo/mergework/issues/167",
+            title="Account scoped pending bounty",
+            reward_mrwk="75",
+            acceptance="Activity account filters should scope pending work.",
+        )
+        alice_proof = pay_bounty(
+            session,
+            bounty_id=paid_bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/166",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        pay_bounty(
+            session,
+            bounty_id=paid_bounty.id,
+            to_account="github:bob",
+            submission_url="https://github.com/ramimbo/mergework/pull/168",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        proposal = propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": pending_bounty.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/167",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+        proposal_id = proposal.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    scoped = client.get("/api/v1/activity?account=GitHub:Alice").json()
+    scoped_with_query = client.get("/api/v1/activity?account=github:alice&q=pull%2F166").json()
+    missing = client.get("/api/v1/activity?account=github:carol").json()
+
+    assert scoped["account"] == "github:alice"
+    assert scoped["query"] == ""
+    assert scoped["totals"] == {
+        "accepted_awards": 1,
+        "accepted_mrwk": "25",
+        "contributors": 1,
+    }
+    assert scoped["pending_totals"] == {
+        "pending_awards": 1,
+        "pending_mrwk": "75",
+    }
+    assert [row["account"] for row in scoped["contributors"]] == ["github:alice"]
+    assert [row["proof_hash"] for row in scoped["recent"]] == [alice_proof.hash]
+    assert [row["proposal_id"] for row in scoped["pending_payouts"]] == [proposal_id]
+
+    assert scoped_with_query["account"] == "github:alice"
+    assert scoped_with_query["query"] == "pull/166"
+    assert scoped_with_query["recent"][0]["proof_hash"] == alice_proof.hash
+    assert scoped_with_query["pending_payouts"] == []
+
+    assert missing["account"] == "github:carol"
+    assert missing["totals"] == {
+        "accepted_awards": 0,
+        "accepted_mrwk": "0",
+        "contributors": 0,
+    }
+    assert missing["pending_totals"] == {
+        "pending_awards": 0,
+        "pending_mrwk": "0",
+    }
+    assert missing["contributors"] == []
+    assert missing["pending_payouts"] == []
+    assert missing["recent"] == []
+
+
 def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -212,6 +305,11 @@ def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
     masked_api_response = client.get("/api/v1/activity?q=%C2%85github&q=alice")
     repeated_api_response = client.get("/api/v1/activity?q=github&q=alice")
     repeated_page_response = client.get("/activity?q=github&q=alice")
+    account_control_response = client.get("/api/v1/activity?account=%C2%85github:alice")
+    repeated_account_response = client.get(
+        "/api/v1/activity?account=github:alice&account=github:bob"
+    )
+    invalid_account_response = client.get("/api/v1/activity?account=github%3A%20")
 
     assert api_response.status_code == 400
     assert api_response.json()["detail"] == "q must not contain control characters"
@@ -223,6 +321,14 @@ def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
     assert repeated_api_response.json()["detail"] == "q must be provided at most once"
     assert repeated_page_response.status_code == 400
     assert repeated_page_response.json()["detail"] == "q must be provided at most once"
+    assert account_control_response.status_code == 400
+    assert account_control_response.json()["detail"] == (
+        "account must not contain control characters"
+    )
+    assert repeated_account_response.status_code == 400
+    assert repeated_account_response.json()["detail"] == "account must be provided at most once"
+    assert invalid_account_response.status_code == 400
+    assert invalid_account_response.json()["detail"] == "github login must be valid"
 
 
 def test_activity_api_exposes_pending_payouts_separately_from_paid_work(


### PR DESCRIPTION
## Summary
- Adds an exact `account=` filter for `/api/v1/activity`.
- Applies the filter to both proof-backed accepted-work activity and pending payout activity.
- Documents the account-scoped activity query in the agent guide and API examples.

## Bounty / Source
/claim #761

Source: #786 identified that `/api/v1/activity?account=...` was accepted but returned the global feed instead of a scoped account view.

## Validation
- `python -m pytest tests/test_activity.py tests/test_activity_routes.py tests/test_docs_public_urls.py -q` -> 41 passed, 1 warning
- `python -m ruff check app/activity.py app/serializers.py tests/test_activity.py tests/test_activity_routes.py tests/test_docs_public_urls.py`
- `python -m ruff format --check app/activity.py app/serializers.py tests/test_activity.py tests/test_activity_routes.py tests/test_docs_public_urls.py`
- `python scripts/docs_smoke.py`
- `python -m mypy app/activity.py app/serializers.py`
- `git diff --check origin/main...HEAD`

## Scope
No payout execution, treasury mutation, wallet mutation, bridge/exchange/off-ramp/cash-out behavior, price/liquidity claims, private data, secrets, or admin-token behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The activity API endpoint now supports filtering results by an exact account using an `account` query parameter.

* **Documentation**
  * Added examples and explanations for using the new `account` filter in the user and API guides.

* **Bug Fixes**
  * Improved validation for the `account` query parameter, including control character and duplicate parameter checks.

* **Tests**
  * Added comprehensive tests for activity filtering by account and input validation for the query parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->