### PR TITLE
Refactor bounty summary pool calculation

### DIFF
--- a/app/serializers.py
+++ b/app/serializers.py
@@ -174,8 +174,7 @@ def bounty_list_summary(bounties: list[dict[str, Any]]) -> dict[str, Any]:
     """Aggregate visible bounty rows into capacity totals."""
     open_awards = sum(int(bounty["awards_remaining"]) for bounty in bounties)
     open_pool_microunits = sum(
-        _bounty_reward_microunits(bounty) * int(bounty["awards_remaining"])
-        for bounty in bounties
+        _bounty_reward_microunits(bounty) * int(bounty["awards_remaining"]) for bounty in bounties
     )
     effective_open_awards = sum(
         int(bounty.get("effective_awards_remaining", bounty["awards_remaining"]))

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -25,6 +25,7 @@ from app.submission_requirements import (
 )
 
 PendingBountyProposals = tuple[list[dict[str, Any]], dict[str, Any] | None]
+MRWK_MICROUNITS = Decimal(1_000_000)
 
 
 def public_utc_timestamp(value: datetime) -> str:
@@ -173,8 +174,7 @@ def bounty_list_summary(bounties: list[dict[str, Any]]) -> dict[str, Any]:
     """Aggregate visible bounty rows into capacity totals."""
     open_awards = sum(int(bounty["awards_remaining"]) for bounty in bounties)
     open_pool_microunits = sum(
-        int(Decimal(str(bounty["reward_mrwk"])) * Decimal(1_000_000))
-        * int(bounty["awards_remaining"])
+        _bounty_reward_microunits(bounty) * int(bounty["awards_remaining"])
         for bounty in bounties
     )
     effective_open_awards = sum(
@@ -182,8 +182,7 @@ def bounty_list_summary(bounties: list[dict[str, Any]]) -> dict[str, Any]:
         for bounty in bounties
     )
     effective_open_pool_microunits = sum(
-        int(Decimal(str(bounty["reward_mrwk"])) * Decimal(1_000_000))
-        * int(bounty.get("effective_awards_remaining", bounty["awards_remaining"]))
+        _bounty_reward_microunits(bounty) * _effective_awards_from_payload(bounty)
         for bounty in bounties
     )
     availability_state_counts: dict[str, int] = {}
@@ -213,6 +212,14 @@ def bounty_list_summary(bounties: list[dict[str, Any]]) -> dict[str, Any]:
         "reduced_capacity_bounties": reduced_capacity_bounties,
         "effectively_unavailable_bounties": effectively_unavailable_bounties,
     }
+
+
+def _bounty_reward_microunits(bounty: dict[str, Any]) -> int:
+    return int(Decimal(str(bounty["reward_mrwk"])) * MRWK_MICROUNITS)
+
+
+def _effective_awards_from_payload(bounty: dict[str, Any]) -> int:
+    return int(bounty.get("effective_awards_remaining", bounty["awards_remaining"]))
 
 
 def _proposal_payload(proposal: TreasuryProposal) -> dict[str, Any] | None:

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -122,6 +122,31 @@ def test_bounty_list_summary_breaks_down_availability_states() -> None:
     }
 
 
+def test_bounty_list_summary_preserves_fractional_reward_pool_totals() -> None:
+    summary = bounty_list_summary(
+        [
+            {
+                "reward_mrwk": "0.5",
+                "awards_remaining": 3,
+                "effective_awards_remaining": 2,
+                "availability_state": "pending_payouts_partial",
+                "pending_payout_awards": 1,
+            },
+            {
+                "reward_mrwk": "1.25",
+                "awards_remaining": 2,
+                "availability_state": "open",
+                "pending_payout_awards": 0,
+            },
+        ]
+    )
+
+    assert summary["open_awards"] == 5
+    assert summary["open_pool_mrwk"] == "4"
+    assert summary["effective_open_awards"] == 4
+    assert summary["effective_open_pool_mrwk"] == "3.5"
+
+
 def test_bounty_serializer_marks_proposed_work_issue_submission_mode(
     sqlite_url: str,
 ) -> None:


### PR DESCRIPTION
Refs #846

## What changed

- Added small local helpers for bounty summary reward-microunit conversion and effective-award fallback handling.
- Reused those helpers in `bounty_list_summary()` so open and effective pool totals share the same conversion path.
- Added regression coverage for fractional MRWK reward values so the summary totals stay stable.

## Validation

- `uv run --extra dev python -m pytest tests/test_serializers.py -q` -> 12 passed
- `uv run --extra dev python -m ruff check app/serializers.py tests/test_serializers.py` -> passed
- `uv run --extra dev python -m ruff format --check app/serializers.py tests/test_serializers.py` -> passed
- `git diff --check` -> passed

## Scope

This is a focused maintainability cleanup for the public bounty summary serializer. It does not change ledger, wallet, treasury, payout, deployment, bridge, exchange, or off-ramp behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced precision in bounty pool reward calculations, ensuring accurate handling and reporting of fractional reward values so displayed pool totals and award counts remain correct.

* **Tests**
  * Added test coverage to verify correct calculation and aggregation of fractional reward pool totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->