### PR TITLE
Validate staging dry-run identity envs

### DIFF
--- a/scripts/staging_webhook_dry_run.py
+++ b/scripts/staging_webhook_dry_run.py
@@ -5,11 +5,14 @@ import hmac
 import ipaddress
 import json
 import os
+import re
 import sys
 import time
 from urllib.parse import urlparse
 
 import httpx
+
+_REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
 
 
 def _required_env(name: str) -> str:
@@ -61,6 +64,22 @@ def _validate_http_url(url: str) -> None:
         raise RuntimeError(f"{url} must use http or https")
 
 
+def _dry_run_repo() -> str:
+    repo = os.environ.get("MERGEWORK_DRY_RUN_REPO", "ramimbo/mergework").strip()
+    if not repo:
+        raise RuntimeError("MERGEWORK_DRY_RUN_REPO is required")
+    if not _REPO_SLUG_RE.fullmatch(repo):
+        raise RuntimeError("MERGEWORK_DRY_RUN_REPO must be a GitHub repo slug in owner/name form")
+    return repo
+
+
+def _dry_run_contributor() -> str:
+    contributor = os.environ.get("MERGEWORK_DRY_RUN_CONTRIBUTOR", "mergework-dry-run").strip()
+    if not contributor:
+        raise RuntimeError("MERGEWORK_DRY_RUN_CONTRIBUTOR is required")
+    return contributor
+
+
 def _enforce_staging_target(base_url: str) -> None:
     parsed = urlparse(base_url)
     host = parsed.hostname or ""
@@ -84,8 +103,8 @@ def main() -> int:
         _enforce_staging_target(base_url)
         admin_token = _required_env("MERGEWORK_ADMIN_TOKEN")
         webhook_secret = _required_env("MERGEWORK_GITHUB_WEBHOOK_SECRET")
-        repo = os.environ.get("MERGEWORK_DRY_RUN_REPO", "ramimbo/mergework").strip()
-        contributor = os.environ.get("MERGEWORK_DRY_RUN_CONTRIBUTOR", "mergework-dry-run").strip()
+        repo = _dry_run_repo()
+        contributor = _dry_run_contributor()
         labeler = _required_env("MERGEWORK_GITHUB_ACCEPTED_LABELERS").split(",", 1)[0].strip()
         issue_number = int(time.time() * 1000)
         issue_url = f"https://github.com/{repo}/issues/{issue_number}"

--- a/tests/test_staging_webhook_dry_run.py
+++ b/tests/test_staging_webhook_dry_run.py
@@ -2,7 +2,20 @@ from __future__ import annotations
 
 import pytest
 
-from scripts.staging_webhook_dry_run import _enforce_staging_target, _validate_http_url
+from scripts.staging_webhook_dry_run import (
+    _dry_run_contributor,
+    _dry_run_repo,
+    _enforce_staging_target,
+    _validate_http_url,
+    main,
+)
+
+
+def _set_required_dry_run_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MERGEWORK_STAGING_BASE_URL", "http://localhost:8000")
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token")
+    monkeypatch.setenv("MERGEWORK_GITHUB_WEBHOOK_SECRET", "webhook-secret")
+    monkeypatch.setenv("MERGEWORK_GITHUB_ACCEPTED_LABELERS", "maintainer")
 
 
 def test_staging_webhook_dry_run_allows_loopback_hosts() -> None:
@@ -31,3 +44,59 @@ def test_staging_webhook_dry_run_rejects_url_credentials() -> None:
         _validate_http_url("ftp://operator:secret@staging.mrwk.example.test")
 
     _validate_http_url("https://staging.mrwk.example.test")
+
+
+def test_staging_webhook_dry_run_uses_valid_default_identity_envs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MERGEWORK_DRY_RUN_REPO", raising=False)
+    monkeypatch.delenv("MERGEWORK_DRY_RUN_CONTRIBUTOR", raising=False)
+
+    assert _dry_run_repo() == "ramimbo/mergework"
+    assert _dry_run_contributor() == "mergework-dry-run"
+
+
+@pytest.mark.parametrize(
+    "repo",
+    [
+        "",
+        "   ",
+        "ramimbo",
+        "ramimbo/",
+        "/mergework",
+        "ramimbo/mergework/extra",
+        "https://github.com/ramimbo/mergework",
+    ],
+)
+def test_staging_webhook_dry_run_rejects_malformed_repo_before_http(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    repo: str,
+) -> None:
+    _set_required_dry_run_env(monkeypatch)
+    monkeypatch.setenv("MERGEWORK_DRY_RUN_REPO", repo)
+    monkeypatch.setattr(
+        "scripts.staging_webhook_dry_run.httpx.post",
+        lambda *_args, **_kwargs: pytest.fail("dry run posted before repo validation"),
+    )
+
+    assert main() == 1
+    assert "MERGEWORK_DRY_RUN_REPO" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("contributor", ["", "   "])
+def test_staging_webhook_dry_run_rejects_blank_contributor_before_http(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    contributor: str,
+) -> None:
+    _set_required_dry_run_env(monkeypatch)
+    monkeypatch.setenv("MERGEWORK_DRY_RUN_REPO", "ramimbo/mergework")
+    monkeypatch.setenv("MERGEWORK_DRY_RUN_CONTRIBUTOR", contributor)
+    monkeypatch.setattr(
+        "scripts.staging_webhook_dry_run.httpx.post",
+        lambda *_args, **_kwargs: pytest.fail("dry run posted before contributor validation"),
+    )
+
+    assert main() == 1
+    assert "MERGEWORK_DRY_RUN_CONTRIBUTOR" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- validate `MERGEWORK_DRY_RUN_REPO` before the staging dry-run helper builds an issue URL or posts to staging
- reject blank or malformed repo slugs unless they are in `owner/name` form
- validate `MERGEWORK_DRY_RUN_CONTRIBUTOR` before building the webhook payload
- add regression tests proving invalid dry-run identity inputs fail before any HTTP request

Bounty #761: https://github.com/ramimbo/mergework/issues/761
Source issue #813: https://github.com/ramimbo/mergework/issues/813
Refs #761

## Validation

- `uv run --extra dev pytest tests/test_staging_webhook_dry_run.py -q` -> 13 passed
- `uv run --extra dev ruff format --check scripts/staging_webhook_dry_run.py tests/test_staging_webhook_dry_run.py` -> 2 files already formatted
- `uv run --extra dev ruff check scripts/staging_webhook_dry_run.py tests/test_staging_webhook_dry_run.py` -> All checks passed
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --extra dev mypy app` -> Success: no issues found in 39 source files
- `git diff --check` -> clean

Live duplicate/capacity check before PR:

- `gh issue view 813 -R ramimbo/mergework --json number,title,state,url,body,labels,updatedAt` -> #813 open, labeled `proposed-work`
- `gh pr list -R ramimbo/mergework --state open --search "813 OR staging webhook dry run OR MERGEWORK_DRY_RUN_REPO OR MERGEWORK_DRY_RUN_CONTRIBUTOR" --json number,title,author,url,headRefName,updatedAt,body` -> no staging dry-run identity duplicate PR found
- `curl -sS https://api.mrwk.online/api/v1/bounties?repo=ramimbo%2Fmergework` -> #761 open with 6 effective awards remaining

No wallet, payout, treasury execution, bridge, exchange, cash-out, price, secrets, private details, or issue automation changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved validation of staging dry-run configuration parameters with better error detection before processing requests.

* **Tests**
  * Added comprehensive test coverage for dry-run configuration validation and default value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->