### PR TITLE
Share query guard helpers

### DIFF
--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -12,24 +12,28 @@ CANONICAL_INTEGER_QUERY_RE = re.compile(r"^(?:0|[1-9][0-9]*)$")
 CANONICAL_BOOLEAN_QUERY_VALUES = {"true", "false"}
 
 
+def _query_param_values(request: Request, name: str) -> list[str]:
+    return request.query_params.getlist(name)
+
+
+def _reject_control_char_value(value: str, name: str) -> None:
+    if contains_control_character(value):
+        raise HTTPException(
+            status_code=400,
+            detail=f"{name} must not contain control characters",
+        )
+
+
 def reject_control_char_query_param(request: Request, name: str) -> None:
     """Reject raw control characters before FastAPI coerces query values."""
-    for value in request.query_params.getlist(name):
-        if contains_control_character(value):
-            raise HTTPException(
-                status_code=400,
-                detail=f"{name} must not contain control characters",
-            )
+    for value in _query_param_values(request, name):
+        _reject_control_char_value(value, name)
 
 
 def reject_noncanonical_int_query_param(request: Request, name: str) -> None:
     """Reject non-canonical integer query spellings before FastAPI coerces them."""
-    for value in request.query_params.getlist(name):
-        if contains_control_character(value):
-            raise HTTPException(
-                status_code=400,
-                detail=f"{name} must not contain control characters",
-            )
+    for value in _query_param_values(request, name):
+        _reject_control_char_value(value, name)
         if not CANONICAL_INTEGER_QUERY_RE.fullmatch(value):
             raise HTTPException(
                 status_code=400,
@@ -39,12 +43,8 @@ def reject_noncanonical_int_query_param(request: Request, name: str) -> None:
 
 def reject_noncanonical_bool_query_param(request: Request, name: str) -> None:
     """Reject boolean query aliases before application code trusts coerced values."""
-    for value in request.query_params.getlist(name):
-        if contains_control_character(value):
-            raise HTTPException(
-                status_code=400,
-                detail=f"{name} must not contain control characters",
-            )
+    for value in _query_param_values(request, name):
+        _reject_control_char_value(value, name)
         if value not in CANONICAL_BOOLEAN_QUERY_VALUES:
             raise HTTPException(
                 status_code=400,
@@ -54,7 +54,7 @@ def reject_noncanonical_bool_query_param(request: Request, name: str) -> None:
 
 def reject_repeated_query_param(request: Request, name: str) -> None:
     """Reject ambiguous scalar query parameters before FastAPI chooses one value."""
-    if len(request.query_params.getlist(name)) > 1:
+    if len(_query_param_values(request, name)) > 1:
         raise HTTPException(
             status_code=400,
             detail=f"{name} must be provided at most once",

--- a/tests/test_query_validation.py
+++ b/tests/test_query_validation.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException, Request
+
+from app.query_validation import (
+    reject_control_char_query_param,
+    reject_noncanonical_bool_query_param,
+    reject_noncanonical_int_query_param,
+    reject_repeated_query_param,
+)
+
+
+def _request(query_string: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [],
+            "query_string": query_string.encode("ascii"),
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("guard_name", "detail"),
+    [
+        ("control", "q must not contain control characters"),
+        ("int", "limit must not contain control characters"),
+        ("bool", "include_expired must not contain control characters"),
+    ],
+)
+def test_query_guards_share_control_character_rejection(guard_name: str, detail: str) -> None:
+    request = _request("q=%C2%85term&limit=%C2%851&include_expired=%C2%85true")
+
+    with pytest.raises(HTTPException) as exc_info:
+        if guard_name == "control":
+            reject_control_char_query_param(request, "q")
+        elif guard_name == "int":
+            reject_noncanonical_int_query_param(request, "limit")
+        else:
+            reject_noncanonical_bool_query_param(request, "include_expired")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == detail
+
+
+def test_query_guards_keep_canonical_and_repeated_boundaries() -> None:
+    request = _request("limit=01&include_expired=yes&status=open&status=paid")
+
+    with pytest.raises(HTTPException) as int_error:
+        reject_noncanonical_int_query_param(request, "limit")
+    assert int_error.value.status_code == 400
+    assert int_error.value.detail == "limit must be a canonical positive integer"
+
+    with pytest.raises(HTTPException) as bool_error:
+        reject_noncanonical_bool_query_param(request, "include_expired")
+    assert bool_error.value.status_code == 400
+    assert bool_error.value.detail == "include_expired must be true or false"
+
+    with pytest.raises(HTTPException) as repeated_error:
+        reject_repeated_query_param(request, "status")
+    assert repeated_error.value.status_code == 400
+    assert repeated_error.value.detail == "status must be provided at most once"


### PR DESCRIPTION
Refs #846 / Bounty #846.

## Summary

- Adds tiny internal helpers in `app/query_validation.py` for reading raw query values and rejecting control characters.
- Reuses those helpers across the control-char, canonical integer, canonical boolean, and repeated-parameter guards.
- Adds focused unit coverage for shared control-character rejection plus canonical/repeated boundary behavior.

## Duplicate check

I searched open PRs for `query guard helpers`, `_query_param_values`, `_reject_control_char_value`, and `reject_control_char_query_param` cleanup before opening this. I did not find an open PR covering this helper extraction. This is distinct from the open padded-filter hardening PRs and from bounty URL/availability cleanup PRs.

## Validation

- `uv run --extra dev python -m pytest tests/test_query_validation.py tests/test_admin_routes.py tests/test_bounty_attempts.py tests/test_api_mcp.py::test_ledger_api_rejects_noncanonical_limit tests/test_api_mcp.py::test_ledger_api_rejects_repeated_limit_before_using_later_value tests/test_api_mcp.py::test_mcp_rejects_noncanonical_integer_string_arguments -q` -> 44 passed, 1 existing Starlette/httpx warning.
- `uv run --extra dev ruff check app/query_validation.py tests/test_query_validation.py` -> passed.
- `uv run --extra dev ruff format --check app/query_validation.py tests/test_query_validation.py` -> 2 files already formatted.
- `uv run --extra dev mypy app/query_validation.py` -> success.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `ace7e128bee0f82180b3e6265755c0a8d2f5990d`.

## Scope

Focused maintainability cleanup only. It does not change route behavior, ledger, wallet, treasury, payout, proposal execution, bridge, exchange, cash-out, MRWK price, private data, credentials, or secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for query parameter validation, including control character rejection and format enforcement.

* **Refactor**
  * Improved query parameter validation code structure for better maintainability and consistency across validators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->