### PR TITLE
Reject empty submission quality source arguments

### DIFF
--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -619,6 +619,12 @@ def _load_input(path: str) -> dict[str, Any]:
     return data
 
 
+def _require_non_empty_path(parser: argparse.ArgumentParser, option_name: str, value: str) -> str:
+    if not value.strip():
+        parser.error(f"{option_name} must be a non-empty path")
+    return value
+
+
 def format_text(result: dict[str, Any]) -> str:
     lines = [f"Submission quality gate: {result['status'].upper()}"]
     if result.get("load_warning"):
@@ -654,10 +660,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--format", choices=["json", "text"], default="text")
     args = parser.parse_args(argv)
 
-    if args.input:
-        data = _load_input(args.input)
+    if args.input is not None:
+        data = _load_input(_require_non_empty_path(parser, "--input", args.input))
     else:
-        with open(args.text_file, encoding="utf-8") as handle:
+        text_file = _require_non_empty_path(parser, "--text-file", args.text_file)
+        with open(text_file, encoding="utf-8") as handle:
             data = _load_live_context(
                 args.repo,
                 handle.read(),

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -645,6 +645,30 @@ def test_submission_quality_gate_cli_returns_failure_exit(capsys, tmp_path) -> N
     assert json.loads(capsys.readouterr().out)["status"] == "fail"
 
 
+@pytest.mark.parametrize(
+    ("source_args", "expected_message"),
+    (
+        (["--input", ""], "--input must be a non-empty path"),
+        (["--input", "   "], "--input must be a non-empty path"),
+        (["--text-file", ""], "--text-file must be a non-empty path"),
+        (["--text-file", "   "], "--text-file must be a non-empty path"),
+    ),
+)
+def test_submission_quality_gate_rejects_empty_source_paths(
+    source_args: list[str],
+    expected_message: str,
+    capsys,
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main([*source_args, "--format", "json"])
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert expected_message in captured.err
+    assert "Traceback" not in captured.err
+    assert captured.out == ""
+
+
 def test_submission_quality_gate_live_mode_warns_when_github_unavailable(
     monkeypatch, capsys, tmp_path
 ) -> None:


### PR DESCRIPTION
Bounty #761
Source issue: #805

## Summary
- reject empty or whitespace-only `--input` values before loading fixture data
- reject empty or whitespace-only `--text-file` values before live-context collection
- choose source mode by explicit argument presence instead of truthiness

## Evidence
#805 reproduced raw `TypeError` / `FileNotFoundError` tracebacks for empty submission quality gate source arguments on current public code.

## Verification
- `/tmp/mergework-py312-venv/bin/python -m pytest tests/test_submission_quality_gate.py`
- `/tmp/mergework-py312-venv/bin/python scripts/docs_smoke.py`
- `/tmp/mergework-py312-venv/bin/python -m ruff check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py`
- `/tmp/mergework-py312-venv/bin/python -m ruff format --check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py`
- `git diff --check`

No automatic PR review, claim submission, label, acceptance, payment, treasury, wallet, private data, secret, bridge, exchange, off-ramp, cash-out, or price behavior is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation to reject empty or whitespace-only values with appropriate error messages.

* **Tests**
  * Added comprehensive test coverage for input validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->