### PR TITLE
Use current proposed-work payment state

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -303,13 +303,13 @@ the intake queue before creating, rejecting, or consolidating future bounties:
 ```bash
 python scripts/proposed_work_triage.py \
   --repo ramimbo/mergework \
-  --payment-bounty-issue 722 \
   --format markdown
 ```
 
-During accepted-proposed-work round transitions, repeat
-`--payment-bounty-issue` for each intake bounty whose payment state should be
-included, such as `--payment-bounty-issue 649 --payment-bounty-issue 722`.
+The default payment-state lookup includes the original accepted-proposed-work
+round #649 and the current round #722. During future round transitions, repeat
+`--payment-bounty-issue` for each intake bounty whose payment state should
+override the default set.
 
 For deterministic review or incident write-ups, use an offline fixture instead:
 

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -9,7 +9,7 @@ import urllib.parse
 import urllib.request
 from collections import defaultdict
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 
 def _positive_int(value: str) -> int:
@@ -76,7 +76,7 @@ STOPWORDS = {
 GH_TIMEOUT_SECONDS = 30
 HTTP_TIMEOUT_SECONDS = 30
 DEFAULT_API_HOST = "https://api.mrwk.online"
-DEFAULT_PAYMENT_BOUNTY_ISSUE_NUMBERS = (649,)
+DEFAULT_PAYMENT_BOUNTY_ISSUE_NUMBERS = (649, 722)
 LIVE_ISSUE_SEARCHES = (
     "label:proposed-work",
     '"proposed work"',
@@ -394,7 +394,7 @@ def _run_gh(args: list[str]) -> Any:
 
 
 def _gh_issue_search(repo: str, query: str, limit: int) -> list[dict[str, Any]]:
-    return _run_gh(
+    rows = _run_gh(
         [
             "issue",
             "list",
@@ -410,6 +410,9 @@ def _gh_issue_search(repo: str, query: str, limit: int) -> list[dict[str, Any]]:
             "number",
         ]
     )
+    if not isinstance(rows, list):
+        raise RuntimeError("gh issue list returned non-list JSON")
+    return [cast(dict[str, Any], row) for row in rows if isinstance(row, dict)]
 
 
 def _load_public_json(url: str) -> Any:

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -425,14 +425,19 @@ def test_proposed_work_triage_live_mode_uses_read_only_gh(monkeypatch, capsys) -
             )
         return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
 
+    loaded_urls: list[str] = []
+
     def fake_urlopen(request, timeout):  # noqa: ANN001, ANN202, ARG001
         url = request.full_url
+        loaded_urls.append(url)
         if url.endswith("/api/v1/bounties?issue_number=649&limit=5"):
-            return FakeResponse([{"id": 96}])
-        if url.endswith("/api/v1/bounties/96"):
+            return FakeResponse([])
+        if url.endswith("/api/v1/bounties?issue_number=722&limit=5"):
+            return FakeResponse([{"id": 101}])
+        if url.endswith("/api/v1/bounties/101"):
             return FakeResponse(
                 {
-                    "id": 96,
+                    "id": 101,
                     "pending_payout_proposals": [
                         {
                             "proposal_id": 100,
@@ -453,6 +458,8 @@ def test_proposed_work_triage_live_mode_uses_read_only_gh(monkeypatch, capsys) -
     output = json.loads(capsys.readouterr().out)
     assert output["summary"]["proposed_work_issues"] == 2
     assert output["summary"]["payment_counts"] == {"none": 1, "pending": 1}
+    assert any(url.endswith("/api/v1/bounties?issue_number=649&limit=5") for url in loaded_urls)
+    assert any(url.endswith("/api/v1/bounties?issue_number=722&limit=5") for url in loaded_urls)
     pending = next(item for item in output["proposals"] if item["number"] == 672)
     unlabeled = next(item for item in output["proposals"] if item["number"] == 673)
     assert "accepted_pending_payout" in pending["warnings"]
@@ -649,7 +656,8 @@ def test_proposed_work_triage_live_mode_warns_when_payment_state_is_incomplete(
 
     assert output["summary"]["payment_counts"] == {"none": 1}
     assert output["summary"]["data_warnings"] == [
-        "payment_state_incomplete: failed to load public bounty list for issue #649 (URLError)"
+        "payment_state_incomplete: failed to load public bounty list for issue #649 (URLError)",
+        "payment_state_incomplete: failed to load public bounty list for issue #722 (URLError)",
     ]
     markdown = format_markdown(output)
     assert "data warning: payment_state_incomplete" in markdown
@@ -677,6 +685,8 @@ def test_proposed_work_triage_live_mode_warns_when_bounty_detail_fetch_fails(
     def fake_urlopen(request, timeout):  # noqa: ANN001, ANN202, ARG001
         if request.full_url.endswith("/api/v1/bounties?issue_number=649&limit=5"):
             return FakeResponse([{"id": 96}])
+        if request.full_url.endswith("/api/v1/bounties?issue_number=722&limit=5"):
+            return FakeResponse([])
         raise urllib.error.URLError("offline")
 
     monkeypatch.setattr("scripts.proposed_work_triage.subprocess.run", fake_run)


### PR DESCRIPTION
Bounty #799
Source issue: #802

## What changed
- Include both accepted proposed-work rounds #649 and #722 in the default proposed-work triage payment-state lookup.
- Keep explicit `--payment-bounty-issue` overrides available for future transitions.
- Tighten `_gh_issue_search()` to return only list-shaped issue rows, which keeps the script clean under mypy.
- Update the admin runbook and focused tests for the new default behavior.

## Why
The live proposed-work triage report was still loading payment state from #649 by default, so accepted/pending #722 proposals such as source issue #802 were shown as `none` unless operators manually passed `--payment-bounty-issue 722`.

## Validation
- `uv run --extra dev python -m pytest tests/test_proposed_work_triage.py -q`
- `uv run --extra dev ruff format --check scripts/proposed_work_triage.py tests/test_proposed_work_triage.py`
- `uv run --extra dev ruff check scripts/proposed_work_triage.py tests/test_proposed_work_triage.py`
- `uv run --extra dev mypy scripts/proposed_work_triage.py`
- `uv run --extra dev python scripts/docs_smoke.py`
- Live read-only smoke: default triage output now reports #802 as `pending` from proposal 129 without passing `--payment-bounty-issue 722`.