### PR TITLE
Expose bounty finalization evidence in public rows

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -94,7 +94,7 @@ def _bounty_attempt_warnings_for_count(
         session=lookup_session,
         pending_proposals=pending_proposals,
         attempt_summary={},
-        finalization_evidence=finalization_evidence,
+        finalization_evidence=finalization_evidence if finalization_evidence is not None else {},
     )
     awards_remaining = int(bounty_data["effective_awards_remaining"])
     if bounty_data["status"] != "open":

--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -83,15 +83,18 @@ def _bounty_attempt_warnings_for_count(
     *,
     session: Session | None = None,
     pending_proposals: tuple[list[dict[str, Any]], dict[str, Any] | None] | None = None,
+    finalization_evidence: dict[str, Any] | None = None,
 ) -> list[str]:
     from app.serializers import bounty_to_dict
 
     warnings: list[str] = []
+    lookup_session = None if pending_proposals is not None else session
     bounty_data = bounty_to_dict(
         bounty,
-        session=session,
+        session=lookup_session,
         pending_proposals=pending_proposals,
         attempt_summary={},
+        finalization_evidence=finalization_evidence,
     )
     awards_remaining = int(bounty_data["effective_awards_remaining"])
     if bounty_data["status"] != "open":
@@ -148,6 +151,7 @@ def bounty_attempt_summary_from_count(
     *,
     session: Session | None = None,
     pending_proposals: tuple[list[dict[str, Any]], dict[str, Any] | None] | None = None,
+    finalization_evidence: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
         "active_attempt_count": active_count,
@@ -156,6 +160,7 @@ def bounty_attempt_summary_from_count(
             active_count,
             session=session,
             pending_proposals=pending_proposals,
+            finalization_evidence=finalization_evidence,
         ),
         "attempt_endpoint": f"/api/v1/bounties/{bounty.id}/attempts",
     }
