### PR TITLE
Honor ledger page limit

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import Annotated, Any
 from urllib.parse import quote, urlencode
 
 from fastapi import FastAPI, HTTPException, Query, Request
@@ -270,7 +270,7 @@ def register_public_routes(
         list[dict[str, Any]],
     ],
     api_bounty: Callable[[str], dict[str, Any]],
-    api_ledger: Callable[[], list[dict[str, Any]]],
+    api_ledger: Callable[[int], list[dict[str, Any]]],
     api_ledger_entry: Callable[[str], dict[str, Any]],
     api_proof: Callable[[str], dict[str, Any]],
 ) -> None:
@@ -314,8 +314,13 @@ def register_public_routes(
         )
 
     @app.get("/ledger", response_class=HTMLResponse)
-    def ledger_page(request: Request) -> HTMLResponse:
-        return templates.TemplateResponse(request, "ledger.html", {"entries": api_ledger()})
+    def ledger_page(
+        request: Request,
+        limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    ) -> HTMLResponse:
+        reject_repeated_query_param(request, "limit")
+        reject_noncanonical_int_query_param(request, "limit")
+        return templates.TemplateResponse(request, "ledger.html", {"entries": api_ledger(limit)})
 
     @app.get("/ledger/{sequence}", response_class=HTMLResponse)
     def ledger_entry_page(request: Request, sequence: str) -> HTMLResponse:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -923,6 +923,7 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
         proof_hash = proof.hash
         payment_sequence = proof.ledger_sequence
         unsafe_proof_hash = unsafe_proof.hash
+        unsafe_payment_sequence = unsafe_proof.ledger_sequence
 
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
@@ -940,6 +941,13 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
         in ledger_page.text
     )
     assert f'href="/proofs/{proof_hash}">Payment proof</a>' in ledger_page.text
+    limited_ledger_page = client.get("/ledger?limit=1")
+    assert limited_ledger_page.status_code == 200
+    assert limited_ledger_page.text.count('class="ledger-row ledger-row--') == 1
+    assert f'href="/ledger/{unsafe_payment_sequence}"' in limited_ledger_page.text
+    assert f'href="/ledger/{payment_sequence}"' not in limited_ledger_page.text
+    assert client.get("/ledger?limit=01").status_code == 400
+    assert client.get("/ledger?limit=1&limit=2").status_code == 400
 
     ledger_entry_page = client.get(f"/ledger/{payment_sequence}")
     assert ledger_entry_page.status_code == 200

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -946,8 +946,12 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert limited_ledger_page.text.count('class="ledger-row ledger-row--') == 1
     assert f'href="/ledger/{unsafe_payment_sequence}"' in limited_ledger_page.text
     assert f'href="/ledger/{payment_sequence}"' not in limited_ledger_page.text
-    assert client.get("/ledger?limit=01").status_code == 400
-    assert client.get("/ledger?limit=1&limit=2").status_code == 400
+    noncanonical_limit = client.get("/ledger?limit=01")
+    repeated_limit = client.get("/ledger?limit=1&limit=2")
+    assert noncanonical_limit.status_code == 400
+    assert noncanonical_limit.json()["detail"] == "limit must be a canonical positive integer"
+    assert repeated_limit.status_code == 400
+    assert repeated_limit.json()["detail"] == "limit must be provided at most once"
 
     ledger_entry_page = client.get(f"/ledger/{payment_sequence}")
     assert ledger_entry_page.status_code == 200


### PR DESCRIPTION
## Summary
- Add bounded `limit=1..200` support to the public `/ledger` HTML page.
- Reuse the same repeated and non-canonical integer query guards as `/api/v1/ledger`.
- Keep the default page at 50 rows when no limit is supplied.

Bounty #799
Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4621866557

## Production behavior before fix
- `GET https://api.mrwk.online/api/v1/ledger?limit=1` -> 1 JSON row.
- `GET https://api.mrwk.online/api/v1/ledger?limit=01` -> HTTP 400.
- `GET https://mrwk.online/ledger?limit=1` -> still rendered 50 ledger links.
- `GET https://mrwk.online/ledger?limit=01` -> still rendered 50 ledger links.
- `GET https://mrwk.online/ledger?limit=1&limit=2` -> still rendered 50 ledger links.

## Validation
- `python -m pytest tests\test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable -q`
- `python -m pytest tests\test_bounty_pages.py -q`
- `python -m ruff check app\public_routes.py tests\test_bounty_pages.py`
- `python -m ruff format --check app\public_routes.py tests\test_bounty_pages.py`
- `python -m mypy app\public_routes.py`
- `python scripts\docs_smoke.py`
- `git diff --check`
- `git merge-tree --write-tree origin/main HEAD`

## Scope
Public ledger page row limiting only. No ledger writes, payout execution, treasury mutation, wallet behavior, private data, secrets, bridge/exchange/cash-out behavior, or MRWK price behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The /ledger page accepts an optional limit query to control returned entries (default 50, range 1–200). Values must be canonical integers; invalid or duplicate parameters return 400.

* **Tests**
  * Added/updated tests to verify limit behavior, correct entry selection when limited, and proper rejection messages for non-canonical or repeated limit parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->