### PR TITLE
Normalize MCP proof timestamps

### DIFF
--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -28,6 +28,7 @@ from app.serializers import (
     bounties_to_dict,
     bounty_awards_to_dict,
     bounty_to_dict,
+    public_utc_timestamp,
     wallet_to_dict,
     wallet_transfer_to_dict,
 )
@@ -265,7 +266,7 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                     "ledger_sequence": proof.ledger_sequence,
                     "bounty_id": proof.bounty_id,
                     "submission_id": proof.submission_id,
-                    "created_at": proof.created_at.isoformat(),
+                    "created_at": public_utc_timestamp(proof.created_at),
                     "proof": public_payload,
                 }
             )

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -772,7 +772,7 @@ proof payload as both JSON text and parsed `structuredContent`:
     "content": [
       {
         "type": "text",
-        "text": "{\"hash\":\"<proof_hash>\",\"kind\":\"bounty_payment\",\"ledger_sequence\":322,\"bounty_id\":32,\"submission_id\":279,\"created_at\":\"2026-05-24T20:28:53.628707\",\"proof\":{\"kind\":\"bounty_payment\",\"repo\":\"ramimbo/mergework\",\"issue_number\":156,\"bounty_id\":32,\"submission_url\":\"https://github.com/ramimbo/mergework/pull/155#pullrequestreview-4353350771\",\"to_account\":\"github:ckeplinger199\",\"amount_mrwk\":\"40\"}}"
+        "text": "{\"hash\":\"<proof_hash>\",\"kind\":\"bounty_payment\",\"ledger_sequence\":322,\"bounty_id\":32,\"submission_id\":279,\"created_at\":\"2026-05-24T20:28:53.628707Z\",\"proof\":{\"kind\":\"bounty_payment\",\"repo\":\"ramimbo/mergework\",\"issue_number\":156,\"bounty_id\":32,\"submission_url\":\"https://github.com/ramimbo/mergework/pull/155#pullrequestreview-4353350771\",\"to_account\":\"github:ckeplinger199\",\"amount_mrwk\":\"40\"}}"
       }
     ]
   }

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1445,6 +1445,7 @@ def test_mcp_get_proof_returns_public_proof_details(sqlite_url: str) -> None:
     assert payload["hash"] == proof.hash
     assert payload["kind"] == "bounty_payment"
     assert payload["ledger_sequence"] == proof.ledger_sequence
+    assert payload["created_at"] == public_utc_timestamp(proof.created_at)
     assert payload["proof"]["repo"] == "ramimbo/mergework"
     assert payload["proof"]["submission_url"] == "https://github.com/ramimbo/mergework/pull/37"
     assert payload["proof"]["accepted_by"] == "maintainer"


### PR DESCRIPTION
## Related bounty

Refs #798

## Summary

- serialize MCP `get_proof` proof metadata `created_at` with the existing public UTC timestamp helper
- keep the MCP proof response consistent with the related ledger entry timestamp shape
- update the public MCP example and add a regression assertion

## Evidence

Live read-only checks still show MCP `get_proof` returning `2026-06-01T11:42:20.646161` while `get_ledger_entry` for the same proof-backed ledger item returns `2026-06-01T11:42:20.644787Z`.

Final preflight before publication: `mergework-798-mcp-final-preflight-20260604T035708Z.md`.

## Tests

- focused MCP/docs tests: `140 passed, 1 warning`
- full pytest: `790 passed, 1 warning`
- Ruff check and format check passed
- docs smoke passed
- mypy app passed
- diff whitespace check clean

## Out of scope

- No wallet, payout, transfer, bridge, exchange, cash-out, price, or investment behavior changes.
- No private data, secrets, credentials, account creation, or live mutation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected timestamp format in the `get_proof` API response to use proper UTC notation (ISO 8601 standard)

* **Documentation**
  * Updated API example payload to reflect the corrected timestamp format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->