### PR TITLE
Align submit_work_proof MCP contract

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -79,7 +79,17 @@ MCP_TOOLS: list[dict[str, Any]] = [
                 },
             },
             "additionalProperties": False,
-            "not": {"required": ["bounty_id", "issue_number"]},
+            "allOf": [
+                {"not": {"required": ["bounty_id", "issue_number"]}},
+                {
+                    "if": {"required": ["repo"]},
+                    "then": {
+                        "required": ["issue_number"],
+                        "not": {"required": ["bounty_id"]},
+                    },
+                },
+                {"if": {"required": ["bounty_id"]}, "then": {"not": {"required": ["repo"]}}},
+            ],
         },
     },
 ]

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -126,6 +126,11 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             raise ValueError(f"{field} must be a boolean")
         return value
 
+    def require_known_fields(*allowed_fields: str) -> None:
+        unknown_fields = set(args) - set(allowed_fields)
+        if unknown_fields:
+            raise ValueError(f"unknown argument: {sorted(unknown_fields)[0]}")
+
     def bounty_by_issue_number(repo_selector: str | None) -> Bounty | None:
         issue_query = select(Bounty).where(Bounty.issue_number == positive_int_arg("issue_number"))
         if repo_selector is not None:
@@ -270,6 +275,7 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 }
             )
         if name == "submit_work_proof":
+            require_known_fields("bounty_id", "issue_number", "repo", "format")
             output_format = output_format_arg()
             has_bounty_id = "bounty_id" in args and args.get("bounty_id") is not None
             has_issue_number = "issue_number" in args and args.get("issue_number") is not None

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -261,7 +261,17 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert submit_schema["properties"]["bounty_id"]["minimum"] == 1
     assert submit_schema["properties"]["issue_number"]["minimum"] == 1
     assert submit_schema["properties"]["repo"]["maxLength"] == 200
-    assert submit_schema["not"] == {"required": ["bounty_id", "issue_number"]}
+    assert submit_schema["allOf"] == [
+        {"not": {"required": ["bounty_id", "issue_number"]}},
+        {
+            "if": {"required": ["repo"]},
+            "then": {
+                "required": ["issue_number"],
+                "not": {"required": ["bounty_id"]},
+            },
+        },
+        {"if": {"required": ["bounty_id"]}, "then": {"not": {"required": ["repo"]}}},
+    ]
     bounty_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_bounty")
     assert "accepted awards" in bounty_tool["description"]
     attempt_tool = next(
@@ -1996,6 +2006,42 @@ def test_mcp_submit_work_proof_scopes_issue_number_by_repo(sqlite_url: str) -> N
     ],
 )
 def test_mcp_submit_work_proof_rejects_invalid_bounty_selectors(
+    sqlite_url: str, arguments: dict[str, object], request_id: int
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {"name": "submit_work_proof", "arguments": arguments},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
+@pytest.mark.parametrize(
+    ("arguments", "request_id"),
+    [
+        ({"unexpected": "ignored"}, 33),
+        ({"format": "json", "unexpected": "ignored"}, 34),
+        ({"formta": "json"}, 35),
+        ({"bounty_id": 1, "unexpected": "ignored"}, 36),
+    ],
+)
+def test_mcp_submit_work_proof_rejects_undeclared_arguments(
     sqlite_url: str, arguments: dict[str, object], request_id: int
 ) -> None:
     create_schema(sqlite_url)


### PR DESCRIPTION
## Summary
- reject undeclared `submit_work_proof` MCP arguments instead of silently ignoring them
- align the advertised `submit_work_proof` input schema with the runtime selector rules so `repo` is only valid with `issue_number`
- add focused regression coverage for both the schema contract and undeclared argument rejection

Bounty #799

Source reports:
- https://github.com/ramimbo/mergework/issues/656#issuecomment-4600135684
- https://github.com/ramimbo/mergework/issues/656#issuecomment-4600251202

## Production evidence before fix
- `POST https://api.mrwk.online/mcp` `tools/call submit_work_proof` with `{"format":"json","unexpected":"ignored"}` returned a successful structured result instead of `invalid tool arguments`.
- `POST https://api.mrwk.online/mcp` `tools/call submit_work_proof` with `{"formta":"json"}` returned successful generic text guidance instead of `invalid tool arguments`.
- `tools/list` advertised `additionalProperties: false`, but the schema did not encode the runtime rule that `repo` only works with `issue_number` and not with `bounty_id`.

## Validation
- `uv run --extra dev python -m pytest tests/test_api_mcp.py tests/test_mcp_tools.py -q` -> `116 passed, 1 warning`
- `ruff check app/mcp.py app/mcp_tools.py tests/test_api_mcp.py tests/test_mcp_tools.py` -> passed
- `ruff format --check app/mcp.py app/mcp_tools.py tests/test_api_mcp.py tests/test_mcp_tools.py` -> passed
- `uv run --extra dev python -m mypy app` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check -- app/mcp.py app/mcp_tools.py tests/test_api_mcp.py` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`

## Scope
- limited to the public MCP `submit_work_proof` contract
- no payout execution, treasury mutation, wallet mutation, transfer signing, admin-token behavior, bridge/exchange/cash-out behavior, MRWK price behavior, or private data handling changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Improved input validation for the work proof submission tool to enforce stricter relationships between submission fields.
  * The tool now rejects unexpected parameters and prevents invalid argument combinations from being processed.
  * These enhancements strengthen data integrity, improve system reliability, and prevent potential misuse of the submission functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->