### PR TITLE
Honor accepted-work API limit

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
@@ -14,7 +14,7 @@ from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
 from app.ledger_views import account_ledger_transactions
 from app.models import Account
 from app.path_params import SQLITE_INTEGER_MAX, reject_path_whitespace_padding
-from app.query_validation import reject_repeated_query_param
+from app.query_validation import reject_noncanonical_int_query_param, reject_repeated_query_param
 from app.serializers import (
     accepted_work_for_account,
     account_accepted_summary,
@@ -124,13 +124,15 @@ def account_api_context(session: Session, account: str) -> dict[str, Any]:
     }
 
 
-def account_accepted_work_context(session: Session, account: str) -> dict[str, Any]:
+def account_accepted_work_context(
+    session: Session, account: str, limit: int | None = None
+) -> dict[str, Any]:
     account = normalized_account(account)
     pending_payouts = pending_payouts_for_account(session, account)
     return {
         "account": account,
         "summary": account_accepted_summary(session, account),
-        "accepted_work": accepted_work_for_account(session, account),
+        "accepted_work": accepted_work_for_account(session, account, limit=limit),
         "pending_summary": pending_payout_summary(pending_payouts),
         "pending_payouts": pending_payouts,
     }
@@ -181,10 +183,16 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
             return account_api_context(session, account)
 
     @app.get("/api/v1/accounts/{account}/accepted-work")
-    def api_account_accepted_work(account: str) -> dict[str, Any]:
+    def api_account_accepted_work(
+        request: Request,
+        account: str,
+        limit: Annotated[int | None, Query(ge=1, le=200)] = None,
+    ) -> dict[str, Any]:
         reject_path_whitespace_padding(account, "account")
+        reject_repeated_query_param(request, "limit")
+        reject_noncanonical_int_query_param(request, "limit")
         with session_scope(db_url) as session:
-            return account_accepted_work_context(session, account)
+            return account_accepted_work_context(session, account, limit)
 
     @app.get("/accounts/{account}", response_class=HTMLResponse)
     def account_page(

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -737,9 +737,11 @@ def account_accepted_summary(session: Session, account: str) -> dict[str, Any]:
     }
 
 
-def accepted_work_for_account(session: Session, account: str) -> list[dict[str, Any]]:
+def accepted_work_for_account(
+    session: Session, account: str, limit: int | None = None
+) -> list[dict[str, Any]]:
     """Return accepted work proof rows for one ledger account."""
