### PR TITLE
Validate review candidate source arguments

### DIFF
--- a/scripts/review_bounty_candidates.py
+++ b/scripts/review_bounty_candidates.py
@@ -342,8 +342,11 @@ def _load_input(path: str) -> dict[str, Any]:
 
 
 def _require_non_empty_arg(parser: argparse.ArgumentParser, option_name: str, value: str) -> str:
-    if not value.strip():
+    stripped = value.strip()
+    if not stripped:
         parser.error(f"{option_name} must be a non-empty value")
+    if stripped != value:
+        parser.error(f"{option_name} must not include leading or trailing whitespace")
     return value
 
 

--- a/scripts/review_bounty_candidates.py
+++ b/scripts/review_bounty_candidates.py
@@ -341,6 +341,12 @@ def _load_input(path: str) -> dict[str, Any]:
     return data
 
 
+def _require_non_empty_arg(parser: argparse.ArgumentParser, option_name: str, value: str) -> str:
+    if not value.strip():
+        parser.error(f"{option_name} must be a non-empty value")
+    return value
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Rank open PRs for reviewer-specific review-bounty work."
@@ -353,7 +359,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--format", choices=["json", "markdown", "text"], default="text")
     args = parser.parse_args(argv)
 
-    data = _load_input(args.input) if args.input else load_live_candidates(args.repo)
+    if args.input is not None:
+        data = _load_input(_require_non_empty_arg(parser, "--input", args.input))
+    else:
+        data = load_live_candidates(_require_non_empty_arg(parser, "--repo", args.repo))
     report = analyze_candidates(
         data,
         reviewer=args.reviewer,

--- a/tests/test_review_bounty_candidates.py
+++ b/tests/test_review_bounty_candidates.py
@@ -165,8 +165,10 @@ def test_review_bounty_candidates_classifies_review_states(tmp_path, capsys) -> 
     (
         (["--input", ""], "--input must be a non-empty value"),
         (["--input", "   "], "--input must be a non-empty value"),
+        (["--input", " tests/fixtures/missing.json "], "--input must not include"),
         (["--repo", ""], "--repo must be a non-empty value"),
         (["--repo", "   "], "--repo must be a non-empty value"),
+        (["--repo", " ramimbo/mergework "], "--repo must not include"),
     ),
 )
 def test_review_bounty_candidates_rejects_empty_source_args(

--- a/tests/test_review_bounty_candidates.py
+++ b/tests/test_review_bounty_candidates.py
@@ -160,6 +160,30 @@ def test_review_bounty_candidates_classifies_review_states(tmp_path, capsys) -> 
     assert output["summary"]["pull_requests"] == 9
 
 
+@pytest.mark.parametrize(
+    ("source_args", "expected_message"),
+    (
+        (["--input", ""], "--input must be a non-empty value"),
+        (["--input", "   "], "--input must be a non-empty value"),
+        (["--repo", ""], "--repo must be a non-empty value"),
+        (["--repo", "   "], "--repo must be a non-empty value"),
+    ),
+)
+def test_review_bounty_candidates_rejects_empty_source_args(
+    source_args: list[str],
+    expected_message: str,
+    capsys,
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main([*source_args, "--reviewer", "reviewer", "--format", "json"])
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert expected_message in captured.err
+    assert "Traceback" not in captured.err
+    assert captured.out == ""
+
+
 def test_review_bounty_candidates_ignores_author_and_bot_reviews() -> None:
     report = analyze_candidates(
         {


### PR DESCRIPTION
Bounty #761
Source issue: #801

## Summary
- reject empty or whitespace-only `--input` values before fixture loading
- reject empty or whitespace-only `--repo` values before `gh` collection
- choose fixture/live mode by explicit source argument presence instead of truthiness

## Evidence
#801 reproduced a raw traceback when `scripts/review_bounty_candidates.py --input ""` satisfied argparse but fell through to live mode with `repo=None`.

## Verification
- `/tmp/mergework-py312-venv/bin/python -m pytest tests/test_review_bounty_candidates.py`
- `/tmp/mergework-py312-venv/bin/python scripts/docs_smoke.py`
- `/tmp/mergework-py312-venv/bin/python -m ruff check scripts/review_bounty_candidates.py tests/test_review_bounty_candidates.py`
- `/tmp/mergework-py312-venv/bin/python -m ruff format --check scripts/review_bounty_candidates.py tests/test_review_bounty_candidates.py`
- `git diff --check`

No automatic reviews, claim submission, label changes, acceptance decisions, payments, treasury actions, wallet behavior, private data, secrets, bridge, exchange, off-ramp, cash-out, or price behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI validation so empty or whitespace-only values for input/source options are rejected with a clear error and non-zero exit before processing.

* **Tests**
  * Added test coverage that asserts invalid empty/whitespace CLI arguments produce the expected error message, no traceback, and the correct exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->