### PR TITLE
Guard public intake templates in docs smoke

### DIFF
--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -133,6 +133,8 @@ REQUIRED_PUBLIC_PHRASES = {
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"
+SECURITY_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/security-report.yml"
+BUG_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/bug.yml"
 PR_TEMPLATE = ".github/pull_request_template.md"
 
 
@@ -233,6 +235,49 @@ def main() -> int:
     elif "expected pr size:" not in pr_template.read_text(encoding="utf-8").lower():
         print("pull request template must ask for expected PR size")
         ok = False
+    security_issue_template = ROOT / SECURITY_ISSUE_TEMPLATE
+    if not security_issue_template.exists():
+        print(f"missing security issue template: {SECURITY_ISSUE_TEMPLATE}")
+        ok = False
+    else:
+        security_template = security_issue_template.read_text(encoding="utf-8").lower()
+        for phrase in [
+            "do not paste exploit details here",
+            "follow security.md for private reporting",
+            "public-safe summary",
+        ]:
+            if phrase not in security_template:
+                print(f"security issue template missing required phrase: {phrase}")
+                ok = False
+        if "security" not in _issue_template_labels(security_template):
+            print("security issue template must auto-apply the security label")
+            ok = False
+        if not _template_field_is_required(security_template, "summary"):
+            print("security issue template summary field must be required")
+            ok = False
+        if "mrwk:bounty" in _issue_template_labels(security_template):
+            print("security issue template must not auto-apply mrwk:bounty")
+            ok = False
+    bug_issue_template = ROOT / BUG_ISSUE_TEMPLATE
+    if not bug_issue_template.exists():
+        print(f"missing bug issue template: {BUG_ISSUE_TEMPLATE}")
+        ok = False
+    else:
+        bug_template = bug_issue_template.read_text(encoding="utf-8").lower()
+        if "bug" not in _issue_template_labels(bug_template):
+            print("bug issue template must auto-apply the bug label")
+            ok = False
+        for field_id in ("expected", "actual", "reproduce"):
+            if not _template_field_is_required(bug_template, field_id):
+                print(f"bug issue template {field_id} field must be required")
+                ok = False
+        for phrase in ["expected behavior", "actual behavior", "reproduction"]:
+            if phrase not in bug_template:
+                print(f"bug issue template missing required phrase: {phrase}")
+                ok = False
+        if "mrwk:bounty" in _issue_template_labels(bug_template):
+            print("bug issue template must not auto-apply mrwk:bounty")
+            ok = False
     bounty_issue_template = ROOT / ".github/ISSUE_TEMPLATE/bounty.yml"
     if not bounty_issue_template.exists():
         print("missing bounty issue template: .github/ISSUE_TEMPLATE/bounty.yml")

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -153,6 +153,31 @@ def test_bounty_issue_template_does_not_auto_mark_issue_live() -> None:
     assert "Do not add the live bounty label from this template" in template
 
 
+def test_security_report_template_routes_private_details_safely() -> None:
+    template = Path(".github/ISSUE_TEMPLATE/security-report.yml").read_text(encoding="utf-8")
+    lowered = template.lower()
+
+    assert "security" in _issue_template_labels(template)
+    assert "mrwk:bounty" not in _issue_template_labels(template)
+    assert "do not paste exploit details here" in lowered
+    assert "follow security.md for private reporting" in lowered
+    assert "public-safe summary" in lowered
+    assert _template_field_is_required(template, "summary")
+
+
+def test_bug_report_template_requires_actionable_repro_fields() -> None:
+    template = Path(".github/ISSUE_TEMPLATE/bug.yml").read_text(encoding="utf-8")
+    lowered = template.lower()
+
+    assert "bug" in _issue_template_labels(template)
+    assert "mrwk:bounty" not in _issue_template_labels(template)
+    assert "expected behavior" in lowered
+    assert "actual behavior" in lowered
+    assert "reproduction" in lowered
+    for field_id in ("expected", "actual", "reproduce"):
+        assert _template_field_is_required(template, field_id)
+
+
 def test_issue_template_labels_parse_inline_and_block_styles() -> None:
     assert _issue_template_labels('labels: ["proposed-work", "docs"]') == {
         "proposed-work",


### PR DESCRIPTION
## Summary

- Add docs-smoke coverage for the public security-report and bug-report issue templates.
- Guard the security template's private-report routing, security label, public-safe summary, and no-live-bounty-label behavior.
- Guard the bug template's bug label and required expected, actual, and reproduction fields.

## Source

Bounty #761

Source proposed-work issue: #812

This is the focused implementation of the accepted proposed-work request to add docs-smoke guardrails for public security and bug issue templates.

## Evidence

- #812 was accepted as useful proposed work under #722 and queued as pending pay_bounty proposal 132.
- #761 is now live and accepts focused PRs from accepted proposed-work issues.
- The change is limited to `scripts/docs_smoke.py` and `tests/test_docs_public_urls.py`.

## Validation

- `uv run --extra dev pytest tests/test_docs_public_urls.py -q` -> `35 passed`
- `uv run --extra dev python scripts/docs_smoke.py` -> `docs smoke ok`
- `uv run --extra dev ruff format --check scripts/docs_smoke.py tests/test_docs_public_urls.py` -> `2 files already formatted`
- `uv run --extra dev ruff check scripts/docs_smoke.py tests/test_docs_public_urls.py` -> `All checks passed!`
- `uv run --extra dev pytest -q` -> `708 passed, 1 warning`
- `uv run --extra dev mypy app` -> `Success: no issues found in 39 source files`
- `git diff --check` -> clean

## Out of Scope

No wallet, payout, treasury execution, bridge, exchange, cash-out, price, private security details, secrets, or issue automation changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests for GitHub issue template structure and content requirements.

* **Chores**
  * Enhanced issue template validation tooling to enforce required fields and label configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->