### PR TITLE
Validate remaining admin scalar query forms

### DIFF
--- a/app/admin_routes.py
+++ b/app/admin_routes.py
@@ -15,6 +15,7 @@ from app.admin import (
 from app.config import Settings
 from app.db import session_scope
 from app.ledger.service import LedgerError
+from app.query_validation import reject_noncanonical_int_query_param, reject_repeated_query_param
 
 
 def register_admin_routes(
@@ -52,6 +53,9 @@ def register_admin_routes(
         webhook_limit: Annotated[int, Query(ge=1, le=max(ADMIN_WEBHOOK_LIMIT_OPTIONS))] = 25,
         proposal_id: Annotated[int | None, Query(ge=1)] = None,
     ) -> Any:
+        reject_repeated_query_param(request, "webhook_status")
+        reject_repeated_query_param(request, "proposal_id")
+        reject_noncanonical_int_query_param(request, "proposal_id")
         login = admin_login_from_request(request)
         if login is None:
             if oauth_configured(settings):

--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -244,11 +244,13 @@ def register_bounty_api_routes(
 
     @app.get("/api/v1/admin/webhook-events")
     def api_admin_webhook_events(
+        request: Request,
         status: str | None = Query(None),
         limit: Annotated[int, Query(ge=1, le=200)] = 50,
         admin_login: str = Depends(require_admin_token),
     ) -> list[dict[str, Any]]:
         del admin_login
+        reject_repeated_query_param(request, "status")
         with session_scope(db_url) as session:
             try:
                 return webhook_events_to_dict(list_webhook_events(session, status, limit))

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -91,3 +91,50 @@ def test_admin_webhook_page_rejects_c1_control_status_before_normalizing(
 
     assert response.status_code == 400
     assert response.json()["detail"] == "webhook_status must not contain control characters"
+
+
+def test_admin_webhook_page_rejects_repeated_status_filter(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(
+        "/admin?webhook_status=missing_submitter&webhook_status=paid",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "webhook_status must be provided at most once"
+
+
+def test_admin_page_rejects_noncanonical_proposal_id_query(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    for query in ("proposal_id=01", "proposal_id=%2B1", "proposal_id=1.0", "proposal_id=%C2%851"):
+        response = client.get(
+            f"/admin?{query}",
+            headers={"x-mergework-admin-token": "admin-token-for-tests"},
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"].startswith("proposal_id must ")
+
+    repeated = client.get(
+        "/admin?proposal_id=bad&proposal_id=1",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+    valid = client.get(
+        "/admin?proposal_id=1",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+
+    assert repeated.status_code == 400
+    assert repeated.json()["detail"] == "proposal_id must be provided at most once"
+    assert valid.status_code == 200

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -252,6 +252,25 @@ def test_admin_page_renders_safe_webhook_events_for_cookie_admin(
     assert too_large.status_code == 422
 
 
+def test_admin_webhook_events_api_rejects_repeated_status_filter(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    create_schema(sqlite_url)
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+
+    response = client.get(
+        "/api/v1/admin/webhook-events?status=missing_submitter&status=paid",
+        headers={"x-mergework-admin-token": "admin-token-for-tests"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "status must be provided at most once"
+
+
 def test_admin_page_calls_out_pending_create_proposals_when_they_limit_capacity(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- reject repeated `webhook_status` and repeated `proposal_id` on the admin page before FastAPI collapses scalar query values
- reject non-canonical admin `proposal_id` query forms before they are coerced into integers
- reject repeated `status` on the admin webhook-events API while preserving the existing status normalization/error path

Refs #761
Source: #818

## Validation

- `uv run --extra dev pytest tests/test_admin_routes.py tests/test_security.py tests/test_bounty_api.py -q` -> 81 passed, 1 warning
- `uv run --extra dev ruff format --check app/admin_routes.py app/bounty_api.py tests/test_admin_routes.py tests/test_security.py` -> 4 files already formatted
- `uv run --extra dev ruff check app/admin_routes.py app/bounty_api.py tests/test_admin_routes.py tests/test_security.py` -> All checks passed
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --extra dev mypy app` -> Success: no issues found in 39 source files
- `git diff --check` -> clean

No wallet, payout, treasury execution, bridge, exchange, cash-out, price, private security details, secrets, or issue automation changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved query parameter validation on admin endpoints: now rejects duplicate parameters (repeated status, proposal_id) and malformed integer values to enhance security and prevent unintended behavior.

* **Tests**
  * Added multiple test cases covering query parameter validation scenarios for admin webhook event filtering and proposal page access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->