### PR TITLE
Validate report script source arguments

### DIFF
--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -661,6 +661,12 @@ def _load_input(path: str) -> dict[str, Any]:
     return data
 
 
+def _require_non_empty_arg(parser: argparse.ArgumentParser, option_name: str, value: str) -> str:
+    if not value.strip():
+        parser.error(f"{option_name} must be a non-empty value")
+    return value
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Inventory public MergeWork claim surfaces and payout status."
@@ -672,7 +678,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--format", choices=["json", "markdown"], default="markdown")
     args = parser.parse_args(argv)
 
-    data = _load_input(args.input) if args.input else load_live_inventory(args.repo, args.api_host)
+    if args.input is not None:
+        data = _load_input(_require_non_empty_arg(parser, "--input", args.input))
+    else:
+        repo = _require_non_empty_arg(parser, "--repo", args.repo)
+        data = load_live_inventory(repo, args.api_host)
     report = analyze_inventory(data, api_host=args.api_host)
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -662,8 +662,11 @@ def _load_input(path: str) -> dict[str, Any]:
 
 
 def _require_non_empty_arg(parser: argparse.ArgumentParser, option_name: str, value: str) -> str:
-    if not value.strip():
+    stripped = value.strip()
+    if not stripped:
         parser.error(f"{option_name} must be a non-empty value")
+    if stripped != value:
+        parser.error(f"{option_name} must not include leading or trailing whitespace")
     return value
 
 

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -443,8 +443,11 @@ def _load_input(path: str) -> dict[str, Any]:
 
 
 def _require_non_empty_arg(parser: argparse.ArgumentParser, option_name: str, value: str) -> str:
-    if not value.strip():
+    stripped = value.strip()
+    if not stripped:
         parser.error(f"{option_name} must be a non-empty value")
+    if stripped != value:
+        parser.error(f"{option_name} must not include leading or trailing whitespace")
     return value
 
 

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -442,6 +442,12 @@ def _load_input(path: str) -> dict[str, Any]:
     return data
 
 
+def _require_non_empty_arg(parser: argparse.ArgumentParser, option_name: str, value: str) -> str:
+    if not value.strip():
+        parser.error(f"{option_name} must be a non-empty value")
+    return value
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Summarize MergeWork open PR queue health.")
     source = parser.add_mutually_exclusive_group(required=True)
@@ -454,7 +460,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--fail-on-issues", action="store_true")
     args = parser.parse_args(argv)
 
-    data = _load_input(args.input) if args.input else load_live_queue(args.repo)
+    if args.input is not None:
+        data = _load_input(_require_non_empty_arg(parser, "--input", args.input))
+    else:
+        data = load_live_queue(_require_non_empty_arg(parser, "--repo", args.repo))
     report = analyze_queue(data)
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -511,10 +511,16 @@ def load_live_issues(
     }
 
 
+def _require_non_empty_arg(parser: argparse.ArgumentParser, option_name: str, value: str) -> str:
+    if not value.strip():
+        parser.error(f"{option_name} must be a non-empty value")
+    return value
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Read-only proposed-work intake triage report")
     source = parser.add_mutually_exclusive_group(required=True)
-    source.add_argument("--input", type=Path, help="Offline JSON fixture with issues/payments")
+    source.add_argument("--input", help="Offline JSON fixture with issues/payments")
     source.add_argument("--repo", help="GitHub repo for read-only gh live mode")
     parser.add_argument("--limit", type=_positive_int, default=50)
     parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
