### PR TITLE
Limit wallet search query length

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -34,6 +34,8 @@ from app.status import (
     UNSUPPORTED_PUBLIC_PATHS_SUMMARY,
 )
 
+WALLET_SEARCH_QUERY_MAX_LENGTH = 500
+
 
 def _bounties_api_url(
     status: str | None,
@@ -181,6 +183,11 @@ def public_bounties_context(
 def wallets_page_context(session: Session, q: str | None = None) -> dict[str, Any]:
     if q is not None and contains_control_character(q):
         raise HTTPException(status_code=400, detail="q must not contain control characters")
+    if q is not None and len(q) > WALLET_SEARCH_QUERY_MAX_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"q must be at most {WALLET_SEARCH_QUERY_MAX_LENGTH} characters",
+        )
     query_text = q.strip() if q is not None else ""
     query = select(Wallet)
     if query_text:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -740,6 +740,8 @@ def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
     repeated_search_response = client.get("/wallets?q=Main&q=smoke")
     masked_type_response = client.get(f"/wallets/{address}?type=%C2%85test_funding&type=all")
     repeated_type_response = client.get(f"/wallets/{address}?type=test_funding&type=all")
+    max_length_search_response = client.get("/wallets", params={"q": "a" * 500})
+    oversized_search_response = client.get("/wallets", params={"q": "a" * 501})
 
     assert search_response.status_code == 400
     assert search_response.json()["detail"] == "q must not contain control characters"
@@ -756,6 +758,9 @@ def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
     )
     assert repeated_type_response.status_code == 400
     assert repeated_type_response.json()["detail"] == "type must be provided at most once"
+    assert max_length_search_response.status_code == 200
+    assert oversized_search_response.status_code == 400
+    assert oversized_search_response.json()["detail"] == "q must be at most 500 characters"
 
 
 def test_me_page_shows_signed_in_github_claim_balance(sqlite_url: str, monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- cap `/wallets?q=` search strings at 500 characters before building wallet `LIKE` filters
- keep 500-character searches accepted while rejecting 501+ characters with a bounded 400 response
- add regression coverage for the wallet search boundary alongside existing control-character/repeated-query checks

Bounty #799

Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4621476071

## Production evidence before fix

- `GET https://mrwk.online/wallets?q=<500 a characters>` -> HTTP 200, 3890 bytes.
- `GET https://mrwk.online/wallets?q=<501 a characters>` -> HTTP 200, 3892 bytes.
- `GET https://mrwk.online/wallets?q=<10000 a characters>` -> HTTP 200, 25016 bytes.

Current production therefore accepts oversized public wallet search strings instead of failing fast before building SQL `LIKE` filters.

## Duplicate/current check

- Open PR search for `wallets` + `q` + `length` / `500` found no PR covering this scope.
- PR #858 covers activity `q` length, not wallet search.
- Existing wallet PRs cover path canonicalization or padded query filters, not oversized wallet search values.
- Public bounty API showed #799 open with 5 effective awards remaining before this work.

## Validation

- `uv run --extra dev pytest tests/test_wallet_api.py::test_wallet_pages_reject_control_character_filters -q` -> 1 passed, 1 existing Starlette/httpx warning.
- `uv run --extra dev pytest tests/test_wallet_api.py -q` -> 45 passed, 1 existing Starlette/httpx warning.
- `uv run --extra dev ruff check app/public_routes.py tests/test_wallet_api.py` -> passed.
- `uv run --extra dev ruff format --check app/public_routes.py tests/test_wallet_api.py` -> 2 files already formatted.
- `uv run --extra dev mypy app/public_routes.py` -> success.
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`.

## Scope

This PR is limited to the public wallet search page input boundary. It does not change wallet registration, wallet signatures, balances, account normalization, ledger mutation, bounty lifecycle, payout execution, treasury mutation, private data, secrets, bridge/exchange/cash-out behavior, or MRWK price behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added input validation for wallet search queries with a 500-character maximum limit. Requests exceeding this character threshold will be rejected with a clear validation error message indicating the limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->