### PR TITLE
Limit bounty repo filter length

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -41,6 +41,8 @@ from app.serializers import (
 )
 from app.treasury import proposal_to_dict, propose_treasury_action
 
+BOUNTY_REPO_FILTER_MAX_LENGTH = 200
+
 
 def _payout_response_from_proof(proof: Proof, *, status: str) -> dict[str, Any]:
     data = json.loads(proof.public_json)
@@ -170,6 +172,8 @@ def register_bounty_api_routes(
                         status_code=400, detail="repo must not contain control characters"
                     )
                 normalized_repo = repo.strip().lower()
+                if len(normalized_repo) > BOUNTY_REPO_FILTER_MAX_LENGTH:
+                    raise HTTPException(status_code=400, detail="repo is too long")
                 if normalized_repo:
                     query = query.where(func.lower(Bounty.repo) == normalized_repo)
             if issue_number is not None:

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -601,8 +601,16 @@ def test_bounty_api_filters_by_exact_repo_and_issue_number(sqlite_url: str) -> N
     assert [row["id"] for row in composed.json()] == [mergework_649.id]
 
     invalid_repo = client.get("/api/v1/bounties?repo=ramimbo%C2%85mergework")
+    max_length_repo = client.get("/api/v1/bounties", params={"repo": "a" * 200})
+    oversized_repo = client.get("/api/v1/bounties", params={"repo": "a" * 201})
+    oversized_summary_repo = client.get("/api/v1/bounties/summary", params={"repo": "a" * 201})
     assert invalid_repo.status_code == 400
     assert invalid_repo.json()["detail"] == "repo must not contain control characters"
+    assert max_length_repo.status_code == 200
+    assert oversized_repo.status_code == 400
+    assert oversized_repo.json()["detail"] == "repo is too long"
+    assert oversized_summary_repo.status_code == 400
+    assert oversized_summary_repo.json()["detail"] == "repo is too long"
     assert controlled_issue.status_code == 400
     assert controlled_issue.json()["detail"] == "issue_number must not contain control characters"
     assert controlled_summary_issue.status_code == 400

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -602,11 +602,13 @@ def test_bounty_api_filters_by_exact_repo_and_issue_number(sqlite_url: str) -> N
 
     invalid_repo = client.get("/api/v1/bounties?repo=ramimbo%C2%85mergework")
     max_length_repo = client.get("/api/v1/bounties", params={"repo": "a" * 200})
+    max_length_summary_repo = client.get("/api/v1/bounties/summary", params={"repo": "a" * 200})
     oversized_repo = client.get("/api/v1/bounties", params={"repo": "a" * 201})
     oversized_summary_repo = client.get("/api/v1/bounties/summary", params={"repo": "a" * 201})
     assert invalid_repo.status_code == 400
     assert invalid_repo.json()["detail"] == "repo must not contain control characters"
     assert max_length_repo.status_code == 200
+    assert max_length_summary_repo.status_code == 200
     assert oversized_repo.status_code == 400
     assert oversized_repo.json()["detail"] == "repo is too long"
     assert oversized_summary_repo.status_code == 400

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -448,6 +448,7 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     leading_zero_source_filter_page = client.get(
         "/bounties?repo=ramimbo%2Fmergework&issue_number=0064"
     )
+    oversized_repo_filter_page = client.get("/bounties", params={"repo": "a" * 201})
     plus_limit_page = client.get("/bounties?limit=%2B1")
     leading_zero_limit_page = client.get("/bounties?limit=01")
     assert source_filter_page.status_code == 200
@@ -485,6 +486,8 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
         leading_zero_source_filter_page.json()["detail"]
         == "issue_number must be a canonical positive integer"
     )
+    assert oversized_repo_filter_page.status_code == 400
+    assert oversized_repo_filter_page.json()["detail"] == "repo is too long"
     assert plus_limit_page.status_code == 400
     assert plus_limit_page.json()["detail"] == "limit must be a canonical positive integer"
     assert leading_zero_limit_page.status_code == 400

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -448,6 +448,7 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     leading_zero_source_filter_page = client.get(
         "/bounties?repo=ramimbo%2Fmergework&issue_number=0064"
     )
+    max_length_repo_filter_page = client.get("/bounties", params={"repo": "a" * 200})
     oversized_repo_filter_page = client.get("/bounties", params={"repo": "a" * 201})
     plus_limit_page = client.get("/bounties?limit=%2B1")
     leading_zero_limit_page = client.get("/bounties?limit=01")
@@ -486,6 +487,7 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
         leading_zero_source_filter_page.json()["detail"]
         == "issue_number must be a canonical positive integer"
     )
+    assert max_length_repo_filter_page.status_code == 200
     assert oversized_repo_filter_page.status_code == 400
     assert oversized_repo_filter_page.json()["detail"] == "repo is too long"
     assert plus_limit_page.status_code == 400


### PR DESCRIPTION
## Summary

- Reject public bounty `repo` filters longer than 200 characters before querying.
- Apply the same guard through the shared bounty list helper, covering `/api/v1/bounties`, `/api/v1/bounties/summary`, and `/bounties`.
- Add regression coverage for the 200-character accepted boundary and 201-character rejected boundary.

Bounty #799
Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4621655404

## Validation

- `python -m pytest tests\test_bounty_api_routes.py::test_bounty_api_filters_by_exact_repo_and_issue_number tests\test_bounty_pages.py::test_bounties_page_and_api_search_by_text_and_issue_number -q` -> 2 passed, 1 existing Starlette/httpx warning.
- `python -m pytest tests\test_bounty_api_routes.py tests\test_bounty_pages.py -q` -> 38 passed, 1 existing Starlette/httpx warning.
- `python -m ruff check app\bounty_api.py tests\test_bounty_api_routes.py tests\test_bounty_pages.py` -> passed.
- `python -m ruff format --check app\bounty_api.py tests\test_bounty_api_routes.py tests\test_bounty_pages.py` -> 3 files already formatted.
- `python -m mypy app\bounty_api.py` -> success.
- `python scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`.

## Scope

Public bounty source filtering only. No bounty creation, payout execution, treasury mutation, wallet behavior, ledger mutation, admin-token behavior, private data, secrets, bridge/exchange/cash-out behavior, or MRWK price behavior is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repo filter now enforces a 200-character maximum. Requests using the repo filter up to 200 characters are accepted; values over 200 characters are rejected with HTTP 400 and an error message "repo is too long". This applies to bounty listing endpoints and the bounties page search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->