### PR TITLE
Expose public work discovery queue

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -40,6 +40,11 @@ from app.serializers import (
     payout_reconciliation_to_dict,
 )
 from app.treasury import proposal_to_dict, propose_treasury_action
+from app.work_discovery import (
+    DEFAULT_WORK_DISCOVERY_LIMIT,
+    MAX_WORK_DISCOVERY_LIMIT,
+    work_discovery_to_dict,
+)
 
 
 def _payout_response_from_proof(proof: Proof, *, status: str) -> dict[str, Any]:
@@ -241,6 +246,19 @@ def register_bounty_api_routes(
                 availability=availability,
             )
         )
+
+    @app.get("/api/v1/work-discovery")
+    def api_work_discovery(
+        request: Request,
+        limit: Annotated[
+            int,
+            Query(ge=1, le=MAX_WORK_DISCOVERY_LIMIT),
+        ] = DEFAULT_WORK_DISCOVERY_LIMIT,
+    ) -> dict[str, Any]:
+        reject_repeated_query_param(request, "limit")
+        reject_noncanonical_int_query_param(request, "limit")
+        with session_scope(db_url) as session:
+            return work_discovery_to_dict(session, limit=limit)
 
     @app.get("/api/v1/admin/webhook-events")
     def api_admin_webhook_events(

--- a/app/work_discovery.py
+++ b/app/work_discovery.py
@@ -11,6 +11,8 @@ from app.treasury import proposal_payload
 
 DEFAULT_WORK_DISCOVERY_LIMIT = 50
 MAX_WORK_DISCOVERY_LIMIT = 100
+OPEN_BOUNTY_SCAN_PAGE_SIZE = 25
+MAX_OPEN_BOUNTY_SCAN_ROWS = 500
 
 STATE_DEFINITIONS = {
     "live_bounty": "Public bounty row is open and has positive effective_awards_remaining.",
@@ -90,6 +92,56 @@ def _pending_create_item(proposal: TreasuryProposal) -> dict[str, Any]:
     }
 
 
+def _append_capped_item(bucket: list[dict[str, Any]], item: dict[str, Any], *, limit: int) -> None:
+    if len(bucket) < limit:
+        bucket.append(item)
+
+
+def _scan_open_bounty_buckets(
+    session: Session,
+    *,
+    limit: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    claimable_now: list[dict[str, Any]] = []
+    not_claimable: list[dict[str, Any]] = []
+    last_seen_id: int | None = None
+    scanned_rows = 0
+    page_size = min(MAX_WORK_DISCOVERY_LIMIT, max(limit, OPEN_BOUNTY_SCAN_PAGE_SIZE))
+
+    while scanned_rows < MAX_OPEN_BOUNTY_SCAN_ROWS:
+        batch_limit = min(page_size, MAX_OPEN_BOUNTY_SCAN_ROWS - scanned_rows)
+        query = select(Bounty).where(Bounty.status == "open")
+        if last_seen_id is not None:
+            query = query.where(Bounty.id < last_seen_id)
+        batch = session.scalars(query.order_by(Bounty.id.desc()).limit(batch_limit)).all()
+        if not batch:
+            break
+
+        rows = bounties_to_dict(batch, session=session)
+        scanned_rows += len(rows)
+        last_seen_id = int(batch[-1].id)
+        for row in rows:
+            if int(row["effective_awards_remaining"]) > 0:
+                _append_capped_item(
+                    claimable_now,
+                    _bounty_work_item(row, "live_bounty"),
+                    limit=limit,
+                )
+            else:
+                _append_capped_item(
+                    not_claimable,
+                    _bounty_work_item(row, _not_claimable_state(row)),
+                    limit=limit,
+                )
+
+        if len(batch) < batch_limit:
+            break
+        if len(claimable_now) >= limit and len(not_claimable) >= limit:
+            break
+
+    return claimable_now, not_claimable
+
+
 def work_discovery_to_dict(
     session: Session,
     *,
@@ -97,23 +149,22 @@ def work_discovery_to_dict(
 ) -> dict[str, Any]:
     """Return public read-only work discovery grouped by claimability."""
     capped_limit = max(1, min(limit, MAX_WORK_DISCOVERY_LIMIT))
-    open_bounties = session.scalars(
-        select(Bounty).where(Bounty.status == "open").order_by(Bounty.id.desc())
-    ).all()
-    terminal_bounties = session.scalars(
-        select(Bounty).where(Bounty.status != "open").order_by(Bounty.id.desc()).limit(capped_limit)
-    ).all()
-    open_rows = bounties_to_dict(open_bounties, session=session)
-    terminal_rows = bounties_to_dict(terminal_bounties, session=session)
-    claimable_now: list[dict[str, Any]] = []
-    not_claimable: list[dict[str, Any]] = []
-    for row in open_rows:
-        if int(row["effective_awards_remaining"]) > 0:
-            claimable_now.append(_bounty_work_item(row, "live_bounty"))
-        else:
-            not_claimable.append(_bounty_work_item(row, _not_claimable_state(row)))
-    for row in terminal_rows:
-        not_claimable.append(_bounty_work_item(row, _not_claimable_state(row)))
+    claimable_now, not_claimable = _scan_open_bounty_buckets(session, limit=capped_limit)
+
+    if len(not_claimable) < capped_limit:
+        terminal_bounties = session.scalars(
+            select(Bounty)
+            .where(Bounty.status != "open")
+            .order_by(Bounty.id.desc())
+            .limit(capped_limit)
+        ).all()
+        terminal_rows = bounties_to_dict(terminal_bounties, session=session)
+        for row in terminal_rows:
+            _append_capped_item(
+                not_claimable,
+                _bounty_work_item(row, _not_claimable_state(row)),
+                limit=capped_limit,
+            )
 
     pending_create_proposals = session.scalars(
         select(TreasuryProposal)
@@ -128,12 +179,12 @@ def work_discovery_to_dict(
         "summary": {
             "claimable_now_count": len(claimable_now),
             "opening_soon_count": len(opening_soon),
-            "not_claimable_count": len(not_claimable[:capped_limit]),
+            "not_claimable_count": len(not_claimable),
             "limit": capped_limit,
         },
         "state_definitions": STATE_DEFINITIONS,
-        "claimable_now": claimable_now[:capped_limit],
+        "claimable_now": claimable_now,
         "opening_soon": opening_soon,
-        "not_claimable": not_claimable[:capped_limit],
+        "not_claimable": not_claimable,
         "non_claimable_issue_states": NON_CLAIMABLE_ISSUE_STATES,
     }

--- a/app/work_discovery.py
+++ b/app/work_discovery.py
@@ -152,11 +152,12 @@ def work_discovery_to_dict(
     claimable_now, not_claimable = _scan_open_bounty_buckets(session, limit=capped_limit)
 
     if len(not_claimable) < capped_limit:
+        remaining_not_claimable = capped_limit - len(not_claimable)
         terminal_bounties = session.scalars(
             select(Bounty)
             .where(Bounty.status != "open")
             .order_by(Bounty.id.desc())
-            .limit(capped_limit)
+            .limit(remaining_not_claimable)
         ).all()
         terminal_rows = bounties_to_dict(terminal_bounties, session=session)
         for row in terminal_rows:

--- a/app/work_discovery.py
+++ b/app/work_discovery.py
@@ -98,7 +98,7 @@ def work_discovery_to_dict(
     """Return public read-only work discovery grouped by claimability."""
     capped_limit = max(1, min(limit, MAX_WORK_DISCOVERY_LIMIT))
     open_bounties = session.scalars(
-        select(Bounty).where(Bounty.status == "open").order_by(Bounty.id.desc()).limit(capped_limit)
+        select(Bounty).where(Bounty.status == "open").order_by(Bounty.id.desc())
     ).all()
     terminal_bounties = session.scalars(
         select(Bounty).where(Bounty.status != "open").order_by(Bounty.id.desc()).limit(capped_limit)

--- a/app/work_discovery.py
+++ b/app/work_discovery.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models import Bounty, TreasuryProposal
+from app.serializers import bounties_to_dict, public_utc_timestamp
+from app.treasury import proposal_payload
+
+DEFAULT_WORK_DISCOVERY_LIMIT = 50
+MAX_WORK_DISCOVERY_LIMIT = 100
+
+STATE_DEFINITIONS = {
+    "live_bounty": "Public bounty row is open and has positive effective_awards_remaining.",
+    "pending_create": "Public treasury proposal exists but the bounty row is not live yet.",
+    "pending_payout": "Accepted work has a pending pay_bounty proposal, not proof-backed payment.",
+    "closed_or_exhausted": "Bounty is closed, paid, or has no effective award capacity.",
+    "proposed_work": (
+        "GitHub proposed-work issue is intake only until a create_bounty proposal executes."
+    ),
+    "board_or_index": "Index issues help discovery but are not claimable bounty work.",
+}
+
+
+NON_CLAIMABLE_ISSUE_STATES = [
+    {
+        "availability_state": "proposed_work",
+        "note": STATE_DEFINITIONS["proposed_work"],
+    },
+    {
+        "availability_state": "board_or_index",
+        "repo": "ramimbo/mergework",
+        "issue_number": 785,
+        "issue_url": "https://github.com/ramimbo/mergework/issues/785",
+        "title": "MRWK bounty board",
+        "note": STATE_DEFINITIONS["board_or_index"],
+    },
+]
+
+
+def _bounty_source_urls(row: dict[str, Any]) -> dict[str, str]:
+    bounty_id = int(row["id"])
+    return {
+        "bounty": f"/api/v1/bounties/{bounty_id}",
+        "attempts": f"/api/v1/bounties/{bounty_id}/attempts",
+        "github_issue": str(row["issue_url"]),
+    }
+
+
+def _bounty_work_item(row: dict[str, Any], availability_state: str) -> dict[str, Any]:
+    return {
+        "availability_state": availability_state,
+        "bounty_id": int(row["id"]),
+        "issue_number": int(row["issue_number"]),
+        "title": str(row["title"]),
+        "issue_url": str(row["issue_url"]),
+        "reward_mrwk": str(row["reward_mrwk"]),
+        "max_awards": int(row["max_awards"]),
+        "effective_awards_remaining": int(row["effective_awards_remaining"]),
+        "bounty_availability_state": str(row["availability_state"]),
+        "pending_payout_awards": int(row["pending_payout_awards"]),
+        "source_urls": _bounty_source_urls(row),
+    }
+
+
+def _not_claimable_state(row: dict[str, Any]) -> str:
+    if int(row["pending_payout_awards"]) > 0 and int(row["effective_awards_remaining"]) <= 0:
+        return "pending_payout"
+    return "closed_or_exhausted"
+
+
+def _pending_create_item(proposal: TreasuryProposal) -> dict[str, Any]:
+    payload = proposal_payload(proposal)
+    return {
+        "availability_state": "pending_create",
+        "proposal_id": int(proposal.id),
+        "issue_number": int(payload["issue_number"]),
+        "title": str(payload["title"]),
+        "issue_url": str(payload["issue_url"]),
+        "reward_mrwk": str(payload["reward_mrwk"]),
+        "max_awards": int(payload["max_awards"]),
+        "effective_awards_remaining": 0,
+        "executes_after": public_utc_timestamp(proposal.executes_after),
+        "source_urls": {
+            "proposal": f"/api/v1/treasury/proposals/{proposal.id}",
+            "github_issue": str(payload["issue_url"]),
+        },
+    }
+
+
+def work_discovery_to_dict(
+    session: Session,
+    *,
+    limit: int = DEFAULT_WORK_DISCOVERY_LIMIT,
+) -> dict[str, Any]:
+    """Return public read-only work discovery grouped by claimability."""
+    capped_limit = max(1, min(limit, MAX_WORK_DISCOVERY_LIMIT))
+    open_bounties = session.scalars(
+        select(Bounty).where(Bounty.status == "open").order_by(Bounty.id.desc()).limit(capped_limit)
+    ).all()
+    terminal_bounties = session.scalars(
+        select(Bounty).where(Bounty.status != "open").order_by(Bounty.id.desc()).limit(capped_limit)
+    ).all()
+    open_rows = bounties_to_dict(open_bounties, session=session)
+    terminal_rows = bounties_to_dict(terminal_bounties, session=session)
+    claimable_now: list[dict[str, Any]] = []
+    not_claimable: list[dict[str, Any]] = []
+    for row in open_rows:
+        if int(row["effective_awards_remaining"]) > 0:
+            claimable_now.append(_bounty_work_item(row, "live_bounty"))
+        else:
+            not_claimable.append(_bounty_work_item(row, _not_claimable_state(row)))
+    for row in terminal_rows:
+        not_claimable.append(_bounty_work_item(row, _not_claimable_state(row)))
+
+    pending_create_proposals = session.scalars(
+        select(TreasuryProposal)
+        .where(TreasuryProposal.status == "pending", TreasuryProposal.action == "create_bounty")
+        .order_by(TreasuryProposal.executes_after.asc(), TreasuryProposal.id.asc())
+        .limit(capped_limit)
+    ).all()
+    opening_soon = [_pending_create_item(proposal) for proposal in pending_create_proposals]
+
+    return {
+        "type": "work_discovery",
+        "summary": {
+            "claimable_now_count": len(claimable_now),
+            "opening_soon_count": len(opening_soon),
+            "not_claimable_count": len(not_claimable[:capped_limit]),
+            "limit": capped_limit,
+        },
+        "state_definitions": STATE_DEFINITIONS,
+        "claimable_now": claimable_now[:capped_limit],
+        "opening_soon": opening_soon,
+        "not_claimable": not_claimable[:capped_limit],
+        "non_claimable_issue_states": NON_CLAIMABLE_ISSUE_STATES,
+    }

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -10,6 +10,7 @@ Submit small, reviewable work and include evidence.
 - `GET /api/v1/bounties`
 - `GET /api/v1/bounties/{id}`
 - `GET /api/v1/bounties/summary`
+- `GET /api/v1/work-discovery`
 - `GET /api/v1/bounties/{id}/attempts`
 - `GET /api/v1/accounts/{account}`
 - `GET /api/v1/wallets/{address}`
@@ -44,6 +45,7 @@ List current system counts and recent bounties:
 ```bash
 curl -s "$API_HOST/api/v1/status"
 curl -s "$API_HOST/api/v1/bounties"
+curl -s "$API_HOST/api/v1/work-discovery"
 ```
 
 Get a lightweight counts-only bounty summary with optional status and search
@@ -110,6 +112,15 @@ Use proposal-list filters when you need one queue slice, such as pending
 `pay_bounty` proposals for one internal MergeWork bounty id.
 Use [docs/bounty-lifecycle.md](bounty-lifecycle.md) as the short checklist for
 claimable, proposed, pending, paid, and closed bounty states.
+
+Use `GET /api/v1/work-discovery` when an agent needs one stable read-only
+surface for current work. Use optional `limit=1..100` to cap each returned
+bucket. It groups `claimable_now` live bounty rows separately from
+`opening_soon` pending `create_bounty` proposals, and keeps closed, paid,
+exhausted, pending payout, proposed-work, and board/index states out of the
+claimable bucket. Each work item includes issue number, title, issue URL,
+reward, max awards, effective awards remaining, bounty availability details,
+pending payout count, and source API URLs.
 
 The GitHub bounty board at
 https://github.com/ramimbo/mergework/issues/785 is an index for humans and

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -29,6 +29,8 @@ curl -s "$API_HOST/api/v1/bounties?repo=ramimbo%2Fmergework&issue_number=649"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open&q=proof"
 curl -s "$API_HOST/api/v1/bounties/summary?repo=ramimbo%2Fmergework"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open&sort=awards&limit=5"
+curl -s "$API_HOST/api/v1/work-discovery"
+curl -s "$API_HOST/api/v1/work-discovery?limit=10"
 ```
 
 The bounties list returns public bounty rows. `status` can be omitted or set to
@@ -143,6 +145,100 @@ Use `availability_state_counts`, `pending_payout_awards`,
 `reduced_capacity_bounties`, and `effectively_unavailable_bounties` to explain
 why effective capacity is lower than raw award capacity without fetching every
 bounty row.
+
+Use `/api/v1/work-discovery` when an agent needs a single read-only work queue.
+It separates live bounty rows from pending create-bounty proposals, keeps
+non-claimable states out of the claimable list, and accepts optional
+`limit=1..100` to cap each returned bucket:
+
+```json
+{
+  "type": "work_discovery",
+  "summary": {
+    "claimable_now_count": 1,
+    "opening_soon_count": 1,
+    "not_claimable_count": 1,
+    "limit": 50
+  },
+  "state_definitions": {
+    "live_bounty": "Public bounty row is open and has positive effective_awards_remaining.",
+    "pending_create": "Public treasury proposal exists but the bounty row is not live yet.",
+    "pending_payout": "Accepted work has a pending pay_bounty proposal, not proof-backed payment.",
+    "closed_or_exhausted": "Bounty is closed, paid, or has no effective award capacity.",
+    "proposed_work": "GitHub proposed-work issue is intake only until a create_bounty proposal executes.",
+    "board_or_index": "Index issues help discovery but are not claimable bounty work."
+  },
+  "claimable_now": [
+    {
+      "availability_state": "live_bounty",
+      "bounty_id": 108,
+      "issue_number": 800,
+      "title": "MRWK bounty: public work discovery",
+      "issue_url": "https://github.com/ramimbo/mergework/issues/800",
+      "reward_mrwk": "600",
+      "max_awards": 1,
+      "effective_awards_remaining": 1,
+      "bounty_availability_state": "open",
+      "pending_payout_awards": 0,
+      "source_urls": {
+        "bounty": "/api/v1/bounties/108",
+        "attempts": "/api/v1/bounties/108/attempts",
+        "github_issue": "https://github.com/ramimbo/mergework/issues/800"
+      }
+    }
+  ],
+  "opening_soon": [
+    {
+      "availability_state": "pending_create",
+      "proposal_id": 125,
+      "issue_number": 798,
+      "title": "MRWK bounty: live verification and bug reports, round 2",
+      "issue_url": "https://github.com/ramimbo/mergework/issues/798",
+      "reward_mrwk": "75",
+      "max_awards": 8,
+      "effective_awards_remaining": 0,
+      "executes_after": "2026-06-03T11:41:52Z",
+      "source_urls": {
+        "proposal": "/api/v1/treasury/proposals/125",
+        "github_issue": "https://github.com/ramimbo/mergework/issues/798"
+      }
+    }
+  ],
+  "not_claimable": [
+    {
+      "availability_state": "closed_or_exhausted",
+      "bounty_id": 102,
+      "issue_number": 761,
+      "title": "MRWK bounty: accepted proposed-work fixes, round 1",
+      "issue_url": "https://github.com/ramimbo/mergework/issues/761",
+      "reward_mrwk": "150",
+      "max_awards": 6,
+      "effective_awards_remaining": 0,
+      "bounty_availability_state": "paid",
+      "pending_payout_awards": 0,
+      "source_urls": {
+        "bounty": "/api/v1/bounties/102",
+        "attempts": "/api/v1/bounties/102/attempts",
+        "github_issue": "https://github.com/ramimbo/mergework/issues/761"
+      }
+    }
+  ],
+  "non_claimable_issue_states": [
+    {
+      "availability_state": "proposed_work",
+      "note": "GitHub proposed-work issue is intake only until a create_bounty proposal executes."
+    },
+    {
+      "availability_state": "board_or_index",
+      "repo": "ramimbo/mergework",
+      "issue_number": 785,
+      "issue_url": "https://github.com/ramimbo/mergework/issues/785",
+      "title": "MRWK bounty board",
+      "note": "Index issues help discovery but are not claimable bounty work."
+    }
+  ]
+}
+```
 
 Read a single bounty with its internal `id` from `/api/v1/bounties`:
 

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -53,6 +53,9 @@ REQUIRED_PUBLIC_PHRASES = {
         ("creating or releasing an attempt requires the GitHub-authenticated browser session"),
         "Proposed work requests are intake issues, not live bounties",
         "wait for `mrwk:bounty`",
+        "GET /api/v1/work-discovery",
+        "claimable_now",
+        "opening_soon",
         "Use [docs/bounty-lifecycle.md](bounty-lifecycle.md) as the short checklist",
     ],
     "docs/bounty-lifecycle.md": [
@@ -106,6 +109,8 @@ REQUIRED_PUBLIC_PHRASES = {
         "effective_awards_remaining` is zero",
         "availability_state` is not",
         "pending payout proposals as proof-backed paid work",
+        "/api/v1/work-discovery",
+        "live bounty rows from pending create-bounty proposals",
         ("Treasury and reserve balances change as bounties are reserved, paid, and released."),
     ],
     "docs/admin-runbook.md": [

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -222,6 +222,18 @@ def test_agent_guide_tells_agents_not_to_claim_proposed_work() -> None:
     assert "wait for `mrwk:bounty`" in guide
 
 
+def test_docs_document_public_work_discovery_endpoint() -> None:
+    guide = Path("docs/agent-guide.md").read_text(encoding="utf-8")
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "GET /api/v1/work-discovery" in guide
+    assert "claimable_now" in guide
+    assert "opening_soon" in guide
+    assert "/api/v1/work-discovery" in examples
+    assert "live bounty rows from pending create-bounty proposals" in examples
+    assert '"availability_state": "pending_create"' in examples
+
+
 def test_admin_runbook_warns_to_validate_production_admin_token() -> None:
     runbook = Path("docs/admin-runbook.md").read_text(encoding="utf-8")
 

--- a/tests/test_work_discovery.py
+++ b/tests/test_work_discovery.py
@@ -163,3 +163,53 @@ def test_work_discovery_limit_caps_public_buckets(sqlite_url: str) -> None:
     assert body["summary"]["limit"] == 1
     assert len(body["claimable_now"]) == 1
     assert len(body["opening_soon"]) == 1
+
+
+def test_work_discovery_limit_keeps_older_claimable_bounty_visible(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        older_live = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=910,
+            issue_url="https://github.com/ramimbo/mergework/issues/910",
+            title="Older live bounty",
+            reward_mrwk="25",
+            max_awards=1,
+            acceptance="This live bounty should remain discoverable.",
+        )
+        newer_pending_full = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=911,
+            issue_url="https://github.com/ramimbo/mergework/issues/911",
+            title="Newer pending payout full bounty",
+            reward_mrwk="30",
+            max_awards=1,
+            acceptance="A pending payout should consume effective capacity.",
+        )
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": newer_pending_full.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/911",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    body = client.get("/api/v1/work-discovery?limit=1").json()
+
+    assert body["summary"]["limit"] == 1
+    assert body["summary"]["claimable_now_count"] == 1
+    assert body["claimable_now"][0]["bounty_id"] == older_live.id
+    assert body["claimable_now"][0]["issue_number"] == 910
+    assert body["claimable_now"][0]["availability_state"] == "live_bounty"
+    assert body["not_claimable"][0]["bounty_id"] == newer_pending_full.id
+    assert body["not_claimable"][0]["issue_number"] == 911
+    assert body["not_claimable"][0]["availability_state"] == "pending_payout"

--- a/tests/test_work_discovery.py
+++ b/tests/test_work_discovery.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+
+from app.db import create_schema, session_scope
+from app.ledger.service import create_bounty, ensure_genesis, pay_bounty
+from app.main import create_app
+from app.treasury import propose_treasury_action
+
+
+def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        live_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=800,
+            issue_url="https://github.com/ramimbo/mergework/issues/800",
+            title="MRWK bounty: public work discovery",
+            reward_mrwk="600",
+            max_awards=1,
+            acceptance="Expose public work discovery data.",
+        )
+        paid_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=761,
+            issue_url="https://github.com/ramimbo/mergework/issues/761",
+            title="Filled bounty round",
+            reward_mrwk="150",
+            max_awards=1,
+            acceptance="Already filled.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=paid_bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/821",
+            accepted_by="maintainer",
+            verifier_result={"source": "test"},
+        )
+        pending_create = propose_treasury_action(
+            session,
+            action="create_bounty",
+            payload={
+                "repo": "ramimbo/mergework",
+                "issue_number": 900,
+                "issue_url": "https://github.com/ramimbo/mergework/issues/900",
+                "title": "Opening soon bounty",
+                "reward_mrwk": "75",
+                "max_awards": 2,
+                "acceptance": "Pending create proposal should be opening soon.",
+            },
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/api/v1/work-discovery")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["type"] == "work_discovery"
+    assert body["summary"] == {
+        "claimable_now_count": 1,
+        "opening_soon_count": 1,
+        "not_claimable_count": 1,
+        "limit": 50,
+    }
+    assert body["state_definitions"]["live_bounty"] == (
+        "Public bounty row is open and has positive effective_awards_remaining."
+    )
+    assert body["state_definitions"]["pending_create"] == (
+        "Public treasury proposal exists but the bounty row is not live yet."
+    )
+    assert body["state_definitions"]["board_or_index"] == (
+        "Index issues help discovery but are not claimable bounty work."
+    )
+    assert body["non_claimable_issue_states"][0]["availability_state"] == "proposed_work"
+    assert body["non_claimable_issue_states"][1]["availability_state"] == "board_or_index"
+    assert body["non_claimable_issue_states"][1]["issue_number"] == 785
+
+    assert body["claimable_now"] == [
+        {
+            "availability_state": "live_bounty",
+            "bounty_id": live_bounty.id,
+            "issue_number": 800,
+            "title": "MRWK bounty: public work discovery",
+            "issue_url": "https://github.com/ramimbo/mergework/issues/800",
+            "reward_mrwk": "600",
+            "max_awards": 1,
+            "effective_awards_remaining": 1,
+            "bounty_availability_state": "open",
+            "pending_payout_awards": 0,
+            "source_urls": {
+                "bounty": f"/api/v1/bounties/{live_bounty.id}",
+                "attempts": f"/api/v1/bounties/{live_bounty.id}/attempts",
+                "github_issue": "https://github.com/ramimbo/mergework/issues/800",
+            },
+        }
+    ]
+    pending_create_executes_after = body["opening_soon"][0]["executes_after"]
+    assert body["opening_soon"] == [
+        {
+            "availability_state": "pending_create",
+            "proposal_id": pending_create.id,
+            "issue_number": 900,
+            "title": "Opening soon bounty",
+            "issue_url": "https://github.com/ramimbo/mergework/issues/900",
+            "reward_mrwk": "75",
+            "max_awards": 2,
+            "effective_awards_remaining": 0,
+            "executes_after": pending_create_executes_after,
+            "source_urls": {
+                "proposal": f"/api/v1/treasury/proposals/{pending_create.id}",
+                "github_issue": "https://github.com/ramimbo/mergework/issues/900",
+            },
+        }
+    ]
+    assert pending_create_executes_after.endswith("Z")
+    assert datetime.fromisoformat(pending_create_executes_after.replace("Z", "+00:00"))
+    assert body["not_claimable"][0]["availability_state"] == "closed_or_exhausted"
+    assert body["not_claimable"][0]["issue_number"] == 761
+
+
+def test_work_discovery_limit_caps_public_buckets(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        for issue_number in (901, 902):
+            create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=issue_number,
+                issue_url=f"https://github.com/ramimbo/mergework/issues/{issue_number}",
+                title=f"Live bounty {issue_number}",
+                reward_mrwk="10",
+                acceptance="Live bounty.",
+            )
+        for issue_number in (903, 904):
+            propose_treasury_action(
+                session,
+                action="create_bounty",
+                payload={
+                    "repo": "ramimbo/mergework",
+                    "issue_number": issue_number,
+                    "issue_url": f"https://github.com/ramimbo/mergework/issues/{issue_number}",
+                    "title": f"Pending bounty {issue_number}",
+                    "reward_mrwk": "5",
+                    "max_awards": 1,
+                    "acceptance": "Pending create.",
+                },
+                proposed_by="maintainer",
+            )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    body = client.get("/api/v1/work-discovery?limit=1").json()
+
+    assert body["summary"]["limit"] == 1
+    assert len(body["claimable_now"]) == 1
+    assert len(body["opening_soon"]) == 1

--- a/tests/test_work_discovery.py
+++ b/tests/test_work_discovery.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from fastapi.testclient import TestClient
 
+from app import work_discovery
 from app.db import create_schema, session_scope
 from app.ledger.service import create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
@@ -213,3 +214,61 @@ def test_work_discovery_limit_keeps_older_claimable_bounty_visible(sqlite_url: s
     assert body["not_claimable"][0]["bounty_id"] == newer_pending_full.id
     assert body["not_claimable"][0]["issue_number"] == 911
     assert body["not_claimable"][0]["availability_state"] == "pending_payout"
+
+
+def test_work_discovery_scans_open_bounties_in_bounded_pages(
+    sqlite_url: str,
+    monkeypatch,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        for issue_number in range(950, 990):
+            create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=issue_number,
+                issue_url=f"https://github.com/ramimbo/mergework/issues/{issue_number}",
+                title=f"Live bounty {issue_number}",
+                reward_mrwk="10",
+                max_awards=1,
+                acceptance="Live bounty.",
+            )
+        newest_pending_full = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=990,
+            issue_url="https://github.com/ramimbo/mergework/issues/990",
+            title="Newest pending payout full bounty",
+            reward_mrwk="30",
+            max_awards=1,
+            acceptance="Newest open row should fill the not-claimable bucket.",
+        )
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": newest_pending_full.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/990",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+    batch_sizes: list[int] = []
+    real_bounties_to_dict = work_discovery.bounties_to_dict
+
+    def instrumented_bounties_to_dict(bounties, *, session):
+        batch_sizes.append(len(bounties))
+        return real_bounties_to_dict(bounties, session=session)
+
+    monkeypatch.setattr(work_discovery, "bounties_to_dict", instrumented_bounties_to_dict)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    body = client.get("/api/v1/work-discovery?limit=1").json()
+
+    assert body["claimable_now"][0]["issue_number"] == 989
+    assert body["not_claimable"][0]["issue_number"] == 990
+    assert batch_sizes == [work_discovery.OPEN_BOUNTY_SCAN_PAGE_SIZE]


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/work-discovery`, a public read-only work queue for agents and contributors.
- Groups live claimable bounty rows under `claimable_now` and pending `create_bounty` proposals under `opening_soon`.
- Includes issue number, title, issue URL, reward, max awards, effective awards remaining, and source API URLs for bounty/proposal records.
- Documents the endpoint in the agent guide and API examples, with docs smoke coverage.

Bounty #800

## Evidence
- Live bounty rows require `status=open` and positive `effective_awards_remaining`.
- Pending `create_bounty` proposals are shown as `pending_create` with `executes_after` and proposal source URLs, not as claimable work.
- Closed, paid, exhausted, pending payout, proposed-work, and board/index states are documented outside the claimable bucket.

Example output shape:
```json
{
  type: work_discovery,
  summary: {claimable_now_count: 1, opening_soon_count: 1, not_claimable_count: 1},
  claimable_now: [{availability_state: live_bounty, issue_number: 800, reward_mrwk: 600, effective_awards_remaining: 1}],
  opening_soon: [{availability_state: pending_create, issue_number: 900, reward_mrwk: 75, executes_after: <timestamp>}]
}
```

## Test Evidence
- `uv run --extra dev pytest tests\test_work_discovery.py tests\test_bounty_api.py tests\test_bounty_api_routes.py tests\test_treasury_proposals.py tests\test_docs_public_urls.py -q` -> 133 passed, 1 existing TestClient warning
- `uv run --extra dev python scripts\docs_smoke.py` -> docs smoke ok
- `uv run --extra dev ruff check app\work_discovery.py app\bounty_api.py tests\test_work_discovery.py tests\test_docs_public_urls.py scripts\docs_smoke.py` -> passed
- `uv run --extra dev ruff format --check app\work_discovery.py app\bounty_api.py tests\test_work_discovery.py tests\test_docs_public_urls.py scripts\docs_smoke.py` -> passed
- `uv run --extra dev mypy app` -> success
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `95c0eab9089b7d4b1f09165647260e4cf02283ba`

## Scope and Safety
- No admin token APIs are used by the new endpoint.
- No labels, comments, bounty creation, proposal execution, payouts, ledger mutation, wallet material, exchange, bridge, cash-out, or price behavior is invoked or changed.
- The endpoint reads local public bounty and treasury proposal state only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public GET /api/v1/work-discovery: read-only endpoint returning grouped work items (claimable_now, opening_soon, not_claimable) with a configurable numeric limit and stable response metadata.

* **Documentation**
  * Added docs and curl examples, full JSON example, usage guidance, and exported state definitions.

* **Tests**
  * Added integration tests validating payload structure, grouping semantics, timestamps, limit and pagination behavior.

* **Chores**
  * Documentation smoke checks updated to require the new endpoint and fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->