### PR TITLE
Reject oversized account filters

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -27,6 +27,7 @@ from app.serializers import (
 from app.wallets import WalletError, normalize_wallet_address
 
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+ACCOUNT_MAX_LENGTH = 128
 ACCOUNT_TRANSACTION_TYPE_OPTIONS = [
     {"value": "all", "label": "All"},
     {"value": "bounty_payment", "label": "Bounty payments"},
@@ -54,6 +55,8 @@ def normalized_account(account: str) -> str:
     if contains_control_character(account):
         raise HTTPException(status_code=400, detail="account must not contain control characters")
     clean = account.strip()
+    if len(clean) > ACCOUNT_MAX_LENGTH:
+        raise HTTPException(status_code=400, detail="account is too long")
     lower = clean.lower()
     if lower == TREASURY_ACCOUNT:
         return TREASURY_ACCOUNT

--- a/app/accounts.py
+++ b/app/accounts.py
@@ -55,8 +55,6 @@ def normalized_account(account: str) -> str:
     if contains_control_character(account):
         raise HTTPException(status_code=400, detail="account must not contain control characters")
     clean = account.strip()
-    if len(clean) > ACCOUNT_MAX_LENGTH:
-        raise HTTPException(status_code=400, detail="account is too long")
     lower = clean.lower()
     if lower == TREASURY_ACCOUNT:
         return TREASURY_ACCOUNT
@@ -85,6 +83,8 @@ def normalized_account(account: str) -> str:
         if not GITHUB_LOGIN_RE.fullmatch(login):
             raise HTTPException(status_code=400, detail="github login must be valid")
         return f"github:{login}"
+    if len(clean) > ACCOUNT_MAX_LENGTH:
+        raise HTTPException(status_code=400, detail="account is too long")
     return clean
 
 

--- a/tests/test_account_validation.py
+++ b/tests/test_account_validation.py
@@ -110,6 +110,40 @@ def test_account_views_reject_oversized_generic_accounts(sqlite_url: str) -> Non
     assert body["error"]["message"] == "invalid tool arguments"
 
 
+@pytest.mark.parametrize(
+    ("account", "detail"),
+    [
+        ("github:" + ("a" * 129), "github login must be valid"),
+        ("mrwk1" + ("0" * 129), "invalid MRWK wallet address"),
+        ("reserve:bounty:" + ("9" * 129), "reserve bounty id is too large"),
+        ("treasury:" + ("ops" * 50), "treasury account must be treasury:mrwk"),
+    ],
+)
+def test_account_views_preserve_prefixed_validation_for_oversized_accounts(
+    sqlite_url: str, account: str, detail: str
+) -> None:
+    client = _setup_app(sqlite_url)
+
+    api_resp = client.get(f"/api/v1/accounts/{account}")
+    page_resp = client.get(f"/accounts/{account}")
+    mcp_resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": {"name": "get_balance", "arguments": {"account": account}},
+        },
+    )
+
+    assert api_resp.status_code == 400
+    assert api_resp.json()["detail"] == detail
+    assert page_resp.status_code == 400
+    assert page_resp.json()["detail"] == detail
+    assert mcp_resp.status_code == 200
+    assert mcp_resp.json()["error"]["code"] == -32602
+
+
 def test_api_account_rejects_empty_github_login(sqlite_url: str) -> None:
     client = _setup_app(sqlite_url)
     resp = client.get("/api/v1/accounts/github:%20")

--- a/tests/test_account_validation.py
+++ b/tests/test_account_validation.py
@@ -84,6 +84,32 @@ def test_api_account_accepts_valid(sqlite_url: str) -> None:
     assert resp.json()["account"] == "github:alice"
 
 
+def test_account_views_reject_oversized_generic_accounts(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    account = "a" * 129
+
+    api_resp = client.get(f"/api/v1/accounts/{account}")
+    page_resp = client.get(f"/accounts/{account}")
+    mcp_resp = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 1,
+            "params": {"name": "get_balance", "arguments": {"account": account}},
+        },
+    )
+
+    assert api_resp.status_code == 400
+    assert api_resp.json()["detail"] == "account is too long"
+    assert page_resp.status_code == 400
+    assert page_resp.json()["detail"] == "account is too long"
+    assert mcp_resp.status_code == 200
+    body = mcp_resp.json()
+    assert body["error"]["code"] == -32602
+    assert body["error"]["message"] == "invalid tool arguments"
+
+
 def test_api_account_rejects_empty_github_login(sqlite_url: str) -> None:
     client = _setup_app(sqlite_url)
     resp = client.get("/api/v1/accounts/github:%20")

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -310,6 +310,7 @@ def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
         "/api/v1/activity?account=github:alice&account=github:bob"
     )
     invalid_account_response = client.get("/api/v1/activity?account=github%3A%20")
+    oversized_account_response = client.get("/api/v1/activity", params={"account": "a" * 129})
 
     assert api_response.status_code == 400
     assert api_response.json()["detail"] == "q must not contain control characters"
@@ -329,6 +330,8 @@ def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
     assert repeated_account_response.json()["detail"] == "account must be provided at most once"
     assert invalid_account_response.status_code == 400
     assert invalid_account_response.json()["detail"] == "github login must be valid"
+    assert oversized_account_response.status_code == 400
+    assert oversized_account_response.json()["detail"] == "account is too long"
 
 
 def test_activity_api_exposes_pending_payouts_separately_from_paid_work(


### PR DESCRIPTION
## Summary

- Reject normalized account values longer than 128 characters before public account/activity filtering.
- Preserve the existing stricter validators for `github:`, `mrwk1`, `reserve:bounty:`, and `treasury:mrwk` account forms.
- Add regression coverage for oversized generic accounts across `/api/v1/activity`, account API/page routes, and MCP balance calls.

Bounty #799
Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4621709113

## Validation

- `uv run --extra dev pytest tests/test_activity.py::test_activity_query_rejects_control_characters tests/test_account_validation.py::test_account_views_reject_oversized_generic_accounts -q` -> 2 passed, 1 existing Starlette/httpx warning.
- `uv run --extra dev pytest tests/test_activity.py tests/test_account_validation.py -q` -> 52 passed, 1 existing Starlette/httpx warning.
- `uv run --extra dev ruff check app/accounts.py tests/test_activity.py tests/test_account_validation.py` -> passed.
- `uv run --extra dev ruff format --check app/accounts.py tests/test_activity.py tests/test_account_validation.py` -> 3 files already formatted.
- `uv run --extra dev mypy app/accounts.py app/activity.py` -> success.
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`.

## Scope

Public account normalization and public activity/account inspection only. No payout execution, treasury mutation, wallet mutation, transfer signing, ledger mutation, admin-token behavior, private data, secrets, bridge/exchange/cash-out behavior, or MRWK price behavior is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Account inputs are now limited to 128 characters; overly long accounts are rejected with HTTP 400 and the message "account is too long" across API endpoints and query parameters.

* **Tests**
  * Test suite expanded to cover oversized account rejection across web pages, API endpoints, and internal RPC calls, including prefixed/parameterized cases to preserve existing validation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->