### PR TITLE
Reject control-padded MCP work-proof format

### DIFF
--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -97,6 +97,8 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             return "text"
         if not isinstance(value, str):
             raise ValueError("format must be a string")
+        if contains_control_character(value):
+            raise ValueError("format must not contain control characters")
         normalized = value.strip().lower()
         if normalized not in {"text", "json"}:
             raise ValueError("format must be text or json")

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1821,6 +1821,7 @@ def test_mcp_submit_work_proof_scopes_issue_number_by_repo(sqlite_url: str) -> N
         ({"bounty_id": 1, "issue_number": 1}, 25),
         ({"format": "xml"}, 26),
         ({"format": 1}, 27),
+        ({"format": "\x85json"}, 28),
         ({"repo": "ramimbo/mergework"}, 29),
         ({"bounty_id": 1, "repo": "ramimbo/mergework"}, 30),
         ({"issue_number": 1, "repo": 1}, 31),

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -83,6 +83,17 @@ def test_call_mcp_tool_rejects_c1_status_before_normalizing(sqlite_url: str) -> 
         call_mcp_tool(sqlite_url, "list_bounties", {"status": "\u0085open"})
 
 
+def test_call_mcp_tool_rejects_c1_work_proof_format_before_normalizing(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    with pytest.raises(ValueError, match="format must not contain control characters"):
+        call_mcp_tool(sqlite_url, "submit_work_proof", {"format": "\u0085json"})
+
+
 def test_call_mcp_tool_rejects_c1_nonce_before_integer_parsing(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
## Summary

- Reject raw control characters in the MCP `submit_work_proof` `format` argument before trimming/lowercasing.
- Add JSON-RPC and direct dispatcher regression coverage for C1 control-padded `format` values.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: `format` previously normalized a C1-control-padded JSON format value to `json`, unlike neighboring MCP string helpers that reject raw control characters before normalization.
- Bounty capacity and active attempts/open PRs checked: no open PR found for #819; this is a maintainer PR and does not request MRWK.
- Intended files or surfaces: `app/mcp_tools.py`, `tests/test_api_mcp.py`, `tests/test_mcp_tools.py`.
- Expected PR size: small.
- Out of scope: no ledger, wallet, treasury, bounty lifecycle, payout, proof, docs, or valid `text`/`json` behavior changes.

## Test Evidence

- [x] `python scripts/check_agents.py`
- [x] `pytest tests/test_api_mcp.py::test_mcp_submit_work_proof_rejects_invalid_bounty_selectors -q` (red before fix, green after fix)
- [x] `pytest tests/test_api_mcp.py tests/test_mcp_tools.py -q`
- [x] `pytest`
- [x] `ruff format --check .`
- [x] `ruff check .`
- [x] `mypy app`
- [x] `python scripts/docs_smoke.py`
- [x] `git diff --check`

## MRWK

Related bounty or issue: Refs #819.

Maintainer PR; no MRWK bounty requested.
