### PR TITLE
Share submission availability field copying

### DIFF
--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -173,9 +173,7 @@ def _bounty_payability_verified(raw: dict[str, Any]) -> bool:
     return raw.get("payability_verified", True) is not False
 
 
-def _copy_effective_availability_fields(
-    source: dict[str, Any], target: dict[str, Any]
-) -> None:
+def _copy_effective_availability_fields(source: dict[str, Any], target: dict[str, Any]) -> None:
     for field in EFFECTIVE_AVAILABILITY_FIELDS:
         if field in source:
             target[field] = source.get(field)

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -173,6 +173,14 @@ def _bounty_payability_verified(raw: dict[str, Any]) -> bool:
     return raw.get("payability_verified", True) is not False
 
 
+def _copy_effective_availability_fields(
+    source: dict[str, Any], target: dict[str, Any]
+) -> None:
+    for field in EFFECTIVE_AVAILABILITY_FIELDS:
+        if field in source:
+            target[field] = source.get(field)
+
+
 def _active_attempts_verified(raw: dict[str, Any]) -> bool:
     return raw.get("active_attempts_verified", True) is not False
 
@@ -580,9 +588,7 @@ def _load_api_bounties(repo: str, api_host: str) -> dict[int, dict[str, Any]]:
             "state": item.get("status", "open"),
             "awards_remaining": item.get("awards_remaining"),
         }
-        for field in EFFECTIVE_AVAILABILITY_FIELDS:
-            if field in item:
-                bounties[issue_number][field] = item.get(field)
+        _copy_effective_availability_fields(item, bounties[issue_number])
     return bounties
 
 
@@ -691,9 +697,7 @@ def _load_live_context(
                 or api_bounty.get("effective_awards_remaining") is not None
             ),
         }
-        for field in EFFECTIVE_AVAILABILITY_FIELDS:
-            if field in api_bounty:
-                bounty_record[field] = api_bounty[field]
+        _copy_effective_availability_fields(api_bounty, bounty_record)
         bounties.append(bounty_record)
         if issue["number"] in referenced_bounties:
             try:

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -978,6 +978,10 @@ def test_submission_quality_gate_live_context_preserves_effective_availability(
     assert bounty["effective_awards_remaining"] == 2
     assert bounty["effective_available_mrwk"] == "300"
     assert bounty["availability_state"] == "pending_payouts_partial"
+    assert (
+        bounty["availability_note"]
+        == "3 awards covered by pending payout proposals; 2 awards effectively available."
+    )
     assert bounty["pending_payout_awards"] == 3
     assert bounty["payability_verified"] is True
 


### PR DESCRIPTION
Refs #846

## What changed

- Added a small helper for copying effective bounty availability fields in `submission_quality_gate.py`.
- Reused it when normalizing API bounty rows and when assembling live submission-gate context.
- Extended the live-context regression test to assert that `availability_note` is preserved with the other effective availability fields.

## Validation

- `uv run --extra dev python -m pytest tests/test_submission_quality_gate.py -q` -> 45 passed
- `uv run --extra dev python -m ruff check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` -> passed
- `uv run --extra dev python -m ruff format --check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` -> passed
- `git diff --check` -> passed

## Scope

This is a focused maintainability cleanup for the submission quality gate. It does not change ledger, wallet, treasury, payout, deployment, bridge, exchange, or off-ramp behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal handling of availability-related fields was consolidated for clearer, more maintainable code; no user-facing behavior changes.

* **Tests**
  * Test assertions reformatted and tightened to improve validation and guard against regressions; no change to test expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->