### PR TITLE
Validate markdown anchors in docs smoke

### DIFF
--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -133,6 +133,7 @@ REQUIRED_PUBLIC_PHRASES = {
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 HEADING_RE = re.compile(r"^#{1,6}\s+(.+?)\s*#*\s*$", re.MULTILINE)
+FENCE_RE = re.compile(r"^\s{0,3}(`{3,}|~{3,})")
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"
 SECURITY_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/security-report.yml"
 BUG_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/bug.yml"
@@ -146,8 +147,31 @@ def _markdown_heading_anchor(heading: str) -> str:
 
 
 def _markdown_anchors(path: Path) -> set[str]:
-    text = path.read_text(encoding="utf-8")
-    return {_markdown_heading_anchor(match.group(1)) for match in HEADING_RE.finditer(text)}
+    anchors: set[str] = set()
+    counts: dict[str, int] = {}
+    fence_marker = ""
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        fence_match = FENCE_RE.match(line)
+        if fence_match:
+            marker = fence_match.group(1)
+            if not fence_marker:
+                fence_marker = marker
+            elif marker.startswith(fence_marker[0]) and len(marker) >= len(fence_marker):
+                fence_marker = ""
+            continue
+        if fence_marker:
+            continue
+
+        heading_match = HEADING_RE.match(line)
+        if not heading_match:
+            continue
+        anchor = _markdown_heading_anchor(heading_match.group(1))
+        count = counts.get(anchor, 0)
+        counts[anchor] = count + 1
+        anchors.add(anchor if count == 0 else f"{anchor}-{count}")
+
+    return anchors
 
 
 def _local_target_exists(source: Path, target: str) -> bool:

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -132,17 +132,34 @@ REQUIRED_PUBLIC_PHRASES = {
     ],
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+HEADING_RE = re.compile(r"^#{1,6}\s+(.+?)\s*#*\s*$", re.MULTILINE)
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"
 SECURITY_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/security-report.yml"
 BUG_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/bug.yml"
 PR_TEMPLATE = ".github/pull_request_template.md"
 
 
+def _markdown_heading_anchor(heading: str) -> str:
+    text = re.sub(r"`([^`]+)`", r"\1", heading.strip().lower())
+    text = re.sub(r"[^\w\s-]", "", text)
+    return re.sub(r"[\s-]+", "-", text).strip("-")
+
+
+def _markdown_anchors(path: Path) -> set[str]:
+    text = path.read_text(encoding="utf-8")
+    return {_markdown_heading_anchor(match.group(1)) for match in HEADING_RE.finditer(text)}
+
+
 def _local_target_exists(source: Path, target: str) -> bool:
-    clean = target.split("#", 1)[0]
-    if not clean or clean.startswith(("http://", "https://", "mailto:")):
+    clean, separator, fragment = target.partition("#")
+    if clean.startswith(("http://", "https://", "mailto:")):
         return True
-    return (source.parent / clean).resolve().exists()
+    target_path = (source.parent / clean).resolve() if clean else source.resolve()
+    if not target_path.exists():
+        return False
+    if separator and fragment and target_path.suffix.lower() in {".md", ".markdown"}:
+        return fragment in _markdown_anchors(target_path)
+    return True
 
 
 def _squash(text: str) -> str:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -7,6 +7,7 @@ from scripts.docs_smoke import (
     REQUIRED,
     _issue_template_labels,
     _local_target_exists,
+    _markdown_anchors,
     _markdown_heading_anchor,
     _template_field_is_required,
 )
@@ -203,6 +204,39 @@ def test_docs_smoke_validates_markdown_heading_anchors(tmp_path: Path) -> None:
 
     assert _local_target_exists(source, "docs.md#current-transfer-paths") is True
     assert _local_target_exists(source, "docs.md#missing-section") is False
+
+
+def test_docs_smoke_validates_duplicate_markdown_heading_anchors(tmp_path: Path) -> None:
+    source = tmp_path / "README.md"
+    target = tmp_path / "docs.md"
+    source.write_text(
+        "[First](docs.md#current-transfer-paths)\n[Second](docs.md#current-transfer-paths-1)\n",
+        encoding="utf-8",
+    )
+    target.write_text(
+        "## Current Transfer Paths\n\nDetails.\n\n## Current Transfer Paths\n\nMore details.\n",
+        encoding="utf-8",
+    )
+
+    assert _local_target_exists(source, "docs.md#current-transfer-paths") is True
+    assert _local_target_exists(source, "docs.md#current-transfer-paths-1") is True
+    assert _local_target_exists(source, "docs.md#current-transfer-paths-2") is False
+
+
+def test_markdown_anchors_ignore_fenced_code_headings(tmp_path: Path) -> None:
+    target = tmp_path / "docs.md"
+    target.write_text(
+        "## Real Heading\n\n"
+        "```markdown\n"
+        "## Pseudo Heading\n"
+        "```\n"
+        "~~~\n"
+        "## Other Pseudo Heading\n"
+        "~~~\n",
+        encoding="utf-8",
+    )
+
+    assert _markdown_anchors(target) == {"real-heading"}
 
 
 def test_markdown_heading_anchor_handles_inline_code() -> None:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from scripts.docs_smoke import REQUIRED, _issue_template_labels, _template_field_is_required
+from scripts.docs_smoke import (
+    REQUIRED,
+    _issue_template_labels,
+    _local_target_exists,
+    _markdown_heading_anchor,
+    _template_field_is_required,
+)
 
 
 def test_readme_lists_live_and_legacy_urls() -> None:
@@ -187,6 +193,20 @@ def test_issue_template_labels_parse_inline_and_block_styles() -> None:
         "proposed-work",
         "docs",
     }
+
+
+def test_docs_smoke_validates_markdown_heading_anchors(tmp_path: Path) -> None:
+    source = tmp_path / "README.md"
+    target = tmp_path / "docs.md"
+    source.write_text("[Docs](docs.md#current-transfer-paths)", encoding="utf-8")
+    target.write_text("## Current Transfer Paths\n\nDetails.\n", encoding="utf-8")
+
+    assert _local_target_exists(source, "docs.md#current-transfer-paths") is True
+    assert _local_target_exists(source, "docs.md#missing-section") is False
+
+
+def test_markdown_heading_anchor_handles_inline_code() -> None:
+    assert _markdown_heading_anchor("Use `mrwk1` Wallets!") == "use-mrwk1-wallets"
 
 
 def test_bounty_rules_document_proposed_work_lifecycle() -> None:


### PR DESCRIPTION
## Summary

Refs #846.

- extends `scripts/docs_smoke.py` so local Markdown links with `#heading` fragments verify the target heading exists;
- keeps existing file-existence behavior for external links and non-Markdown local files;
- adds focused tests for a valid heading anchor, a missing anchor, and inline-code heading slugging.

## Validation

- `uv run --extra dev python -m pytest tests/test_docs_public_urls.py -q` -> 37 passed
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `uv run --extra dev python -m ruff check scripts/docs_smoke.py tests/test_docs_public_urls.py` -> passed
- `git diff --check` -> passed

## Scope

Docs-smoke maintainability only. No ledger, wallet, treasury, payout, admin-token, exchange, bridge, off-ramp, price, liquidity, or production data behavior is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Stricter documentation link validation: verifies local Markdown fragment targets exist, recognizes duplicate heading anchors (with suffixed numbering), ignores headings inside fenced code blocks, and normalizes inline/backticked text when resolving anchors.

* **Tests**
  * Added tests covering heading-anchor validation, duplicate-anchor behavior, fenced-code exclusions, and inline-code normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->