### PR TITLE
Add review bounty claim saturation checks

### DIFF
--- a/scripts/review_bounty_candidates.py
+++ b/scripts/review_bounty_candidates.py
@@ -207,20 +207,18 @@ def _claim_from_comment(
 
 def extract_bounty_claims(comments: list[dict[str, Any]]) -> list[dict[str, Any]]:
     claims: list[dict[str, Any]] = []
-    seen: set[tuple[int, str | None, str | None]] = set()
-    for comment in comments:
+    seen: set[tuple[int, str | None]] = set()
+    for comment_index, comment in enumerate(comments):
         body = str(comment.get("body") or "")
         if "/claim" not in body.lower():
             continue
+        comment_url = _comment_url(comment)
+        comment_key = comment_url or f"comment-{comment_index}"
         for match in PR_URL_RE.finditer(body):
             pull_request = int(match.group("number"))
             evidence_url = match.group(0)
             evidence_type = _claim_evidence_type(match.group("fragment"), body)
-            url_key: tuple[int, str | None, str | None] = (
-                pull_request,
-                evidence_url,
-                _comment_url(comment),
-            )
+            url_key = (pull_request, comment_key)
             if url_key in seen:
                 continue
             seen.add(url_key)
@@ -234,11 +232,7 @@ def extract_bounty_claims(comments: list[dict[str, Any]]) -> list[dict[str, Any]
             )
         for match in BARE_PR_RE.finditer(body):
             pull_request = int(match.group("number"))
-            bare_key: tuple[int, str | None, str | None] = (
-                pull_request,
-                None,
-                _comment_url(comment),
-            )
+            bare_key = (pull_request, comment_key)
             if bare_key in seen:
                 continue
             seen.add(bare_key)
@@ -314,8 +308,26 @@ def _classify_pr(
     current_head_claims = [
         claim for claim in bounty_claims if _claim_matches_head(claim.get("head_sha"), head_oid)
     ]
+    stale_head_claims = [
+        claim
+        for claim in bounty_claims
+        if claim.get("head_sha") and not _claim_matches_head(claim.get("head_sha"), head_oid)
+    ]
+    base_claims = [
+        claim for claim in bounty_claims if claim.get("base_sha") and not claim.get("head_sha")
+    ]
+    stale_or_base_claims = [*stale_head_claims, *base_claims]
     pr_comment_claims = [
-        claim for claim in bounty_claims if claim.get("evidence_type") == "pr_comment"
+        claim
+        for claim in bounty_claims
+        if claim.get("evidence_type") == "pr_comment" and not claim.get("head_sha")
+    ]
+    unqualified_claims = [
+        claim
+        for claim in bounty_claims
+        if not claim.get("head_sha")
+        and not claim.get("base_sha")
+        and claim.get("evidence_type") != "pr_comment"
     ]
     changes_requested = any(
         str(review.get("state") or "").upper() == "CHANGES_REQUESTED" for review in current_reviews
@@ -332,13 +344,13 @@ def _classify_pr(
     elif current_head_claims:
         state = "already_claimed_current_head"
         reason = "active bounty issue has a claim tied to the current head"
-    elif bounty_claims and merge_state in DIRTY_MERGE_STATES:
+    elif stale_or_base_claims and merge_state in DIRTY_MERGE_STATES:
         state = "claimed_stale_head_or_base"
         reason = "active bounty issue has claim evidence, but current merge state is dirty"
     elif pr_comment_claims:
         state = "claimed_by_pr_comment"
         reason = "active bounty issue has a concise PR comment claim"
-    elif bounty_claims:
+    elif unqualified_claims:
         state = "already_claimed_on_bounty_issue"
         reason = "active bounty issue already references this PR"
     elif merge_state in DIRTY_MERGE_STATES:
@@ -358,6 +370,8 @@ def _classify_pr(
         reason = f"{len(current_reviews)} current-head human review(s) already present"
     elif latest_reviewer_review is not None:
         reason = "reviewer last reviewed an older head"
+    elif stale_or_base_claims:
+        reason = "active bounty issue only has stale-head/base claim evidence"
     elif latest_human_review is not None:
         reason = "latest useful human review is stale"
 

--- a/scripts/review_bounty_candidates.py
+++ b/scripts/review_bounty_candidates.py
@@ -279,6 +279,14 @@ def _claim_summaries(claims: list[dict[str, Any]]) -> list[dict[str, Any]]:
     ]
 
 
+def _claim_matches_head(claim_sha: Any, head_oid: str) -> bool:
+    if not isinstance(claim_sha, str) or not claim_sha:
+        return False
+    normalized_claim = claim_sha.strip().lower()
+    normalized_head = head_oid.strip().lower()
+    return bool(normalized_head and normalized_head.startswith(normalized_claim))
+
+
 def _classify_pr(
     raw: dict[str, Any],
     *,
@@ -304,7 +312,7 @@ def _classify_pr(
     latest_reviewer_review = _latest_review(reviewer_reviews)
     bounty_claims = claims_by_pr.get(number, [])
     current_head_claims = [
-        claim for claim in bounty_claims if claim.get("head_sha") and claim["head_sha"] == head_oid
+        claim for claim in bounty_claims if _claim_matches_head(claim.get("head_sha"), head_oid)
     ]
     pr_comment_claims = [
         claim for claim in bounty_claims if claim.get("evidence_type") == "pr_comment"

--- a/scripts/review_bounty_candidates.py
+++ b/scripts/review_bounty_candidates.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from collections import Counter
@@ -12,6 +13,21 @@ GH_TIMEOUT_SECONDS = 30
 GH_PR_SAFETY_CAP = 201
 STANDARD_QUALITY_CHECK = "Quality, readiness, docs, and image checks"
 HUMAN_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED", "COMMENTED"}
+PR_URL_RE = re.compile(
+    r"https://github\.com/[^/\s]+/[^/\s]+/pull/(?P<number>\d+)(?:#(?P<fragment>[A-Za-z0-9_-]+))?",
+    re.IGNORECASE,
+)
+BARE_PR_RE = re.compile(r"\b(?:PR|pull request|pull)\s*#(?P<number>\d+)\b", re.IGNORECASE)
+SHA_RE = r"[0-9a-f]{7,40}"
+HEAD_SHA_RE = re.compile(
+    rf"\b(?:head(?:refoid| sha)?|commit)\b\s*[:=`'\"]+\s*`?(?P<sha>{SHA_RE})",
+    re.IGNORECASE,
+)
+BASE_SHA_RE = re.compile(
+    rf"\b(?:base|main|origin/main|base/main)\b(?:\s+sha|\s+commit)?"
+    rf"\s*[:=`'\"]+\s*`?(?P<sha>{SHA_RE})",
+    re.IGNORECASE,
+)
 
 
 def _login(raw: Any) -> str:
@@ -140,11 +156,135 @@ def _latest_review(reviews: list[dict[str, Any]]) -> dict[str, Any] | None:
     return reviews[-1]
 
 
+def _comment_author(raw: dict[str, Any]) -> Any:
+    return raw.get("author", raw.get("user"))
+
+
+def _comment_created_at(raw: dict[str, Any]) -> str | None:
+    value = raw.get("createdAt", raw.get("created_at"))
+    return str(value) if value else None
+
+
+def _comment_url(raw: dict[str, Any]) -> str | None:
+    value = raw.get("url", raw.get("html_url"))
+    return str(value) if value else None
+
+
+def _first_match(pattern: re.Pattern[str], body: str) -> str | None:
+    match = pattern.search(body)
+    return match.group("sha") if match else None
+
+
+def _claim_evidence_type(fragment: str | None, body: str) -> str:
+    clean_fragment = (fragment or "").lower()
+    body_lower = body.lower()
+    if clean_fragment.startswith("pullrequestreview-"):
+        return "pr_review"
+    if clean_fragment.startswith("issuecomment-") or "pr comment" in body_lower:
+        return "pr_comment"
+    return "pr_reference"
+
+
+def _claim_from_comment(
+    comment: dict[str, Any],
+    *,
+    pull_request: int,
+    evidence_type: str,
+    evidence_url: str | None,
+) -> dict[str, Any]:
+    body = str(comment.get("body") or "")
+    return {
+        "pull_request": pull_request,
+        "url": _comment_url(comment),
+        "author": _display_login(_comment_author(comment)),
+        "created_at": _comment_created_at(comment),
+        "evidence_type": evidence_type,
+        "evidence_url": evidence_url,
+        "head_sha": _first_match(HEAD_SHA_RE, body),
+        "base_sha": _first_match(BASE_SHA_RE, body),
+    }
+
+
+def extract_bounty_claims(comments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    claims: list[dict[str, Any]] = []
+    seen: set[tuple[int, str | None, str | None]] = set()
+    for comment in comments:
+        body = str(comment.get("body") or "")
+        if "/claim" not in body.lower():
+            continue
+        for match in PR_URL_RE.finditer(body):
+            pull_request = int(match.group("number"))
+            evidence_url = match.group(0)
+            evidence_type = _claim_evidence_type(match.group("fragment"), body)
+            url_key: tuple[int, str | None, str | None] = (
+                pull_request,
+                evidence_url,
+                _comment_url(comment),
+            )
+            if url_key in seen:
+                continue
+            seen.add(url_key)
+            claims.append(
+                _claim_from_comment(
+                    comment,
+                    pull_request=pull_request,
+                    evidence_type=evidence_type,
+                    evidence_url=evidence_url,
+                )
+            )
+        for match in BARE_PR_RE.finditer(body):
+            pull_request = int(match.group("number"))
+            bare_key: tuple[int, str | None, str | None] = (
+                pull_request,
+                None,
+                _comment_url(comment),
+            )
+            if bare_key in seen:
+                continue
+            seen.add(bare_key)
+            claims.append(
+                _claim_from_comment(
+                    comment,
+                    pull_request=pull_request,
+                    evidence_type="pr_reference",
+                    evidence_url=None,
+                )
+            )
+    return claims
+
+
+def _claims_by_pr(data: dict[str, Any]) -> dict[int, list[dict[str, Any]]]:
+    comments = data.get("bounty_claim_comments", [])
+    if not isinstance(comments, list):
+        return {}
+    claims_by_pr: dict[int, list[dict[str, Any]]] = {}
+    valid_comments = [comment for comment in comments if isinstance(comment, dict)]
+    for claim in extract_bounty_claims(valid_comments):
+        claims_by_pr.setdefault(int(claim["pull_request"]), []).append(claim)
+    return claims_by_pr
+
+
+def _claim_summaries(claims: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "url": claim["url"],
+            "author": claim["author"],
+            "created_at": claim["created_at"],
+            "evidence_type": claim["evidence_type"],
+            "evidence_url": claim["evidence_url"],
+            "head_sha": claim["head_sha"],
+            "base_sha": claim["base_sha"],
+        }
+        for claim in claims
+    ]
+
+
 def _classify_pr(
     raw: dict[str, Any],
     *,
     reviewer: str,
     sufficient_reviews: int,
+    claims_by_pr: dict[int, list[dict[str, Any]]],
 ) -> dict[str, Any]:
     number = int(raw["number"])
     title = str(raw.get("title") or "")
@@ -162,6 +302,13 @@ def _classify_pr(
     reviewer_reviews = [review for review in reviews if _login(review.get("author")) == reviewer]
     latest_human_review = _latest_review(reviews)
     latest_reviewer_review = _latest_review(reviewer_reviews)
+    bounty_claims = claims_by_pr.get(number, [])
+    current_head_claims = [
+        claim for claim in bounty_claims if claim.get("head_sha") and claim["head_sha"] == head_oid
+    ]
+    pr_comment_claims = [
+        claim for claim in bounty_claims if claim.get("evidence_type") == "pr_comment"
+    ]
     changes_requested = any(
         str(review.get("state") or "").upper() == "CHANGES_REQUESTED" for review in current_reviews
     )
@@ -174,6 +321,18 @@ def _classify_pr(
     elif "mrwk:needs-info" in normalized_labels:
         state = "needs_info"
         reason = "PR has mrwk:needs-info label"
+    elif current_head_claims:
+        state = "already_claimed_current_head"
+        reason = "active bounty issue has a claim tied to the current head"
+    elif bounty_claims and merge_state in DIRTY_MERGE_STATES:
+        state = "claimed_stale_head_or_base"
+        reason = "active bounty issue has claim evidence, but current merge state is dirty"
+    elif pr_comment_claims:
+        state = "claimed_by_pr_comment"
+        reason = "active bounty issue has a concise PR comment claim"
+    elif bounty_claims:
+        state = "already_claimed_on_bounty_issue"
+        reason = "active bounty issue already references this PR"
     elif merge_state in DIRTY_MERGE_STATES:
         state = "dirty_or_conflicted"
         reason = f"merge state is {merge_state}"
@@ -207,6 +366,8 @@ def _classify_pr(
         "labels": labels,
         "current_head_human_reviews": len(current_reviews),
         "latest_human_review": _review_summary(latest_human_review),
+        "bounty_claim_count": len(bounty_claims),
+        "bounty_claims": _claim_summaries(bounty_claims),
     }
 
 
@@ -221,8 +382,14 @@ def analyze_candidates(
         raise ValueError("reviewer must not be empty")
     if sufficient_reviews < 1:
         raise ValueError("sufficient_reviews must be at least 1")
+    claim_index = _claims_by_pr(data)
     rows = [
-        _classify_pr(raw, reviewer=reviewer_login, sufficient_reviews=sufficient_reviews)
+        _classify_pr(
+            raw,
+            reviewer=reviewer_login,
+            sufficient_reviews=sufficient_reviews,
+            claims_by_pr=claim_index,
+        )
         for raw in data.get("pull_requests", [])
         if isinstance(raw, dict) and isinstance(raw.get("number"), int)
     ]
@@ -246,9 +413,19 @@ def format_text_report(report: dict[str, Any]) -> str:
     for key, value in report["summary"].items():
         lines.append(f"- {key.replace('_', ' ')}: {value}")
     for row in report["pull_requests"]:
+        claim_suffix = ""
+        bounty_claims = row.get("bounty_claims", [])
+        if isinstance(bounty_claims, list) and bounty_claims:
+            claim_urls = [
+                str(claim.get("url"))
+                for claim in bounty_claims
+                if isinstance(claim, dict) and claim.get("url")
+            ]
+            if claim_urls:
+                claim_suffix = f" claims: {', '.join(claim_urls[:2])}"
         lines.append(
             f"- PR #{row['pull_request']}: {row['state']} - "
-            f"{_single_line(row['title'])} ({_single_line(row['reason'])})"
+            f"{_single_line(row['title'])} ({_single_line(row['reason'])}){claim_suffix}"
         )
     return "\n".join(lines)
 
@@ -261,9 +438,19 @@ def format_markdown_report(report: dict[str, Any]) -> str:
         label = f"PR #{row['pull_request']}"
         if row.get("url"):
             label = f"[{label}]({row['url']})"
+        claim_suffix = ""
+        bounty_claims = row.get("bounty_claims", [])
+        if isinstance(bounty_claims, list) and bounty_claims:
+            claim_links = [
+                f"[claim]({claim['url']})"
+                for claim in bounty_claims[:2]
+                if isinstance(claim, dict) and claim.get("url")
+            ]
+            if claim_links:
+                claim_suffix = f"; {' '.join(claim_links)}"
         lines.append(
             f"- {label}: `{row['state']}` - {_single_line(row['title'])} "
-            f"({_single_line(row['reason'])})"
+            f"({_single_line(row['reason'])}){claim_suffix}"
         )
     return "\n".join(lines)
 
@@ -297,7 +484,33 @@ def _run_gh_json(args: list[str]) -> Any:
     return json.loads(completed.stdout)
 
 
-def load_live_candidates(repo: str) -> dict[str, Any]:
+def _run_gh_api_paginated_array(endpoint: str) -> list[dict[str, Any]]:
+    pages = _run_gh_json(["gh", "api", "--paginate", "--slurp", endpoint])
+    if not isinstance(pages, list):
+        raise RuntimeError("gh api paginated response must be a JSON array")
+    rows: list[dict[str, Any]] = []
+    for page in pages:
+        if isinstance(page, list):
+            rows.extend([item for item in page if isinstance(item, dict)])
+        elif isinstance(page, dict):
+            rows.append(page)
+    return rows
+
+
+def load_bounty_claim_comments(repo: str, issue_number: int) -> list[dict[str, Any]]:
+    comments = _run_gh_api_paginated_array(f"repos/{repo}/issues/{issue_number}/comments")
+    return [
+        {
+            "url": comment.get("html_url"),
+            "author": comment.get("user"),
+            "createdAt": comment.get("created_at"),
+            "body": comment.get("body"),
+        }
+        for comment in comments
+    ]
+
+
+def load_live_candidates(repo: str, *, bounty_issue: int | None = None) -> dict[str, Any]:
     prs = _run_gh_json(
         [
             "gh",
@@ -330,7 +543,10 @@ def load_live_candidates(repo: str) -> dict[str, Any]:
             f"gh pr list reached the {GH_PR_SAFETY_CAP} item safety cap; "
             "use an API-paginated collector before trusting this live report"
         )
-    return {"pull_requests": prs}
+    data = {"pull_requests": prs}
+    if bounty_issue is not None:
+        data["bounty_claim_comments"] = load_bounty_claim_comments(repo, bounty_issue)
+    return data
 
 
 def _load_input(path: str) -> dict[str, Any]:
@@ -349,11 +565,22 @@ def main(argv: list[str] | None = None) -> int:
     source.add_argument("--input", help="Read candidate data from a JSON fixture file.")
     source.add_argument("--repo", help="Collect live open PR data with gh.")
     parser.add_argument("--reviewer", required=True, help="GitHub login of the reviewer.")
+    parser.add_argument(
+        "--bounty-issue",
+        type=int,
+        help="When using --repo, read active bounty issue claim comments and join them to PRs.",
+    )
     parser.add_argument("--sufficient-reviews", type=int, default=1)
     parser.add_argument("--format", choices=["json", "markdown", "text"], default="text")
     args = parser.parse_args(argv)
 
-    data = _load_input(args.input) if args.input else load_live_candidates(args.repo)
+    if args.input and args.bounty_issue is not None:
+        raise ValueError("--bounty-issue is only available with --repo live mode")
+    data = (
+        _load_input(args.input)
+        if args.input
+        else load_live_candidates(args.repo, bounty_issue=args.bounty_issue)
+    )
     report = analyze_candidates(
         data,
         reviewer=args.reviewer,

--- a/scripts/review_bounty_candidates.py
+++ b/scripts/review_bounty_candidates.py
@@ -191,8 +191,9 @@ def _claim_from_comment(
     pull_request: int,
     evidence_type: str,
     evidence_url: str | None,
+    head_sha: str | None,
+    base_sha: str | None,
 ) -> dict[str, Any]:
-    body = str(comment.get("body") or "")
     return {
         "pull_request": pull_request,
         "url": _comment_url(comment),
@@ -200,8 +201,8 @@ def _claim_from_comment(
         "created_at": _comment_created_at(comment),
         "evidence_type": evidence_type,
         "evidence_url": evidence_url,
-        "head_sha": _first_match(HEAD_SHA_RE, body),
-        "base_sha": _first_match(BASE_SHA_RE, body),
+        "head_sha": head_sha,
+        "base_sha": base_sha,
     }
 
 
@@ -214,6 +215,13 @@ def extract_bounty_claims(comments: list[dict[str, Any]]) -> list[dict[str, Any]
             continue
         comment_url = _comment_url(comment)
         comment_key = comment_url or f"comment-{comment_index}"
+        referenced_prs = {
+            int(match.group("number"))
+            for pattern in (PR_URL_RE, BARE_PR_RE)
+            for match in pattern.finditer(body)
+        }
+        scoped_head_sha = _first_match(HEAD_SHA_RE, body) if len(referenced_prs) == 1 else None
+        scoped_base_sha = _first_match(BASE_SHA_RE, body) if len(referenced_prs) == 1 else None
         for match in PR_URL_RE.finditer(body):
             pull_request = int(match.group("number"))
             evidence_url = match.group(0)
@@ -228,6 +236,8 @@ def extract_bounty_claims(comments: list[dict[str, Any]]) -> list[dict[str, Any]
                     pull_request=pull_request,
                     evidence_type=evidence_type,
                     evidence_url=evidence_url,
+                    head_sha=scoped_head_sha,
+                    base_sha=scoped_base_sha,
                 )
             )
         for match in BARE_PR_RE.finditer(body):
@@ -242,6 +252,8 @@ def extract_bounty_claims(comments: list[dict[str, Any]]) -> list[dict[str, Any]
                     pull_request=pull_request,
                     evidence_type="pr_reference",
                     evidence_url=None,
+                    head_sha=scoped_head_sha,
+                    base_sha=scoped_base_sha,
                 )
             )
     return claims

--- a/tests/test_review_bounty_candidates.py
+++ b/tests/test_review_bounty_candidates.py
@@ -296,6 +296,68 @@ def test_review_bounty_candidates_marks_bounty_claim_comment_evidence() -> None:
     assert "issuecomment-3" in markdown
 
 
+def test_review_bounty_candidates_matches_uppercase_and_abbreviated_head_claims() -> None:
+    current_head = "f8cad3798db475f94c1a9e5cc0acf01ed965f11e"
+    report = analyze_candidates(
+        {
+            "pull_requests": [
+                {
+                    "number": 21,
+                    "title": "Uppercase full head",
+                    "url": "https://github.com/ramimbo/mergework/pull/21",
+                    "author": {"login": "alice"},
+                    "headRefOid": current_head,
+                    "mergeStateStatus": "CLEAN",
+                    "labels": [],
+                    "statusCheckRollup": _quality_check(),
+                    "reviews": [],
+                },
+                {
+                    "number": 22,
+                    "title": "Abbreviated head",
+                    "url": "https://github.com/ramimbo/mergework/pull/22",
+                    "author": {"login": "alice"},
+                    "headRefOid": current_head,
+                    "mergeStateStatus": "CLEAN",
+                    "labels": [],
+                    "statusCheckRollup": _quality_check(),
+                    "reviews": [],
+                },
+            ],
+            "bounty_claim_comments": [
+                {
+                    "url": "https://github.com/ramimbo/mergework/issues/654#issuecomment-21",
+                    "author": {"login": "reviewer-one"},
+                    "createdAt": "2026-06-03T13:20:00Z",
+                    "body": (
+                        "/claim #654\n"
+                        "PR: https://github.com/ramimbo/mergework/pull/21\n"
+                        f"Head SHA: `{current_head.upper()}`"
+                    ),
+                },
+                {
+                    "url": "https://github.com/ramimbo/mergework/issues/654#issuecomment-22",
+                    "author": {"login": "reviewer-two"},
+                    "createdAt": "2026-06-03T13:21:00Z",
+                    "body": (
+                        "/claim #654\n"
+                        "PR: https://github.com/ramimbo/mergework/pull/22\n"
+                        f"Head SHA: `{current_head[:12]}`"
+                    ),
+                },
+            ],
+        },
+        reviewer="reviewer",
+    )
+
+    states = {row["pull_request"]: row["state"] for row in report["pull_requests"]}
+
+    assert states == {
+        21: "already_claimed_current_head",
+        22: "already_claimed_current_head",
+    }
+
+
 def test_analyze_candidates_rejects_invalid_arguments() -> None:
     data = {"pull_requests": []}
 
@@ -379,6 +441,7 @@ def test_live_candidates_can_join_paginated_bounty_claim_comments(monkeypatch) -
                 ]
             )
         elif args[:4] == ["gh", "api", "--paginate", "--slurp"]:
+            assert args[4].endswith("/issues/654/comments")
             stdout = json.dumps(
                 [
                     [
@@ -392,7 +455,19 @@ def test_live_candidates_can_join_paginated_bounty_claim_comments(monkeypatch) -
                                 "/claim #654\nPR: https://github.com/ramimbo/mergework/pull/41"
                             ),
                         }
-                    ]
+                    ],
+                    [
+                        {
+                            "html_url": (
+                                "https://github.com/ramimbo/mergework/issues/654#issuecomment-100"
+                            ),
+                            "user": {"login": "claimant-two"},
+                            "created_at": "2026-06-02T10:05:00Z",
+                            "body": (
+                                "/claim #654\nPR: https://github.com/ramimbo/mergework/pull/41"
+                            ),
+                        }
+                    ],
                 ]
             )
         else:
@@ -406,4 +481,6 @@ def test_live_candidates_can_join_paginated_bounty_claim_comments(monkeypatch) -
 
     assert any(args[:4] == ["gh", "api", "--paginate", "--slurp"] for args in calls)
     assert report["pull_requests"][0]["state"] == "already_claimed_on_bounty_issue"
+    assert report["pull_requests"][0]["bounty_claim_count"] == 2
     assert report["pull_requests"][0]["bounty_claims"][0]["author"] == "claimant"
+    assert report["pull_requests"][0]["bounty_claims"][1]["author"] == "claimant-two"

--- a/tests/test_review_bounty_candidates.py
+++ b/tests/test_review_bounty_candidates.py
@@ -191,6 +191,111 @@ def test_review_bounty_candidates_ignores_author_and_bot_reviews() -> None:
     assert row["current_head_human_reviews"] == 0
 
 
+def test_review_bounty_candidates_marks_bounty_claim_comment_evidence() -> None:
+    current_head = "a" * 40
+    stale_head = "b" * 40
+    report = analyze_candidates(
+        {
+            "pull_requests": [
+                {
+                    "number": 11,
+                    "title": "Already claimed current head",
+                    "url": "https://github.com/ramimbo/mergework/pull/11",
+                    "author": {"login": "alice"},
+                    "headRefOid": current_head,
+                    "mergeStateStatus": "CLEAN",
+                    "labels": [],
+                    "statusCheckRollup": _quality_check(),
+                    "reviews": [],
+                },
+                {
+                    "number": 12,
+                    "title": "Dirty claimed old head",
+                    "url": "https://github.com/ramimbo/mergework/pull/12",
+                    "author": {"login": "alice"},
+                    "headRefOid": current_head,
+                    "mergeStateStatus": "DIRTY",
+                    "labels": [],
+                    "statusCheckRollup": _quality_check(),
+                    "reviews": [],
+                },
+                {
+                    "number": 13,
+                    "title": "Claimed by concise PR comment",
+                    "url": "https://github.com/ramimbo/mergework/pull/13",
+                    "author": {"login": "alice"},
+                    "headRefOid": current_head,
+                    "mergeStateStatus": "CLEAN",
+                    "labels": [],
+                    "statusCheckRollup": _quality_check(),
+                    "reviews": [],
+                },
+                {
+                    "number": 14,
+                    "title": "Fresh candidate",
+                    "url": "https://github.com/ramimbo/mergework/pull/14",
+                    "author": {"login": "alice"},
+                    "headRefOid": current_head,
+                    "mergeStateStatus": "CLEAN",
+                    "labels": [],
+                    "statusCheckRollup": _quality_check(),
+                    "reviews": [],
+                },
+            ],
+            "bounty_claim_comments": [
+                {
+                    "url": "https://github.com/ramimbo/mergework/issues/654#issuecomment-1",
+                    "author": {"login": "reviewer-one"},
+                    "createdAt": "2026-06-02T10:00:00Z",
+                    "body": (
+                        "/claim #654\n\n"
+                        "PR: https://github.com/ramimbo/mergework/pull/11"
+                        "#pullrequestreview-4400000000\n"
+                        f"Head SHA: `{current_head}`"
+                    ),
+                },
+                {
+                    "url": "https://github.com/ramimbo/mergework/issues/654#issuecomment-2",
+                    "author": {"login": "reviewer-two"},
+                    "createdAt": "2026-06-02T10:05:00Z",
+                    "body": (
+                        "/claim #654\n\n"
+                        "PR #12\n"
+                        f"Head SHA: `{stale_head}`\n"
+                        f"Base/main SHA: `{'c' * 40}`"
+                    ),
+                },
+                {
+                    "url": "https://github.com/ramimbo/mergework/issues/654#issuecomment-3",
+                    "author": {"login": "reviewer-three"},
+                    "createdAt": "2026-06-02T10:10:00Z",
+                    "body": (
+                        "/claim #654\n\n"
+                        "PR comment: https://github.com/ramimbo/mergework/pull/13"
+                        "#issuecomment-4400000001"
+                    ),
+                },
+            ],
+        },
+        reviewer="reviewer",
+    )
+
+    rows = {row["pull_request"]: row for row in report["pull_requests"]}
+
+    assert rows[11]["state"] == "already_claimed_current_head"
+    assert rows[11]["bounty_claims"][0]["evidence_type"] == "pr_review"
+    assert rows[11]["bounty_claims"][0]["head_sha"] == current_head
+    assert rows[12]["state"] == "claimed_stale_head_or_base"
+    assert rows[12]["bounty_claims"][0]["head_sha"] == stale_head
+    assert rows[13]["state"] == "claimed_by_pr_comment"
+    assert rows[13]["bounty_claims"][0]["evidence_type"] == "pr_comment"
+    assert rows[14]["state"] == "candidate_for_fresh_review"
+
+    markdown = format_markdown_report(report)
+    assert "issuecomment-1" in markdown
+    assert "issuecomment-3" in markdown
+
+
 def test_analyze_candidates_rejects_invalid_arguments() -> None:
     data = {"pull_requests": []}
 
@@ -250,3 +355,55 @@ def test_live_candidates_reports_missing_github_cli(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="GitHub CLI executable 'gh' was not found"):
         load_live_candidates("ramimbo/mergework")
+
+
+def test_live_candidates_can_join_paginated_bounty_claim_comments(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        if args[:3] == ["gh", "pr", "list"]:
+            stdout = json.dumps(
+                [
+                    {
+                        "number": 41,
+                        "title": "Open PR",
+                        "url": "https://github.com/ramimbo/mergework/pull/41",
+                        "author": {"login": "alice"},
+                        "headRefOid": "a" * 40,
+                        "mergeStateStatus": "CLEAN",
+                        "labels": [],
+                        "statusCheckRollup": _quality_check(),
+                        "reviews": [],
+                    }
+                ]
+            )
+        elif args[:4] == ["gh", "api", "--paginate", "--slurp"]:
+            stdout = json.dumps(
+                [
+                    [
+                        {
+                            "html_url": (
+                                "https://github.com/ramimbo/mergework/issues/654#issuecomment-99"
+                            ),
+                            "user": {"login": "claimant"},
+                            "created_at": "2026-06-02T10:00:00Z",
+                            "body": (
+                                "/claim #654\nPR: https://github.com/ramimbo/mergework/pull/41"
+                            ),
+                        }
+                    ]
+                ]
+            )
+        else:
+            raise AssertionError(f"unexpected command: {args}")
+        return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    data = load_live_candidates("ramimbo/mergework", bounty_issue=654)
+    report = analyze_candidates(data, reviewer="reviewer")
+
+    assert any(args[:4] == ["gh", "api", "--paginate", "--slurp"] for args in calls)
+    assert report["pull_requests"][0]["state"] == "already_claimed_on_bounty_issue"
+    assert report["pull_requests"][0]["bounty_claims"][0]["author"] == "claimant"

--- a/tests/test_review_bounty_candidates.py
+++ b/tests/test_review_bounty_candidates.py
@@ -252,6 +252,39 @@ def test_review_bounty_candidates_marks_bounty_claim_comment_evidence() -> None:
                     "statusCheckRollup": _quality_check(),
                     "reviews": [],
                 },
+                {
+                    "number": 16,
+                    "title": "Dirty base-only claim",
+                    "url": "https://github.com/ramimbo/mergework/pull/16",
+                    "author": {"login": "alice"},
+                    "headRefOid": current_head,
+                    "mergeStateStatus": "DIRTY",
+                    "labels": [],
+                    "statusCheckRollup": _quality_check(),
+                    "reviews": [],
+                },
+                {
+                    "number": 17,
+                    "title": "Clean base-only claim needs follow-up",
+                    "url": "https://github.com/ramimbo/mergework/pull/17",
+                    "author": {"login": "alice"},
+                    "headRefOid": current_head,
+                    "mergeStateStatus": "CLEAN",
+                    "labels": [],
+                    "statusCheckRollup": _quality_check(),
+                    "reviews": [],
+                },
+                {
+                    "number": 18,
+                    "title": "Multi PR comment with body-level SHA",
+                    "url": "https://github.com/ramimbo/mergework/pull/18",
+                    "author": {"login": "alice"},
+                    "headRefOid": current_head,
+                    "mergeStateStatus": "CLEAN",
+                    "labels": [],
+                    "statusCheckRollup": _quality_check(),
+                    "reviews": [],
+                },
             ],
             "bounty_claim_comments": [
                 {
@@ -297,6 +330,24 @@ def test_review_bounty_candidates_marks_bounty_claim_comment_evidence() -> None:
                         f"Head SHA: `{stale_head}`"
                     ),
                 },
+                {
+                    "url": "https://github.com/ramimbo/mergework/issues/654#issuecomment-5",
+                    "author": {"login": "reviewer-five"},
+                    "createdAt": "2026-06-02T10:20:00Z",
+                    "body": (f"/claim #654\n\nPR #16\nBase/main SHA: `{'d' * 40}`"),
+                },
+                {
+                    "url": "https://github.com/ramimbo/mergework/issues/654#issuecomment-6",
+                    "author": {"login": "reviewer-six"},
+                    "createdAt": "2026-06-02T10:25:00Z",
+                    "body": (f"/claim #654\n\nPR #17\nBase/main SHA: `{'e' * 40}`"),
+                },
+                {
+                    "url": "https://github.com/ramimbo/mergework/issues/654#issuecomment-7",
+                    "author": {"login": "reviewer-seven"},
+                    "createdAt": "2026-06-02T10:30:00Z",
+                    "body": (f"/claim #654\n\nPR #18\nPR #999\nHead SHA: `{current_head}`"),
+                },
             ],
         },
         reviewer="reviewer",
@@ -315,6 +366,15 @@ def test_review_bounty_candidates_marks_bounty_claim_comment_evidence() -> None:
     assert rows[14]["state"] == "candidate_for_fresh_review"
     assert rows[15]["state"] == "candidate_for_fresh_review"
     assert rows[15]["reason"] == "active bounty issue only has stale-head/base claim evidence"
+    assert rows[16]["state"] == "claimed_stale_head_or_base"
+    assert rows[16]["bounty_claims"][0]["base_sha"] == "d" * 40
+    assert rows[17]["state"] == "candidate_for_fresh_review"
+    assert rows[17]["reason"] == "active bounty issue only has stale-head/base claim evidence"
+    assert rows[17]["bounty_claims"][0]["base_sha"] == "e" * 40
+    assert rows[18]["state"] == "already_claimed_on_bounty_issue"
+    assert rows[18]["bounty_claim_count"] == 1
+    assert rows[18]["bounty_claims"][0]["head_sha"] is None
+    assert rows[18]["bounty_claims"][0]["base_sha"] is None
 
     markdown = format_markdown_report(report)
     assert "issuecomment-1" in markdown

--- a/tests/test_review_bounty_candidates.py
+++ b/tests/test_review_bounty_candidates.py
@@ -241,6 +241,17 @@ def test_review_bounty_candidates_marks_bounty_claim_comment_evidence() -> None:
                     "statusCheckRollup": _quality_check(),
                     "reviews": [],
                 },
+                {
+                    "number": 15,
+                    "title": "Clean claimed old head needs follow-up",
+                    "url": "https://github.com/ramimbo/mergework/pull/15",
+                    "author": {"login": "alice"},
+                    "headRefOid": current_head,
+                    "mergeStateStatus": "CLEAN",
+                    "labels": [],
+                    "statusCheckRollup": _quality_check(),
+                    "reviews": [],
+                },
             ],
             "bounty_claim_comments": [
                 {
@@ -251,6 +262,7 @@ def test_review_bounty_candidates_marks_bounty_claim_comment_evidence() -> None:
                         "/claim #654\n\n"
                         "PR: https://github.com/ramimbo/mergework/pull/11"
                         "#pullrequestreview-4400000000\n"
+                        "PR #11\n"
                         f"Head SHA: `{current_head}`"
                     ),
                 },
@@ -275,6 +287,16 @@ def test_review_bounty_candidates_marks_bounty_claim_comment_evidence() -> None:
                         "#issuecomment-4400000001"
                     ),
                 },
