### PR TITLE
Clarify bounty attempt coordination on detail pages

### DIFF
--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -71,6 +71,7 @@
     <ol>
       <li>Confirm the source issue is still open and your change is not already covered by another PR.</li>
       <li>Keep the PR focused, link the source issue as <strong>Bounty #{{ bounty.issue_number }}</strong>, and include test or smoke-check evidence.</li>
+      <li>Check active attempt reservations if you need to coordinate before opening a PR; attempts are advisory only and do not reserve MRWK, acceptance, or payment.</li>
       <li>
         {% if bounty.effective_awards_remaining %}
           {% if bounty.effective_awards_remaining == bounty.awards_remaining %}
@@ -88,6 +89,7 @@
     <div class="next-steps-actions" aria-label="Bounty action links">
       {% if issue_url %}<a href="{{ issue_url }}" rel="nofollow noopener">Open source issue</a>{% endif %}
       <a href="/api/v1/bounties/{{ bounty.id }}">View JSON details</a>
+      <a href="/api/v1/bounties/{{ bounty.id }}/attempts">Check active attempts</a>
     </div>
   </section>
 </section>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -690,12 +690,17 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert "Confirm the source issue is still open" in response.text
     assert bounty.id != bounty.issue_number
     assert "link the source issue as <strong>Bounty #4</strong>" in response.text
+    assert (
+        "attempts are advisory only and do not reserve MRWK, acceptance, or payment"
+        in response.text
+    )
     assert "1 award still open for distinct accepted work." in response.text
     assert (
         'href="https://github.com/ramimbo/mergework/issues/4" rel="nofollow noopener"'
         in response.text
     )
     assert f'href="/api/v1/bounties/{bounty.id}"' in response.text
+    assert f'href="/api/v1/bounties/{bounty.id}/attempts"' in response.text
 
     missing_response = client.get("/api/v1/bounties/999")
     assert missing_response.status_code == 404


### PR DESCRIPTION
## Summary
- Adds a "Check active attempts" action to public bounty detail pages.
- Adds contributor guidance that attempt reservations are advisory only and do not reserve MRWK, acceptance, or payment.
- Keeps the existing source issue and JSON detail links intact while making overlap checks easier before contributors open a PR.

## Linked bounty
Bounty #777

## User-facing confusion fixed
Contributors can now check active attempt reservations from the detail page before starting work, while the page explicitly avoids implying that attempts reserve payout, acceptance, or claim priority.

## Tests
- `uv run --extra dev python -m pytest tests/test_bounty_pages.py::test_bounty_detail_highlights_action_fields tests/test_bounty_attempts.py -q`
- `uv run --extra dev python -m pytest tests/test_bounty_pages.py tests/test_bounty_attempts.py -q`
- `uv run --extra dev python scripts/docs_smoke.py`
- `uv run --extra dev ruff check tests/test_bounty_pages.py`
- `uv run --extra dev ruff format --check tests/test_bounty_pages.py`
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## Out of scope
No payout, treasury, wallet, exchange, bridge, admin, pricing, or private-data behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a checklist reminder for users to review active attempt reservations for coordination
  * Clarified that attempts are advisory and do not reserve payment or acceptance
  * Added a link to view active attempts on bounty detail pages

* **Tests**
  * Updated test coverage for new attempts UI elements and guidance messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->