### PR TITLE
Add read-only ledger snapshot exporter

### DIFF
--- a/app/ledger/snapshot.py
+++ b/app/ledger/snapshot.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.ledger.service import (
+    GENESIS_SUPPLY_MICRO,
+    canonical_json,
+    verify_hash_chain,
+    verify_supply_conservation,
+)
+from app.models import LedgerEntry
+
+LEDGER_SNAPSHOT_SCHEMA = "mergework.ledger_snapshot.v1"
+LEDGER_SNAPSHOT_SCHEMA_VERSION = 1
+PROPOSAL_VALIDATION_EXPLANATION = (
+    "Snapshot verification covers committed ledger entries, the ledger hash chain, "
+    "and fixed-supply conservation. It does not replay every historical treasury "
+    "proposal, challenge, or governance rule, and it does not treat pending proposals "
+    "as committed ledger state."
+)
+
+LEDGER_SNAPSHOT_JSON_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": LEDGER_SNAPSHOT_SCHEMA,
+    "type": "object",
+    "required": [
+        "schema",
+        "schema_version",
+        "generated_at",
+        "source",
+        "proposal_validation",
+        "ledger_anchor",
+        "genesis_supply_microunits",
+        "accounts",
+        "totals",
+        "verification",
+    ],
+    "properties": {
+        "schema": {"const": LEDGER_SNAPSHOT_SCHEMA},
+        "schema_version": {"const": LEDGER_SNAPSHOT_SCHEMA_VERSION},
+        "generated_at": {"type": "string"},
+        "source": {
+            "type": "object",
+            "required": ["mode", "host"],
+            "properties": {
+                "mode": {"type": "string"},
+                "host": {"type": ["string", "null"]},
+            },
+            "additionalProperties": False,
+        },
+        "proposal_validation": {
+            "type": "object",
+            "required": ["status", "explanation"],
+            "properties": {
+                "status": {"const": "partial"},
+                "explanation": {"type": "string"},
+            },
+            "additionalProperties": False,
+        },
+        "ledger_anchor": {
+            "type": "object",
+            "required": ["latest_sequence", "latest_entry_hash"],
+            "properties": {
+                "latest_sequence": {"type": "integer"},
+                "latest_entry_hash": {"type": ["string", "null"]},
+            },
+            "additionalProperties": False,
+        },
+        "genesis_supply_microunits": {"type": "integer"},
+        "accounts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["account", "balance_microunits"],
+                "properties": {
+                    "account": {"type": "string"},
+                    "balance_microunits": {"type": "integer"},
+                },
+                "additionalProperties": False,
+            },
+        },
+        "totals": {
+            "type": "object",
+            "required": [
+                "credited_microunits",
+                "debited_microunits",
+                "net_supply_microunits",
+            ],
+            "properties": {
+                "credited_microunits": {"type": "integer"},
+                "debited_microunits": {"type": "integer"},
+                "net_supply_microunits": {"type": "integer"},
+            },
+            "additionalProperties": False,
+        },
+        "verification": {
+            "type": "object",
+            "required": ["hash_chain_ok", "supply_conservation_ok"],
+            "properties": {
+                "hash_chain_ok": {"type": "boolean"},
+                "supply_conservation_ok": {"type": "boolean"},
+            },
+            "additionalProperties": False,
+        },
+    },
+    "additionalProperties": False,
+}
+
+
+def ledger_snapshot(
+    session: Session,
+    *,
+    generated_at: datetime | None = None,
+    source_mode: str = "database",
+    source_host: str | None = None,
+) -> dict[str, Any]:
+    generated = generated_at or datetime.now(UTC)
+    entries = list(session.scalars(select(LedgerEntry).order_by(LedgerEntry.sequence)).all())
+    latest_entry = entries[-1] if entries else None
+    credited_microunits = int(
+        session.scalar(select(func.coalesce(func.sum(LedgerEntry.amount_microunits), 0))) or 0
+    )
+    debited_microunits = int(
+        session.scalar(
+            select(func.coalesce(func.sum(LedgerEntry.amount_microunits), 0)).where(
+                LedgerEntry.from_account.is_not(None)
+            )
+        )
+        or 0
+    )
+    net_supply_microunits = credited_microunits - debited_microunits
+    return {
+        "schema": LEDGER_SNAPSHOT_SCHEMA,
+        "schema_version": LEDGER_SNAPSHOT_SCHEMA_VERSION,
+        "generated_at": _utc_timestamp(generated),
+        "source": {
+            "mode": source_mode,
+            "host": source_host,
+        },
+        "proposal_validation": {
+            "status": "partial",
+            "explanation": PROPOSAL_VALIDATION_EXPLANATION,
+        },
+        "ledger_anchor": {
+            "latest_sequence": latest_entry.sequence if latest_entry else 0,
+            "latest_entry_hash": latest_entry.entry_hash if latest_entry else None,
+        },
+        "genesis_supply_microunits": GENESIS_SUPPLY_MICRO,
+        "accounts": _account_balances(entries),
+        "totals": {
+            "credited_microunits": credited_microunits,
+            "debited_microunits": debited_microunits,
+            "net_supply_microunits": net_supply_microunits,
+        },
+        "verification": {
+            "hash_chain_ok": verify_hash_chain(session),
+            "supply_conservation_ok": verify_supply_conservation(session),
+        },
+    }
+
+
+def ledger_snapshot_json(snapshot: dict[str, Any]) -> str:
+    return canonical_json(snapshot) + "\n"
+
+
+def ledger_snapshot_schema_json() -> str:
+    return (
+        json.dumps(
+            LEDGER_SNAPSHOT_JSON_SCHEMA,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        )
+        + "\n"
+    )
+
+
+def _account_balances(entries: list[LedgerEntry]) -> list[dict[str, Any]]:
+    balances: dict[str, int] = {}
+    for entry in entries:
+        if entry.to_account is not None:
+            balances[entry.to_account] = balances.get(entry.to_account, 0) + entry.amount_microunits
+        if entry.from_account is not None:
+            balances[entry.from_account] = (
+                balances.get(entry.from_account, 0) - entry.amount_microunits
+            )
+    return [
+        {"account": account, "balance_microunits": balances[account]}
+        for account in sorted(balances)
+    ]
+
+
+def _utc_timestamp(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")

--- a/app/ledger/snapshot.py
+++ b/app/ledger/snapshot.py
@@ -4,7 +4,7 @@ import json
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.ledger.service import (
@@ -122,16 +122,9 @@ def ledger_snapshot(
     generated = generated_at or datetime.now(UTC)
     entries = list(session.scalars(select(LedgerEntry).order_by(LedgerEntry.sequence)).all())
     latest_entry = entries[-1] if entries else None
-    credited_microunits = int(
-        session.scalar(select(func.coalesce(func.sum(LedgerEntry.amount_microunits), 0))) or 0
-    )
-    debited_microunits = int(
-        session.scalar(
-            select(func.coalesce(func.sum(LedgerEntry.amount_microunits), 0)).where(
-                LedgerEntry.from_account.is_not(None)
-            )
-        )
-        or 0
+    credited_microunits = sum(entry.amount_microunits for entry in entries)
+    debited_microunits = sum(
+        entry.amount_microunits for entry in entries if entry.from_account is not None
     )
     net_supply_microunits = credited_microunits - debited_microunits
     return {

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -187,6 +187,21 @@ The public app flow is `/auth/github/login?next=/me`.
 Before describing payout or transfer behavior, check the current transfer paths
 in [docs/ledger.md](ledger.md#current-transfer-paths).
 
+## Ledger Snapshots
+
+For read-only Phase 2A ledger reconciliation, use the local snapshot exporter:
+
+```bash
+python scripts/export_ledger_snapshot.py > ledger-snapshot.json
+python scripts/export_ledger_snapshot.py --schema > ledger-snapshot.schema.json
+```
+
+Snapshots include committed ledger balances in integer microunits, hash-chain
+verification, fixed-supply conservation verification, and
+`proposal_validation: "partial"`. They do not replay every historical treasury
+proposal or include pending proposals as committed ledger state, and they are
+not a bridge, exchange, off-ramp, redemption mechanism, or price signal.
+
 ## MCP Endpoint
 
 The MCP JSON-RPC endpoint is `POST /mcp`.

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -75,6 +75,29 @@ Public ledger state and proof hashes make future snapshot, bridge, or
 onchain-claim experiments auditable if maintainers and contributors decide to
 explore them.
 
+The read-only Phase 2A snapshot exporter is the first boring foundation for
+that path. It exports deterministic JSON from committed ledger entries only:
+
+```bash
+python scripts/export_ledger_snapshot.py > ledger-snapshot.json
+python scripts/export_ledger_snapshot.py --schema > ledger-snapshot.schema.json
+```
+
+The snapshot includes schema/version metadata, a generated UTC timestamp, source
+metadata, the latest ledger sequence and entry hash, the fixed genesis supply in
+integer microunits, deterministically sorted account balances in integer
+microunits, credited/debited/net supply totals, hash-chain verification, and
+fixed-supply conservation verification.
+
+Snapshot `proposal_validation` is intentionally `partial`: the exporter verifies
+committed ledger entries, the hash chain, and fixed-supply conservation, but it
+does not replay every historical treasury proposal, challenge, or governance
+rule. Pending treasury proposals are not committed ledger state.
+
+This snapshot is read-only infrastructure. It is not a bridge, exchange,
+off-ramp, custody path, relayer, redemption mechanism, price signal, or live
+external-value claim.
+
 ## Wallets and Sending
 
 MRWK supports native wallet addresses and signed transfers inside the ledger.

--- a/scripts/export_ledger_snapshot.py
+++ b/scripts/export_ledger_snapshot.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.config import get_settings
+from app.db import session_scope
+from app.ledger.snapshot import (
+    ledger_snapshot,
+    ledger_snapshot_json,
+    ledger_snapshot_schema_json,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export a read-only MRWK ledger snapshot.")
+    parser.add_argument("--database-url", help="Database URL. Defaults to MERGEWORK_DATABASE_URL.")
+    parser.add_argument("--source-host", help="Public source host/origin for snapshot metadata.")
+    parser.add_argument(
+        "--source-mode",
+        default="database",
+        help="Source mode label for snapshot metadata. Defaults to database.",
+    )
+    parser.add_argument(
+        "--schema",
+        action="store_true",
+        help="Print the ledger snapshot JSON Schema instead of a live snapshot.",
+    )
+    args = parser.parse_args()
+    if args.schema:
+        sys.stdout.write(ledger_snapshot_schema_json())
+        return 0
+
+    settings = get_settings()
+    database_url = args.database_url or settings.database_url
+    source_host = args.source_host if args.source_host is not None else settings.public_base_url
+    with session_scope(database_url) as session:
+        sys.stdout.write(
+            ledger_snapshot_json(
+                ledger_snapshot(
+                    session,
+                    source_mode=args.source_mode,
+                    source_host=source_host,
+                )
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_ledger_snapshot.py
+++ b/scripts/export_ledger_snapshot.py
@@ -2,18 +2,35 @@ from __future__ import annotations
 
 import argparse
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from sqlalchemy.orm import Session, sessionmaker
+
 from app.config import get_settings
-from app.db import session_scope
+from app.db import make_engine
 from app.ledger.snapshot import (
     ledger_snapshot,
     ledger_snapshot_json,
     ledger_snapshot_schema_json,
 )
+
+
+@contextmanager
+def read_only_session_scope(database_url: str) -> Iterator[Session]:
+    engine = make_engine(database_url)
+    factory = sessionmaker(bind=engine, future=True, expire_on_commit=False)
+    session = factory()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+        engine.dispose()
 
 
 def main() -> int:
@@ -38,7 +55,7 @@ def main() -> int:
     settings = get_settings()
     database_url = args.database_url or settings.database_url
     source_host = args.source_host if args.source_host is not None else settings.public_base_url
-    with session_scope(database_url) as session:
+    with read_only_session_scope(database_url) as session:
         sys.stdout.write(
             ledger_snapshot_json(
                 ledger_snapshot(

--- a/tests/test_ledger_snapshot.py
+++ b/tests/test_ledger_snapshot.py
@@ -20,6 +20,7 @@ from app.ledger.snapshot import (
     ledger_snapshot_schema_json,
 )
 from app.models import LedgerEntry
+from scripts.export_ledger_snapshot import read_only_session_scope
 
 
 def test_ledger_snapshot_exports_deterministic_integer_balances(sqlite_url: str) -> None:
@@ -60,8 +61,13 @@ def test_ledger_snapshot_exports_deterministic_integer_balances(sqlite_url: str)
             source_host="https://mrwk.example",
         )
 
+    first_json = ledger_snapshot_json(first)
+    second_json = ledger_snapshot_json(second)
+
     assert first == second
-    assert json.loads(ledger_snapshot_json(first)) == first
+    assert first_json == second_json
+    assert first_json.endswith("\n")
+    assert json.loads(first_json) == first
     assert first["schema"] == LEDGER_SNAPSHOT_SCHEMA
     assert first["schema_version"] == LEDGER_SNAPSHOT_SCHEMA_VERSION
     assert first["generated_at"] == "2026-06-02T12:00:00.000000Z"
@@ -143,6 +149,16 @@ def test_ledger_snapshot_handles_empty_ledger(sqlite_url: str) -> None:
         "hash_chain_ok": True,
         "supply_conservation_ok": False,
     }
+
+
+def test_exporter_read_only_session_rolls_back_writes(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with read_only_session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    with session_scope(sqlite_url) as session:
+        assert session.get(LedgerEntry, 1) is None
 
 
 def test_ledger_snapshot_schema_is_deterministic_json() -> None:

--- a/tests/test_ledger_snapshot.py
+++ b/tests/test_ledger_snapshot.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+from app.db import create_schema, session_scope
+from app.ledger.service import (
+    GENESIS_SUPPLY_MICRO,
+    TREASURY_ACCOUNT,
+    add_ledger_entry,
+    create_bounty,
+    ensure_genesis,
+    pay_bounty,
+)
+from app.ledger.snapshot import (
+    LEDGER_SNAPSHOT_SCHEMA,
+    LEDGER_SNAPSHOT_SCHEMA_VERSION,
+    ledger_snapshot,
+    ledger_snapshot_json,
+    ledger_snapshot_schema_json,
+)
+from app.models import LedgerEntry
+
+
+def test_ledger_snapshot_exports_deterministic_integer_balances(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    generated_at = datetime(2026, 6, 2, 12, 0, tzinfo=UTC)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=764,
+            issue_url="https://github.com/ramimbo/mergework/issues/764",
+            title="Snapshot exporter",
+            reward_mrwk="12.5",
+            max_awards=2,
+            acceptance="Focused read-only ledger snapshot exporter.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/800",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+        first = ledger_snapshot(
+            session,
+            generated_at=generated_at,
+            source_mode="test",
+            source_host="https://mrwk.example",
+        )
+        second = ledger_snapshot(
+            session,
+            generated_at=generated_at,
+            source_mode="test",
+            source_host="https://mrwk.example",
+        )
+
+    assert first == second
+    assert json.loads(ledger_snapshot_json(first)) == first
+    assert first["schema"] == LEDGER_SNAPSHOT_SCHEMA
+    assert first["schema_version"] == LEDGER_SNAPSHOT_SCHEMA_VERSION
+    assert first["generated_at"] == "2026-06-02T12:00:00.000000Z"
+    assert first["source"] == {"mode": "test", "host": "https://mrwk.example"}
+    assert first["proposal_validation"]["status"] == "partial"
+    assert first["genesis_supply_microunits"] == GENESIS_SUPPLY_MICRO
+    assert first["ledger_anchor"]["latest_sequence"] == 3
+    assert isinstance(first["ledger_anchor"]["latest_entry_hash"], str)
+    assert first["verification"] == {
+        "hash_chain_ok": True,
+        "supply_conservation_ok": True,
+    }
+    assert first["totals"] == {
+        "credited_microunits": GENESIS_SUPPLY_MICRO + 25_000_000 + 12_500_000,
+        "debited_microunits": 25_000_000 + 12_500_000,
+        "net_supply_microunits": GENESIS_SUPPLY_MICRO,
+    }
+    assert first["accounts"] == [
+        {"account": "github:alice", "balance_microunits": 12_500_000},
+        {"account": "reserve:bounty:1", "balance_microunits": 12_500_000},
+        {
+            "account": TREASURY_ACCOUNT,
+            "balance_microunits": GENESIS_SUPPLY_MICRO - 25_000_000,
+        },
+    ]
+    assert all(isinstance(row["balance_microunits"], int) for row in first["accounts"])
+
+
+def test_ledger_snapshot_reports_hash_chain_failure(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        entry = session.get(LedgerEntry, 1)
+        assert entry is not None
+        entry.reference = "tampered-genesis"
+
+        snapshot = ledger_snapshot(session, generated_at=datetime(2026, 6, 2, tzinfo=UTC))
+
+    assert snapshot["verification"]["hash_chain_ok"] is False
+    assert snapshot["verification"]["supply_conservation_ok"] is True
+
+
+def test_ledger_snapshot_reports_supply_conservation_failure(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        add_ledger_entry(
+            session,
+            entry_type="test_airdrop",
+            from_account=None,
+            to_account="github:alice",
+            amount_microunits=1,
+            reference="test-airdrop",
+        )
+
+        snapshot = ledger_snapshot(session, generated_at=datetime(2026, 6, 2, tzinfo=UTC))
+
+    assert snapshot["verification"]["hash_chain_ok"] is True
+    assert snapshot["verification"]["supply_conservation_ok"] is False
+    assert snapshot["totals"]["net_supply_microunits"] == GENESIS_SUPPLY_MICRO + 1
+
+
+def test_ledger_snapshot_handles_empty_ledger(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        snapshot = ledger_snapshot(session, generated_at=datetime(2026, 6, 2, tzinfo=UTC))
+
+    assert snapshot["ledger_anchor"] == {"latest_sequence": 0, "latest_entry_hash": None}
+    assert snapshot["accounts"] == []
+    assert snapshot["totals"] == {
+        "credited_microunits": 0,
+        "debited_microunits": 0,
+        "net_supply_microunits": 0,
+    }
+    assert snapshot["verification"] == {
+        "hash_chain_ok": True,
+        "supply_conservation_ok": False,
+    }
+
+
+def test_ledger_snapshot_schema_is_deterministic_json() -> None:
+    schema = json.loads(ledger_snapshot_schema_json())
+
+    assert schema["$id"] == LEDGER_SNAPSHOT_SCHEMA
+    assert schema["properties"]["accounts"]["items"]["properties"]["balance_microunits"] == {
+        "type": "integer"
+    }
+    assert ledger_snapshot_schema_json() == ledger_snapshot_schema_json()


### PR DESCRIPTION
Bounty #764

Implements the focused read-only Phase 2A ledger snapshot exporter/schema.

What changed:
- added `app/ledger/snapshot.py` for deterministic snapshot dictionaries, canonical JSON output, and a JSON Schema helper;
- added `scripts/export_ledger_snapshot.py` for read-only database snapshot exports and schema exports;
- documented the snapshot fields and read-only boundaries in the agent guide and ledger docs;
- added fixture-backed tests for deterministic output, integer microunit balances, normal export, hash-chain failure, supply-conservation failure, empty ledgers, and deterministic schema output.

Snapshot shape includes:
- schema/version metadata;
- generated UTC timestamp;
- source mode/host metadata;
- `proposal_validation.status = "partial"` with an explanation that pending proposals are not committed ledger state;
- latest ledger sequence and latest entry hash;
- genesis supply in integer microunits;
- sorted account balances in integer microunits;
- credited/debited/net supply totals;
- hash-chain and supply-conservation verification booleans.

Validation on current `origin/main`:
- `python -m pytest tests/test_ledger_snapshot.py tests/test_ledger.py tests/test_ledger_views.py tests/test_ledger_reconciliation.py -q` -> 37 passed
- `python -m ruff check app/ledger/snapshot.py scripts/export_ledger_snapshot.py tests/test_ledger_snapshot.py` -> passed
- `python -m ruff format --check app/ledger/snapshot.py scripts/export_ledger_snapshot.py tests/test_ledger_snapshot.py` -> passed
- `python -m mypy app/ledger/snapshot.py scripts/export_ledger_snapshot.py` -> success
- `python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean
- exporter smoke against the local sqlite DB -> `schema=mergework.ledger_snapshot.v1; sequence=1; hash_chain=True; supply=True`

Boundaries:
- read-only export only;
- no bridge, exchange, off-ramp, liquidity, custody, relayer, contract, payout, treasury mutation, wallet mutation, admin-token behavior, private secrets, or external-value claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only ledger snapshot export with canonical JSON schema, deterministic serialization, verification flags, ledger anchor, and per-account microunit balances.

* **Documentation**
  * Added user-facing guides describing how to export snapshots, their contents, and limitations (partial proposal validation; not a bridge/redemption).

* **Tests**
  * Added end-to-end tests validating snapshot determinism, verification behavior, empty-ledger handling, and read-only export safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->