### PR TITLE
Tighten docs smoke field matching

### DIFF
--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -132,6 +132,7 @@ REQUIRED_PUBLIC_PHRASES = {
     ],
 }
 LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+FIELD_ID_RE = re.compile(r"^(?P<indent>\s*)id:\s*(?P<field_id>[^\s#]+)")
 DOCS_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/docs.yml"
 SECURITY_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/security-report.yml"
 BUG_ISSUE_TEMPLATE = ".github/ISSUE_TEMPLATE/bug.yml"
@@ -150,12 +151,20 @@ def _squash(text: str) -> str:
 
 
 def _template_field_block(template: str, field_id: str) -> str:
-    marker = f"id: {field_id}"
-    if marker not in template:
-        return ""
-    block = template.split(marker, 1)[1]
-    next_field = block.find("\n    id: ")
-    return block if next_field == -1 else block[:next_field]
+    lines = template.splitlines()
+    for index, line in enumerate(lines):
+        match = FIELD_ID_RE.match(line)
+        if not match or match.group("field_id").strip("\"'") != field_id:
+            continue
+        indent = match.group("indent")
+        end = len(lines)
+        for next_index, next_line in enumerate(lines[index + 1 :], start=index + 1):
+            next_match = FIELD_ID_RE.match(next_line)
+            if next_match and next_match.group("indent") == indent:
+                end = next_index
+                break
+        return "\n".join(lines[index:end])
+    return ""
 
 
 def _template_field_is_required(template: str, field_id: str) -> bool:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -437,6 +437,18 @@ def test_docs_smoke_requires_bounty_evidence_exclusion_and_duplicate_fields() ->
     )
 
 
+def test_docs_smoke_matches_required_template_field_ids_exactly() -> None:
+    template = """
+body:
+  - type: textarea
+    id: evidence_extra
+    validations:
+      required: true
+"""
+
+    assert not _template_field_is_required(template, "evidence")
+
+
 def test_contributing_names_docs_smoke_for_public_docs_changes() -> None:
     contributing = Path("CONTRIBUTING.md").read_text(encoding="utf-8")
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -447,6 +447,7 @@ body:
 """
 
     assert not _template_field_is_required(template, "evidence")
+    assert _template_field_is_required(template, "evidence_extra")
 
 
 def test_contributing_names_docs_smoke_for_public_docs_changes() -> None:


### PR DESCRIPTION
## Summary

Refs #846 / Bounty #846.

This tightens the docs smoke check so required template field ids are matched exactly instead of by substring.

## Problem

The smoke check could treat a longer field id, such as `evidence_extra`, as satisfying the required `evidence` field.

## Fix

- Parse the referenced field ids from docs pages before matching required template ids.
- Add a regression test for the exact-match behavior.

## Validation

- `./.venv/bin/python -m pytest tests/test_docs_public_urls.py::test_docs_smoke_matches_required_template_field_ids_exactly -q` -> passed
- `./.venv/bin/python -m pytest tests/test_docs_public_urls.py -q` -> 36 passed
- `./.venv/bin/python -m ruff check scripts/docs_smoke.py tests/test_docs_public_urls.py` -> passed
- `./.venv/bin/python -m ruff format --check scripts/docs_smoke.py tests/test_docs_public_urls.py` -> passed
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok

## Risk notes

I did not rerun the full test suite for this PR. Open PR #873 also touches the docs smoke files for Markdown anchor validation; this PR is limited to exact field-id matching and may need a rebase if that PR lands first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation test to ensure precise matching of GitHub issue template field identifiers, preventing similar field names from being confused.

* **Chores**
  * Improved field-matching logic in documentation validation for enhanced accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->