### PR TITLE
Validate report/gate numeric CLI options (#809)

### DIFF
--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -11,6 +11,23 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
+
+def _positive_int(value: str) -> int:
+    """Argparse type that rejects --limit values below 1.
+
+    A non-positive limit silently changes result size via Python slice
+    semantics (e.g. ``[:0]`` returns nothing, ``[:-1]`` drops the last row),
+    producing a successful but misleading report instead of a clear error.
+    """
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(f"expected an integer, got {value!r}") from None
+    if parsed < 1:
+        raise argparse.ArgumentTypeError(f"must be >= 1, got {parsed}")
+    return parsed
+
+
 REQUIRED_TEMPLATE_SECTIONS = {
     "problem": ("problem", "current problem"),
     "evidence": ("evidence", "current evidence"),
@@ -470,7 +487,7 @@ def main(argv: list[str] | None = None) -> int:
     source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument("--input", type=Path, help="Offline JSON fixture with issues/payments")
     source.add_argument("--repo", help="GitHub repo for read-only gh live mode")
-    parser.add_argument("--limit", type=int, default=50)
+    parser.add_argument("--limit", type=_positive_int, default=50)
     parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
     parser.add_argument("--api-host", default=DEFAULT_API_HOST)
     args = parser.parse_args(argv)

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -17,6 +17,23 @@ if __package__ in {None, ""}:
 
 from scripts.bounty_refs import BOUNTY_REF_RE, GITHUB_LINKED_ISSUE_RE, LEADING_BOUNTY_REF_RE
 
+
+def _non_negative_int(value: str) -> int:
+    """Argparse type that rejects negative --max-maintainer-age-days values.
+
+    A negative threshold makes any maintainer activity look stale (the delta
+    always exceeds a negative window), so the gate emits a misleading
+    "stale activity" warning instead of flagging the invalid input.
+    """
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(f"expected an integer, got {value!r}") from None
+    if parsed < 0:
+        raise argparse.ArgumentTypeError(f"must be >= 0, got {parsed}")
+    return parsed
+
+
 EVIDENCE_RE = re.compile(
     r"\b(pytest|ruff|mypy|validation|verified|test evidence|checks? passed)\b",
     re.IGNORECASE,
@@ -157,6 +174,13 @@ def _maintainer_activity_check(
             "maintainer_activity",
             "warn",
             f"recent maintainer activity for bounty #{bounty_ref} could not be verified",
+        )
+    if max_age_days < 0:
+        return _check(
+            "maintainer_activity",
+            "warn",
+            f"invalid maintainer activity threshold for bounty #{bounty_ref}: "
+            f"max_maintainer_age_days must be >= 0, got {max_age_days}",
         )
     delta = now - last_activity
     age_days = max(0, int(delta.total_seconds() // 86400))
@@ -647,7 +671,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--api-host", default=DEFAULT_API_HOST)
     parser.add_argument(
         "--max-maintainer-age-days",
-        type=int,
+        type=_non_negative_int,
         default=DEFAULT_MAX_MAINTAINER_AGE_DAYS,
         help="Warn when the referenced bounty has no maintainer activity within this many days.",
     )

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -566,3 +566,28 @@ def test_run_gh_rejects_mutating_commands_before_subprocess(monkeypatch) -> None
             assert "only permits read-only gh commands" in str(exc)
         else:  # pragma: no cover - defensive assertion
             raise AssertionError(f"expected read-only guard for {args}")
+
+
+def test_proposed_work_triage_rejects_non_positive_limit(capsys) -> None:
+    """A --limit below 1 must fail loudly instead of slicing to a misleading size.
+
+    Regression for #809: `--limit 0`/`-1` previously returned status=ok with a
+    silently truncated issue list via Python slice semantics.
+    """
+    import pytest
+
+    for bad in ("0", "-1"):
+        with pytest.raises(SystemExit) as excinfo:
+            main(["--repo", "ramimbo/mergework", "--format", "json", "--limit", bad])
+        assert excinfo.value.code == 2
+        err = capsys.readouterr().err
+        assert "must be >= 1" in err
+
+
+def test_proposed_work_triage_rejects_non_integer_limit(capsys) -> None:
+    import pytest
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--repo", "ramimbo/mergework", "--format", "json", "--limit", "abc"])
+    assert excinfo.value.code == 2
+    assert "expected an integer" in capsys.readouterr().err

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -1104,3 +1104,35 @@ def test_submission_quality_gate_treats_incomplete_api_bounty_as_unverified(
         "status": "warn",
         "message": "referenced bounty #319 payability could not be verified",
     } in result["checks"]
+
+
+def test_maintainer_activity_check_rejects_negative_threshold() -> None:
+    """A negative max_maintainer_age_days must produce a clear invalid-threshold
+    warning, not a misleading stale-activity warning.
+
+    Regression for #809: a negative window made same-day maintainer activity
+    look stale because the time delta always exceeds a negative timedelta.
+    """
+    from datetime import UTC, datetime
+
+    from scripts.submission_quality_gate import _maintainer_activity_check
+
+    now = datetime(2026, 6, 2, 12, 0, 0, tzinfo=UTC)
+    bounty = {
+        "last_maintainer_activity_at": "2026-06-02T12:00:00Z",
+        "max_maintainer_age_days": -1,
+    }
+    result = _maintainer_activity_check(319, bounty, now)
+    assert result is not None
+    assert result["status"] == "warn"
+    assert "invalid maintainer activity threshold" in result["message"]
+    assert "must be >= 0" in result["message"]
+
+
+def test_quality_gate_cli_rejects_negative_max_maintainer_age_days(tmp_path, capsys) -> None:
+    fixture = tmp_path / "input.json"
+    fixture.write_text("{}", encoding="utf-8")
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--input", str(fixture), "--max-maintainer-age-days", "-1"])
+    assert excinfo.value.code == 2
+    assert "must be >= 0" in capsys.readouterr().err


### PR DESCRIPTION
Bounty #761

Add bounded numeric validation for report/gate options that affect result
size or stale-activity classification. Fixes the validation gap called out
in proposed-work #809.

## Problem

Two report/gate CLIs in this repo accept `type=int` numeric options whose
invalid values still produce successful but misleading reports:

* `scripts/proposed_work_triage.py --limit` uses Python slice semantics,
  so `--limit 0` returns an empty list and `--limit -1` returns everything
  except the newest issue.
* `scripts/submission_quality_gate.py --max-maintainer-age-days` accepts
  negative values; with a negative window the activity delta always
  exceeds the threshold, so the gate prints a stale-activity warning
  instead of flagging the invalid input.

## Fix

* `proposed_work_triage.py`: add a `_positive_int` argparse type and
  apply it to `--limit`. Non-integer input and values below 1 fail with
  a clear argparse error (`exit 2`).
* `submission_quality_gate.py`:
  * add a `_non_negative_int` argparse type for `--max-maintainer-age-days`;
  * `_maintainer_activity_check` now rejects `max_maintainer_age_days < 0`
    with a clear `invalid maintainer activity threshold` warning that
    names the bad value, instead of a misleading stale-activity warn.

## Tests

* `tests/test_proposed_work_triage.py`:
  * `test_proposed_work_triage_rejects_non_positive_limit` (0, -1)
  * `test_proposed_work_triage_rejects_non_integer_limit` ("abc")
* `tests/test_submission_quality_gate.py`:
  * `test_maintainer_activity_check_rejects_negative_threshold`
  * `test_quality_gate_cli_rejects_negative_max_maintainer_age_days`

## Validation

* 53 passed in targeted suites
  (`tests/test_proposed_work_triage.py` + `tests/test_submission_quality_gate.py`).
* `ruff check` + `ruff format --check` on the four touched files: All
  checks passed.
* Read-only change; no mutation, secrets, wallet, treasury, payout, or
  production write paths touched.

## Source

Proposed-work #809
Bounty #761

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added input validation for the `--limit` parameter to reject non-positive values with clear error messaging.
  * Added input validation for the `--max-maintainer-age-days` parameter to reject negative values with explicit error messaging.

* **Tests**
  * Added regression tests for CLI argument validation to ensure invalid inputs are properly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->