### PR TITLE
Reject padded activity account filters

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from app.accounts import normalized_account
 from app.control_chars import contains_control_character
 from app.db import session_scope
+from app.path_params import reject_path_whitespace_padding
 from app.query_validation import reject_control_char_query_param, reject_repeated_query_param
 from app.serializers import activity_to_dict
 
@@ -19,7 +20,11 @@ def activity_context(
 ) -> dict[str, Any]:
     if query is not None and contains_control_character(query):
         raise HTTPException(status_code=400, detail="q must not contain control characters")
-    normalized = normalized_account(account) if account is not None else None
+    if account is not None:
+        reject_path_whitespace_padding(account, "account")
+        normalized = normalized_account(account)
+    else:
+        normalized = None
     return activity_to_dict(session, query, account=normalized)
 
 

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -309,7 +309,8 @@ def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
     repeated_account_response = client.get(
         "/api/v1/activity?account=github:alice&account=github:bob"
     )
-    invalid_account_response = client.get("/api/v1/activity?account=github%3A%20")
+    padded_account_response = client.get("/api/v1/activity?account=%20github:alice%20")
+    invalid_account_response = client.get("/api/v1/activity?account=github%3A_bad")
 
     assert api_response.status_code == 400
     assert api_response.json()["detail"] == "q must not contain control characters"
@@ -327,6 +328,10 @@ def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
     )
     assert repeated_account_response.status_code == 400
     assert repeated_account_response.json()["detail"] == "account must be provided at most once"
+    assert padded_account_response.status_code == 400
+    assert padded_account_response.json()["detail"] == (
+        "account must not contain leading or trailing whitespace"
+    )
     assert invalid_account_response.status_code == 400
     assert invalid_account_response.json()["detail"] == "github login must be valid"
 


### PR DESCRIPTION
## Summary

- reject whitespace-padded `account` query values on `/api/v1/activity` before account normalization
- keep clean mixed-case account filters such as `GitHub:Alice` working through existing normalization
- add regression coverage for padded activity account filters while preserving invalid-login coverage

Bounty #799
Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4622683293

## Production evidence before fix

Current production treats a padded account filter as the canonical account:

```text
GET https://api.mrwk.online/api/v1/activity?account=github%3Akeilogic
-> status 200, bytes 7148, accepted_awards 12, contributors 1, first_account github:keilogic

GET https://api.mrwk.online/api/v1/activity?account=%20github%3Akeilogic%20
-> status 200, bytes 7148, accepted_awards 12, contributors 1, first_account github:keilogic
```

## Validation

- `uv run --extra dev pytest tests/test_activity.py::test_activity_query_rejects_control_characters tests/test_activity.py::test_activity_api_filters_by_exact_account -q` -> 2 passed, 1 warning
- `uv run --extra dev pytest tests/test_activity.py -q` -> 7 passed, 1 warning
- `uv run --extra dev pytest tests/test_activity.py tests/test_account_validation.py -q` -> 51 passed, 1 warning
- `uv run --extra dev ruff check app/activity.py tests/test_activity.py` -> passed
- `uv run --extra dev ruff format --check app/activity.py tests/test_activity.py` -> passed
- `uv run --extra dev mypy app/activity.py` -> passed
- `git diff --check` -> clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced account input validation to properly reject entries containing leading or trailing whitespace.

* **Tests**
  * Updated test suite to validate improved account input validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->