### PR TITLE
Limit bounty search query length

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -41,6 +41,8 @@ from app.serializers import (
 )
 from app.treasury import proposal_to_dict, propose_treasury_action
 
+BOUNTY_SEARCH_QUERY_MAX_LENGTH = 500
+
 
 def _payout_response_from_proof(proof: Proof, *, status: str) -> dict[str, Any]:
     data = json.loads(proof.public_json)
@@ -145,6 +147,11 @@ def register_bounty_api_routes(
                 if contains_control_character(query_text):
                     raise HTTPException(
                         status_code=400, detail="q must not contain control characters"
+                    )
+                if len(query_text) > BOUNTY_SEARCH_QUERY_MAX_LENGTH:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"q must be at most {BOUNTY_SEARCH_QUERY_MAX_LENGTH} characters",
                     )
                 normalized_query = query_text.strip()
                 if normalized_query:

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -411,6 +411,29 @@ def test_bounty_api_search_query_rejects_control_characters(sqlite_url: str) -> 
     assert summary_response.json()["detail"] == "q must not contain control characters"
 
 
+def test_bounty_api_search_query_rejects_oversized_values(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    accepted_query = "a" * 500
+    oversized_query = "a" * 501
+
+    list_boundary = client.get("/api/v1/bounties", params={"q": accepted_query})
+    summary_boundary = client.get("/api/v1/bounties/summary", params={"q": accepted_query})
+    list_oversized = client.get("/api/v1/bounties", params={"q": oversized_query})
+    summary_oversized = client.get("/api/v1/bounties/summary", params={"q": oversized_query})
+
+    assert list_boundary.status_code == 200
+    assert summary_boundary.status_code == 200
+    assert list_oversized.status_code == 400
+    assert list_oversized.json()["detail"] == "q must be at most 500 characters"
+    assert summary_oversized.status_code == 400
+    assert summary_oversized.json()["detail"] == "q must be at most 500 characters"
+
+
 @pytest.mark.parametrize(
     ("path", "detail"),
     [

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -418,9 +418,26 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     assert oversized_issue_search.status_code == 200
     assert oversized_issue_search.json() == []
 
-    digit_limit_issue_search = client.get("/api/v1/bounties", params={"q": "9" * 5000})
+    digit_limit_issue_search = client.get("/api/v1/bounties", params={"q": "9" * 500})
     assert digit_limit_issue_search.status_code == 200
     assert digit_limit_issue_search.json() == []
+
+    digit_limit_issue_page = client.get("/bounties", params={"q": "9" * 500})
+    assert digit_limit_issue_page.status_code == 200
+    assert "No bounties match these filters." in digit_limit_issue_page.text
+    assert 'href="/bounties">Clear filters</a>' in digit_limit_issue_page.text
+
+    oversized_query = "9" * 501
+    oversized_query_search = client.get("/api/v1/bounties", params={"q": oversized_query})
+    oversized_query_summary = client.get("/api/v1/bounties/summary", params={"q": oversized_query})
+    oversized_query_page = client.get("/bounties", params={"q": oversized_query})
+
+    assert oversized_query_search.status_code == 400
+    assert oversized_query_search.json()["detail"] == "q must be at most 500 characters"
+    assert oversized_query_summary.status_code == 400
+    assert oversized_query_summary.json()["detail"] == "q must be at most 500 characters"
+    assert oversized_query_page.status_code == 400
+    assert oversized_query_page.json()["detail"] == "q must be at most 500 characters"
 
     oversized_issue_page = client.get("/bounties", params={"q": "9" * 40})
     assert oversized_issue_page.status_code == 200


### PR DESCRIPTION
Bounty #799

Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4621519413

## Summary

- Add a 500-character maximum for public bounty search `q` values in the shared bounty list path.
- Applies to `/api/v1/bounties`, `/api/v1/bounties/summary`, and the public `/bounties` page because they all route through the same list helper.
- Preserve existing behavior for valid 500-character searches and existing control-character/repeated-parameter validation.

## Production evidence before fix

The source report reproduced current production accepting oversized public bounty searches:

- `GET https://api.mrwk.online/api/v1/bounties?q=<10000 chars>` -> HTTP 200, `[]`
- `GET https://api.mrwk.online/api/v1/bounties/summary?q=<10000 chars>` -> HTTP 200, normal summary object
- `GET https://mrwk.online/bounties?q=<10000 chars>` -> HTTP 200, full HTML page rendered

## Validation

- `.venv\Scripts\python.exe -m pytest tests/test_bounty_api_routes.py::test_bounty_api_search_query_rejects_control_characters tests/test_bounty_api_routes.py::test_bounty_api_search_query_rejects_oversized_values tests/test_bounty_pages.py::test_bounties_page_and_api_search_by_text_and_issue_number -q` -> 3 passed, 1 existing Starlette/httpx warning.
- `.venv\Scripts\python.exe -m pytest tests/test_bounty_api_routes.py tests/test_bounty_pages.py -q` -> 39 passed, 1 existing Starlette/httpx warning.
- `.venv\Scripts\python.exe -m ruff format --check app/bounty_api.py tests/test_bounty_api_routes.py tests/test_bounty_pages.py` -> 3 files already formatted.
- `.venv\Scripts\python.exe -m ruff check app/bounty_api.py tests/test_bounty_api_routes.py tests/test_bounty_pages.py` -> All checks passed.
- `.venv\Scripts\python.exe -m mypy app/bounty_api.py` -> Success.
- `.venv\Scripts\python.exe scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.

## Scope

Public bounty search validation only. No wallet behavior, wallet signatures, balances, ledger mutation, bounty creation, payout execution, treasury mutation, admin-token behavior, private data, secrets, bridge, exchange, cash-out, or MRWK price behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced a 500-character maximum for bounty search queries; queries exceeding this return HTTP 400 with a clear "q must be at most 500 characters" message.
* **Tests**
  * Added and updated tests to verify the 500-character boundary for API search, summary endpoints, and the public bounties page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->