### PR TITLE
Reject ambiguous admin webhook event query params

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -251,6 +251,8 @@ def register_bounty_api_routes(
     ) -> list[dict[str, Any]]:
         del admin_login
         reject_repeated_query_param(request, "status")
+        reject_repeated_query_param(request, "limit")
+        reject_noncanonical_int_query_param(request, "limit")
         with session_scope(db_url) as session:
             try:
                 return webhook_events_to_dict(list_webhook_events(session, status, limit))

--- a/tests/test_bounty_api.py
+++ b/tests/test_bounty_api.py
@@ -122,6 +122,37 @@ def test_admin_webhook_events_api_rejects_c1_control_status(monkeypatch):
     assert resp.json()["detail"] == "webhook_status must not contain control characters"
 
 
+def test_admin_webhook_events_api_rejects_ambiguous_scalar_query_params(monkeypatch):
+    monkeypatch.setenv("MERGEWORK_ADMIN_TOKEN", "admin-token-for-tests")
+    client = TestClient(create_app(webhook_secret="secret"))
+    headers = {"x-mergework-admin-token": "admin-token-for-tests"}
+
+    repeated_status = client.get(
+        "/api/v1/admin/webhook-events?status=paid&status=missing_submitter",
+        headers=headers,
+    )
+    repeated_limit = client.get(
+        "/api/v1/admin/webhook-events?limit=1&limit=2",
+        headers=headers,
+    )
+    padded_limit = client.get(
+        "/api/v1/admin/webhook-events?limit=01",
+        headers=headers,
+    )
+    clean_filter = client.get(
+        "/api/v1/admin/webhook-events?status=missing_submitter&limit=1",
+        headers=headers,
+    )
+
+    assert repeated_status.status_code == 400
+    assert repeated_status.json()["detail"] == "status must be provided at most once"
+    assert repeated_limit.status_code == 400
+    assert repeated_limit.json()["detail"] == "limit must be provided at most once"
+    assert padded_limit.status_code == 400
+    assert padded_limit.json()["detail"] == "limit must be a canonical positive integer"
+    assert clean_filter.status_code == 200
+
+
 class TestBountyCloseRoute:
     """Bounty close requires admin token."""
 


### PR DESCRIPTION
## Summary

Tightens `/api/v1/admin/webhook-events` query parsing so it fails closed for the same ambiguous scalar inputs already rejected by nearby API routes.

Fixes the verified report for #656.

## Changes

- Reject repeated `status` query parameters.
- Reject repeated `limit` query parameters.
- Reject non-canonical integer spellings for `limit`, such as `01`.
- Preserve the existing clean admin webhook event filter path.

## Validation

```text
.\\.venv\\Scripts\\python.exe -m pytest tests\\test_bounty_api.py -q
19 passed, 1 warning

.\\.venv\\Scripts\\python.exe -m ruff format --check app tests
85 files already formatted

.\\.venv\\Scripts\\python.exe -m ruff check app tests
All checks passed!

git diff --check
passed
```

## Bounty

This is a fix for the report submitted under `MRWK bounty: 75 MRWK - live verification and bug reports, round 1`.

Reference: #656


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook events API now rejects duplicate scalar query parameters and enforces canonical integer formatting for the limit parameter, returning clear validation errors.
* **Tests**
  * Added a test verifying ambiguous or non-canonical query parameters produce 400 responses and that a canonical request succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->