### PR TITLE
Share bounty filter URL construction

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -35,7 +35,7 @@ from app.status import (
 )
 
 
-def _bounties_api_url(
+def _bounty_filter_params(
     status: str | None,
     query_text: str,
     selected_sort: str,
@@ -43,7 +43,7 @@ def _bounties_api_url(
     repo: str,
     issue_number: int | None,
     selected_availability: str,
-) -> str:
+) -> list[tuple[str, str]]:
     params: list[tuple[str, str]] = []
     if status:
         params.append(("status", status))
@@ -59,7 +59,56 @@ def _bounties_api_url(
         params.append(("limit", str(limit)))
     if selected_availability != "all":
         params.append(("availability", selected_availability))
-    return f"/api/v1/bounties?{urlencode(params)}" if params else "/api/v1/bounties"
+    return params
+
+
+def _bounties_url(
+    path: str,
+    status: str | None,
+    query_text: str,
+    selected_sort: str,
+    limit: int | None,
+    repo: str,
+    issue_number: int | None,
+    selected_availability: str,
+    *,
+    quote_spaces: bool = False,
+) -> str:
+    params = _bounty_filter_params(
+        status,
+        query_text,
+        selected_sort,
+        limit,
+        repo,
+        issue_number,
+        selected_availability,
+    )
+    if not params:
+        return path
+    if quote_spaces:
+        return f"{path}?{urlencode(params, quote_via=quote)}"
+    return f"{path}?{urlencode(params)}"
+
+
+def _bounties_api_url(
+    status: str | None,
+    query_text: str,
+    selected_sort: str,
+    limit: int | None,
+    repo: str,
+    issue_number: int | None,
+    selected_availability: str,
+) -> str:
+    return _bounties_url(
+        "/api/v1/bounties",
+        status,
+        query_text,
+        selected_sort,
+        limit,
+        repo,
+        issue_number,
+        selected_availability,
+    )
 
 
 def _bounties_page_url(
@@ -71,22 +120,17 @@ def _bounties_page_url(
     issue_number: int | None,
     selected_availability: str,
 ) -> str:
-    params: list[tuple[str, str]] = []
-    if status:
-        params.append(("status", status))
-    if query_text:
-        params.append(("q", query_text))
-    if repo:
-        params.append(("repo", repo))
-    if issue_number is not None:
-        params.append(("issue_number", str(issue_number)))
-    if selected_sort != "newest":
-        params.append(("sort", selected_sort))
-    if limit is not None:
-        params.append(("limit", str(limit)))
-    if selected_availability != "all":
-        params.append(("availability", selected_availability))
-    return f"/bounties?{urlencode(params, quote_via=quote)}" if params else "/bounties"
+    return _bounties_url(
+        "/bounties",
+        status,
+        query_text,
+        selected_sort,
+        limit,
+        repo,
+        issue_number,
+        selected_availability,
+        quote_spaces=True,
+    )
 
 
 def public_bounties_context(


### PR DESCRIPTION
Refs #846

## Summary
- Extract a shared bounty filter parameter builder for public bounty list URLs.
- Reuse the shared builder for both `/api/v1/bounties` and `/bounties` links so status, query, repo, issue number, sort, limit, and availability filters stay in one place.
- Preserve the existing encoding difference: API links keep default `urlencode` behavior, while HTML page links keep `quote_via=quote` for spaces.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_public_routes.py tests/test_bounty_pages.py -q` -> 24 passed, 1 existing Starlette/httpx warning.
- `uv run --python 3.12 --extra dev ruff check app/public_routes.py tests/test_public_routes.py tests/test_bounty_pages.py` -> passed, with a local `.ruff_cache` write-permission warning only.
- `uv run --python 3.12 --extra dev ruff format --check app/public_routes.py tests/test_public_routes.py tests/test_bounty_pages.py` -> 3 files already formatted.
- `uv run --python 3.12 --extra dev mypy app/public_routes.py` -> success.
- `git diff --check` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `f3af1f967da213bcdc5445d86f3b4ea396900581`.

## Scope
Focused maintainability-only cleanup in the public bounty URL helper path. No public contract change is intended; existing tests cover API links, page links, encoded query spaces, filter preservation, invalid filters, and bounty detail/list rendering. No ledger behavior, wallet behavior, treasury behavior, payout behavior, admin-token behavior, private data handling, exchange/bridge/cash-out behavior, or MRWK price behavior is changed.

Duplicate/current check before submission: #846 is live/reserved as bounty id 112 with 8 effective awards remaining. Current open PRs touching `app/public_routes.py` are ledger page limit, wallet search limit, uppercase wallet path aliases, and older public string padding work; I did not find an open PR sharing the bounty list/API URL filter parameter construction.

Preferred payment details can be provided privately after maintainer acceptance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal consistency of bounty list URL handling and parameter management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->