+                {
+                    "url": "https://github.com/ramimbo/mergework/issues/654#issuecomment-4",
+                    "author": {"login": "reviewer-four"},
+                    "createdAt": "2026-06-02T10:15:00Z",
+                    "body": (
+                        "/claim #654\n\n"
+                        "PR: https://github.com/ramimbo/mergework/pull/15\n"
+                        f"Head SHA: `{stale_head}`"
+                    ),
+                },
             ],
         },
         reviewer="reviewer",
@@ -283,6 +305,7 @@ def test_review_bounty_candidates_marks_bounty_claim_comment_evidence() -> None:
     rows = {row["pull_request"]: row for row in report["pull_requests"]}
 
     assert rows[11]["state"] == "already_claimed_current_head"
+    assert rows[11]["bounty_claim_count"] == 1
     assert rows[11]["bounty_claims"][0]["evidence_type"] == "pr_review"
     assert rows[11]["bounty_claims"][0]["head_sha"] == current_head
     assert rows[12]["state"] == "claimed_stale_head_or_base"
@@ -290,6 +313,8 @@ def test_review_bounty_candidates_marks_bounty_claim_comment_evidence() -> None:
     assert rows[13]["state"] == "claimed_by_pr_comment"
     assert rows[13]["bounty_claims"][0]["evidence_type"] == "pr_comment"
     assert rows[14]["state"] == "candidate_for_fresh_review"