@@ -530,21 +536,21 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     args = parser.parse_args(argv)
-    if args.input and args.payment_bounty_issue:
-        parser.error("--payment-bounty-issue is only valid in live --repo mode")
-
-    data = (
-        json.loads(args.input.read_text(encoding="utf-8"))
-        if args.input
-        else load_live_issues(
-            args.repo,
+    if args.input is not None:
+        if args.payment_bounty_issue:
+            parser.error("--payment-bounty-issue is only valid in live --repo mode")
+        input_path = Path(_require_non_empty_arg(parser, "--input", args.input))
+        data = json.loads(input_path.read_text(encoding="utf-8"))
+    else:
+        repo = _require_non_empty_arg(parser, "--repo", args.repo)
+        data = load_live_issues(
+            repo,
             args.limit,
             api_host=args.api_host,
             payment_bounty_issue_numbers=(
                 args.payment_bounty_issue or list(DEFAULT_PAYMENT_BOUNTY_ISSUE_NUMBERS)
             ),
         )
-    )
     report = analyze_proposed_work(data)
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -512,8 +512,11 @@ def load_live_issues(
 
 
 def _require_non_empty_arg(parser: argparse.ArgumentParser, option_name: str, value: str) -> str:
-    if not value.strip():
+    stripped = value.strip()
+    if not stripped:
         parser.error(f"{option_name} must be a non-empty value")
+    if stripped != value:
+        parser.error(f"{option_name} must not include leading or trailing whitespace")
     return value
 
 

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -520,6 +520,13 @@ def _require_non_empty_arg(parser: argparse.ArgumentParser, option_name: str, va
     return value
 
 
+def _load_input(path: str) -> dict[str, Any]:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("proposed-work input must be a JSON object")
+    return data
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Read-only proposed-work intake triage report")
     source = parser.add_mutually_exclusive_group(required=True)
@@ -542,8 +549,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.input is not None:
         if args.payment_bounty_issue:
             parser.error("--payment-bounty-issue is only valid in live --repo mode")
-        input_path = Path(_require_non_empty_arg(parser, "--input", args.input))
-        data = json.loads(input_path.read_text(encoding="utf-8"))
+        data = _load_input(_require_non_empty_arg(parser, "--input", args.input))
     else:
         repo = _require_non_empty_arg(parser, "--repo", args.repo)
         data = load_live_issues(

--- a/tests/test_claim_inventory.py
+++ b/tests/test_claim_inventory.py
@@ -293,7 +293,10 @@ def test_claim_inventory_classifies_required_statuses(tmp_path, capsys) -> None:
     (
         (["--input", ""], "--input must be a non-empty value"),
         (["--input", "   "], "--input must be a non-empty value"),
+        (["--input", " tests/fixtures/missing.json "], "--input must not include"),
+        (["--repo", ""], "--repo must be a non-empty value"),
         (["--repo", "   "], "--repo must be a non-empty value"),
+        (["--repo", " ramimbo/mergework "], "--repo must not include"),
     ),
 )
 def test_claim_inventory_rejects_empty_source_args(

--- a/tests/test_claim_inventory.py
+++ b/tests/test_claim_inventory.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts import claim_inventory
 from scripts.claim_inventory import analyze_inventory, format_markdown_report, main
 
@@ -284,6 +286,29 @@ def test_claim_inventory_classifies_required_statuses(tmp_path, capsys) -> None:
     assert main(["--input", str(input_path), "--format", "json"]) == 0
     output = json.loads(capsys.readouterr().out)
     assert output["summary"]["already_paid"] == 3
+
+
+@pytest.mark.parametrize(
+    ("source_args", "expected_message"),
+    (
+        (["--input", ""], "--input must be a non-empty value"),
+        (["--input", "   "], "--input must be a non-empty value"),
+        (["--repo", "   "], "--repo must be a non-empty value"),
+    ),
+)
+def test_claim_inventory_rejects_empty_source_args(
+    source_args: list[str],
+    expected_message: str,
+    capsys,
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main([*source_args, "--format", "json"])
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert expected_message in captured.err
+    assert "Traceback" not in captured.err
+    assert captured.out == ""
 
 
 def test_claim_inventory_markdown_report_is_pasteable() -> None:

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -104,6 +104,29 @@ def test_pr_queue_health_script_entrypoint_loads_shared_parser() -> None:
     assert "usage:" in result.stdout
 
 
+@pytest.mark.parametrize(
+    ("source_args", "expected_message"),
+    (
+        (["--input", ""], "--input must be a non-empty value"),
+        (["--input", "   "], "--input must be a non-empty value"),
+        (["--repo", "   "], "--repo must be a non-empty value"),
+    ),
+)
+def test_pr_queue_health_rejects_empty_source_args(
+    source_args: list[str],
+    expected_message: str,
+    capsys,
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main([*source_args, "--format", "json"])
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert expected_message in captured.err
+    assert "Traceback" not in captured.err
+    assert captured.out == ""
+
+
 def test_pr_queue_health_text_report_is_pasteable() -> None:
     report = analyze_queue(
         {

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -109,7 +109,10 @@ def test_pr_queue_health_script_entrypoint_loads_shared_parser() -> None:
     (
         (["--input", ""], "--input must be a non-empty value"),
         (["--input", "   "], "--input must be a non-empty value"),
+        (["--input", " tests/fixtures/missing.json "], "--input must not include"),
+        (["--repo", ""], "--repo must be a non-empty value"),
         (["--repo", "   "], "--repo must be a non-empty value"),
+        (["--repo", " ramimbo/mergework "], "--repo must not include"),
     ),
 )
 def test_pr_queue_health_rejects_empty_source_args(

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -403,6 +403,29 @@ def test_proposed_work_triage_rejects_payment_bounty_issue_in_offline_mode(
     assert "--payment-bounty-issue is only valid in live --repo mode" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize(
+    ("source_args", "expected_message"),
+    (
+        (["--input", ""], "--input must be a non-empty value"),
+        (["--input", "   "], "--input must be a non-empty value"),
+        (["--repo", "   "], "--repo must be a non-empty value"),
+    ),
+)
+def test_proposed_work_triage_rejects_empty_source_args(
+    source_args: list[str],
+    expected_message: str,
+    capsys,
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main([*source_args, "--format", "json"])
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert expected_message in captured.err
+    assert "Traceback" not in captured.err
+    assert captured.out == ""
+
+
 def test_proposed_work_triage_live_mode_uses_read_only_gh(monkeypatch, capsys) -> None:
     calls: list[list[str]] = []
 

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -390,6 +390,14 @@ def test_proposed_work_triage_markdown_and_json_cli(tmp_path, capsys) -> None:
     assert "#672 Read-only proposed-work intake triage report" in markdown
 
 
+def test_proposed_work_triage_rejects_non_object_offline_fixture(tmp_path) -> None:
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps([]), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="proposed-work input must be a JSON object"):
+        main(["--input", str(fixture), "--format", "json"])
+
+
 def test_proposed_work_triage_rejects_payment_bounty_issue_in_offline_mode(
     tmp_path, capsys
 ) -> None:

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -408,7 +408,10 @@ def test_proposed_work_triage_rejects_payment_bounty_issue_in_offline_mode(
     (
         (["--input", ""], "--input must be a non-empty value"),
         (["--input", "   "], "--input must be a non-empty value"),
+        (["--input", " tests/fixtures/missing.json "], "--input must not include"),
+        (["--repo", ""], "--repo must be a non-empty value"),
         (["--repo", "   "], "--repo must be a non-empty value"),
+        (["--repo", " ramimbo/mergework "], "--repo must not include"),
     ),
 )
 def test_proposed_work_triage_rejects_empty_source_args(
@@ -768,8 +771,6 @@ def test_proposed_work_triage_rejects_non_positive_limit(capsys) -> None:
     Regression for #809: `--limit 0`/`-1` previously returned status=ok with a
     silently truncated issue list via Python slice semantics.
     """
-    import pytest
-
     for bad in ("0", "-1"):
         with pytest.raises(SystemExit) as excinfo:
             main(["--repo", "ramimbo/mergework", "--format", "json", "--limit", bad])
@@ -779,8 +780,6 @@ def test_proposed_work_triage_rejects_non_positive_limit(capsys) -> None:
 
 
 def test_proposed_work_triage_rejects_non_integer_limit(capsys) -> None:
-    import pytest
-
     with pytest.raises(SystemExit) as excinfo:
         main(["--repo", "ramimbo/mergework", "--format", "json", "--limit", "abc"])
     assert excinfo.value.code == 2


### PR DESCRIPTION
Bounty #761
Source issue: #807

## Summary
- reject empty or whitespace-only `--input` / `--repo` source values in proposed-work triage, claim inventory, and PR queue health
- choose fixture/live source mode by explicit argument presence instead of truthiness
- add focused regression tests for each script

## Evidence
#807 reproduced raw tracebacks or malformed `gh` invocations for empty source arguments across the remaining report helpers.

## Verification
- `/tmp/mergework-py312-venv/bin/python -m pytest tests/test_proposed_work_triage.py tests/test_claim_inventory.py tests/test_pr_queue_health.py`
- `/tmp/mergework-py312-venv/bin/python scripts/docs_smoke.py`
- `/tmp/mergework-py312-venv/bin/python -m ruff check scripts/proposed_work_triage.py scripts/claim_inventory.py scripts/pr_queue_health.py tests/test_proposed_work_triage.py tests/test_claim_inventory.py tests/test_pr_queue_health.py`
- `/tmp/mergework-py312-venv/bin/python -m ruff format --check scripts/proposed_work_triage.py scripts/claim_inventory.py scripts/pr_queue_health.py tests/test_proposed_work_triage.py tests/test_claim_inventory.py tests/test_pr_queue_health.py`
- `git diff --check`

No changes to review candidate or submission quality source validation, no report scoring rewrite, no GitHub mutation, treasury, payout, wallet, private data, secret, bridge, exchange, off-ramp, cash-out, or price behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI now rejects empty, whitespace-only, or values with leading/trailing whitespace for input and repository options, returning a clear parse error and non-zero exit instead of silently proceeding.
  * Offline fixture input is validated as JSON object; non-object fixtures now raise an error.

* **Tests**
  * Added parameterized tests asserting argument/fixture validation triggers the expected error (exit code 2 or ValueError), emits no traceback, and produces no stdout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->