### PR TITLE
Honor treasury proposal offset pagination

### DIFF
--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -115,16 +115,17 @@ def register_treasury_routes(
     def api_treasury_proposals(
         request: Request,
         limit: Annotated[int, Query(ge=1, le=200)] = 100,
+        offset: Annotated[int, Query(ge=0, le=SQLITE_INTEGER_MAX)] = 0,
         action: Annotated[str | None, Query(max_length=40)] = None,
         status: Annotated[str | None, Query(max_length=40)] = None,
         to_account: Annotated[str | None, Query(max_length=128)] = None,
         bounty_id: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
     ) -> list[dict[str, Any]]:
-        for name in ("limit", "action", "status", "to_account", "bounty_id"):
+        for name in ("limit", "offset", "action", "status", "to_account", "bounty_id"):
             reject_repeated_query_param(request, name)
         for name in ("action", "status", "to_account"):
             reject_control_char_query_param(request, name)
-        for name in ("limit", "bounty_id"):
+        for name in ("limit", "offset", "bounty_id"):
             reject_noncanonical_int_query_param(request, name)
         action_filter = _optional_query_filter(
             action,
@@ -154,16 +155,21 @@ def register_treasury_routes(
                 query = query.where(TreasuryProposal.action == action_filter)
             if status_filter is not None:
                 query = query.where(TreasuryProposal.status == status_filter)
-            if to_account_filter is None and bounty_id is None:
-                query = query.limit(limit)
+            payload_filter_active = to_account_filter is not None or bounty_id is not None
+            if not payload_filter_active:
+                query = query.offset(offset).limit(limit)
 
             proposals: list[dict[str, Any]] = []
+            skipped = 0
             for proposal in session.scalars(query):
                 if not _proposal_payload_matches(
                     proposal,
                     to_account=to_account_filter,
                     bounty_id=bounty_id,
                 ):
+                    continue
+                if payload_filter_active and skipped < offset:
+                    skipped += 1
                     continue
                 proposals.append(proposal_to_dict(proposal))
                 if len(proposals) >= limit:

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -172,6 +172,7 @@ Read proposals:
 ```bash
 curl -s "$API_HOST/api/v1/treasury/status"
 curl -s "$API_HOST/api/v1/treasury/proposals"
+curl -s "$API_HOST/api/v1/treasury/proposals?limit=25&offset=25"
 curl -s "$API_HOST/api/v1/treasury/proposals?action=pay_bounty&status=pending&bounty_id=<bounty_id>"
 curl -s "$API_HOST/api/v1/treasury/proposals/<proposal_id>"
 ```
@@ -179,7 +180,8 @@ curl -s "$API_HOST/api/v1/treasury/proposals/<proposal_id>"
 Use the optional `action`, `status`, and `bounty_id` filters to inspect one
 queue slice without client-side scanning. The `bounty_id` filter matches
 proposal payloads such as pending payout or close-bounty proposals, not GitHub
-issue numbers.
+issue numbers. Use canonical `limit` and `offset` values to page through the
+newest-first proposal list.
 
 The treasury status endpoint reports the 24-hour create-bounty reserve cap,
 recent executed reserves, pending create-bounty proposal reserves, remaining

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -429,6 +429,46 @@ def test_treasury_proposals_list_honors_limit(
     assert controlled_limit.json()["detail"] == "limit must not contain control characters"
 
 
+def test_treasury_proposals_list_honors_offset(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _client(sqlite_url, monkeypatch)
+    first = client.post(
+        "/api/v1/bounties", headers=ADMIN_HEADERS, json=_bounty_payload(issue_number=170)
+    ).json()
+    second = client.post(
+        "/api/v1/bounties", headers=ADMIN_HEADERS, json=_bounty_payload(issue_number=171)
+    ).json()
+    third = client.post(
+        "/api/v1/bounties", headers=ADMIN_HEADERS, json=_bounty_payload(issue_number=172)
+    ).json()
+
+    newest = client.get("/api/v1/treasury/proposals?limit=1")
+    second_page = client.get("/api/v1/treasury/proposals?limit=1&offset=1")
+    zero_offset = client.get("/api/v1/treasury/proposals?limit=1&offset=0")
+    exhausted = client.get("/api/v1/treasury/proposals?limit=1&offset=3")
+    negative_offset = client.get("/api/v1/treasury/proposals?limit=1&offset=-1")
+    oversized_offset = client.get("/api/v1/treasury/proposals?limit=1&offset=9223372036854775808")
+    noncanonical_offset = client.get("/api/v1/treasury/proposals?limit=1&offset=01")
+    repeated_offset = client.get("/api/v1/treasury/proposals?limit=1&offset=1&offset=2")
+
+    assert newest.status_code == 200
+    assert [proposal["id"] for proposal in newest.json()] == [third["id"]]
+    assert second_page.status_code == 200
+    assert [proposal["id"] for proposal in second_page.json()] == [second["id"]]
+    assert zero_offset.status_code == 200
+    assert zero_offset.json() == newest.json()
+    assert exhausted.status_code == 200
+    assert exhausted.json() == []
+    assert first["id"] not in [proposal["id"] for proposal in second_page.json()]
+    assert negative_offset.status_code == 422
+    assert oversized_offset.status_code == 422
+    assert noncanonical_offset.status_code == 400
+    assert noncanonical_offset.json()["detail"] == "offset must be a canonical positive integer"
+    assert repeated_offset.status_code == 400
+    assert repeated_offset.json()["detail"] == "offset must be provided at most once"
+
+
 def test_treasury_proposals_list_filters_by_recipient_before_limit(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -442,7 +482,7 @@ def test_treasury_proposals_list_filters_by_recipient_before_limit(
             issue_url="https://github.com/ramimbo/mergework/issues/74",
             title="Recipient filter proposal",
             reward_mrwk="5",
-            max_awards=2,
+            max_awards=3,
             acceptance="Contributor comments with proof.",
         )
         bounty_id = bounty.id
@@ -465,10 +505,23 @@ def test_treasury_proposals_list_filters_by_recipient_before_limit(
             "accepted_by": "maintainer",
         },
     )
+    alice_second = client.post(
+        f"/api/v1/bounties/{bounty_id}/pay",
+        headers=ADMIN_HEADERS,
+        json={
+            "to_account": "github:alice",
+            "submission_url": "https://github.com/ramimbo/mergework/pull/7403",
+            "accepted_by": "maintainer",
+        },
+    )
 
     filtered = client.get(
         "/api/v1/treasury/proposals"
         "?status=pending&action=pay_bounty&to_account=github%3Aalice&limit=1"
+    )
+    offset_filtered = client.get(
+        "/api/v1/treasury/proposals"
+        "?status=pending&action=pay_bounty&to_account=github%3Aalice&limit=1&offset=1"
     )
     uppercase_recipient_filtered = client.get(
         "/api/v1/treasury/proposals",
@@ -486,9 +539,12 @@ def test_treasury_proposals_list_filters_by_recipient_before_limit(
 
     assert alice.status_code == 200
     assert bob.status_code == 200
+    assert alice_second.status_code == 200
     assert filtered.status_code == 200
-    assert [proposal["id"] for proposal in filtered.json()] == [alice.json()["id"]]
+    assert [proposal["id"] for proposal in filtered.json()] == [alice_second.json()["id"]]
     assert filtered.json()[0]["payload"]["to_account"] == "github:alice"
+    assert offset_filtered.status_code == 200
+    assert [proposal["id"] for proposal in offset_filtered.json()] == [alice.json()["id"]]
     assert uppercase_recipient_filtered.status_code == 200
     assert uppercase_recipient_filtered.json() == filtered.json()
     assert bob_filtered.status_code == 200


### PR DESCRIPTION
## Summary

Refs #799

Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4622273541

This PR fixes the public treasury proposal list silently ignoring caller-supplied `offset` values.

Changes:
- Adds a bounded canonical `offset` query parameter to `GET /api/v1/treasury/proposals`.
- Applies SQL `offset + limit` for the normal newest-first list path.
- Applies offset after payload matching for `to_account` / `bounty_id` filtered proposal scans.
- Rejects repeated and non-canonical `offset` values through the existing query validation helpers.
- Documents `limit + offset` proposal-list paging in `docs/api-examples.md`.

## Production evidence before fix

Current production repeats the first page instead of paging:

```text
https://api.mrwk.online/api/v1/treasury/proposals?limit=1 -> status=200 rows=1 ids=[147]
https://api.mrwk.online/api/v1/treasury/proposals?limit=1&offset=1 -> status=200 rows=1 ids=[147]
https://api.mrwk.online/api/v1/treasury/proposals?offset=1 -> status=200 rows=100 ids=[147,146,145,...,48]
https://api.mrwk.online/api/v1/treasury/proposals?limit=1&offset=01 -> status=200 rows=1 ids=[147]
https://api.mrwk.online/api/v1/treasury/proposals?limit=1&offset=1&offset=2 -> status=200 rows=1 ids=[147]
```

## Validation

- `uv run --extra dev pytest tests/test_treasury_proposals.py::test_treasury_proposals_list_honors_offset tests/test_treasury_proposals.py::test_treasury_proposals_list_filters_by_recipient_before_limit tests/test_treasury_proposals.py::test_treasury_proposals_list_rejects_invalid_filters tests/test_treasury_proposals.py::test_treasury_proposals_list_rejects_repeated_scalar_filters -q` -> 18 passed, 1 warning
- `uv run --extra dev pytest tests/test_treasury_proposals.py -q` -> 59 passed, 1 warning
- `uv run --extra dev pytest tests/test_docs_public_urls.py tests/test_treasury_proposals.py -q` -> 94 passed, 1 warning
- `uv run --extra dev ruff check app/treasury_routes.py tests/test_treasury_proposals.py` -> passed
- `uv run --extra dev ruff format --check app/treasury_routes.py tests/test_treasury_proposals.py` -> passed
- `uv run --extra dev mypy app/treasury_routes.py` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> no whitespace errors; Git emitted the existing Windows line-ending warning for `docs/api-examples.md`

Scope: public treasury proposal list pagination only. No proposal creation/execution, payout execution, wallet behavior, ledger mutation, admin-token behavior, private data, secrets, bridge/exchange/cash-out behavior, or MRWK price behavior is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced offset parameter validation in Treasury Proposals API pagination.
  * Fixed pagination behavior when using account/bounty filters to ensure accurate results.

* **Documentation**
  * Updated Treasury Proposals API examples with pagination query parameters (limit/offset).
  * Clarified bounty_id filter targets internal proposal identifiers, not GitHub issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->