-    rows = session.execute(
+    query = (
         select(Proof, LedgerEntry)
         .join(LedgerEntry, LedgerEntry.sequence == Proof.ledger_sequence)
         .where(
@@ -748,7 +750,10 @@ def accepted_work_for_account(session: Session, account: str) -> list[dict[str, 
             LedgerEntry.to_account == account,
         )
         .order_by(LedgerEntry.sequence.desc())
-    ).all()
+    )
+    if limit is not None:
+        query = query.limit(limit)
+    rows = session.execute(query).all()
     accepted_work: list[dict[str, Any]] = []
     public_base_url = get_settings().public_base_url if rows else None
     for proof, entry in rows:

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -99,6 +99,46 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     assert f'href="/proofs/{proof.hash}"' in page_response.text
 
 
+def test_account_accepted_work_api_honors_canonical_limit(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        for issue_number in (190, 191, 192):
+            bounty = create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=issue_number,
+                issue_url=f"https://github.com/ramimbo/mergework/issues/{issue_number}",
+                title=f"Accepted work limit {issue_number}",
+                reward_mrwk="10",
+                acceptance="Accepted-work API limits should bound row output.",
+            )
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account="github:alice",
+                submission_url=f"https://github.com/ramimbo/mergework/pull/{issue_number}",
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted"},
+            )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    full_response = client.get("/api/v1/accounts/github:alice/accepted-work")
+    limited_response = client.get("/api/v1/accounts/github:alice/accepted-work?limit=1")
+    noncanonical_response = client.get("/api/v1/accounts/github:alice/accepted-work?limit=01")
+
+    assert full_response.status_code == 200
+    assert len(full_response.json()["accepted_work"]) == 3
+    assert limited_response.status_code == 200
+    limited_payload = limited_response.json()
+    assert limited_payload["summary"]["accepted_awards"] == 3
+    assert len(limited_payload["accepted_work"]) == 1
+    assert limited_payload["accepted_work"][0]["issue_number"] == 192
+    assert noncanonical_response.status_code == 400
+    assert noncanonical_response.json()["detail"] == "limit must be a canonical positive integer"
+
+
 def test_account_routes_expose_pending_payouts_separately_from_paid_work(
     sqlite_url: str,
 ) -> None:

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -126,7 +126,13 @@ def test_account_accepted_work_api_honors_canonical_limit(sqlite_url: str) -> No
 
     full_response = client.get("/api/v1/accounts/github:alice/accepted-work")
     limited_response = client.get("/api/v1/accounts/github:alice/accepted-work?limit=1")
+    max_limit_response = client.get("/api/v1/accounts/github:alice/accepted-work?limit=200")
+    zero_limit_response = client.get("/api/v1/accounts/github:alice/accepted-work?limit=0")
+    too_large_limit_response = client.get("/api/v1/accounts/github:alice/accepted-work?limit=201")
     noncanonical_response = client.get("/api/v1/accounts/github:alice/accepted-work?limit=01")
+    repeated_limit_response = client.get(
+        "/api/v1/accounts/github:alice/accepted-work?limit=1&limit=2"
+    )
 
     assert full_response.status_code == 200
     assert len(full_response.json()["accepted_work"]) == 3
@@ -135,8 +141,14 @@ def test_account_accepted_work_api_honors_canonical_limit(sqlite_url: str) -> No
     assert limited_payload["summary"]["accepted_awards"] == 3
     assert len(limited_payload["accepted_work"]) == 1
     assert limited_payload["accepted_work"][0]["issue_number"] == 192
+    assert max_limit_response.status_code == 200
+    assert len(max_limit_response.json()["accepted_work"]) == 3
+    assert zero_limit_response.status_code == 422
+    assert too_large_limit_response.status_code == 422
     assert noncanonical_response.status_code == 400
     assert noncanonical_response.json()["detail"] == "limit must be a canonical positive integer"
+    assert repeated_limit_response.status_code == 400
+    assert repeated_limit_response.json()["detail"] == "limit must be provided at most once"
 
 
 def test_account_routes_expose_pending_payouts_separately_from_paid_work(


### PR DESCRIPTION
Bounty #799

Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4621794667

This PR implements a focused fix for the public account accepted-work API silently ignoring `limit` query values:

- `/api/v1/accounts/{account}/accepted-work?limit=1` now returns one accepted-work row while keeping the summary totals uncapped.
- `limit` is bounded with the same 1..200 shape used by nearby public list endpoints.
- repeated or non-canonical integer spellings such as `limit=01` are rejected before FastAPI coercion.
- existing account normalization and the account page behavior remain unchanged.

Validation:
- `uv run --extra dev pytest tests/test_account_routes.py::test_account_accepted_work_api_honors_canonical_limit -q` -> 1 passed, 1 existing Starlette/httpx warning.
- `uv run --extra dev pytest tests/test_account_routes.py tests/test_serializers.py tests/test_api_mcp.py::test_explorer_links_ledger_proof_and_account tests/test_api_mcp.py::test_account_api_keeps_schema_when_accepted_work_proof_is_malformed -q` -> 21 passed, 1 existing Starlette/httpx warning.
- `uv run --extra dev ruff check app/accounts.py app/serializers.py tests/test_account_routes.py` -> passed.
- `uv run --extra dev ruff format --check app/accounts.py app/serializers.py tests/test_account_routes.py` -> 3 files already formatted.
- `uv run --extra dev mypy app/accounts.py app/serializers.py` -> success.
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `7fb1b2541ddfeb1b3655e87b5f2dd4a4de39f295`.

Scope: public account accepted-work row limiting only. No payout execution, treasury mutation, wallet mutation, ledger mutation, admin-token behavior, private data, secrets, bridge/exchange/cash-out behavior, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `limit` query parameter (1–200) to the accepted-work endpoint; requests with non-canonical formatting are rejected with appropriate validation errors.
* **Tests**
  * Added API tests covering default behavior, valid limits, out-of-range rejections, non-canonical formatting rejection, and repeated-parameter rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->