### PR TITLE
Show active attempt pressure on bounty cards

### DIFF
--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -84,6 +84,19 @@
       {{ bounty.effective_available_mrwk }} MRWK effectively available ·
       {{ bounty.effective_awards_remaining }}/{{ bounty.max_awards }} awards effectively open
     </p>
+    {% if bounty.attempt_endpoint %}
+    <p class="bounty-card-attempts">
+      Active attempts: <strong>{{ bounty.active_attempt_count | default(0) }}</strong> ·
+      <a href="{{ bounty.attempt_endpoint }}">Check active attempts</a>
+    </p>
+    {% endif %}
+    {% if bounty.active_attempt_warnings %}
+    <ul class="bounty-card-attempt-warnings">
+      {% for warning in bounty.active_attempt_warnings %}
+      <li>{{ warning }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
     {% if bounty.availability_state != "open" or bounty.effective_awards_remaining != bounty.awards_remaining %}
     <p class="notice">{{ bounty.availability_note }}</p>
     {% endif %}

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
 from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
-from app.models import LedgerEntry, Proof
+from app.models import BountyAttempt, LedgerEntry, Proof
 from app.path_params import SQLITE_INTEGER_MAX
 from app.treasury import propose_treasury_action
 
@@ -1146,6 +1147,46 @@ def test_bounties_list_cards_have_status_pills(sqlite_url: str) -> None:
     assert page.status_code == 200
     assert "status-pill status-closed" in page.text
     assert "bounty-card bounty-card--closed" in page.text
+
+
+def test_bounties_list_cards_show_active_attempt_pressure(sqlite_url: str) -> None:
+    """Bounty list cards should expose active attempt pressure before detail navigation."""
+    create_schema(sqlite_url)
+    now = datetime.now(UTC)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=94,
+            issue_url="https://github.com/ramimbo/mergework/issues/94",
+            title="Attempt pressure list-card bounty",
+            reward_mrwk="75",
+            max_awards=2,
+            acceptance="List cards should show active attempt pressure.",
+        )
+        for submitter in ("github:alice", "github:bob"):
+            session.add(
+                BountyAttempt(
+                    bounty_id=bounty.id,
+                    submitter_account=submitter,
+                    status="active",
+                    expires_at=now + timedelta(hours=1),
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        session.flush()
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    page = client.get("/bounties")
+
+    assert page.status_code == 200
+    assert "Active attempts: <strong>2</strong>" in page.text
+    assert f'href="/api/v1/bounties/{bounty_id}/attempts">Check active attempts</a>' in page.text
+    assert "bounty has 2 active attempts" in page.text
 
 
 def test_bounty_detail_page_has_back_navigation(sqlite_url: str) -> None:


### PR DESCRIPTION
This PR fixes #845.

Problem:
The public bounty list cards already include status, reward, and availability context, but they do not show active attempt pressure. Contributors need to open each bounty detail page before seeing whether there are active attempts or attempt warnings.

Reproduction:
I added a focused regression test for a bounty-list row with `active_attempt_count`, `active_attempt_warnings`, and `attempt_endpoint`. Before the template change, the list card did not render the active-attempt count/link and the new test failed.

Change:
The bounty list card now renders existing public attempt-summary fields when present:
- active attempt count
- attempt warning text
- a link to view attempts

This is limited to the public list-card template and test coverage. It does not change API, model, admin, ledger, wallet, treasury, payout, or claim behavior.

Tests:
- `./.venv/bin/python -m pytest -q`
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/python -m ruff format --check .`
- `./.venv/bin/python -m mypy app`
- `./.venv/bin/python scripts/docs_smoke.py`
- `git diff --check origin/main..HEAD`

Risk:
Low. This only adds display of fields that are already serialized for bounty rows, and only when those fields are present.

Notes:
No bounty claim is made in this PR. I will wait for maintainer review and adjust the patch if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounty cards now show active attempt details when available: an "Active attempts" count, a link to view attempts, and a list of warning messages if present.

* **Tests**
  * Added test coverage to confirm active attempt counts, the attempts link, and warning messages render correctly on the bounty listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->