### PR TITLE
Reject non-json MCP content types

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -89,6 +89,13 @@ def _jsonrpc_error(response_id: Any, code: int, message: str) -> dict[str, Any]:
     return {"jsonrpc": "2.0", "id": response_id, "error": {"code": code, "message": message}}
 
 
+def _is_json_content_type(content_type: str | None) -> bool:
+    if content_type is None:
+        return False
+    media_type = content_type.split(";", 1)[0].strip().lower()
+    return media_type == "application/json"
+
+
 def _structured_json_payload(text: str) -> dict[str, Any] | list[Any] | None:
     try:
         payload = json.loads(text)
@@ -129,6 +136,12 @@ def _tool_result_response(response_id: Any, tool_result: str | dict[str, Any]) -
 async def handle_mcp_request(
     request: Request, database_url: str, call_tool: MCPToolHandler
 ) -> dict[str, Any] | JSONResponse:
+    if not _is_json_content_type(request.headers.get("content-type")):
+        return JSONResponse(
+            _jsonrpc_error(None, -32700, "unsupported media type"),
+            status_code=415,
+        )
+
     try:
         payload = await request.json()
     except ValueError:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -729,6 +729,14 @@ def test_mcp_list_bounties_rejects_invalid_filters(
 def test_mcp_rejects_malformed_requests_without_500(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
+    charset_response = client.post(
+        "/mcp",
+        content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+        headers={"content-type": "application/json; charset=utf-8"},
+    )
+    assert charset_response.status_code == 200
+    assert charset_response.json()["result"]["tools"]
+
     malformed = client.post(
         "/mcp",
         content="not-json",
@@ -758,6 +766,34 @@ def test_mcp_rejects_malformed_requests_without_500(sqlite_url: str) -> None:
         "jsonrpc": "2.0",
         "id": 7,
         "error": {"code": -32602, "message": "invalid params"},
+    }
+
+
+@pytest.mark.parametrize(
+    "content_type",
+    [
+        "text/plain",
+        "text/html",
+        "application/xml",
+        "multipart/form-data; boundary=mergework",
+        None,
+    ],
+)
+def test_mcp_rejects_non_json_content_types(sqlite_url: str, content_type: str | None) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    headers = {} if content_type is None else {"content-type": content_type}
+    response = client.post(
+        "/mcp",
+        content=json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+        headers=headers,
+    )
+
+    assert response.status_code == 415
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": None,
+        "error": {"code": -32700, "message": "unsupported media type"},
     }
 
 


### PR DESCRIPTION
﻿Summary:
- rejects `/mcp` requests whose `Content-Type` is missing or not `application/json` before parsing the JSON-RPC body;
- keeps `application/json; charset=utf-8` accepted and preserves the existing JSON-RPC parse-error response for malformed JSON;
- adds regressions for `text/plain`, `text/html`, `application/xml`, `multipart/form-data`, and missing `Content-Type`.

Bounty #799

Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4620928000

Production evidence before fix:
- `POST https://mcp.mrwk.online/mcp` with a valid `tools/list` JSON-RPC body and `Content-Type: application/json` -> HTTP 200, returns the tools list.
- The same valid JSON body with `Content-Type: text/plain` -> HTTP 200, returns the tools list.
- The same valid JSON body with `Content-Type: text/html` -> HTTP 200, returns the tools list.
- The same valid JSON body with `Content-Type: application/xml` -> HTTP 200, returns the tools list.
- The same valid JSON body with no explicit `Content-Type` -> HTTP 200, returns the tools list.

Duplicate/current check:
- Public bounty API before submission: #799 is open with 5 effective awards remaining and 0 active attempts.
- `gh pr list --repo ramimbo/mergework --state open --search "content-type mcp in:title,body"` returned no open PRs for this scope.

Scope:
- This PR intentionally stays on the public MCP `/mcp` request media-type gate.
- It does not change MCP tool semantics, wallet behavior, ledger mutation, bounty creation, payout execution, treasury mutation, private data, secrets, bridge/exchange/cash-out behavior, or MRWK price behavior.

Validation:
- `uv run --extra dev pytest tests/test_api_mcp.py::test_mcp_rejects_malformed_requests_without_500 tests/test_api_mcp.py::test_mcp_rejects_non_json_content_types tests/test_api_mcp.py::test_mcp_tools_list_and_call -q` -> 7 passed, 1 warning.
- `uv run --extra dev pytest tests/test_api_mcp.py tests/test_mcp_tools.py -q` -> 117 passed, 1 warning.
- `uv run --extra dev ruff check app/mcp.py tests/test_api_mcp.py` -> passed.
- `uv run --extra dev ruff format --check app/mcp.py tests/test_api_mcp.py` -> 2 files already formatted.
- `uv run --extra dev mypy app/mcp.py` -> success.
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request validation by detecting and rejecting non-JSON Content-Type headers early, returning HTTP 415 status with appropriate error messages instead of attempting to parse invalid requests

* **Tests**
  * Added comprehensive test coverage for Content-Type validation across various media types and edge cases
  * Enhanced existing malformed request tests to verify proper handling of JSON requests with charset specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->