### PR TITLE
Honor bounty API offset pagination

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -114,6 +114,7 @@ def register_bounty_api_routes(
         repo: str | None = None,
         issue_number: int | None = None,
         availability: str | None = None,
+        offset: int = 0,
     ) -> list[dict[str, Any]]:
         try:
             normalized_sort = normalize_bounty_sort(sort)
@@ -182,6 +183,8 @@ def register_bounty_api_routes(
                 ),
                 normalized_sort,
             )
+            if offset:
+                sorted_bounties = sorted_bounties[offset:]
             if limit is not None:
                 return sorted_bounties[:limit]
             return sorted_bounties
@@ -192,22 +195,33 @@ def register_bounty_api_routes(
         status: str | None = Query(None),
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+        offset: Annotated[int, Query(ge=0, le=SQLITE_INTEGER_MAX)] = 0,
         sort: str | None = Query(None),
         repo: str | None = Query(None),
         issue_number: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
         availability: str | None = Query(None),
     ) -> list[dict[str, Any]]:
-        for name in ("status", "q", "limit", "sort", "repo", "issue_number", "availability"):
+        for name in (
+            "status",
+            "q",
+            "limit",
+            "offset",
+            "sort",
+            "repo",
+            "issue_number",
+            "availability",
+        ):
             reject_repeated_query_param(request, name)
         for name in ("status", "q", "sort", "repo", "availability"):
             reject_control_char_query_param(request, name)
