### PR TITLE
Clean up MCP bounty selector reuse

### DIFF
--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -137,7 +137,12 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             raise ValueError("issue_number matches multiple bounties")
         return bounties[0]
 
-    def selected_bounty(internal_id_field: str) -> Bounty | None:
+    def has_bounty_selector(internal_id_field: str) -> bool:
+        return (internal_id_field in args and args.get(internal_id_field) is not None) or (
+            "issue_number" in args and args.get("issue_number") is not None
+        )
+
+    def selected_bounty(internal_id_field: str, *, require_selector: bool = True) -> Bounty | None:
         has_internal_id = internal_id_field in args and args.get(internal_id_field) is not None
         has_issue_number = "issue_number" in args and args.get("issue_number") is not None
         repo_selector = optional_repo_selector_arg()
@@ -149,6 +154,8 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             return session.get(Bounty, positive_int_arg(internal_id_field))
         if has_issue_number:
             return bounty_by_issue_number(repo_selector)
+        if not require_selector:
+            return None
         raise ValueError(f"{internal_id_field} or issue_number is required")
 
     with session_scope(database_url) as session:
@@ -271,31 +278,15 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             )
         if name == "submit_work_proof":
             output_format = output_format_arg()
-            has_bounty_id = "bounty_id" in args and args.get("bounty_id") is not None
-            has_issue_number = "issue_number" in args and args.get("issue_number") is not None
-            repo_selector = optional_repo_selector_arg()
-            if has_bounty_id and has_issue_number:
-                raise ValueError("use bounty_id or issue_number, not both")
-            if repo_selector is not None and not has_issue_number:
-                raise ValueError("repo can only be used with issue_number")
-            if has_bounty_id:
-                bounty = session.get(Bounty, positive_int_arg("bounty_id"))
-                if bounty is None:
-                    return "bounty not found"
+            bounty = selected_bounty("bounty_id", require_selector=False)
+            if bounty is not None:
                 return (
                     work_proof_guidance_json(bounty, session=session)
                     if output_format == "json"
                     else work_proof_guidance(bounty, session=session)
                 )
-            if has_issue_number:
-                bounty = bounty_by_issue_number(repo_selector)
-                if bounty is None:
-                    return "bounty not found"
-                return (
-                    work_proof_guidance_json(bounty, session=session)
-                    if output_format == "json"
-                    else work_proof_guidance(bounty, session=session)
-                )
+            if has_bounty_selector("bounty_id"):
+                return "bounty not found"
             if output_format == "json":
                 return generic_work_proof_guidance_json()
             return (

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -55,12 +55,67 @@ def test_submit_work_proof_repo_selector_matches_stored_repo_case(sqlite_url: st
     assert "Bounty #390" in result
 
 
+def test_submit_work_proof_reuses_bounty_selector_for_id_and_issue_number(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=391,
+            issue_url="https://github.com/ramimbo/mergework/issues/391",
+            title="Shared selector bounty",
+            reward_mrwk="150",
+            acceptance="Keep MCP selector behavior centralized.",
+        )
+        bounty_id = bounty.id
+
+    by_id = call_mcp_tool(sqlite_url, "submit_work_proof", {"bounty_id": bounty_id})
+    by_issue = call_mcp_tool(
+        sqlite_url,
+        "submit_work_proof",
+        {"issue_number": 391, "repo": "Ramimbo/MergeWork"},
+    )
+
+    assert by_id == by_issue
+    assert "Bounty #391: Shared selector bounty" in by_id
+
+
+def test_submit_work_proof_keeps_generic_and_unknown_bounty_paths(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    generic = call_mcp_tool(sqlite_url, "submit_work_proof", {})
+    unknown = call_mcp_tool(sqlite_url, "submit_work_proof", {"issue_number": 999})
+
+    assert generic == (
+        "Open a focused PR or issue, reference the MRWK bounty, include test evidence, "
+        "and wait for a maintainer to apply mrwk:accepted."
+    )
+    assert unknown == "bounty not found"
+
+
 @pytest.mark.parametrize(
     ("tool_name", "arguments", "message"),
     [
         ("list_bounties", {"status": "blocked"}, "status must be one of"),
         ("get_bounty", {"id": 0}, "id must be positive"),
         ("get_balance", {"account": ""}, "account must not be empty"),
+        (
+            "submit_work_proof",
+            {"bounty_id": 1, "issue_number": 1},
+            "use bounty_id or issue_number, not both",
+        ),
+        (
+            "submit_work_proof",
+            {"repo": "ramimbo/mergework"},
+            "repo can only be used with issue_number",
+        ),
     ],
 )
 def test_call_mcp_tool_preserves_argument_validation_errors(


### PR DESCRIPTION
Refs #846

## Summary

- Reuses the existing MCP bounty selector helper for submit_work_proof instead of maintaining a second selector path.
- Preserves the generic no-selector guidance and the selected-bounty / unknown-bounty behavior.
- Adds dispatcher-level regression coverage for id, issue+repo, generic, unknown, and invalid selector paths.

## Validation

- uv run --extra dev python -m pytest tests/test_mcp_tools.py tests/test_api_mcp.py -q -> 116 passed, 1 existing Starlette/httpx warning
- uv run --extra dev python -m pytest -q -> 794 passed, 1 existing Starlette/httpx warning
- uv run --extra dev ruff format --check app/mcp_tools.py tests/test_mcp_tools.py -> 2 files already formatted
- uv run --extra dev ruff check app/mcp_tools.py tests/test_mcp_tools.py -> All checks passed
- uv run --extra dev mypy app -> Success: no issues found in 42 source files
- git diff --check -> clean

No private data, credentials, wallet material, production mutation, proposal execution, payout/proof/ledger behavior, balance, exchange, bridge, cash-out, price behavior, or fabricated payout claims used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified bounty selection behavior so guidance vs "bounty not found" is returned consistently (returns generic guidance when no selector supplied; reports "bounty not found" only when a selector was provided).
  * Strengthened argument validation to reject conflicting or incomplete parameter combinations.

* **Tests**
  * Added tests covering selector equivalence (ID vs issue number), case-insensitive repo matching, generic guidance path, and expanded validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->