### PR TITLE
Add pending create-bounty comment helper

### DIFF
--- a/app/github_issue_finalization.py
+++ b/app/github_issue_finalization.py
@@ -22,6 +22,7 @@ STALE_PENDING_BOUNTY_STATUS_TEXT = (
     "Status: proposed bounty. This issue is not claimable yet.",
 )
 PAID_BOUNTY_FINALIZATION_COMMENT_MARKER = "<!-- mergework:mrwk:paid-bounty-finalized -->"
+DEFAULT_PUBLIC_API_BASE_URL = "https://api.mrwk.online"
 
 
 def _github_request(
@@ -128,6 +129,30 @@ def _github_issue_api_base(repo: str, issue_number: int) -> str:
     owner = quote(owner_part, safe="")
     name = quote(name_part, safe="")
     return f"https://api.github.com/repos/{owner}/{name}/issues/{issue_number}"
+
+
+def pending_create_bounty_comment_body(
+    proposal: dict[str, Any], *, api_base_url: str = DEFAULT_PUBLIC_API_BASE_URL
+) -> str:
+    if str(proposal.get("action") or "") != "create_bounty":
+        raise ValueError("pending bounty comment requires a create_bounty proposal")
+    if str(proposal.get("status") or "") != "pending":
+        raise ValueError("pending bounty comment requires a pending proposal")
+    proposal_id = int(str(proposal.get("id") or "0"))
+    if proposal_id <= 0:
+        raise ValueError("pending bounty comment requires a positive proposal id")
+    executes_after = str(proposal.get("executes_after") or "").strip()
+    if not executes_after:
+        raise ValueError("pending bounty comment requires executes_after")
+    proposal_url = f"{api_base_url.rstrip('/')}/api/v1/treasury/proposals/{proposal_id}"
+    return (
+        "Status: pending `create_bounty` proposal. This issue is not claimable yet.\n\n"
+        f"Proposal: {proposal_url}\n"
+        f"Earliest execution: {executes_after}\n\n"
+        "Wait until proposal execution creates the public bounty row and finalizes this "
+        "GitHub issue with `mrwk:bounty` and the claims-open comment before treating this "
+        "as live bounty work."
+    )
 
 
 def _has_label(issue: dict[str, Any], label: str) -> bool:

--- a/app/github_issue_finalization.py
+++ b/app/github_issue_finalization.py
@@ -138,7 +138,10 @@ def pending_create_bounty_comment_body(
         raise ValueError("pending bounty comment requires a create_bounty proposal")
     if str(proposal.get("status") or "") != "pending":
         raise ValueError("pending bounty comment requires a pending proposal")
-    proposal_id = int(str(proposal.get("id") or "0"))
+    try:
+        proposal_id = int(str(proposal.get("id") or "0"))
+    except ValueError:
+        raise ValueError("pending bounty comment requires a positive proposal id") from None
     if proposal_id <= 0:
         raise ValueError("pending bounty comment requires a positive proposal id")
     executes_after = str(proposal.get("executes_after") or "").strip()

--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -48,6 +48,26 @@ curl -s "https://api.mrwk.online/api/v1/treasury/proposals?status=pending&action
 curl -s https://api.mrwk.online/api/v1/treasury/proposals/<proposal_id>
 ```
 
+When posting a GitHub comment for a pending `create_bounty` proposal, include
+the public proposal URL and the earliest execution timestamp. Use the
+`pending_create_bounty_comment_body()` helper from
+`app.github_issue_finalization` or this equivalent shape:
+
+```text
+Status: pending `create_bounty` proposal. This issue is not claimable yet.
+
+Proposal: https://api.mrwk.online/api/v1/treasury/proposals/<proposal_id>
+Earliest execution: <executes_after UTC>
+
+Wait until proposal execution creates the public bounty row and finalizes this
+GitHub issue with `mrwk:bounty` and the claims-open comment before treating this
+as live bounty work.
+```
+
+This is separate from the post-execution claims-open finalization comment. Do
+not add `mrwk:bounty`, post `Reserved on MergeWork:`, or imply claims are open
+while the proposal is still pending.
+
 Use the filtered proposal list to reconcile pending payouts for one recipient
 without mixing unrelated `pay_bounty` proposals from busy review rounds.
 

--- a/tests/test_github_issue_finalization.py
+++ b/tests/test_github_issue_finalization.py
@@ -5,6 +5,8 @@ from typing import Any
 from urllib.error import HTTPError
 from urllib.request import Request
 
+import pytest
+
 from app.github_issue_finalization import (
     LIVE_BOUNTY_STATUS_BLOCK_END,
     LIVE_BOUNTY_STATUS_BLOCK_START,
@@ -45,6 +47,31 @@ def test_pending_create_bounty_comment_includes_execution_time_without_open_clai
     assert "claims-open comment" in body
     assert "Reserved on MergeWork:" not in body
     assert "Claims are now open" not in body
+
+
+@pytest.mark.parametrize(
+    ("proposal_update", "expected_message"),
+    (
+        ({"id": "abc"}, "pending bounty comment requires a positive proposal id"),
+        ({"id": -1}, "pending bounty comment requires a positive proposal id"),
+        ({"executes_after": ""}, "pending bounty comment requires executes_after"),
+        ({"action": "pay_claim"}, "pending bounty comment requires a create_bounty proposal"),
+        ({"status": "executed"}, "pending bounty comment requires a pending proposal"),
+    ),
+)
+def test_pending_create_bounty_comment_rejects_invalid_proposals(
+    proposal_update: dict[str, object], expected_message: str
+) -> None:
+    proposal = {
+        "id": 125,
+        "action": "create_bounty",
+        "status": "pending",
+        "executes_after": "2026-06-03T11:41:52Z",
+    }
+    proposal.update(proposal_update)
+
+    with pytest.raises(ValueError, match=expected_message):
+        pending_create_bounty_comment_body(proposal)
 
 
 def test_finalize_created_bounty_issue_adds_label_and_claims_open_comment() -> None:

--- a/tests/test_github_issue_finalization.py
+++ b/tests/test_github_issue_finalization.py
@@ -10,6 +10,7 @@ from app.github_issue_finalization import (
     LIVE_BOUNTY_STATUS_BLOCK_START,
     finalize_created_bounty_issue,
     finalize_paid_bounty_issue,
+    pending_create_bounty_comment_body,
 )
 
 
@@ -25,6 +26,25 @@ class _FakeResponse:
 
     def read(self) -> bytes:
         return json.dumps(self._body).encode()
+
+
+def test_pending_create_bounty_comment_includes_execution_time_without_open_claims() -> None:
+    body = pending_create_bounty_comment_body(
+        {
+            "id": 125,
+            "action": "create_bounty",
+            "status": "pending",
+            "executes_after": "2026-06-03T11:41:52Z",
+        }
+    )
+
+    assert "Status: pending `create_bounty` proposal. This issue is not claimable yet." in body
+    assert "Proposal: https://api.mrwk.online/api/v1/treasury/proposals/125" in body
+    assert "Earliest execution: 2026-06-03T11:41:52Z" in body
+    assert "`mrwk:bounty`" in body
+    assert "claims-open comment" in body
+    assert "Reserved on MergeWork:" not in body
+    assert "Claims are now open" not in body
 
 
 def test_finalize_created_bounty_issue_adds_label_and_claims_open_comment() -> None:


### PR DESCRIPTION
Bounty #761
Source issue: #804

## Summary
- add `pending_create_bounty_comment_body()` for pending `create_bounty` GitHub comments
- include the public proposal URL and `executes_after` timestamp
- document the copy block in the admin runbook while keeping it distinct from claims-open finalization

## Evidence
#804 showed newer pending create-bounty comments could omit the proposal execution timestamp even though the public proposal API exposes it.

## Verification
- `/tmp/mergework-py312-venv/bin/python -m pytest tests/test_github_issue_finalization.py tests/test_docs_public_urls.py`
- `/tmp/mergework-py312-venv/bin/python scripts/docs_smoke.py`
- `/tmp/mergework-py312-venv/bin/python -m ruff check app/github_issue_finalization.py tests/test_github_issue_finalization.py`
- `/tmp/mergework-py312-venv/bin/python -m ruff format --check app/github_issue_finalization.py tests/test_github_issue_finalization.py`
- `git diff --check`

No bounty creation, claim acceptance, treasury execution, wallet, bridge, exchange, off-ramp, cash-out, price, private data, or secret behavior is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generate GitHub comment bodies for pending bounty proposals that include a public treasury proposal URL and the earliest execution timestamp, with input validation.

* **Documentation**
  * Runbook instructions for posting GitHub comments on pending bounty treasury proposals, specifying required content and what to omit.

* **Tests**
  * Added unit tests covering comment generation, content expectations, and validation error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->