### PR TITLE
Preserve account filter on activity page

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlencode
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
@@ -20,7 +21,18 @@ def activity_context(
     if query is not None and contains_control_character(query):
         raise HTTPException(status_code=400, detail="q must not contain control characters")
     normalized = normalized_account(account) if account is not None else None
-    return activity_to_dict(session, query, account=normalized)
+    context = activity_to_dict(session, query, account=normalized)
+    context["api_activity_url"] = _activity_api_url(context["query"], context.get("account"))
+    return context
+
+
+def _activity_api_url(query: str, account: str | None) -> str:
+    params: list[tuple[str, str]] = []
+    if query:
+        params.append(("q", query))
+    if account:
+        params.append(("account", account))
+    return f"/api/v1/activity?{urlencode(params)}" if params else "/api/v1/activity"
 
 
 def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
@@ -38,9 +50,15 @@ def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Temp
             return activity_context(session, q, account)
 
     @app.get("/activity", response_class=HTMLResponse)
-    def activity_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:
+    def activity_page(
+        request: Request,
+        q: str | None = Query(None),
+        account: str | None = Query(None),
+    ) -> HTMLResponse:
         reject_control_char_query_param(request, "q")
         reject_repeated_query_param(request, "q")
+        reject_control_char_query_param(request, "account")
+        reject_repeated_query_param(request, "account")
         with session_scope(db_url) as session:
-            context = activity_context(session, q)
+            context = activity_context(session, q, account)
         return templates.TemplateResponse(request, "activity.html", context)

--- a/app/activity.py
+++ b/app/activity.py
@@ -23,6 +23,7 @@ def activity_context(
     normalized = normalized_account(account) if account is not None else None
     context = activity_to_dict(session, query, account=normalized)
     context["api_activity_url"] = _activity_api_url(context["query"], context.get("account"))
+    context["clear_activity_url"] = _activity_page_url(context.get("account"))
     return context
 
 
@@ -33,6 +34,10 @@ def _activity_api_url(query: str, account: str | None) -> str:
     if account:
         params.append(("account", account))
     return f"/api/v1/activity?{urlencode(params)}" if params else "/api/v1/activity"
+
+
+def _activity_page_url(account: str | None) -> str:
+    return f"/activity?{urlencode({'account': account})}" if account else "/activity"
 
 
 def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -644,11 +644,11 @@ def activity_to_dict(
 
     by_account: dict[str, dict[str, Any]] = {}
     for row in recent:
-        account = str(row["account"])
+        contributor_account = str(row["account"])
         contributor = by_account.setdefault(
-            account,
+            contributor_account,
             {
-                "account": account,
+                "account": contributor_account,
                 "accepted_awards": 0,
                 "accepted_microunits": 0,
                 "accepted_mrwk": "0",

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -10,7 +10,7 @@
     {% if account %}<input type="hidden" name="account" value="{{ account }}">{% endif %}
     <input id="activity-q" name="q" value="{{ query }}" placeholder="account, PR, proof, issue, bounty">
     <button type="submit">Search</button>
-    {% if query %}<a href="/activity">Clear</a>{% endif %}
+    {% if query %}<a href="{{ clear_activity_url }}">Clear</a>{% endif %}
   </div>
 </form>
 {% if account and query %}
@@ -176,7 +176,7 @@
   {% else %}
   {% if query %}
   <p>No accepted work matches this search.</p>
-  <p><a href="/activity">Clear search</a></p>
+  <p><a href="{{ clear_activity_url }}">Clear search</a></p>
   {% else %}
   <p>No proof-backed accepted work rows yet.</p>
   {% endif %}

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -7,16 +7,21 @@
 <form class="search-form" method="get" action="/activity" role="search">
   <label for="activity-q">Search accepted work</label>
   <div class="search-row">
+    {% if account %}<input type="hidden" name="account" value="{{ account }}">{% endif %}
     <input id="activity-q" name="q" value="{{ query }}" placeholder="account, PR, proof, issue, bounty">
     <button type="submit">Search</button>
     {% if query %}<a href="/activity">Clear</a>{% endif %}
   </div>
 </form>
-{% if query %}
+{% if account and query %}
+<p class="notice">Showing accepted work for <code>{{ account }}</code> matching "{{ query }}"</p>
+{% elif account %}
+<p class="notice">Showing accepted work for <code>{{ account }}</code></p>
+{% elif query %}
 <p class="notice">Showing accepted work matching “{{ query }}”.</p>
 {% endif %}
 <nav class="actions detail-actions" aria-label="Activity inspection links">
-  <a href="/api/v1/activity{% if query %}?q={{ query | urlencode }}{% endif %}">View JSON activity</a>
+  <a href="{{ api_activity_url }}">View JSON activity</a>
 </nav>
 
 <section class="grid">

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -307,10 +307,13 @@ def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
     repeated_api_response = client.get("/api/v1/activity?q=github&q=alice")
     repeated_page_response = client.get("/activity?q=github&q=alice")
     account_control_response = client.get("/api/v1/activity?account=%C2%85github:alice")
+    page_account_control_response = client.get("/activity?account=%C2%85github:alice")
     repeated_account_response = client.get(
         "/api/v1/activity?account=github:alice&account=github:bob"
     )
+    repeated_page_account_response = client.get("/activity?account=github:alice&account=github:bob")
     invalid_account_response = client.get("/api/v1/activity?account=github%3A%20")
+    invalid_page_account_response = client.get("/activity?account=github%3A%20")
 
     assert api_response.status_code == 400
     assert api_response.json()["detail"] == "q must not contain control characters"
@@ -326,10 +329,20 @@ def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
     assert account_control_response.json()["detail"] == (
         "account must not contain control characters"
     )
+    assert page_account_control_response.status_code == 400
+    assert page_account_control_response.json()["detail"] == (
+        "account must not contain control characters"
+    )
     assert repeated_account_response.status_code == 400
     assert repeated_account_response.json()["detail"] == "account must be provided at most once"
+    assert repeated_page_account_response.status_code == 400
+    assert repeated_page_account_response.json()["detail"] == (
+        "account must be provided at most once"
+    )
     assert invalid_account_response.status_code == 400
     assert invalid_account_response.json()["detail"] == "github login must be valid"
+    assert invalid_page_account_response.status_code == 400
+    assert invalid_page_account_response.json()["detail"] == "github login must be valid"
 
 
 def test_activity_api_exposes_pending_payouts_separately_from_paid_work(
@@ -502,6 +515,7 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert 'Showing accepted work for <code>github:bob</code> matching "pull/12"' in (
         scoped_account_query.text
     )
+    assert 'href="/activity?account=github%3Abob">Clear</a>' in scoped_account_query.text
     assert (
         'href="/api/v1/activity?q=pull%2F12&amp;account=github%3Abob">View JSON activity</a>'
     ) in scoped_account_query.text
@@ -533,6 +547,11 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert "No accepted bounty payments yet." not in no_match.text
     assert "No proof-backed accepted work rows yet." not in no_match.text
     assert 'href="/activity">Clear search</a>' in no_match.text
+
+    scoped_no_match = client.get("/activity?account=GitHub:Bob&q=alice")
+
+    assert scoped_no_match.status_code == 200
+    assert 'href="/activity?account=github%3Abob">Clear search</a>' in scoped_no_match.text
 
 
 def test_activity_page_renders_pending_accepted_work(sqlite_url: str) -> None:

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -79,6 +79,7 @@ def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -
 
     assert response.status_code == 200
     payload = response.json()
+    assert "account" not in payload
     assert payload["totals"] == {
         "accepted_awards": 3,
         "accepted_mrwk": "90",
@@ -473,6 +474,7 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert 'role="search"' in paid.text
     assert 'aria-label="Activity inspection links"' in paid.text
     assert 'href="/api/v1/activity">View JSON activity</a>' in paid.text
+    assert 'name="account"' not in paid.text
     assert 'name="q"' in paid.text
     assert f'href="/bounties/{bounty.id}">Bounty #{bounty.id}</a>' in paid.text
     assert "Latest bounty" in paid.text
@@ -481,6 +483,28 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert f'href="/proofs/{proof.hash}"' in paid.text
     assert "/accounts/github:bob" in paid.text
     assert "Pending accepted work" in paid.text
+
+    scoped_account = client.get("/activity?account=GitHub:Bob")
+
+    assert scoped_account.status_code == 200
+    assert 'name="account" value="github:bob"' in scoped_account.text
+    assert "Showing accepted work for <code>github:bob</code>" in scoped_account.text
+    assert (
+        'href="/api/v1/activity?account=github%3Abob">View JSON activity</a>' in scoped_account.text
+    )
+    assert "github:bob" in scoped_account.text
+    assert "75 MRWK" in scoped_account.text
+
+    scoped_account_query = client.get("/activity?account=GitHub:Bob&q=pull%2F12")
+
+    assert scoped_account_query.status_code == 200
+    assert 'value="pull/12"' in scoped_account_query.text
+    assert 'Showing accepted work for <code>github:bob</code> matching "pull/12"' in (
+        scoped_account_query.text
+    )
+    assert (
+        'href="/api/v1/activity?q=pull%2F12&amp;account=github%3Abob">View JSON activity</a>'
+    ) in scoped_account_query.text
 
     filtered = client.get("/activity?q=bob")
     issue_ref = client.get("/activity?q=%2312")

--- a/tests/test_activity_routes.py
+++ b/tests/test_activity_routes.py
@@ -11,6 +11,7 @@ def test_activity_context_preserves_empty_feed_shape(sqlite_url: str) -> None:
         assert activity_context(session) == {
             "query": "",
             "api_activity_url": "/api/v1/activity",
+            "clear_activity_url": "/activity",
             "totals": {
                 "accepted_awards": 0,
                 "accepted_mrwk": "0",

--- a/tests/test_activity_routes.py
+++ b/tests/test_activity_routes.py
@@ -10,6 +10,7 @@ def test_activity_context_preserves_empty_feed_shape(sqlite_url: str) -> None:
     with session_scope(sqlite_url) as session:
         assert activity_context(session) == {
             "query": "",
+            "api_activity_url": "/api/v1/activity",
             "totals": {
                 "accepted_awards": 0,
                 "accepted_mrwk": "0",


### PR DESCRIPTION
## Summary

Bounty #799
Refs #798

Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4620048324

The activity API now honors `account=github:<login>`, but the HTML activity page still ignored that query string and rendered the global activity page. This PR makes the page preserve the same account-scoped view and fixes a serializer variable shadowing bug that could leak a last contributor account into global activity context once the template started reading `account`.

## Changes

- Accept and validate `account` on `/activity` with the same repeated/control-character checks as the API route.
- Reuse the normalized activity context account for the page notice, hidden search field, and "View JSON activity" link.
- Build the activity JSON inspection URL server-side so `q` and `account` are preserved together.
- Rename the contributor aggregation loop variable in `activity_to_dict()` so global activity responses do not gain a synthetic top-level `account`.
- Add regression coverage for global responses without `account`, account-scoped HTML, and combined `q + account` links.

## Validation

```text
uv run --extra dev pytest tests/test_activity.py -q
# 7 passed, 1 warning

uv run --extra dev ruff check app/activity.py app/serializers.py tests/test_activity.py
# All checks passed!

uv run --extra dev ruff format --check app/activity.py app/serializers.py tests/test_activity.py
# 3 files already formatted

uv run --extra dev mypy app/activity.py app/serializers.py
# Success: no issues found in 2 source files

uv run --extra dev python scripts/docs_smoke.py
# docs smoke ok

git diff --check
# clean

git merge-tree --write-tree origin/main HEAD
# abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1
```

## Scope

No payout execution, treasury mutation, wallet mutation, transfer signing, admin-token behavior, bridge/exchange/cash-out behavior, MRWK price behavior, or private data handling is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter activity by account in addition to free-text search.
  * Activity page shows contextual messages for account-only, search-only, or combined filters.
  * “View JSON activity” link now reliably includes appropriate URL‑encoded filter parameters.

* **Bug Fixes**
  * “Clear search” behavior and no-results links now handle account filters correctly.
  * Input validation extended to catch invalid or repeated account parameters.

* **Tests**
  * Expanded tests for account-scoped views, combined filters, validation, and JSON link generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->