-        for name in ("limit", "issue_number"):
+        for name in ("limit", "offset", "issue_number"):
             reject_noncanonical_int_query_param(request, name)
         return _list_bounties_by_status(
             status,
             q,
             sort=sort,
             limit=limit,
+            offset=offset,
             repo=repo,
             issue_number=issue_number,
             availability=availability,
@@ -219,16 +233,26 @@ def register_bounty_api_routes(
         status: str | None = Query(None),
         q: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+        offset: Annotated[int, Query(ge=0, le=SQLITE_INTEGER_MAX)] = 0,
         sort: str | None = Query(None),
         repo: str | None = Query(None),
         issue_number: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
         availability: str | None = Query(None),
     ) -> dict[str, Any]:
-        for name in ("status", "q", "limit", "sort", "repo", "issue_number", "availability"):
+        for name in (
+            "status",
+            "q",
+            "limit",
+            "offset",
+            "sort",
+            "repo",
+            "issue_number",
+            "availability",
+        ):
             reject_repeated_query_param(request, name)
         for name in ("status", "q", "sort", "repo", "availability"):
             reject_control_char_query_param(request, name)
-        for name in ("limit", "issue_number"):
+        for name in ("limit", "offset", "issue_number"):
             reject_noncanonical_int_query_param(request, name)
         return bounty_list_summary(
             _list_bounties_by_status(
@@ -236,6 +260,7 @@ def register_bounty_api_routes(
                 q,
                 sort=sort,
                 limit=limit,
+                offset=offset,
                 repo=repo,
                 issue_number=issue_number,
                 availability=availability,

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -415,6 +415,7 @@ def test_bounty_api_search_query_rejects_control_characters(sqlite_url: str) -> 
     ("path", "detail"),
     [
         ("/api/v1/bounties?limit=not-an-int&limit=1", "limit must be provided at most once"),
+        ("/api/v1/bounties?offset=1&offset=2", "offset must be provided at most once"),
         ("/api/v1/bounties?sort=bogus&sort=newest", "sort must be provided at most once"),
         (
             "/api/v1/bounties/summary?repo=a%2Fb&repo=c%2Fd",
@@ -486,14 +487,24 @@ def test_bounty_api_limit_caps_filtered_rows(sqlite_url: str) -> None:
 
     limited = client.get("/api/v1/bounties?status=open&limit=2")
     summary = client.get("/api/v1/bounties/summary?status=open&limit=2")
+    shifted = client.get("/api/v1/bounties?status=open&limit=2&offset=1")
+    shifted_summary = client.get("/api/v1/bounties/summary?status=open&limit=2&offset=1")
+    exhausted = client.get("/api/v1/bounties?status=open&limit=2&offset=3")
+    exhausted_summary = client.get("/api/v1/bounties/summary?status=open&limit=2&offset=3")
 
     assert [item["id"] for item in limited.json()] == [third.id, second.id]
     assert summary.json()["bounties_shown"] == 2
     assert summary.json()["open_awards"] == 2
+    assert [item["id"] for item in shifted.json()] == [second.id, first.id]
+    assert shifted_summary.json()["bounties_shown"] == 2
+    assert shifted_summary.json()["open_awards"] == 2
+    assert exhausted.json() == []
+    assert exhausted_summary.json()["bounties_shown"] == 0
+    assert exhausted_summary.json()["open_awards"] == 0
     assert first.id not in [item["id"] for item in limited.json()]
 
 
-def test_bounty_api_limit_rejects_out_of_range_values(sqlite_url: str) -> None:
+def test_bounty_api_pagination_rejects_out_of_range_values(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
         ensure_genesis(session)
@@ -504,23 +515,43 @@ def test_bounty_api_limit_rejects_out_of_range_values(sqlite_url: str) -> None:
     assert client.get("/api/v1/bounties?limit=201").status_code == 422
     assert client.get("/api/v1/bounties/summary?limit=0").status_code == 422
     assert client.get("/api/v1/bounties/summary?limit=201").status_code == 422
+    assert client.get("/api/v1/bounties?offset=0").status_code == 200
+    assert client.get("/api/v1/bounties/summary?offset=0").status_code == 200
+    assert client.get("/api/v1/bounties?offset=-1").status_code == 422
+    assert client.get(f"/api/v1/bounties?offset={SQLITE_INTEGER_MAX + 1}").status_code == 422
+    assert client.get("/api/v1/bounties/summary?offset=-1").status_code == 422
+    assert (
+        client.get(f"/api/v1/bounties/summary?offset={SQLITE_INTEGER_MAX + 1}").status_code == 422
+    )
 
     controlled_list = client.get("/api/v1/bounties?limit=%C2%8550")
     controlled_summary = client.get("/api/v1/bounties/summary?limit=50%C2%85")
+    controlled_offset = client.get("/api/v1/bounties?offset=%C2%851")
     decimal_list = client.get("/api/v1/bounties?limit=50.0")
+    decimal_offset = client.get("/api/v1/bounties?offset=1.0")
     plus_summary = client.get("/api/v1/bounties/summary?limit=%2B50")
+    plus_summary_offset = client.get("/api/v1/bounties/summary?offset=%2B1")
     leading_zero_list = client.get("/api/v1/bounties?limit=050")
+    leading_zero_offset = client.get("/api/v1/bounties?offset=01")
 
     assert controlled_list.status_code == 400
     assert controlled_list.json()["detail"] == "limit must not contain control characters"
     assert controlled_summary.status_code == 400
     assert controlled_summary.json()["detail"] == "limit must not contain control characters"
+    assert controlled_offset.status_code == 400
+    assert controlled_offset.json()["detail"] == "offset must not contain control characters"
     assert decimal_list.status_code == 400
     assert decimal_list.json()["detail"] == "limit must be a canonical positive integer"
+    assert decimal_offset.status_code == 400
+    assert decimal_offset.json()["detail"] == "offset must be a canonical positive integer"
     assert plus_summary.status_code == 400
     assert plus_summary.json()["detail"] == "limit must be a canonical positive integer"
+    assert plus_summary_offset.status_code == 400
+    assert plus_summary_offset.json()["detail"] == "offset must be a canonical positive integer"
     assert leading_zero_list.status_code == 400
     assert leading_zero_list.json()["detail"] == "limit must be a canonical positive integer"
+    assert leading_zero_offset.status_code == 400
+    assert leading_zero_offset.json()["detail"] == "offset must be a canonical positive integer"
 
 
 def test_bounty_api_issue_number_rejects_sqlite_overflow_values(sqlite_url: str) -> None:


### PR DESCRIPTION
Summary:
- adds validated `offset` query support to `/api/v1/bounties` and `/api/v1/bounties/summary`;
- applies offset after status/search/repo/issue/availability filtering and sorting, then applies the existing limit cap;
- rejects repeated, non-canonical, negative, and oversized offset values with focused regressions.

Bounty #799

Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4620927716

Production evidence before fix:
- `GET https://api.mrwk.online/api/v1/bounties?status=paid&limit=3&offset=0` -> ids `[105, 104, 103]`.
- `GET https://api.mrwk.online/api/v1/bounties?status=paid&limit=3&offset=3` -> ids `[105, 104, 103]` again, so offset is currently ignored.

Scope:
- This PR intentionally stays on the public REST bounty list/summary API.
- It does not change MCP, public HTML pages, ledger pagination, bounty creation, payout, treasury execution, wallet behavior, bridge/exchange/cash-out behavior, or MRWK price behavior.
- Historical offset PRs #532 and #575 were closed unmerged when older bounty rounds closed/exhausted; current production and `origin/main` still show the API offset bug.

Validation:
- `uv run --extra dev pytest tests/test_bounty_api_routes.py::test_bounty_api_limit_caps_filtered_rows tests/test_bounty_api_routes.py::test_bounty_api_pagination_rejects_out_of_range_values tests/test_bounty_api_routes.py::test_bounty_api_rejects_repeated_scalar_filters -q` -> 10 passed, 1 warning.
- `uv run --extra dev pytest tests/test_bounty_api_routes.py tests/test_bounty_api.py tests/test_api_mcp.py::test_mcp_list_bounties_filters_status_query_and_limit -q` -> 48 passed, 1 warning.
- `uv run --extra dev ruff check app/bounty_api.py tests/test_bounty_api_routes.py` -> passed.
- `uv run --extra dev ruff format --check app/bounty_api.py tests/test_bounty_api_routes.py` -> passed.
- `uv run --extra dev mypy app/bounty_api.py` -> success.
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `566bc49db83cd9f14164e7a4f4617b918bcb907c`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added offset-based pagination to bounties listing and summary endpoints so users can retrieve paged results starting at a specified offset, with bounds validation.

* **Tests**
  * Added tests for offset behavior: pagination effects, boundary validation, rejection of repeated/invalid offset values, and interactions with limit and summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->