### PR TITLE
Validate OAuth scalar query parameters

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import RedirectResponse
 
 from app.config import Settings
+from app.query_validation import reject_repeated_query_param
 
 
 def oauth_configured(settings: Settings) -> bool:
@@ -108,9 +109,13 @@ def register_auth_routes(app: FastAPI, *, settings: Settings) -> AuthService:
     auth = AuthService(settings)
 
     @app.get("/auth/github/login")
-    def auth_github_login(next_path: str | None = Query(None, alias="next")) -> RedirectResponse:
+    def auth_github_login(
+        request: Request,
+        next_path: str | None = Query(None, alias="next"),
+    ) -> RedirectResponse:
         if not oauth_configured(settings):
             raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
+        reject_repeated_query_param(request, "next")
         safe_next = safe_next_path(next_path)
         state_value = f"{secrets.token_urlsafe(24)},{safe_next}"
         state = signed_value(state_value, settings.cookie_secret)
@@ -134,6 +139,8 @@ def register_auth_routes(app: FastAPI, *, settings: Settings) -> AuthService:
     async def auth_github_callback(request: Request, code: str, state: str) -> RedirectResponse:
         if not oauth_configured(settings):
             raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
+        reject_repeated_query_param(request, "code")
+        reject_repeated_query_param(request, "state")
         cookie_state = request.cookies.get("mrwk_oauth_state")
         if not cookie_state or not hmac.compare_digest(cookie_state, state):
             raise HTTPException(status_code=401, detail="invalid OAuth state")

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -609,6 +609,136 @@ def test_github_login_redirects_when_oauth_is_configured(sqlite_url: str, monkey
     assert "mrwk_oauth_state" in response.cookies
 
 
+def test_github_login_rejects_repeated_next_query(sqlite_url: str, monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    monkeypatch.setenv("MERGEWORK_PUBLIC_BASE_URL", "https://mrwk.example.test")
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(
+        "/auth/github/login",
+        params=[("next", "/first"), ("next", "/second")],
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "next must be provided at most once"
+
+
+class _OAuthResponse:
+    def __init__(self, payload: dict[str, str]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, str]:
+        return self._payload
+
+
+@pytest.mark.parametrize(
+    ("params", "detail"),
+    (
+        ([("code", "first"), ("code", "second")], "code must be provided at most once"),
+        ([("state", "bad"), ("state", "good")], "state must be provided at most once"),
+        (
+            [("code", "second"), ("state", "bad")],
+            "code must be provided at most once",
+        ),
+    ),
+)
+def test_github_callback_rejects_repeated_scalar_queries(
+    sqlite_url: str,
+    monkeypatch,
+    params: list[tuple[str, str]],
+    detail: str,
+) -> None:
+    exchange_calls: list[str] = []
+
+    class FailingOAuthClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            exchange_calls.append("init")
+
+        async def __aenter__(self) -> FailingOAuthClient:
+            raise AssertionError("duplicate OAuth callback queries must not exchange tokens")
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    monkeypatch.setattr("app.auth.httpx.AsyncClient", FailingOAuthClient)
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    monkeypatch.setenv("MERGEWORK_PUBLIC_BASE_URL", "https://mrwk.example.test")
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    state = _signed_value("nonce,/me", "test-cookie-secret")
+    client.cookies.set("mrwk_oauth_state", state)
+    query_params = [("code", "code"), ("state", state), *params]
+
+    response = client.get(
+        "/auth/github/callback",
+        params=query_params,
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == detail
+    assert exchange_calls == []
+    assert client.cookies.get("mrwk_oauth_state") == state
+
+
+def test_github_callback_exchanges_single_scalar_queries(sqlite_url: str, monkeypatch) -> None:
+    exchange_calls: list[tuple[str, str]] = []
+
+    class FakeOAuthClient:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            return None
+
+        async def __aenter__(self) -> FakeOAuthClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def post(self, url: str, **kwargs: object) -> _OAuthResponse:
+            exchange_calls.append(("post", url))
+            assert kwargs["data"]["code"] == "code"
+            return _OAuthResponse({"access_token": "token"})
+
+        async def get(self, url: str, **_kwargs: object) -> _OAuthResponse:
+            exchange_calls.append(("get", url))
+            return _OAuthResponse({"login": "Alice"})
+
+    monkeypatch.setattr("app.auth.httpx.AsyncClient", FakeOAuthClient)
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    monkeypatch.setenv("MERGEWORK_PUBLIC_BASE_URL", "https://mrwk.example.test")
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    state = _signed_value("nonce,/me", "test-cookie-secret")
+    client.cookies.set("mrwk_oauth_state", state)
+
+    response = client.get(
+        "/auth/github/callback",
+        params={"code": "code", "state": state},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/me"
+    assert exchange_calls == [
+        ("post", "https://github.com/login/oauth/access_token"),
+        ("get", "https://api.github.com/user"),
+    ]
+    assert client.cookies.get("mrwk_user") is not None
+    set_cookie_headers = response.headers.get_list("set-cookie")
+    assert any(
+        header.startswith("mrwk_oauth_state=") and "Max-Age=0" in header
+        for header in set_cookie_headers
+    )
+
+
 @pytest.mark.parametrize(
     "next_path",
     (

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -624,6 +624,8 @@ def test_github_login_rejects_repeated_next_query(sqlite_url: str, monkeypatch) 
 
     assert response.status_code == 400
     assert response.json()["detail"] == "next must be provided at most once"
+    assert "location" not in response.headers
+    assert "mrwk_oauth_state" not in response.cookies
 
 
 class _OAuthResponse:


### PR DESCRIPTION
## Summary

- reject repeated `next` on the GitHub OAuth login route before the signed state is built
- reject repeated `code` and `state` on the GitHub OAuth callback route before cookie-state comparison or outbound token exchange
- add regression tests for duplicate callback parameters, no token exchange on duplicate callback input, and the normal single-value callback path

Source issue #820: https://github.com/ramimbo/mergework/issues/820
Related proposed-work bounty #722: https://github.com/ramimbo/mergework/issues/722

Maintainer hold repair: this PR no longer claims #761. Issue #820 is a proposed-work item related to #722, and no payout is queued for #820 while that round is full.

Refs #820

## Validation

- `uv run --extra dev pytest tests/test_wallet_api.py::test_github_callback_rejects_repeated_scalar_queries tests/test_wallet_api.py::test_github_callback_exchanges_single_scalar_queries tests/test_wallet_api.py::test_github_login_rejects_repeated_next_query -q` -> 5 passed, 1 warning
- `uv run --extra dev pytest tests/test_wallet_api.py tests/test_security.py::test_oauth_next_path_rejects_external_or_headerlike_paths -q` -> 61 passed, 1 warning
- `uv run --extra dev ruff format --check app/auth.py tests/test_wallet_api.py` -> 2 files already formatted
- `uv run --extra dev ruff check app/auth.py tests/test_wallet_api.py` -> All checks passed
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --extra dev mypy app` -> Success: no issues found in 39 source files
- `git diff --check` -> clean

Live duplicate/capacity check before PR:

- `gh issue view 820 -R ramimbo/mergework --json number,title,state,url,body,comments,labels,updatedAt` -> #820 open, labeled `proposed-work`
- `gh issue view 722 -R ramimbo/mergework --json number,title,state,url,comments,labels,updatedAt` -> #722 open; maintainer comment says #820 is left for successor intake review and no `pay_bounty` proposal is queued because #722 has 0 effective slots remaining
- `gh pr view 825 -R ramimbo/mergework --json number,title,state,url,mergeStateStatus,statusCheckRollup,comments,body,headRefName,headRepositoryOwner,updatedAt` -> PR #825 open and clean; maintainer hold requested corrected bounty/source reference plus no-cookie/no-Location assertions for repeated `next`
- `gh pr list -R ramimbo/mergework --state open --search "820 OR OAuth scalar OR repeated next OR repeated state OR repeated code OR github callback OR github login" --json number,title,author,url,headRefName,updatedAt,body` -> no OAuth scalar duplicate PR found

No wallet, payout, treasury execution, bridge, exchange, cash-out, price, secrets, private details, or issue automation changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub login and callback endpoints now reject requests with duplicated or malformed OAuth query parameters (e.g., repeated next, code, or state), preventing invalid or ambiguous authentication attempts.

* **Tests**
  * Added end-to-end tests covering OAuth query validation and successful single-parameter authentication flows, including cookie and redirect behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->