@@ -167,6 +172,7 @@ def bounty_attempt_summary(
     now: datetime | None = None,
     *,
     pending_proposals: tuple[list[dict[str, Any]], dict[str, Any] | None] | None = None,
+    finalization_evidence: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     now = _as_utc(now or _utc_now())
     return bounty_attempt_summary_from_count(
@@ -174,6 +180,7 @@ def bounty_attempt_summary(
         active_bounty_attempt_count(session, bounty.id, now),
         session=session,
         pending_proposals=pending_proposals,
+        finalization_evidence=finalization_evidence,
     )
 
 

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Collection, Sequence
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
@@ -127,11 +127,10 @@ def bounties_to_dict(
     if session is None or not bounties:
         return [bounty_to_dict(bounty) for bounty in bounties]
 
+    bounty_ids = [bounty.id for bounty in bounties]
     pending_by_bounty = _pending_bounty_proposals_by_bounty_id(session)
-    finalization_by_bounty = _create_bounty_finalization_evidence_by_bounty_id(session)
-    attempt_counts = active_bounty_attempt_counts(
-        session, [bounty.id for bounty in bounties], datetime.now(UTC)
-    )
+    finalization_by_bounty = _create_bounty_finalization_evidence_by_bounty_id(session, bounty_ids)
+    attempt_counts = active_bounty_attempt_counts(session, bounty_ids, datetime.now(UTC))
     payloads: list[dict[str, Any]] = []
     for bounty in bounties:
         pending_proposals = pending_by_bounty.get(bounty.id, ([], None))
@@ -319,12 +318,17 @@ def _bounty_finalization_evidence(session: Session, bounty: Bounty) -> dict[str,
 
 def _create_bounty_finalization_evidence_by_bounty_id(
     session: Session,
+    bounty_ids: Collection[int],
 ) -> FinalizationEvidenceByBountyId:
+    target_bounty_ids = {bounty_id for bounty_id in bounty_ids if bounty_id > 0}
+    if not target_bounty_ids:
+        return {}
     proposals = session.scalars(
         select(TreasuryProposal)
         .where(
             TreasuryProposal.status == "executed",
             TreasuryProposal.action == "create_bounty",
+            or_(*[_result_bounty_id_filter(bounty_id) for bounty_id in sorted(target_bounty_ids)]),
         )
         .order_by(TreasuryProposal.id.asc())
     ).all()
@@ -334,7 +338,11 @@ def _create_bounty_finalization_evidence_by_bounty_id(
         if result is None:
             continue
         bounty_id = _result_bounty_id(result)
-        if bounty_id is None or bounty_id in evidence_by_bounty:
+        if (
+            bounty_id is None
+            or bounty_id not in target_bounty_ids
+            or bounty_id in evidence_by_bounty
+        ):
             continue
         evidence = _finalization_evidence_from_result(proposal, result)
         if evidence is not None:

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -25,6 +25,7 @@ from app.submission_requirements import (
 )
 
 PendingBountyProposals = tuple[list[dict[str, Any]], dict[str, Any] | None]
+FinalizationEvidenceByBountyId = dict[int, dict[str, Any]]
 MRWK_MICROUNITS = Decimal(1_000_000)
 
 
@@ -40,6 +41,7 @@ def bounty_to_dict(
     session: Session | None = None,
     pending_proposals: PendingBountyProposals | None = None,
     attempt_summary: dict[str, Any] | None = None,
+    finalization_evidence: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Serialize a bounty row for public API and page consumers."""
     awards_remaining = max(0, bounty.max_awards - bounty.awards_paid)
@@ -52,6 +54,8 @@ def bounty_to_dict(
         pending_payouts, pending_close = pending_proposals
     elif session is not None:
         pending_payouts, pending_close = _pending_bounty_proposals(session, bounty.id)
+    if finalization_evidence is None and session is not None:
+        finalization_evidence = _bounty_finalization_evidence(session, bounty)
     effective_awards_remaining = _effective_awards_remaining(
         awards_remaining, pending_payouts, pending_close
     )
@@ -68,6 +72,7 @@ def bounty_to_dict(
             session,
             bounty,
             pending_proposals=(pending_payouts, pending_close),
+            finalization_evidence=finalization_evidence,
         )
     payload = {
         "id": bounty.id,
@@ -110,6 +115,8 @@ def bounty_to_dict(
     }
     if attempt_summary is not None:
         payload.update(attempt_summary)
+    if finalization_evidence is not None:
+        payload["finalization_evidence"] = finalization_evidence
     return payload
 
 
@@ -121,6 +128,7 @@ def bounties_to_dict(
         return [bounty_to_dict(bounty) for bounty in bounties]
 
     pending_by_bounty = _pending_bounty_proposals_by_bounty_id(session)
+    finalization_by_bounty = _create_bounty_finalization_evidence_by_bounty_id(session)
     attempt_counts = active_bounty_attempt_counts(
         session, [bounty.id for bounty in bounties], datetime.now(UTC)
     )
@@ -131,10 +139,12 @@ def bounties_to_dict(
             bounty_to_dict(
                 bounty,
                 pending_proposals=pending_proposals,
+                finalization_evidence=finalization_by_bounty.get(bounty.id),
                 attempt_summary=bounty_attempt_summary_from_count(
                     bounty,
                     attempt_counts.get(bounty.id, 0),
                     pending_proposals=pending_proposals,
+                    finalization_evidence=finalization_by_bounty.get(bounty.id),
                 ),
             )
         )
@@ -229,6 +239,109 @@ def _proposal_payload(proposal: TreasuryProposal) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
+def _proposal_result(proposal: TreasuryProposal) -> dict[str, Any] | None:
+    try:
+        result = json.loads(proposal.result_json)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    return result if isinstance(result, dict) else None
+
+
+def _public_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    clean = value.strip()
+    return clean or None
+
+
+def _result_bounty_id(result: dict[str, Any]) -> int | None:
+    bounty = result.get("bounty")
+    if not isinstance(bounty, dict):
+        return None
+    value = bounty.get("id")
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        return None
+    try:
+        bounty_id = int(value)
+    except (TypeError, ValueError):
+        return None
+    return bounty_id if bounty_id > 0 else None
+
+
+def _finalization_evidence_from_result(
+    proposal: TreasuryProposal, result: dict[str, Any]
+) -> dict[str, Any] | None:
+    finalization = result.get("github_issue_finalization")
+    if not isinstance(finalization, dict):
+        return None
+    bounty_url = _public_string(finalization.get("bounty_url"))
+    comment_url = _public_string(finalization.get("comment_url"))
+    if bounty_url is None and comment_url is None:
+        return None
+    evidence: dict[str, Any] = {
+        "create_bounty_proposal_id": proposal.id,
+        "create_bounty_proposal_url": f"/api/v1/treasury/proposals/{proposal.id}",
+    }
+    status = _public_string(finalization.get("status"))
+    if status is not None:
+        evidence["status"] = status
+    if bounty_url is not None:
+        evidence["public_bounty_url"] = bounty_url
+    if comment_url is not None:
+        evidence["claims_open_comment_url"] = comment_url
+    label = _public_string(finalization.get("label"))
+    if label is not None:
+        evidence["label"] = label
+    issue_body_status = _public_string(finalization.get("issue_body_status"))
+    if issue_body_status is not None:
+        evidence["issue_body_status"] = issue_body_status
+    return evidence
+
+
+def _bounty_finalization_evidence(session: Session, bounty: Bounty) -> dict[str, Any] | None:
+    proposal = session.scalar(
+        select(TreasuryProposal)
+        .where(
+            TreasuryProposal.status == "executed",
+            TreasuryProposal.action == "create_bounty",
+            _result_bounty_id_filter(bounty.id),
+        )
+        .order_by(TreasuryProposal.id.asc())
+        .limit(1)
+    )
+    if proposal is None:
+        return None
+    result = _proposal_result(proposal)
+    if result is None or _result_bounty_id(result) != bounty.id:
+        return None
+    return _finalization_evidence_from_result(proposal, result)
+
+
+def _create_bounty_finalization_evidence_by_bounty_id(
+    session: Session,
+) -> FinalizationEvidenceByBountyId:
+    proposals = session.scalars(
+        select(TreasuryProposal)
+        .where(
+            TreasuryProposal.status == "executed",
+            TreasuryProposal.action == "create_bounty",
+        )
+        .order_by(TreasuryProposal.id.asc())
+    ).all()
+    evidence_by_bounty: FinalizationEvidenceByBountyId = {}
+    for proposal in proposals:
+        result = _proposal_result(proposal)
+        if result is None:
+            continue
+        bounty_id = _result_bounty_id(result)
+        if bounty_id is None or bounty_id in evidence_by_bounty:
+            continue
+        evidence = _finalization_evidence_from_result(proposal, result)
+        if evidence is not None:
+            evidence_by_bounty[bounty_id] = evidence
+    return evidence_by_bounty
+
+
 def _proposal_bounty_id(payload: dict[str, Any]) -> int | None:
     try:
         return int(payload["bounty_id"])
@@ -288,6 +401,15 @@ def _payload_bounty_id_filter(bounty_id: int) -> ColumnElement[bool]:
     return or_(
         TreasuryProposal.payload_json.contains(f"{marker},"),
         TreasuryProposal.payload_json.contains(f"{marker}}}"),
+    )
+
+
+def _result_bounty_id_filter(bounty_id: int) -> ColumnElement[bool]:
+    """Narrow executed create-bounty scans for canonical JSON result rows."""
+    marker = f'"id":{bounty_id}'
+    return or_(
+        TreasuryProposal.result_json.contains(f"{marker},"),
+        TreasuryProposal.result_json.contains(f"{marker}}}"),
     )
 
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -66,6 +66,15 @@ The bounties list returns public bounty rows. `status` can be omitted or set to
     "claim_command": "/claim",
     "attempt_endpoint": "/api/v1/bounties/36/attempts"
   },
+  "finalization_evidence": {
+    "create_bounty_proposal_id": 42,
+    "create_bounty_proposal_url": "/api/v1/treasury/proposals/42",
+    "status": "updated",
+    "public_bounty_url": "https://api.mrwk.online/bounties/36",
+    "claims_open_comment_url": "https://github.com/ramimbo/mergework/issues/164#issuecomment-1",
+    "label": "mrwk:bounty",
+    "issue_body_status": "updated"
+  },
   "status": "open",
   "acceptance": "Focused public-facing enhancements that help contributors find bounties, inspect accepted work, or understand proof/account activity, with tests. Duplicate, marketing-only, docs-only, broad redesign, or unrelated changes do not qualify.",
   "created_at": "2026-05-24T20:44:00.015953"
@@ -86,6 +95,13 @@ relying on available slot counts.
 The `active_attempt_count` and `active_attempt_warnings` fields are advisory
 overlap signals. When a warning is present, inspect `attempt_endpoint` before
 opening a PR so you can avoid duplicating another active attempt's scope.
+
+Rows may include `finalization_evidence` when the executed `create_bounty`
+proposal stored public lifecycle evidence. The object links to the public
+proposal API row, the public bounty page, and the GitHub claims-open comment
+when those values are known. Older rows or rows whose GitHub finalization was
+skipped or failed can omit this object; it is evidence that claims opened, not a
+payment, acceptance, cash-out, price, bridge, or exchange guarantee.
 
 `submission_requirements` gives agents the structured submission shape without
 parsing the human acceptance text. Most implementation bounties use

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -116,16 +116,26 @@ def test_bounty_api_omits_finalization_evidence_when_not_recorded(sqlite_url: st
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
         ensure_genesis(session)
-        bounty = create_bounty(
+        proposal = propose_treasury_action(
             session,
-            repo="ramimbo/mergework",
-            issue_number=75,
-            issue_url="https://github.com/ramimbo/mergework/issues/75",
-            title="Older bounty without finalization result",
-            reward_mrwk="25",
-            acceptance="Older rows should stay compatible.",
+            action="create_bounty",
+            payload={
+                "repo": "ramimbo/mergework",
+                "issue_number": 75,
+                "issue_url": "https://github.com/ramimbo/mergework/issues/75",
+                "title": "Older bounty without finalization result",
+                "reward_mrwk": "25",
+                "max_awards": 1,
+                "acceptance": "Older rows should stay compatible.",
+            },
+            proposed_by="maintainer",
         )
-        bounty_id = bounty.id
+        proposal.executes_after = utc_now() - timedelta(seconds=1)
+        session.flush()
+        executed = execute_treasury_proposal(
+            session, proposal_id=proposal.id, executed_by="maintainer"
+        )
+        bounty_id = int(json.loads(executed.result_json)["bounty"]["id"])
 
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -112,7 +112,7 @@ def test_bounty_api_exposes_create_bounty_finalization_evidence(sqlite_url: str)
     assert listed["finalization_evidence"] == expected
 
 
-def test_bounty_api_omits_finalization_evidence_when_not_recorded(sqlite_url: str) -> None:
+def test_bounty_api_omits_finalization_evidence_without_public_urls(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
         ensure_genesis(session)
@@ -136,6 +136,16 @@ def test_bounty_api_omits_finalization_evidence_when_not_recorded(sqlite_url: st
             session, proposal_id=proposal.id, executed_by="maintainer"
         )
         bounty_id = int(json.loads(executed.result_json)["bounty"]["id"])
+        record_proposal_result_field(
+            session,
+            proposal_id=proposal.id,
+            field="github_issue_finalization",
+            value={
+                "status": "updated",
+                "label": "mrwk:bounty",
+                "issue_body_status": "updated",
+            },
+        )
 
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+import json
+from datetime import timedelta
+
 import pytest
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
+from app.models import utc_now
 from app.path_params import SQLITE_INTEGER_MAX
-from app.treasury import propose_treasury_action
+from app.treasury import (
+    execute_treasury_proposal,
+    propose_treasury_action,
+    record_proposal_result_field,
+)
 
 
 def test_bounty_api_reports_multi_award_capacity(sqlite_url: str) -> None:
@@ -44,6 +52,88 @@ def test_bounty_api_reports_multi_award_capacity(sqlite_url: str) -> None:
     assert bounty["submission_requirements"]["expected_artifact"] == (
         "focused PR, issue, report, or evidence URL"
     )
+
+
+def test_bounty_api_exposes_create_bounty_finalization_evidence(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        proposal = propose_treasury_action(
+            session,
+            action="create_bounty",
+            payload={
+                "repo": "ramimbo/mergework",
+                "issue_number": 74,
+                "issue_url": "https://github.com/ramimbo/mergework/issues/74",
+                "title": "Expose finalization evidence",
+                "reward_mrwk": "25",
+                "max_awards": 1,
+                "acceptance": "Public rows should link the create-bounty evidence.",
+            },
+            proposed_by="maintainer",
+        )
+        proposal_id = proposal.id
+        proposal.executes_after = utc_now() - timedelta(seconds=1)
+        session.flush()
+        executed = execute_treasury_proposal(
+            session, proposal_id=proposal_id, executed_by="maintainer"
+        )
+        bounty_id = int(json.loads(executed.result_json)["bounty"]["id"])
+        record_proposal_result_field(
+            session,
+            proposal_id=proposal_id,
+            field="github_issue_finalization",
+            value={
+                "status": "updated",
+                "label": "mrwk:bounty",
+                "bounty_url": "https://api.mrwk.online/bounties/74",
+                "comment_url": ("https://github.com/ramimbo/mergework/issues/74#issuecomment-1"),
+                "issue_body_status": "updated",
+            },
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    detail = client.get(f"/api/v1/bounties/{bounty_id}").json()
+    listed = client.get("/api/v1/bounties?repo=ramimbo%2Fmergework&issue_number=74").json()[0]
+
+    expected = {
+        "create_bounty_proposal_id": proposal_id,
+        "create_bounty_proposal_url": f"/api/v1/treasury/proposals/{proposal_id}",
+        "status": "updated",
+        "public_bounty_url": "https://api.mrwk.online/bounties/74",
+        "claims_open_comment_url": (
+            "https://github.com/ramimbo/mergework/issues/74#issuecomment-1"
+        ),
+        "label": "mrwk:bounty",
+        "issue_body_status": "updated",
+    }
+    assert detail["finalization_evidence"] == expected
+    assert listed["finalization_evidence"] == expected
+
+
+def test_bounty_api_omits_finalization_evidence_when_not_recorded(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=75,
+            issue_url="https://github.com/ramimbo/mergework/issues/75",
+            title="Older bounty without finalization result",
+            reward_mrwk="25",
+            acceptance="Older rows should stay compatible.",
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    detail = client.get(f"/api/v1/bounties/{bounty_id}").json()
+    listed = client.get("/api/v1/bounties?repo=ramimbo%2Fmergework&issue_number=75").json()[0]
+
+    assert "finalization_evidence" not in detail
+    assert "finalization_evidence" not in listed
 
 
 def test_bounty_api_reports_issue_submission_requirements(sqlite_url: str) -> None:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -575,6 +575,18 @@ def test_api_examples_document_activity_response_shape() -> None:
     assert "/api/v1/proofs/<proof_hash>" in examples
 
 
+def test_api_examples_document_bounty_finalization_evidence() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert '"finalization_evidence": {' in examples
+    assert '"create_bounty_proposal_url": "/api/v1/treasury/proposals/42"' in examples
+    assert (
+        '"claims_open_comment_url": "https://github.com/ramimbo/mergework/issues/164#issuecomment-1"'
+        in examples
+    )
+    assert "it is evidence that claims opened, not a" in examples
+
+
 def test_api_examples_document_accepted_work_bounty_context() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta, timezone
 
 from sqlalchemy import event
 
+from app import serializers as serializer_module
 from app.db import create_schema, session_scope
 from app.ledger.service import create_bounty, ensure_genesis, pay_bounty, register_wallet
 from app.models import Bounty, Proof, WalletTransfer, utc_now
@@ -352,6 +353,70 @@ def test_bounties_to_dict_exposes_preloaded_finalization_evidence(sqlite_url: st
         "issue_body_status": "updated",
     }
     assert len(treasury_selects) == 2
+
+
+def test_bounties_to_dict_limits_finalization_preload_to_serialized_bounties(
+    sqlite_url: str, monkeypatch
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+        def execute_create_bounty(issue_number: int) -> tuple[int, int]:
+            proposal = propose_treasury_action(
+                session,
+                action="create_bounty",
+                payload={
+                    "repo": "ramimbo/mergework",
+                    "issue_number": issue_number,
+                    "issue_url": f"https://github.com/ramimbo/mergework/issues/{issue_number}",
+                    "title": f"Finalization preload {issue_number}",
+                    "reward_mrwk": "25",
+                    "max_awards": 1,
+                    "acceptance": "Serializer should only inspect serialized bounties.",
+                },
+                proposed_by="maintainer",
+            )
+            proposal_id = proposal.id
+            proposal.executes_after = utc_now() - timedelta(seconds=1)
+            session.flush()
+            executed = execute_treasury_proposal(
+                session, proposal_id=proposal_id, executed_by="maintainer"
+            )
+            bounty_id = int(json.loads(executed.result_json)["bounty"]["id"])
+            record_proposal_result_field(
+                session,
+                proposal_id=proposal_id,
+                field="github_issue_finalization",
+                value={
+                    "status": "updated",
+                    "bounty_url": f"https://api.mrwk.online/bounties/{issue_number}",
+                    "comment_url": (
+                        f"https://github.com/ramimbo/mergework/issues/{issue_number}#issuecomment-1"
+                    ),
+                },
+            )
+            return proposal_id, bounty_id
+
+        target_proposal_id, target_bounty_id = execute_create_bounty(341)
+        unrelated_proposal_id, _ = execute_create_bounty(342)
+        target_bounty = session.get(Bounty, target_bounty_id)
+        assert target_bounty is not None
+
+        inspected_proposal_ids: list[int] = []
+        original_proposal_result = serializer_module._proposal_result
+
+        def track_proposal_result(proposal):
+            inspected_proposal_ids.append(proposal.id)
+            return original_proposal_result(proposal)
+
+        monkeypatch.setattr(serializer_module, "_proposal_result", track_proposal_result)
+
+        serialized = bounties_to_dict([target_bounty], session=session)
+
+    assert inspected_proposal_ids == [target_proposal_id]
+    assert unrelated_proposal_id not in inspected_proposal_ids
+    assert serialized[0]["finalization_evidence"]["create_bounty_proposal_id"] == target_proposal_id
 
 
 def test_bounty_to_dict_narrows_single_pending_proposal_lookup(sqlite_url: str) -> None:

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta, timezone
 
 from sqlalchemy import event
 
 from app.db import create_schema, session_scope
 from app.ledger.service import create_bounty, ensure_genesis, pay_bounty, register_wallet
-from app.models import Bounty, Proof, WalletTransfer
+from app.models import Bounty, Proof, WalletTransfer, utc_now
 from app.serializers import (
     accepted_work_for_account,
     account_accepted_summary,
@@ -21,7 +22,11 @@ from app.serializers import (
     wallet_to_dict,
     wallet_transfer_to_dict,
 )
-from app.treasury import propose_treasury_action
+from app.treasury import (
+    execute_treasury_proposal,
+    propose_treasury_action,
+    record_proposal_result_field,
+)
 
 
 class BrokenSession:
@@ -270,7 +275,83 @@ def test_bounties_to_dict_preloads_pending_proposals_once(sqlite_url: str) -> No
     assert by_title["Pending payout serializer"]["effective_awards_remaining"] == 1
     assert by_title["Pending close serializer"]["availability_state"] == "pending_close"
     assert by_title["Plain serializer"]["availability_state"] == "open"
-    assert len(treasury_selects) == 1
+    assert len(treasury_selects) == 2
+
+
+def test_bounties_to_dict_exposes_preloaded_finalization_evidence(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        proposal = propose_treasury_action(
+            session,
+            action="create_bounty",
+            payload={
+                "repo": "ramimbo/mergework",
+                "issue_number": 324,
+                "issue_url": "https://github.com/ramimbo/mergework/issues/324",
+                "title": "Finalization evidence serializer",
+                "reward_mrwk": "25",
+                "max_awards": 1,
+                "acceptance": "Serializer should expose stored finalization evidence.",
+            },
+            proposed_by="maintainer",
+        )
+        proposal_id = proposal.id
+        proposal.executes_after = utc_now() - timedelta(seconds=1)
+        session.flush()
+        executed = execute_treasury_proposal(
+            session, proposal_id=proposal_id, executed_by="maintainer"
+        )
+        bounty_id = int(json.loads(executed.result_json)["bounty"]["id"])
+        record_proposal_result_field(
+            session,
+            proposal_id=proposal_id,
+            field="github_issue_finalization",
+            value={
+                "status": "updated",
+                "label": "mrwk:bounty",
+                "bounty_url": "https://api.mrwk.online/bounties/324",
+                "comment_url": ("https://github.com/ramimbo/mergework/issues/324#issuecomment-1"),
+                "issue_body_status": "updated",
+            },
+        )
+        bounty = session.get(Bounty, bounty_id)
+        assert bounty is not None
+        treasury_selects: list[str] = []
+
+        def count_treasury_selects(
+            conn,
+            cursor,
+            statement,
+            parameters,
+            context,
+            executemany,
+        ) -> None:
+            del conn, cursor, parameters, context, executemany
+            if "treasury_proposals" in statement.lower() and statement.lstrip().upper().startswith(
+                "SELECT"
+            ):
+                treasury_selects.append(statement)
+
+        bind = session.get_bind()
+        event.listen(bind, "before_cursor_execute", count_treasury_selects)
+        try:
+            serialized = bounties_to_dict([bounty], session=session)
+        finally:
+            event.remove(bind, "before_cursor_execute", count_treasury_selects)
+
+    assert serialized[0]["finalization_evidence"] == {
+        "create_bounty_proposal_id": proposal_id,
+        "create_bounty_proposal_url": f"/api/v1/treasury/proposals/{proposal_id}",
+        "status": "updated",
+        "public_bounty_url": "https://api.mrwk.online/bounties/324",
+        "claims_open_comment_url": (
+            "https://github.com/ramimbo/mergework/issues/324#issuecomment-1"
+        ),
+        "label": "mrwk:bounty",
+        "issue_body_status": "updated",
+    }
+    assert len(treasury_selects) == 2
 
 
 def test_bounty_to_dict_narrows_single_pending_proposal_lookup(sqlite_url: str) -> None:
@@ -336,8 +417,9 @@ def test_bounty_to_dict_narrows_single_pending_proposal_lookup(sqlite_url: str) 
     assert serialized["availability_state"] == "open"
     assert serialized["pending_payout_awards"] == 0
     assert serialized["effective_awards_remaining"] == 1
-    assert len(treasury_selects) == 1
+    assert len(treasury_selects) == 2
     assert "payload_json" in treasury_selects[0].lower()
+    assert "result_json" in treasury_selects[1].lower()
 
 
 def test_account_and_wallet_serializers_preserve_public_shapes(sqlite_url: str) -> None:

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -283,41 +283,49 @@ def test_bounties_to_dict_exposes_preloaded_finalization_evidence(sqlite_url: st
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
         ensure_genesis(session)
-        proposal = propose_treasury_action(
-            session,
-            action="create_bounty",
-            payload={
-                "repo": "ramimbo/mergework",
-                "issue_number": 324,
-                "issue_url": "https://github.com/ramimbo/mergework/issues/324",
-                "title": "Finalization evidence serializer",
-                "reward_mrwk": "25",
-                "max_awards": 1,
-                "acceptance": "Serializer should expose stored finalization evidence.",
-            },
-            proposed_by="maintainer",
-        )
-        proposal_id = proposal.id
-        proposal.executes_after = utc_now() - timedelta(seconds=1)
-        session.flush()
-        executed = execute_treasury_proposal(
-            session, proposal_id=proposal_id, executed_by="maintainer"
-        )
-        bounty_id = int(json.loads(executed.result_json)["bounty"]["id"])
-        record_proposal_result_field(
-            session,
-            proposal_id=proposal_id,
-            field="github_issue_finalization",
-            value={
-                "status": "updated",
-                "label": "mrwk:bounty",
-                "bounty_url": "https://api.mrwk.online/bounties/324",
-                "comment_url": ("https://github.com/ramimbo/mergework/issues/324#issuecomment-1"),
-                "issue_body_status": "updated",
-            },
-        )
-        bounty = session.get(Bounty, bounty_id)
-        assert bounty is not None
+
+        def execute_create_bounty(issue_number: int) -> tuple[int, Bounty]:
+            proposal = propose_treasury_action(
+                session,
+                action="create_bounty",
+                payload={
+                    "repo": "ramimbo/mergework",
+                    "issue_number": issue_number,
+                    "issue_url": f"https://github.com/ramimbo/mergework/issues/{issue_number}",
+                    "title": f"Finalization evidence serializer {issue_number}",
+                    "reward_mrwk": "25",
+                    "max_awards": 1,
+                    "acceptance": "Serializer should expose stored finalization evidence.",
+                },
+                proposed_by="maintainer",
+            )
+            proposal_id = proposal.id
+            proposal.executes_after = utc_now() - timedelta(seconds=1)
+            session.flush()
+            executed = execute_treasury_proposal(
+                session, proposal_id=proposal_id, executed_by="maintainer"
+            )
+            bounty_id = int(json.loads(executed.result_json)["bounty"]["id"])
+            record_proposal_result_field(
+                session,
+                proposal_id=proposal_id,
+                field="github_issue_finalization",
+                value={
+                    "status": "updated",
+                    "label": "mrwk:bounty",
+                    "bounty_url": f"https://api.mrwk.online/bounties/{issue_number}",
+                    "comment_url": (
+                        f"https://github.com/ramimbo/mergework/issues/{issue_number}#issuecomment-1"
+                    ),
+                    "issue_body_status": "updated",
+                },
+            )
+            bounty = session.get(Bounty, bounty_id)
+            assert bounty is not None
+            return proposal_id, bounty
+
+        proposal_id, bounty = execute_create_bounty(324)
+        other_proposal_id, other_bounty = execute_create_bounty(325)
         treasury_selects: list[str] = []
 
         def count_treasury_selects(
@@ -337,17 +345,29 @@ def test_bounties_to_dict_exposes_preloaded_finalization_evidence(sqlite_url: st
         bind = session.get_bind()
         event.listen(bind, "before_cursor_execute", count_treasury_selects)
         try:
-            serialized = bounties_to_dict([bounty], session=session)
+            serialized = bounties_to_dict([bounty, other_bounty], session=session)
         finally:
             event.remove(bind, "before_cursor_execute", count_treasury_selects)
 
-    assert serialized[0]["finalization_evidence"] == {
+    by_issue_number = {row["issue_number"]: row for row in serialized}
+    assert by_issue_number[324]["finalization_evidence"] == {
         "create_bounty_proposal_id": proposal_id,
         "create_bounty_proposal_url": f"/api/v1/treasury/proposals/{proposal_id}",
         "status": "updated",
         "public_bounty_url": "https://api.mrwk.online/bounties/324",
         "claims_open_comment_url": (
             "https://github.com/ramimbo/mergework/issues/324#issuecomment-1"
+        ),
+        "label": "mrwk:bounty",
+        "issue_body_status": "updated",
+    }
+    assert by_issue_number[325]["finalization_evidence"] == {
+        "create_bounty_proposal_id": other_proposal_id,
+        "create_bounty_proposal_url": f"/api/v1/treasury/proposals/{other_proposal_id}",
+        "status": "updated",
+        "public_bounty_url": "https://api.mrwk.online/bounties/325",
+        "claims_open_comment_url": (
+            "https://github.com/ramimbo/mergework/issues/325#issuecomment-1"
         ),
         "label": "mrwk:bounty",
         "issue_body_status": "updated",

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta, timezone
 from sqlalchemy import event
 
 from app import serializers as serializer_module
+from app.bounty_attempts import bounty_attempt_warnings
 from app.db import create_schema, session_scope
 from app.ledger.service import create_bounty, ensure_genesis, pay_bounty, register_wallet
 from app.models import Bounty, Proof, WalletTransfer, utc_now
@@ -373,6 +374,35 @@ def test_bounties_to_dict_exposes_preloaded_finalization_evidence(sqlite_url: st
         "issue_body_status": "updated",
     }
     assert len(treasury_selects) == 2
+
+
+def test_bounty_attempt_warnings_skip_finalization_evidence_lookup(
+    sqlite_url: str, monkeypatch
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=326,
+            issue_url="https://github.com/ramimbo/mergework/issues/326",
+            title="Attempt warnings serializer",
+            reward_mrwk="25",
+            acceptance="Attempt warnings should not load unused finalization evidence.",
+        )
+
+        def fail_finalization_lookup(*args, **kwargs):
+            del args, kwargs
+            raise AssertionError("attempt warnings should not load finalization evidence")
+
+        monkeypatch.setattr(
+            serializer_module, "_bounty_finalization_evidence", fail_finalization_lookup
+        )
+
+        warnings = bounty_attempt_warnings(session, bounty, utc_now())
+
+    assert warnings == []
 
 
 def test_bounties_to_dict_limits_finalization_preload_to_serialized_bounties(


### PR DESCRIPTION
## Related bounty and source report

Refs #799
Source report: #774

## Summary

- expose optional `finalization_evidence` on public bounty row serialization when an executed `create_bounty` proposal has stored public GitHub finalization evidence
- include the create-bounty proposal API URL, public bounty URL, claims-open GitHub comment URL, finalization status, label, and issue-body status when known
- omit the object for older rows or skipped/failed finalization results without public evidence
- document the field as lifecycle evidence only, not payment, acceptance, cash-out, price, bridge, exchange, or off-ramp evidence

## Evidence

Source report #774 identifies that public bounty rows expose status and capacity but not the public evidence that made a row live: the executed create-bounty proposal and claims-open `Reserved on MergeWork` comment.

The implementation reuses data already persisted in executed treasury proposal `result.github_issue_finalization`. It does not crawl GitHub on read, mutate GitHub, change claim acceptance, change payout behavior, change treasury execution, or add private/admin state.

## Tests

- `/Users/dom/bounty-work/mergework/.venv/bin/python -m pytest tests/test_bounty_api_routes.py tests/test_serializers.py tests/test_docs_public_urls.py -q` -> 70 passed, 1 warning
- `/Users/dom/bounty-work/mergework/.venv/bin/python -m pytest -q` -> 794 passed, 1 warning
- `/Users/dom/bounty-work/mergework/.venv/bin/ruff check .` -> all checks passed
- `/Users/dom/bounty-work/mergework/.venv/bin/ruff format --check .` -> 111 files already formatted
- `/Users/dom/bounty-work/mergework/.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `/Users/dom/bounty-work/mergework/.venv/bin/mypy app` -> success, no issues found in 42 source files
- `git diff --check` -> clean

## Out of scope

- No payment, proof, claim acceptance, wallet, bridge, exchange, liquidity, price, cash-out, or investment behavior changes.
- No GitHub comment posting or issue mutation from public read routes.
- No private security details, secrets, credentials, or private user data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounties now include optional finalization evidence in API responses (treasury proposal metadata and GitHub issue/claim details) when recorded; list endpoints preload per-bounty evidence for efficient serialization.

* **Documentation**
  * API examples updated to show finalization_evidence and explain when it appears.

* **Tests**
  * New and expanded tests validate exposure, preloading behavior, scope limits, and backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->