### PR TITLE
Support MCP initialize handshake

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -10,6 +10,8 @@ from fastapi.responses import JSONResponse
 from app.ledger.service import LedgerError
 
 MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
+MCP_PROTOCOL_VERSION = "2025-06-18"
+MCP_SERVER_INFO = {"name": "mergework", "version": "0.1.0"}
 
 MCP_TOOLS: list[dict[str, Any]] = [
     {
@@ -89,6 +91,25 @@ def _jsonrpc_error(response_id: Any, code: int, message: str) -> dict[str, Any]:
     return {"jsonrpc": "2.0", "id": response_id, "error": {"code": code, "message": message}}
 
 
+def _initialize_response(response_id: Any, params: Any) -> dict[str, Any]:
+    protocol_version = MCP_PROTOCOL_VERSION
+    if (
+        isinstance(params, dict)
+        and isinstance(params.get("protocolVersion"), str)
+        and params["protocolVersion"] == MCP_PROTOCOL_VERSION
+    ):
+        protocol_version = params["protocolVersion"]
+    return {
+        "jsonrpc": "2.0",
+        "id": response_id,
+        "result": {
+            "protocolVersion": protocol_version,
+            "capabilities": {"tools": {"listChanged": False}},
+            "serverInfo": MCP_SERVER_INFO,
+        },
+    }
+
+
 def _structured_json_payload(text: str) -> dict[str, Any] | list[Any] | None:
     try:
         payload = json.loads(text)
@@ -139,6 +160,9 @@ async def handle_mcp_request(
 
     response_id = payload.get("id")
     method = payload.get("method")
+    if method == "initialize":
+        return _initialize_response(response_id, payload.get("params"))
+
     if method == "tools/list":
         return {"jsonrpc": "2.0", "id": response_id, "result": {"tools": MCP_TOOLS}}
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -283,6 +283,64 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert "structuredContent" not in balance["result"]
 
 
+def test_mcp_initialize_returns_server_capabilities(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "0.1.0"},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert "error" not in payload
+    assert payload["jsonrpc"] == "2.0"
+    assert payload["id"] == 1
+    result = payload["result"]
+    assert result["protocolVersion"] == "2025-06-18"
+    assert result["capabilities"] == {"tools": {"listChanged": False}}
+    assert result["serverInfo"] == {"name": "mergework", "version": "0.1.0"}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"jsonrpc": "2.0", "id": 2, "method": "initialize"},
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "initialize",
+            "params": {"protocolVersion": 123},
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "initialize",
+            "params": {"protocolVersion": "invalid-version"},
+        },
+    ],
+)
+def test_mcp_initialize_defaults_unsupported_protocol_versions(
+    sqlite_url: str, payload: dict[str, object]
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post("/mcp", json=payload)
+
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert result["protocolVersion"] == "2025-06-18"
+
+
 def test_mcp_list_bounty_attempts_reports_active_and_expired(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     now = datetime.now(UTC)

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -327,6 +327,12 @@ def test_mcp_initialize_returns_server_capabilities(sqlite_url: str) -> None:
             "method": "initialize",
             "params": {"protocolVersion": "invalid-version"},
         },
+        {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "initialize",
+            "params": {"protocolVersion": ""},
+        },
     ],
 )
 def test_mcp_initialize_defaults_unsupported_protocol_versions(


### PR DESCRIPTION
## Summary
- Add JSON-RPC `initialize` support on the public MCP endpoint.
- Return MCP protocol negotiation data with tool server capabilities and `serverInfo`.
- Default unsupported, empty, or malformed requested protocol versions to the server-supported MCP version.
- Add regression coverage so standard MCP clients no longer receive `unknown method` before `tools/list` / `tools/call`.

Bounty #799
Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4617088095

## Why
The current production MCP endpoint exposes `tools/list`, but a standard MCP lifecycle `initialize` request returns JSON-RPC `-32601 unknown method`. That can break MCP clients that perform the normal initialize handshake before listing or calling tools.

Production repro before this fix:

```text
POST https://mcp.mrwk.online/mcp initialize
-> {"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"unknown method"}}
```

The official MCP schema describes `initialize` as returning `protocolVersion`, server `capabilities`, and `serverInfo`: https://modelcontextprotocol.io/specification/2025-06-18/schema#initialize

## Review Follow-up
CodeRabbit and jakerated-r asked for protocol-version handling and initialize edge-case coverage. Current head returns the server-supported protocol version for missing, non-string, unsupported, or empty requested versions, with regression tests for those cases.

## Test Evidence
- `uv run --extra dev python -m pytest tests/test_api_mcp.py::test_mcp_initialize_returns_server_capabilities tests/test_api_mcp.py::test_mcp_initialize_defaults_unsupported_protocol_versions -q` -> 5 passed
- `uv run --extra dev python -m pytest -q` -> 795 passed, 1 existing Starlette/httpx warning
- `uv run --extra dev ruff format --check .` -> 111 files already formatted
- `uv run --extra dev ruff check .` -> All checks passed
- `uv run --extra dev mypy app` -> Success: no issues found in 42 source files
- `git diff --check origin/main...HEAD` -> clean

## Scope and Safety
This is a focused MCP handshake compatibility fix only. It does not change tool dispatch, bounty lifecycle, ledger, treasury, wallet, payout, proof, balance, exchange, bridge, off-ramp, cash-out, price behavior, private data, secrets, or production mutation behavior.

## Payout
payout address will be provided by the contributor on request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP protocol initialization: server responds with supported protocol version, reports tool capability (tools.listChanged: false), and includes server info (name and version); falls back to the server protocol when client input is invalid.

* **Tests**
  * Added tests for successful initialization and for handling unsupported/invalid protocolVersion inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->