### PR TITLE
Limit account accepted-work rows

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
@@ -14,7 +14,7 @@ from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
 from app.ledger_views import account_ledger_transactions
 from app.models import Account
 from app.path_params import SQLITE_INTEGER_MAX, reject_path_whitespace_padding
-from app.query_validation import reject_repeated_query_param
+from app.query_validation import reject_noncanonical_int_query_param, reject_repeated_query_param
 from app.serializers import (
     accepted_work_for_account,
     account_accepted_summary,
@@ -39,6 +39,8 @@ ACCOUNT_TRANSACTION_TYPE_OPTIONS = [
 ACCOUNT_TRANSACTION_TYPES = {
     str(option["value"]) for option in ACCOUNT_TRANSACTION_TYPE_OPTIONS if option["value"] != "all"
 }
+ACCOUNT_ACCEPTED_WORK_DEFAULT_LIMIT = 100
+ACCOUNT_ACCEPTED_WORK_MAX_LIMIT = 200
 
 
 def normalized_wallet_address(address: str) -> str:
@@ -124,13 +126,16 @@ def account_api_context(session: Session, account: str) -> dict[str, Any]:
     }
 
 
-def account_accepted_work_context(session: Session, account: str) -> dict[str, Any]:
+def account_accepted_work_context(
+    session: Session, account: str, limit: int = ACCOUNT_ACCEPTED_WORK_DEFAULT_LIMIT
+) -> dict[str, Any]:
     account = normalized_account(account)
     pending_payouts = pending_payouts_for_account(session, account)
     return {
         "account": account,
         "summary": account_accepted_summary(session, account),
-        "accepted_work": accepted_work_for_account(session, account),
+        "accepted_work": accepted_work_for_account(session, account)[:limit],
+        "accepted_work_limit": limit,
         "pending_summary": pending_payout_summary(pending_payouts),
         "pending_payouts": pending_payouts,
     }
@@ -154,7 +159,10 @@ def _transaction_type_filter(tx_type: str | None) -> tuple[str, str | None]:
 
 
 def account_page_context(
-    session: Session, account: str, transaction_type: str | None = None
+    session: Session,
+    account: str,
+    transaction_type: str | None = None,
+    accepted_work_limit: int = ACCOUNT_ACCEPTED_WORK_DEFAULT_LIMIT,
 ) -> dict[str, Any]:
     account = normalized_account(account)
     selected_transaction_type, transaction_filter = _transaction_type_filter(transaction_type)
@@ -162,7 +170,8 @@ def account_page_context(
     return {
         "account": account_api_context(session, account),
         "accepted_summary": safe_account_accepted_summary(session, account),
-        "accepted_work": safe_accepted_work_for_account(session, account),
+        "accepted_work": safe_accepted_work_for_account(session, account)[:accepted_work_limit],
+        "accepted_work_limit": accepted_work_limit,
         "pending_summary": pending_payout_summary(pending_payouts),
         "pending_payouts": pending_payouts,
         "selected_transaction_type": selected_transaction_type,
@@ -181,14 +190,27 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
             return account_api_context(session, account)
 
     @app.get("/api/v1/accounts/{account}/accepted-work")
-    def api_account_accepted_work(account: str) -> dict[str, Any]:
+    def api_account_accepted_work(
+        request: Request,
+        account: str,
+        limit: Annotated[
+            int, Query(ge=1, le=ACCOUNT_ACCEPTED_WORK_MAX_LIMIT)
+        ] = ACCOUNT_ACCEPTED_WORK_DEFAULT_LIMIT,
+    ) -> dict[str, Any]:
         reject_path_whitespace_padding(account, "account")
+        reject_repeated_query_param(request, "limit")
+        reject_noncanonical_int_query_param(request, "limit")
         with session_scope(db_url) as session:
-            return account_accepted_work_context(session, account)
+            return account_accepted_work_context(session, account, limit)
 
     @app.get("/accounts/{account}", response_class=HTMLResponse)
     def account_page(
-        request: Request, account: str, tx_type: str | None = Query(None)
+        request: Request,
+        account: str,
+        tx_type: str | None = Query(None),
+        limit: Annotated[
+            int, Query(ge=1, le=ACCOUNT_ACCEPTED_WORK_MAX_LIMIT)
+        ] = ACCOUNT_ACCEPTED_WORK_DEFAULT_LIMIT,
     ) -> HTMLResponse:
         reject_path_whitespace_padding(account, "account")
         for value in request.query_params.getlist("tx_type"):
@@ -197,6 +219,8 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
                     status_code=400, detail="transaction type must not contain control characters"
                 )
         reject_repeated_query_param(request, "tx_type")
+        reject_repeated_query_param(request, "limit")
+        reject_noncanonical_int_query_param(request, "limit")
         with session_scope(db_url) as session:
-            context = account_page_context(session, account, tx_type)
+            context = account_page_context(session, account, tx_type, limit)
         return templates.TemplateResponse(request, "account.html", context)

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -519,13 +519,16 @@ account invariant.
 Read the proof-backed accepted-work list for a single account:
 
 ```bash
-curl -s "$API_HOST/api/v1/accounts/github:carpedkm/accepted-work"
+curl -s "$API_HOST/api/v1/accounts/github:carpedkm/accepted-work?limit=10"
 ```
 
 The response includes the account summary plus the same accepted-work rows used
 by the public account page, so agents can inspect recent proof, ledger,
 submission, source issue, internal bounty id and public bounty URL, and
 maintainer acceptance details without scraping HTML:
+
+Use `limit=1..200` to cap the returned `accepted_work` rows. The default limit
+is 100 rows, and the `summary` totals still cover the full account history.
 
 Relative URL fields are preserved for existing clients. The `*_public_url`
 companions use `https://mrwk.online` so proof-backed accepted-work evidence can

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -130,6 +130,10 @@ def test_account_accepted_work_routes_honor_limit(sqlite_url: str) -> None:
 
     api_response = client.get("/api/v1/accounts/github:limit-user/accepted-work?limit=1")
     page_response = client.get("/accounts/github:limit-user?limit=1")
+    api_max_response = client.get("/api/v1/accounts/github:limit-user/accepted-work?limit=200")
+    page_max_response = client.get("/accounts/github:limit-user?limit=200")
+    api_too_low_response = client.get("/api/v1/accounts/github:limit-user/accepted-work?limit=0")
+    page_too_high_response = client.get("/accounts/github:limit-user?limit=201")
     noncanonical_api = client.get("/api/v1/accounts/github:limit-user/accepted-work?limit=01")
     repeated_page = client.get("/accounts/github:limit-user?limit=1&limit=2")
 
@@ -151,6 +155,14 @@ def test_account_accepted_work_routes_honor_limit(sqlite_url: str) -> None:
     assert f'href="/ledger/{older_sequence}"' not in accepted_work_section
     assert proof_hashes[-1][:12] in accepted_work_section
     assert proof_hashes[0][:12] not in accepted_work_section
+
+    assert api_max_response.status_code == 200
+    assert api_max_response.json()["accepted_work_limit"] == 200
+    assert len(api_max_response.json()["accepted_work"]) == 3
+    assert page_max_response.status_code == 200
+    assert f'href="/ledger/{older_sequence}"' in page_max_response.text
+    assert api_too_low_response.status_code == 422
+    assert page_too_high_response.status_code == 422
 
     assert noncanonical_api.status_code == 400
     assert noncanonical_api.json()["detail"] == "limit must be a canonical positive integer"

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -99,6 +99,65 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     assert f'href="/proofs/{proof.hash}"' in page_response.text
 
 
+def test_account_accepted_work_routes_honor_limit(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    proof_hashes: list[str] = []
+    ledger_sequences: list[int] = []
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        for issue_number in range(200, 203):
+            bounty = create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=issue_number,
+                issue_url=f"https://github.com/ramimbo/mergework/issues/{issue_number}",
+                title=f"Accepted work limit {issue_number}",
+                reward_mrwk="10",
+                acceptance="Accepted-work routes should cap returned rows.",
+            )
+            proof = pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:limit-user",
+                submission_url=f"https://github.com/ramimbo/mergework/pull/{issue_number}",
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted"},
+            )
+            proof_hashes.append(proof.hash)
+            ledger_sequences.append(proof.ledger_sequence)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    api_response = client.get("/api/v1/accounts/github:limit-user/accepted-work?limit=1")
+    page_response = client.get("/accounts/github:limit-user?limit=1")
+    noncanonical_api = client.get("/api/v1/accounts/github:limit-user/accepted-work?limit=01")
+    repeated_page = client.get("/accounts/github:limit-user?limit=1&limit=2")
+
+    api_body = api_response.json()
+    latest_sequence = max(ledger_sequences)
+    older_sequence = min(ledger_sequences)
+
+    assert api_response.status_code == 200
+    assert api_body["summary"]["accepted_awards"] == 3
+    assert api_body["accepted_work_limit"] == 1
+    assert len(api_body["accepted_work"]) == 1
+    assert api_body["accepted_work"][0]["ledger_sequence"] == latest_sequence
+
+    assert page_response.status_code == 200
+    accepted_work_section = page_response.text.split("<h2>Accepted work</h2>", 1)[1].split(
+        "<h2>Transactions</h2>", 1
+    )[0]
+    assert f'href="/ledger/{latest_sequence}"' in accepted_work_section
+    assert f'href="/ledger/{older_sequence}"' not in accepted_work_section
+    assert proof_hashes[-1][:12] in accepted_work_section
+    assert proof_hashes[0][:12] not in accepted_work_section
+
+    assert noncanonical_api.status_code == 400
+    assert noncanonical_api.json()["detail"] == "limit must be a canonical positive integer"
+    assert repeated_page.status_code == 400
+    assert repeated_page.json()["detail"] == "limit must be provided at most once"
+
+
 def test_account_routes_expose_pending_payouts_separately_from_paid_work(
     sqlite_url: str,
 ) -> None:


### PR DESCRIPTION
## Summary
- Add bounded `limit=1..200` support to `/api/v1/accounts/{account}/accepted-work`.
- Apply the same accepted-work row cap to the public `/accounts/{account}` page while leaving transaction history unchanged.
- Keep accepted-work summary totals full-account, and document the default 100-row limit.

Bounty #799
Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4621794667

## Validation
- `python -m pytest tests\test_account_routes.py::test_account_accepted_work_routes_honor_limit -q`
- `python -m pytest tests\test_account_routes.py tests\test_account_validation.py -q`
- `python -m ruff check app\accounts.py tests\test_account_routes.py`
- `python -m ruff format --check app\accounts.py tests\test_account_routes.py`
- `python -m mypy app\accounts.py`
- `python scripts\docs_smoke.py`
- `git diff --check`
- `git merge-tree --write-tree origin/main HEAD`

## Notes
The existing summary remains uncapped so agents can reconcile full-account totals even when callers request only recent rows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account accepted-work endpoints (API and HTML) support a configurable limit (1–200, default 100) to control how many results are returned; pages and API responses now enforce that limit.

* **Documentation**
  * API examples updated to show limit usage and clarify that summary totals still reflect full account history.

* **Tests**
  * Added tests to verify limiting behavior and validation for invalid or repeated limit parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->