+    assert rows[15]["state"] == "candidate_for_fresh_review"
+    assert rows[15]["reason"] == "active bounty issue only has stale-head/base claim evidence"
 
     markdown = format_markdown_report(report)
     assert "issuecomment-1" in markdown


### PR DESCRIPTION
## Summary
- Adds active review-bounty claim-thread awareness to `scripts/review_bounty_candidates.py`.
- Joins read-only `/claim` comments from a live bounty issue into the reviewer candidate report.
- Classifies PRs as `already_claimed_current_head`, `already_claimed_on_bounty_issue`, `claimed_by_pr_comment`, or `claimed_stale_head_or_base` when the active bounty thread already contains relevant evidence.
- Keeps fixture input deterministic and adds live `--bounty-issue` mode using public `gh api --paginate --slurp` issue-comment reads.

Bounty #799
Source report: #797

## Why this matches #797
#797 asks the review candidate helper to stop relying only on PR review objects and to read active review-bounty issue comments so reviewers can avoid duplicate or stale review claims. This PR implements that focused first slice in the existing helper without posting claims, mutating issues, editing labels, or touching payment state.

## Verification
- `uv run --extra dev pytest tests/test_review_bounty_candidates.py -q` -> 8 passed
- `uv run --extra dev pytest -q` -> 751 passed, 1 Starlette/httpx deprecation warning
- `uv run --extra dev ruff format --check scripts/review_bounty_candidates.py tests/test_review_bounty_candidates.py` -> 2 files already formatted
- `uv run --extra dev ruff check scripts/review_bounty_candidates.py tests/test_review_bounty_candidates.py` -> All checks passed
- `uv run --extra dev mypy scripts/review_bounty_candidates.py` -> Success
- `git diff --check` -> clean

