### PR TITLE
Validate admin webhook limit query forms

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -54,7 +54,9 @@ def register_admin_routes(
         proposal_id: Annotated[int | None, Query(ge=1)] = None,
     ) -> Any:
         reject_repeated_query_param(request, "webhook_status")
+        reject_repeated_query_param(request, "webhook_limit")
         reject_repeated_query_param(request, "proposal_id")
+        reject_noncanonical_int_query_param(request, "webhook_limit")
         reject_noncanonical_int_query_param(request, "proposal_id")
         login = admin_login_from_request(request)
         if login is None:

--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -251,6 +251,8 @@ def register_bounty_api_routes(
     ) -> list[dict[str, Any]]:
         del admin_login
         reject_repeated_query_param(request, "status")
+        reject_repeated_query_param(request, "limit")
+        reject_noncanonical_int_query_param(request, "limit")
         with session_scope(db_url) as session:
             try:
                 return webhook_events_to_dict(list_webhook_events(session, status, limit))

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -110,6 +110,50 @@ def test_admin_webhook_page_rejects_repeated_status_filter(
     assert response.json()["detail"] == "webhook_status must be provided at most once"
 
 
+@pytest.mark.parametrize(
+    ("query", "detail"),
+    [
+        ("webhook_limit=01", "webhook_limit must be a canonical positive integer"),
+        ("webhook_limit=%2B1", "webhook_limit must be a canonical positive integer"),
+        ("webhook_limit=1.0", "webhook_limit must be a canonical positive integer"),
+        ("webhook_limit=bad&webhook_limit=1", "webhook_limit must be provided at most once"),
+        ("webhook_limit=%C2%851", "webhook_limit must not contain control characters"),
+    ],
+)
+def test_admin_webhook_page_rejects_noncanonical_limit_values(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch, query: str, detail: str
+) -> None:
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(
+        f"/admin?{query}",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == detail
+
+
+@pytest.mark.parametrize("query", ["webhook_limit=1", "webhook_limit=200"])
+def test_admin_webhook_page_keeps_valid_limit_values(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch, query: str
+) -> None:
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(
+        f"/admin?{query}",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+
+    assert response.status_code == 200
+
+
 def test_admin_page_rejects_noncanonical_proposal_id_query(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_bounty_api.py
+++ b/tests/test_bounty_api.py
@@ -122,6 +122,42 @@ def test_admin_webhook_events_api_rejects_c1_control_status(monkeypatch):
     assert resp.json()["detail"] == "webhook_status must not contain control characters"
 
 
+@pytest.mark.parametrize(
+    ("query", "detail"),
+    [
+        ("limit=01", "limit must be a canonical positive integer"),
+        ("limit=%2B1", "limit must be a canonical positive integer"),
+        ("limit=1.0", "limit must be a canonical positive integer"),
+        ("limit=bad&limit=1", "limit must be provided at most once"),
+        ("limit=%C2%851", "limit must not contain control characters"),
+    ],
+)
+def test_admin_webhook_events_api_rejects_noncanonical_limit_values(monkeypatch, query, detail):
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(create_app(webhook_secret="secret"))
+
+    resp = client.get(
+        f"/api/v1/admin/webhook-events?{query}",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == detail
+
+
+@pytest.mark.parametrize("query", ["limit=1", "limit=200"])
+def test_admin_webhook_events_api_keeps_valid_limit_values(monkeypatch, query):
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(create_app(webhook_secret="secret"))
+
+    resp = client.get(
+        f"/api/v1/admin/webhook-events?{query}",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+
+    assert resp.status_code == 200
+
+
 class TestBountyCloseRoute:
     """Bounty close requires admin token."""
 

--- a/tests/test_bounty_api.py
+++ b/tests/test_bounty_api.py
@@ -122,6 +122,19 @@ def test_admin_webhook_events_api_rejects_c1_control_status(monkeypatch):
     assert resp.json()["detail"] == "webhook_status must not contain control characters"
 
 
+def test_admin_webhook_events_api_rejects_repeated_status(monkeypatch):
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(create_app(webhook_secret="secret"))
+
+    resp = client.get(
+        "/api/v1/admin/webhook-events?status=paid&status=closed",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "status must be provided at most once"
+
+
 @pytest.mark.parametrize(
     ("query", "detail"),
     [


### PR DESCRIPTION
## Summary

- Reject ambiguous/non-canonical admin webhook limit query values before FastAPI scalar coercion.
- Apply the existing repeated-query and canonical-integer guards to `/admin?webhook_limit=...` and `/api/v1/admin/webhook-events?limit=...`.
- Preserve valid `1` and `200` limit values and existing admin-token behavior.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: source issue #817 shows the admin webhook limit controls accepting `01`, `+1`, `1.0`, repeated values, and control-padded values as successful requests.
- Bounty capacity and active attempts/open PRs checked: Bounty #761 is live with `mrwk:bounty`, `Reserved on MergeWork`, API status `open`, and 6 effective awards remaining. `gh pr list --repo ramimbo/mergework --state open --search 817` returned no matching open PRs.
- Intended files or surfaces: `app/admin_routes.py`, `app/bounty_api.py`, `tests/test_admin_routes.py`, `tests/test_bounty_api.py`.
- Expected PR size: small, focused admin/API query validation fix.
- Out of scope: no admin authentication changes, webhook processing changes, treasury/proposal execution, payout behavior, wallet behavior, ledger behavior, private data, bridge/exchange/cash-out behavior, or MRWK price/liquidity claims.

## Test Evidence

- [x] `.\.venv\Scripts\python -m pytest tests\test_admin_routes.py tests\test_bounty_api.py tests\test_security.py -q` -> 92 passed, 1 warning
- [x] `.\.venv\Scripts\python -m pytest -q` -> 720 passed, 1 warning
- [x] `.\.venv\Scripts\python -m ruff check app\admin_routes.py app\bounty_api.py tests\test_admin_routes.py tests\test_bounty_api.py`
- [x] `.\.venv\Scripts\python -m ruff format --check app\admin_routes.py app\bounty_api.py tests\test_admin_routes.py tests\test_bounty_api.py`
- [x] `.\.venv\Scripts\python -m mypy app` -> Success: no issues found in 39 source files
- [x] `.\.venv\Scripts\python scripts\docs_smoke.py` -> docs smoke ok
- [x] `git diff --check`

## MRWK

Bounty #761
Source issue: #817
/claim #761

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for admin webhook limit query parameters (reject repeated parameters and non-canonical integer encodings such as leading zeros, plus sign, floats, and control characters); returns proper 400 errors while preserving valid canonical values.

* **Tests**
  * Added comprehensive tests covering rejection of invalid/duplicate limit values and acceptance of canonical limit values for both admin pages and API endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->