### PR TITLE
Validate report API host arguments

### DIFF
--- a/scripts/api_host_args.py
+++ b/scripts/api_host_args.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import argparse
+import urllib.parse
+
+
+def public_api_host(value: str) -> str:
+    clean = value.strip()
+    if not clean:
+        raise argparse.ArgumentTypeError("api host must be a non-empty HTTP(S) URL")
+    parsed = urllib.parse.urlparse(clean)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise argparse.ArgumentTypeError("api host must be an absolute HTTP(S) URL")
+    return clean

--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -15,6 +15,7 @@ from typing import Any
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from scripts.api_host_args import public_api_host
 from scripts.bounty_refs import BOUNTY_REF_RE
 
 DEFAULT_API_HOST = "https://api.mrwk.online"
@@ -668,7 +669,7 @@ def main(argv: list[str] | None = None) -> int:
     source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument("--input", help="Read public claim fixture JSON.")
     source.add_argument("--repo", help="Collect live public state with read-only gh calls.")
-    parser.add_argument("--api-host", default=DEFAULT_API_HOST)
+    parser.add_argument("--api-host", default=DEFAULT_API_HOST, type=public_api_host)
     parser.add_argument("--format", choices=["json", "markdown"], default="markdown")
     args = parser.parse_args(argv)
 

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -4,12 +4,18 @@ import argparse
 import json
 import re
 import subprocess
+import sys
 import urllib.error
 import urllib.parse
 import urllib.request
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.api_host_args import public_api_host
 
 
 def _positive_int(value: str) -> int:
@@ -518,7 +524,7 @@ def main(argv: list[str] | None = None) -> int:
     source.add_argument("--repo", help="GitHub repo for read-only gh live mode")
     parser.add_argument("--limit", type=_positive_int, default=50)
     parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
