### PR TITLE
fix: limit bounty search query length

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -30,6 +30,7 @@ from app.path_params import SQLITE_INTEGER_MAX, issue_number_search_value, posit
 from app.query_validation import (
     reject_control_char_query_param,
     reject_noncanonical_int_query_param,
+    reject_query_param_max_length,
     reject_repeated_query_param,
 )
 from app.serializers import (
@@ -201,6 +202,7 @@ def register_bounty_api_routes(
             reject_repeated_query_param(request, name)
         for name in ("status", "q", "sort", "repo", "availability"):
             reject_control_char_query_param(request, name)
+        reject_query_param_max_length(request, "q", 500)
         for name in ("limit", "issue_number"):
             reject_noncanonical_int_query_param(request, name)
         return _list_bounties_by_status(
@@ -228,6 +230,7 @@ def register_bounty_api_routes(
             reject_repeated_query_param(request, name)
         for name in ("status", "q", "sort", "repo", "availability"):
             reject_control_char_query_param(request, name)
+        reject_query_param_max_length(request, "q", 500)
         for name in ("limit", "issue_number"):
             reject_noncanonical_int_query_param(request, name)
         return bounty_list_summary(

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -25,6 +25,7 @@ from app.path_params import SQLITE_INTEGER_MAX, proof_hash_from_path, reject_pat
 from app.query_validation import (
     reject_control_char_query_param,
     reject_noncanonical_int_query_param,
+    reject_query_param_max_length,
     reject_repeated_query_param,
 )
 from app.serializers import bounty_list_summary, wallet_to_dict
@@ -289,6 +290,7 @@ def register_public_routes(
             reject_repeated_query_param(request, name)
         for name in ("status", "q", "sort", "repo", "availability"):
             reject_control_char_query_param(request, name)
+        reject_query_param_max_length(request, "q", 500)
         for name in ("limit", "issue_number"):
             reject_noncanonical_int_query_param(request, name)
         bounties = list_bounties_by_status(status, q, sort, limit, repo, issue_number, availability)

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -59,3 +59,13 @@ def reject_repeated_query_param(request: Request, name: str) -> None:
             status_code=400,
             detail=f"{name} must be provided at most once",
         )
+
+
+def reject_query_param_max_length(request: Request, name: str, max_length: int) -> None:
+    """Reject oversized raw query parameter values before they reach DB filters."""
+    for value in request.query_params.getlist(name):
+        if len(value) > max_length:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} must be at most {max_length} characters",
+            )

--- a/tests/test_bounty_api.py
+++ b/tests/test_bounty_api.py
@@ -54,6 +54,18 @@ class TestBountyListRoutes:
         resp = client.get("/api/v1/bounties?q=test")
         assert resp.status_code == 200
 
+    @pytest.mark.parametrize(
+        "path",
+        ("/api/v1/bounties", "/api/v1/bounties/summary"),
+    )
+    def test_bounty_api_rejects_oversized_query_text(self, client, path):
+        accepted = client.get(path, params={"q": "a" * 500})
+        rejected = client.get(path, params={"q": "a" * 501})
+
+        assert accepted.status_code == 200
+        assert rejected.status_code == 400
+        assert rejected.json()["detail"] == "q must be at most 500 characters"
+
     def test_bounties_summary(self, client):
         resp = client.get("/api/v1/bounties/summary")
         assert resp.status_code == 200

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -335,6 +335,21 @@ def test_bounties_page_rejects_repeated_scalar_filters(sqlite_url: str) -> None:
         assert response.json()["detail"] == detail
 
 
+def test_bounties_page_rejects_oversized_query_text(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    accepted = client.get("/bounties", params={"q": "a" * 500})
+    rejected = client.get("/bounties", params={"q": "a" * 501})
+
+    assert accepted.status_code == 200
+    assert rejected.status_code == 400
+    assert rejected.json()["detail"] == "q must be at most 500 characters"
+
+
 def test_bounties_page_rejects_sqlite_overflow_issue_number(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -419,8 +434,8 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     assert oversized_issue_search.json() == []
 
     digit_limit_issue_search = client.get("/api/v1/bounties", params={"q": "9" * 5000})
-    assert digit_limit_issue_search.status_code == 200
-    assert digit_limit_issue_search.json() == []
+    assert digit_limit_issue_search.status_code == 400
+    assert digit_limit_issue_search.json()["detail"] == "q must be at most 500 characters"
 
     oversized_issue_page = client.get("/bounties", params={"q": "9" * 40})
     assert oversized_issue_page.status_code == 200


### PR DESCRIPTION
## Summary
- cap bounty search query parameters to the shared maximum query length before filtering
- apply the same guard to public bounty pages and JSON endpoints
- add regression coverage for overlong bounty search terms

/claim #798

## Test Plan
- `.venv/bin/python -m pytest tests/test_bounty_api.py tests/test_bounty_pages.py -q`
- `.venv/bin/python -m ruff format --check app/bounty_api.py app/public_routes.py app/query_validation.py tests/test_bounty_api.py tests/test_bounty_pages.py`
- `.venv/bin/python -m ruff check app/bounty_api.py app/public_routes.py app/query_validation.py tests/test_bounty_api.py tests/test_bounty_pages.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search queries are now limited to a 500-character maximum length. Requests exceeding this limit will be rejected with a validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->