## Live read-only smoke
Ran:

```bash
uv run --extra dev python scripts/review_bounty_candidates.py \
  --repo ramimbo/mergework \
  --bounty-issue 654 \
  --reviewer jakerated-r \
  --format json
```

Observed current public claim-thread signal joined into the report:

```text
summary {'already_claimed_current_head': 12, 'already_claimed_on_bounty_issue': 1, 'candidate_for_fresh_review': 1, 'needs_info': 16, 'pull_requests': 30}
PR 839 already_claimed_current_head bounty_claim_count=2
PR 837 already_claimed_current_head bounty_claim_count=2
PR 835 already_claimed_current_head bounty_claim_count=5
```

## Safety
Read-only GitHub public reads only. No automatic claim submission, issue editing, labels, acceptance decisions, payments, admin-token APIs, private data, secrets, or wallet material.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR classification considers bounty-claim evidence mined from issue comments; reports show per-PR claim counts and summaries
  * CLI option to load a bounty issue’s comments for live analysis (incompatible with --input); live loading paginates API results
  * Text and Markdown reports append per-PR claim links (up to two) as a claim suffix

* **Bug Fixes**
  * Improved validation of external issue-search responses to avoid unexpected data shapes

* **Tests**
  * Added tests for claim parsing, SHA-matching variants (case/abbrev), and paginated live comment retrieval
<!-- end of auto-generated comment: release notes by coderabbit.ai -->