### PR TITLE
Reject padded MCP bounty filters

### DIFF
--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -80,7 +80,7 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             raise ValueError(f"{field} must be a string")
         return value
 
-    def optional_clean_str_arg(field: str) -> str | None:
+    def optional_clean_str_arg(field: str, *, reject_padding: bool = False) -> str | None:
         value = args.get(field)
         if value is None:
             return None
@@ -88,6 +88,8 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             raise ValueError(f"{field} must be a string")
         if contains_control_character(value):
             raise ValueError(f"{field} must not contain control characters")
+        if reject_padding and value.strip() and value != value.strip():
+            raise ValueError(f"{field} must not contain leading or trailing whitespace")
         clean = value.strip()
         return clean or None
 
@@ -153,12 +155,12 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
 
     with session_scope(database_url) as session:
         if name == "list_bounties":
-            status = optional_clean_str_arg("status") or "open"
+            status = optional_clean_str_arg("status", reject_padding=True) or "open"
             normalized_status = status.lower()
             if normalized_status not in {"open", "paid", "closed"}:
                 raise ValueError("status must be one of: open, paid, closed")
             query = select(Bounty).where(Bounty.status == normalized_status)
-            query_text = optional_clean_str_arg("q")
+            query_text = optional_clean_str_arg("q", reject_padding=True)
             if query_text:
                 escaped_query = (
                     query_text.lower().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
@@ -173,9 +175,9 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 if issue_number is not None:
                     text_filter = or_(text_filter, Bounty.issue_number == issue_number)
                 query = query.where(text_filter)
-            sort = normalize_bounty_sort(optional_clean_str_arg("sort"))
+            sort = normalize_bounty_sort(optional_clean_str_arg("sort", reject_padding=True))
             availability = normalize_bounty_availability_filter(
-                optional_clean_str_arg("availability")
+                optional_clean_str_arg("availability", reject_padding=True)
             )
             limit = list_limit_arg()
             if sort == "newest" and availability == "all":

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -530,7 +530,7 @@ def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> No
             "method": "tools/call",
             "params": {
                 "name": "list_bounties",
-                "arguments": {"status": " Paid ", "q": "proof", "limit": 1},
+                "arguments": {"status": "Paid", "q": "proof", "limit": 1},
             },
         },
     ).json()
@@ -697,6 +697,10 @@ def test_mcp_list_bounties_filters_effective_availability(sqlite_url: str) -> No
         ({"limit": 101}, 35),
         ({"sort": "invalid"}, 36),
         ({"availability": "maybe"}, 37),
+        ({"status": " open "}, 38),
+        ({"q": " proof "}, 39),
+        ({"sort": " reward "}, 40),
+        ({"availability": " effectively_open "}, 41),
     ],
 )
 def test_mcp_list_bounties_rejects_invalid_filters(

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -83,6 +83,16 @@ def test_call_mcp_tool_rejects_c1_status_before_normalizing(sqlite_url: str) -> 
         call_mcp_tool(sqlite_url, "list_bounties", {"status": "\u0085open"})
 
 
+@pytest.mark.parametrize("field", ["status", "q", "sort", "availability"])
+def test_call_mcp_tool_rejects_padded_list_bounty_filters(sqlite_url: str, field: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    with pytest.raises(ValueError, match=f"{field} must not contain leading or trailing"):
+        call_mcp_tool(sqlite_url, "list_bounties", {field: " open "})
+
+
 def test_call_mcp_tool_rejects_c1_nonce_before_integer_parsing(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
## Summary

- reject non-empty leading/trailing whitespace in MCP `list_bounties` string filter arguments before normalization
- apply the padding guard only to `status`, `q`, `sort`, and `availability`
- keep clean case-insensitive status values like `Paid` working and keep blank/omitted filters on the existing default paths

Bounty #799
Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4622777262

## Production evidence before fix

Current production accepts whitespace-padded MCP `list_bounties` filters as hidden aliases for the clean values:

```text
clean status args: {"status":"open","limit":3}
-> HTTP 200, JSON-RPC result, first ids [109,108,107]

padded status args: {"status":" open ","limit":3}
-> HTTP 200, JSON-RPC result, first ids [109,108,107]

invalid status args: {"status":"bogus","limit":3}
-> HTTP 200, JSON-RPC error -32602 / invalid tool arguments

clean q args: {"status":"open","q":"review","limit":3}
-> HTTP 200, JSON-RPC result, first ids [109,107,97]

padded q args: {"status":"open","q":" review ","limit":3}
-> HTTP 200, JSON-RPC result, first ids [109,107,97]

clean sort args: {"status":"open","sort":"reward","limit":3}
-> HTTP 200, JSON-RPC result, first ids [108,107,106]

padded sort args: {"status":"open","sort":" reward ","limit":3}
-> HTTP 200, JSON-RPC result, first ids [108,107,106]
```

## Duplicate/current check

- PR #862 covers oversized MCP `list_bounties` `q` strings, not leading/trailing whitespace aliases.
- PR #783 covers HTTP/page public string filters and does not change MCP `list_bounties` argument handling.
- Existing #798 MCP reports cover `initialize`, `get_proof` timestamp shape, non-JSON content types, and oversized `q`; I did not find this padded MCP filter behavior reported before the linked source report.

## Validation

- `uv run --extra dev pytest tests/test_api_mcp.py::test_mcp_list_bounties_filters_status_query_and_limit tests/test_api_mcp.py::test_mcp_list_bounties_rejects_invalid_filters tests/test_mcp_tools.py::test_call_mcp_tool_rejects_padded_list_bounty_filters -q` -> 16 passed, 1 warning
- `uv run --extra dev pytest tests/test_api_mcp.py tests/test_mcp_tools.py -q` -> 120 passed, 1 warning
- `uv run --extra dev ruff check app/mcp_tools.py tests/test_api_mcp.py tests/test_mcp_tools.py` -> passed
- `uv run --extra dev ruff format --check app/mcp_tools.py tests/test_api_mcp.py tests/test_mcp_tools.py` -> 3 files already formatted
- `uv run --extra dev mypy app/mcp_tools.py` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

## Scope

This PR is limited to read-only MCP `list_bounties` string filter argument validation. It does not change REST/HTML bounty list behavior, valid clean MCP query semantics, bounty creation, payout execution, treasury mutation, wallet behavior, ledger mutation, admin-token behavior, private data, secrets, bridge/exchange/cash-out behavior, or MRWK price behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation for MCP tool filters to reject parameters with leading or trailing whitespace.

* **Tests**
  * Updated and added test cases to verify strict input validation for filter parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->