### PR TITLE
Document live bounty preflight checks

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -111,6 +111,26 @@ Use proposal-list filters when you need one queue slice, such as pending
 Use [docs/bounty-lifecycle.md](bounty-lifecycle.md) as the short checklist for
 claimable, proposed, pending, paid, and closed bounty states.
 
+When starting from a GitHub issue, run a live-vs-pending preflight before
+opening work. First look for a public bounty row for that exact source issue:
+
+```bash
+curl -s "$API_HOST/api/v1/bounties?repo=ramimbo%2Fmergework&issue_number=<issue_number>"
+```
+
+Then check whether the same issue is still only a pending `create_bounty`
+proposal:
+
+```bash
+curl -s "$API_HOST/api/v1/treasury/proposals?action=create_bounty&status=pending"
+```
+
+Treat the issue as claimable only after the public bounty row exists, the row is
+open with positive `effective_awards_remaining`, and the GitHub issue has the
+claims-open `Reserved on MergeWork` comment. A pending `create_bounty` proposal
+can show a future `executes_after` time, but it is still opening-soon work, not a
+live claim lane.
+
 The GitHub bounty board at
 https://github.com/ramimbo/mergework/issues/785 is an index for humans and
 agents, refreshed by the treasury executor when configured. Do not submit

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -127,7 +127,7 @@ curl -s "$API_HOST/api/v1/treasury/proposals?action=create_bounty&status=pending
 
 Treat the issue as claimable only after the public bounty row exists, the row is
 open with positive `effective_awards_remaining`, and the GitHub issue has the
-claims-open `Reserved on MergeWork` comment. A pending `create_bounty` proposal
+`mrwk:bounty` label plus the claims-open `Reserved on MergeWork` comment. A pending `create_bounty` proposal
 can show a future `executes_after` time, but it is still opening-soon work, not a
 live claim lane.
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -125,7 +125,7 @@ curl -s "$API_HOST/api/v1/treasury/proposals?action=create_bounty&status=pending
 The bounty lookup is the claimable-lane check. A matching pending
 `create_bounty` proposal is only opening soon until the proposal executes, the
 public bounty row exists, and the source GitHub issue receives the
-`Reserved on MergeWork` claims-open comment.
+`mrwk:bounty` label plus the `Reserved on MergeWork` claims-open comment.
 
 Use `availability=effectively_open` when discovery should hide raw-open rows
 whose remaining awards are fully covered by pending payout or close proposals.

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -114,6 +114,19 @@ matches the normalized source repository, `issue_number=N` matches the GitHub
 issue number across repos, and the two together identify one source issue. Keep
 `q` for broad text search.
 
+For live-vs-pending contributor routing, pair the exact public bounty lookup
+with the pending create-bounty proposal queue before opening or claiming work:
+
+```bash
+curl -s "$API_HOST/api/v1/bounties?repo=ramimbo%2Fmergework&issue_number=<issue_number>"
+curl -s "$API_HOST/api/v1/treasury/proposals?action=create_bounty&status=pending"
+```
+
+The bounty lookup is the claimable-lane check. A matching pending
+`create_bounty` proposal is only opening soon until the proposal executes, the
+public bounty row exists, and the source GitHub issue receives the
+`Reserved on MergeWork` claims-open comment.
+
 Use `availability=effectively_open` when discovery should hide raw-open rows
 whose remaining awards are fully covered by pending payout or close proposals.
 The default `availability=all` keeps the existing raw list behavior.

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -220,6 +220,10 @@ def test_agent_guide_tells_agents_not_to_claim_proposed_work() -> None:
     assert "Proposed work requests are intake issues, not live bounties" in guide
     assert "Do not submit `/claim`" in guide
     assert "wait for `mrwk:bounty`" in guide
+    assert "live-vs-pending preflight" in guide
+    assert "/api/v1/bounties?repo=ramimbo%2Fmergework&issue_number=<issue_number>" in guide
+    assert "/api/v1/treasury/proposals?action=create_bounty&status=pending" in guide
+    assert "Reserved on MergeWork" in guide
 
 
 def test_admin_runbook_warns_to_validate_production_admin_token() -> None:
@@ -273,6 +277,9 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert '"open_awards": 2' in examples
     assert '"open_pool_mrwk": "50"' in examples
     assert "Award counters can change" in examples
+    assert "live-vs-pending contributor routing" in examples
+    assert "/api/v1/treasury/proposals?action=create_bounty&status=pending" in examples
+    assert "Reserved on MergeWork" in examples
     assert "capacity totals" in examples
     assert "full bounty" in examples
     assert "same optional `status`, `q`, `repo`," in examples

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -223,6 +223,7 @@ def test_agent_guide_tells_agents_not_to_claim_proposed_work() -> None:
     assert "live-vs-pending preflight" in guide
     assert "/api/v1/bounties?repo=ramimbo%2Fmergework&issue_number=<issue_number>" in guide
     assert "/api/v1/treasury/proposals?action=create_bounty&status=pending" in guide
+    assert "`mrwk:bounty` label plus the claims-open `Reserved on MergeWork`" in guide
     assert "Reserved on MergeWork" in guide
 
 
@@ -279,6 +280,7 @@ def test_api_examples_document_bounty_list_response_shape() -> None:
     assert "Award counters can change" in examples
     assert "live-vs-pending contributor routing" in examples
     assert "/api/v1/treasury/proposals?action=create_bounty&status=pending" in examples
+    assert "`mrwk:bounty` label plus the `Reserved on MergeWork`" in examples
     assert "Reserved on MergeWork" in examples
     assert "capacity totals" in examples
     assert "full bounty" in examples


### PR DESCRIPTION
## Summary
- Documents a live-vs-pending preflight for contributors and agents starting from a GitHub bounty issue.
- Shows the exact existing public bounty lookup and pending `create_bounty` proposal queue checks before opening or claiming work.
- Clarifies that a pending proposal with `executes_after` is opening-soon work, not a live claim lane, until the public bounty row and `Reserved on MergeWork` comment exist.
- Adds docs smoke assertions so the preflight guidance stays visible in the agent guide and API examples.

Bounty #845

## Evidence
This is intentionally distinct from useful open contributor-flow PRs:
- It does not add or duplicate the #840 work-discovery endpoint; it documents a narrow preflight using existing `/api/v1/bounties` and `/api/v1/treasury/proposals` APIs.
- It does not overlap #874's bounty-card active-attempt UI work.
- It does not touch bounty creation, proposal execution, payout, ledger, wallet, admin, exchange, bridge, off-ramp, or cash-out behavior.

## Validation
- `uv run --extra dev python -m pytest tests/test_docs_public_urls.py -q` -> `35 passed`
- `uv run --extra dev python scripts/docs_smoke.py` -> `docs smoke ok`
- `uv run --extra dev ruff check docs/agent-guide.md docs/api-examples.md tests/test_docs_public_urls.py` -> passed
- `uv run --extra dev ruff format --check tests/test_docs_public_urls.py` -> `1 file already formatted`
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `74c5f4ba4b5d171d164f3cfaa94eccf148075d97`

## Scope
Docs and docs-smoke assertions only. No runtime behavior, tokens, secrets, private data, payout execution, or price/cash-out claims are changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for agents to verify bounty availability before claiming work from GitHub issues.
  * Added a preflight checklist to distinguish live vs. pending bounties and when a bounty is “opening soon.”
  * Clarified when bounties become claimable and the role of the "Reserved on MergeWork" marker and the mrwk:bounty label.

* **Tests**
  * Added test coverage validating the new documentation and routing guidance for contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->