-    parser.add_argument("--api-host", default=DEFAULT_API_HOST)
+    parser.add_argument("--api-host", default=DEFAULT_API_HOST, type=public_api_host)
     parser.add_argument(
         "--payment-bounty-issue",
         action="append",

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -15,6 +15,7 @@ from urllib.request import urlopen
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from scripts.api_host_args import public_api_host
 from scripts.bounty_refs import BOUNTY_REF_RE, GITHUB_LINKED_ISSUE_RE, LEADING_BOUNTY_REF_RE
 
 
@@ -767,7 +768,7 @@ def main(argv: list[str] | None = None) -> int:
     source.add_argument("--input", help="Read gate input from a JSON fixture file.")
     source.add_argument("--text-file", help="Read submission text and live context with gh.")
     parser.add_argument("--repo", default="ramimbo/mergework")
-    parser.add_argument("--api-host", default=DEFAULT_API_HOST)
+    parser.add_argument("--api-host", default=DEFAULT_API_HOST, type=public_api_host)
     parser.add_argument(
         "--max-maintainer-age-days",
         type=_non_negative_int,

--- a/tests/test_claim_inventory.py
+++ b/tests/test_claim_inventory.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts import claim_inventory
 from scripts.claim_inventory import analyze_inventory, format_markdown_report, main
 
@@ -423,3 +425,11 @@ def test_claim_inventory_script_entrypoint_loads_shared_parser() -> None:
 
     assert result.returncode == 0
     assert "usage:" in result.stdout
+
+
+def test_claim_inventory_rejects_invalid_api_host(capsys) -> None:
+    for bad in ("", "   ", "/relative", "ftp://api.example.test"):
+        with pytest.raises(SystemExit) as excinfo:
+            main(["--repo", "ramimbo/mergework", "--api-host", bad])
+        assert excinfo.value.code == 2
+        assert "api host must" in capsys.readouterr().err

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -762,3 +762,13 @@ def test_proposed_work_triage_rejects_non_integer_limit(capsys) -> None:
         main(["--repo", "ramimbo/mergework", "--format", "json", "--limit", "abc"])
     assert excinfo.value.code == 2
     assert "expected an integer" in capsys.readouterr().err
+
+
+def test_proposed_work_triage_rejects_invalid_api_host(capsys) -> None:
+    import pytest
+
+    for bad in ("", "   ", "/relative", "ftp://api.example.test"):
+        with pytest.raises(SystemExit) as excinfo:
+            main(["--repo", "ramimbo/mergework", "--api-host", bad])
+        assert excinfo.value.code == 2
+        assert "api host must" in capsys.readouterr().err

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -765,8 +765,6 @@ def test_proposed_work_triage_rejects_non_integer_limit(capsys) -> None:
 
 
 def test_proposed_work_triage_rejects_invalid_api_host(capsys) -> None:
-    import pytest
-
     for bad in ("", "   ", "/relative", "ftp://api.example.test"):
         with pytest.raises(SystemExit) as excinfo:
             main(["--repo", "ramimbo/mergework", "--api-host", bad])

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -1315,3 +1315,13 @@ def test_quality_gate_cli_rejects_negative_max_maintainer_age_days(tmp_path, cap
         main(["--input", str(fixture), "--max-maintainer-age-days", "-1"])
     assert excinfo.value.code == 2
     assert "must be >= 0" in capsys.readouterr().err
+
+
+def test_quality_gate_cli_rejects_invalid_api_host(tmp_path, capsys) -> None:
+    draft = tmp_path / "draft.md"
+    draft.write_text("Summary: work\n\nRefs #319\n\nValidation: pytest passed", encoding="utf-8")
+    for bad in ("", "   ", "/relative", "ftp://api.example.test"):
+        with pytest.raises(SystemExit) as excinfo:
+            main(["--text-file", str(draft), "--api-host", bad])
+        assert excinfo.value.code == 2
+        assert "api host must" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- Add a shared `public_api_host` argparse validator for public report-tool API origins.
- Reject blank, whitespace-only, relative, and non-HTTP(S) `--api-host` values before any live GitHub/API collection.
- Apply the validator to `proposed_work_triage.py`, `claim_inventory.py`, and `submission_quality_gate.py` as requested by source issue #815.

Bounty #799
Source issue: #815

## Evidence

#815 reports that report scripts can accept malformed API hosts and crash later while building public API URLs. The issue comment also points out that `submission_quality_gate.py` has the same boundary and should share the validation helper.

This PR keeps valid absolute HTTP(S) hosts working and only changes CLI argument validation for invalid hosts.

## Validation

- `python -m pytest tests\test_proposed_work_triage.py tests\test_claim_inventory.py tests\test_submission_quality_gate.py -q` -> 73 passed
- `python -m pytest -q` -> 752 passed, 1 existing Starlette/httpx warning
- `python -m ruff format --check .` -> 111 files already formatted
- `python -m ruff check .` -> All checks passed
- `python -m mypy app` -> Success
- `git diff --check` -> clean

CLI smoke after the fix:

- `python scripts\proposed_work_triage.py --repo ramimbo/mergework --limit 1 --api-host "   " --format json` -> argparse error: `api host must be a non-empty HTTP(S) URL`
- `python scripts\claim_inventory.py --repo ramimbo/mergework --api-host /relative --format json` -> argparse error: `api host must be an absolute HTTP(S) URL`
- `python scripts\submission_quality_gate.py --text-file draft.md --api-host ftp://api.example.test --format json` -> argparse error: `api host must be an absolute HTTP(S) URL`

## Scope and Safety

- Read-only report tooling only.
- No GitHub mutations, labels, comments, bounty creation, claim acceptance, payout execution, treasury mutation, ledger mutation, wallet behavior, private data, secrets, bridge, exchange, off-ramp, cash-out, or price behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI tools now validate the `--api-host` argument and only accept absolute HTTP(S) URLs; empty, whitespace-only, relative, or non-HTTP(S) values produce clear parse-time errors.

* **Tests**
  * Added CLI tests that verify invalid `--api-host` values are rejected with appropriate exit codes and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->