### PR TITLE
Limit activity query length

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -13,12 +13,19 @@ from app.db import session_scope
 from app.query_validation import reject_control_char_query_param, reject_repeated_query_param
 from app.serializers import activity_to_dict
 
+ACTIVITY_QUERY_MAX_LENGTH = 500
+
 
 def activity_context(
     session: Session, query: str | None = None, account: str | None = None
 ) -> dict[str, Any]:
     if query is not None and contains_control_character(query):
         raise HTTPException(status_code=400, detail="q must not contain control characters")
+    if query is not None and len(query) > ACTIVITY_QUERY_MAX_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"q must be at most {ACTIVITY_QUERY_MAX_LENGTH} characters",
+        )
     normalized = normalized_account(account) if account is not None else None
     return activity_to_dict(session, query, account=normalized)
 

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -310,6 +310,9 @@ def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
         "/api/v1/activity?account=github:alice&account=github:bob"
     )
     invalid_account_response = client.get("/api/v1/activity?account=github%3A%20")
+    max_length_query = "a" * 500
+    max_length_api_response = client.get("/api/v1/activity", params={"q": max_length_query})
+    max_length_page_response = client.get("/activity", params={"q": max_length_query})
     oversized_query = "a" * 501
     oversized_api_response = client.get("/api/v1/activity", params={"q": oversized_query})
     oversized_page_response = client.get("/activity", params={"q": oversized_query})
@@ -332,6 +335,9 @@ def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
     assert repeated_account_response.json()["detail"] == "account must be provided at most once"
     assert invalid_account_response.status_code == 400
     assert invalid_account_response.json()["detail"] == "github login must be valid"
+    assert max_length_api_response.status_code == 200
+    assert max_length_api_response.json()["query"] == max_length_query
+    assert max_length_page_response.status_code == 200
     assert oversized_api_response.status_code == 400
     assert oversized_api_response.json()["detail"] == "q must be at most 500 characters"
     assert oversized_page_response.status_code == 400

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -310,6 +310,9 @@ def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
         "/api/v1/activity?account=github:alice&account=github:bob"
     )
     invalid_account_response = client.get("/api/v1/activity?account=github%3A%20")
+    oversized_query = "a" * 501
+    oversized_api_response = client.get("/api/v1/activity", params={"q": oversized_query})
+    oversized_page_response = client.get("/activity", params={"q": oversized_query})
 
     assert api_response.status_code == 400
     assert api_response.json()["detail"] == "q must not contain control characters"
@@ -329,6 +332,10 @@ def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
     assert repeated_account_response.json()["detail"] == "account must be provided at most once"
     assert invalid_account_response.status_code == 400
     assert invalid_account_response.json()["detail"] == "github login must be valid"
+    assert oversized_api_response.status_code == 400
+    assert oversized_api_response.json()["detail"] == "q must be at most 500 characters"
+    assert oversized_page_response.status_code == 400
+    assert oversized_page_response.json()["detail"] == "q must be at most 500 characters"
 
 
 def test_activity_api_exposes_pending_payouts_separately_from_paid_work(


### PR DESCRIPTION
﻿Summary:
- caps the public activity `q` filter at 500 characters for both `/api/v1/activity` and `/activity`;
- keeps the existing control-character and repeated-parameter behavior intact;
- adds regression coverage for oversized activity searches on the JSON API and HTML page.

Bounty #799

Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4620882743

Production evidence before fix:
- `GET https://api.mrwk.online/api/v1/activity?q=<10000 a characters>` -> HTTP 200, response size 10188 bytes.
- The request is accepted and processed instead of being rejected with a bounded validation error.

Duplicate/current check:
- Public bounty API before submission: #799 is open with 5 effective awards remaining and 0 active attempts.
- `gh pr list --repo ramimbo/mergework --state open --search '"activity" "q" "500" in:title,body'` returned no open PRs for this scope.

Scope:
- This PR intentionally stays on public activity search query validation.
- It does not change activity result semantics for valid queries, account normalization, MCP behavior, ledger mutation, bounty creation, payout execution, treasury mutation, wallet behavior, private data, secrets, bridge/exchange/cash-out behavior, or MRWK price behavior.

Validation:
- `uv run --extra dev pytest tests/test_activity.py -q` -> 7 passed, 1 warning.
- `uv run --extra dev pytest tests/test_activity.py tests/test_activity_routes.py -q` -> 8 passed, 1 warning.
- `uv run --extra dev ruff check app/activity.py tests/test_activity.py tests/test_activity_routes.py` -> passed.
- `uv run --extra dev ruff format --check app/activity.py tests/test_activity.py tests/test_activity_routes.py` -> 3 files already formatted.
- `uv run --extra dev mypy app/activity.py` -> success.
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `e6fc1d0efb5d75ca010137dca3d2ae3817ad3382`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Activity query input now rejects control characters and enforces a 500-character maximum, returning clear 400 errors for invalid input.

* **Tests**
  * Validation tests updated to confirm valid 500-character queries succeed and oversized or control-character queries are rejected with appropriate error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->