### PR TITLE
Limit MCP bounty search query length

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -17,6 +17,42 @@ MCP_TOOLS: list[dict[str, Any]] = [
         "description": (
             "List MRWK bounties with optional status, q, sort, limit, and availability filters"
         ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": ["open", "paid", "closed"],
+                    "default": "open",
+                    "description": "Bounty status filter.",
+                },
+                "q": {
+                    "type": "string",
+                    "maxLength": 500,
+                    "description": "Optional bounty text or issue-number search.",
+                },
+                "sort": {
+                    "type": "string",
+                    "enum": ["newest", "reward"],
+                    "default": "newest",
+                    "description": "Sort order for returned bounties.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "Maximum number of bounties to return.",
+                },
+                "availability": {
+                    "type": "string",
+                    "enum": ["all", "effectively_open"],
+                    "default": "all",
+                    "description": "Optional effective availability filter.",
+                },
+            },
+            "additionalProperties": False,
+        },
     },
     {
         "name": "get_bounty",

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -33,6 +33,7 @@ from app.serializers import (
 )
 
 MCP_INTEGER_RE = re.compile(r"^(?:0|-?[1-9][0-9]*)$")
+MCP_BOUNTY_SEARCH_QUERY_MAX_LENGTH = 500
 
 
 def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | dict[str, Any]:
@@ -90,6 +91,12 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             raise ValueError(f"{field} must not contain control characters")
         clean = value.strip()
         return clean or None
+
+    def optional_bounty_search_query_arg() -> str | None:
+        query = optional_clean_str_arg("q")
+        if query is not None and len(query) > MCP_BOUNTY_SEARCH_QUERY_MAX_LENGTH:
+            raise ValueError("q must be at most 500 characters")
+        return query
 
     def output_format_arg() -> str:
         value = args.get("format", "text")
@@ -158,7 +165,7 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             if normalized_status not in {"open", "paid", "closed"}:
                 raise ValueError("status must be one of: open, paid, closed")
             query = select(Bounty).where(Bounty.status == normalized_status)
-            query_text = optional_clean_str_arg("q")
+            query_text = optional_bounty_search_query_arg()
             if query_text:
                 escaped_query = (
                     query_text.lower().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -250,6 +250,10 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
         "status, q, sort, limit, and availability filters"
         in tools["result"]["tools"][0]["description"]
     )
+    list_bounties_schema = tools["result"]["tools"][0]["inputSchema"]
+    assert list_bounties_schema["additionalProperties"] is False
+    assert list_bounties_schema["properties"]["q"]["maxLength"] == 500
+    assert list_bounties_schema["properties"]["limit"]["maximum"] == 100
     submit_tool = next(
         tool for tool in tools["result"]["tools"] if tool["name"] == "submit_work_proof"
     )
@@ -569,7 +573,7 @@ def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> No
     oversized_payload = json.loads(oversized_result["result"]["content"][0]["text"])
     assert oversized_payload == []
 
-    digit_limit_result = client.post(
+    max_length_search_result = client.post(
         "/mcp",
         json={
             "jsonrpc": "2.0",
@@ -577,12 +581,12 @@ def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> No
             "method": "tools/call",
             "params": {
                 "name": "list_bounties",
-                "arguments": {"q": "9" * 5000},
+                "arguments": {"q": "9" * 500},
             },
         },
     ).json()
-    digit_limit_payload = json.loads(digit_limit_result["result"]["content"][0]["text"])
-    assert digit_limit_payload == []
+    max_length_search_payload = json.loads(max_length_search_result["result"]["content"][0]["text"])
+    assert max_length_search_payload == []
 
 
 def test_mcp_list_bounties_honors_sort_argument(sqlite_url: str) -> None:
@@ -697,6 +701,7 @@ def test_mcp_list_bounties_filters_effective_availability(sqlite_url: str) -> No
         ({"limit": 101}, 35),
         ({"sort": "invalid"}, 36),
         ({"availability": "maybe"}, 37),
+        ({"q": "a" * 501}, 38),
     ],
 )
 def test_mcp_list_bounties_rejects_invalid_filters(


### PR DESCRIPTION
## Summary

- Reject MCP `list_bounties` `q` values longer than 500 characters before building bounty search filters.
- Keep exactly 500-character searches accepted for compatibility.
- Advertise the `list_bounties` input schema, including `q.maxLength = 500`, so MCP clients can validate before calling.

Bounty #799
Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4621691191

## Validation

- `python -m pytest tests\test_api_mcp.py::test_mcp_tools_list_and_call tests\test_api_mcp.py::test_mcp_list_bounties_filters_status_query_and_limit tests\test_api_mcp.py::test_mcp_list_bounties_rejects_invalid_filters -q` -> 10 passed, 1 existing Starlette/httpx warning.
- `python -m pytest tests\test_api_mcp.py tests\test_mcp_tools.py -q` -> 113 passed, 1 existing Starlette/httpx warning.
- `python -m ruff check app\mcp.py app\mcp_tools.py tests\test_api_mcp.py` -> passed.
- `python -m ruff format --check app\mcp.py app\mcp_tools.py tests\test_api_mcp.py` -> 3 files already formatted.
- `python -m mypy app\mcp.py app\mcp_tools.py` -> success.
- `python scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`.

## Scope

Public MCP `list_bounties` argument validation and tool schema only. No REST/HTML bounty list behavior, MCP tool semantics for valid queries, bounty creation, payout execution, treasury mutation, wallet behavior, ledger mutation, admin-token behavior, private data, secrets, bridge/exchange/cash-out behavior, or MRWK price behavior is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive input schema validation for bounty search with explicit constraints on filters including status, sort order, and result limits.
  * Search queries now enforced to a maximum of 500 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->