### PR TITLE
Link bounty detail to source matches

### DIFF
--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -88,6 +88,7 @@
     </ol>
     <div class="next-steps-actions" aria-label="Bounty action links">
       {% if issue_url %}<a href="{{ issue_url }}" rel="nofollow noopener">Open source issue</a>{% endif %}
+      <a href="/bounties?repo={{ bounty.repo | urlencode }}&amp;issue_number={{ bounty.issue_number }}">View source bounty matches</a>
       <a href="/api/v1/bounties/{{ bounty.id }}">View JSON details</a>
       <a href="/api/v1/bounties/{{ bounty.id }}/attempts">Check active attempts</a>
     </div>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -707,6 +707,8 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
         'href="https://github.com/ramimbo/mergework/issues/4" rel="nofollow noopener"'
         in response.text
     )
+    assert "View source bounty matches" in response.text
+    assert 'href="/bounties?repo=ramimbo/mergework&amp;issue_number=4"' in response.text
     assert f'href="/api/v1/bounties/{bounty.id}"' in response.text
     assert f'href="/api/v1/bounties/{bounty.id}/attempts"' in response.text
 


### PR DESCRIPTION
## Summary
- Adds a focused `View source bounty matches` action on bounty detail pages.
- The link routes contributors from a specific bounty row to the source-filtered bounty list for the same `repo` + `issue_number`.
- Extends the existing bounty detail page test to keep the source-lane link visible.

Bounty #845

## Evidence
This is a narrow contributor-routing improvement:
- helps contributors confirm all visible bounty rows for the same source issue before starting or claiming work;
- does not duplicate #874's active-attempt card display;
- does not duplicate #840's `/api/v1/work-discovery` queue endpoint or docs;
- leaves API, bounty lifecycle, attempt behavior, ledger, wallet, treasury, payout, admin, exchange, bridge, off-ramp, and cash-out behavior unchanged.

## Validation
- `uv run --extra dev python -m pytest tests/test_bounty_pages.py::test_bounty_detail_highlights_action_fields -q` -> `1 passed, 1 existing Starlette/httpx warning`
- `uv run --extra dev python -m pytest tests/test_bounty_pages.py tests/test_public_routes.py -q` -> `24 passed, 1 existing Starlette/httpx warning`
- `uv run --extra dev ruff check tests/test_bounty_pages.py tests/test_public_routes.py` -> passed
- `uv run --extra dev ruff format --check tests/test_bounty_pages.py tests/test_public_routes.py` -> `2 files already formatted`
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`

## Scope
Template and test only. No private data, credentials, tokenomics, price, exchange, bridge, off-ramp, cash-out, payout execution, ledger mutation, wallet behavior, or admin-token behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "View source bounty matches" action link on bounty detail pages, enabling quick navigation to related bounties filtered by repository and issue number.

* **Tests**
  * Added test coverage for the new "View source bounty matches" navigation link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->