### PR TITLE
Share GitHub login config validation

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -89,6 +89,21 @@ def _duplicate_github_logins(logins: tuple[str, ...]) -> bool:
     return len(set(present_logins)) != len(present_logins)
 
 
+def _github_login_list_errors(
+    name: str, logins: tuple[str, ...], *, required_detail: str
+) -> list[str]:
+    if not logins:
+        return [required_detail]
+    errors: list[str] = []
+    if "" in logins:
+        errors.append(f"{name} must not include empty entries")
+    if _duplicate_github_logins(logins):
+        errors.append(f"{name} must not include duplicate logins")
+    if _invalid_github_logins(logins):
+        errors.append(f"{name} must contain valid GitHub logins")
+    return errors
+
+
 def _is_valid_dns_hostname(hostname: str) -> bool:
     if IPV4_DOTTED_QUAD_RE.fullmatch(hostname):
         return False
@@ -183,24 +198,20 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
             "MERGEWORK_GITHUB_OAUTH_CLIENT_ID", settings.github_oauth_client_id
         )
     )
-    if not settings.admin_logins:
-        errors.append("MERGEWORK_ADMIN_LOGINS must list admin GitHub logins")
-    else:
-        if "" in settings.admin_logins:
-            errors.append("MERGEWORK_ADMIN_LOGINS must not include empty entries")
-        if _duplicate_github_logins(settings.admin_logins):
-            errors.append("MERGEWORK_ADMIN_LOGINS must not include duplicate logins")
-        if _invalid_github_logins(settings.admin_logins):
-            errors.append("MERGEWORK_ADMIN_LOGINS must contain valid GitHub logins")
-    if not settings.github_accepted_labelers:
-        errors.append("MERGEWORK_GITHUB_ACCEPTED_LABELERS must list maintainer logins")
-    else:
-        if "" in settings.github_accepted_labelers:
-            errors.append("MERGEWORK_GITHUB_ACCEPTED_LABELERS must not include empty entries")
-        if _duplicate_github_logins(settings.github_accepted_labelers):
-            errors.append("MERGEWORK_GITHUB_ACCEPTED_LABELERS must not include duplicate logins")
-        if _invalid_github_logins(settings.github_accepted_labelers):
-            errors.append("MERGEWORK_GITHUB_ACCEPTED_LABELERS must contain valid GitHub logins")
+    errors.extend(
+        _github_login_list_errors(
+            "MERGEWORK_ADMIN_LOGINS",
+            settings.admin_logins,
+            required_detail="MERGEWORK_ADMIN_LOGINS must list admin GitHub logins",
+        )
+    )
+    errors.extend(
+        _github_login_list_errors(
+            "MERGEWORK_GITHUB_ACCEPTED_LABELERS",
+            settings.github_accepted_labelers,
+            required_detail="MERGEWORK_GITHUB_ACCEPTED_LABELERS must list maintainer logins",
+        )
+    )
     if settings.admin_logins and settings.github_accepted_labelers:
         admin_login_set = {login for login in settings.admin_logins if login}
         accepted_labeler_set = {login for login in settings.github_accepted_labelers if login}


### PR DESCRIPTION
Refs #846 / Bounty #846.

## Summary

- Adds a shared `_github_login_list_errors()` helper for deploy-time GitHub login list validation.
- Reuses it for both `MERGEWORK_ADMIN_LOGINS` and `MERGEWORK_GITHUB_ACCEPTED_LABELERS`.
- Preserves the existing required/empty/duplicate/invalid error messages and the cross-list admin inclusion check.

## Duplicate check

I searched open PRs for deploy settings login validation helpers, `MERGEWORK_ADMIN_LOGINS` / `MERGEWORK_GITHUB_ACCEPTED_LABELERS` cleanup, and duplicate GitHub login config cleanup before opening this. I did not find an open PR covering this same helper extraction.

## Validation

- `uv run --extra dev python -m pytest tests/test_deploy_readiness.py -q` -> 36 passed.
- `uv run --extra dev ruff check app/config.py tests/test_deploy_readiness.py` -> passed.
- `uv run --extra dev ruff format --check app/config.py tests/test_deploy_readiness.py` -> 2 files already formatted.
- `uv run --extra dev mypy app/config.py` -> success.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`.

## Scope

Focused deploy-readiness maintainability cleanup only. No runtime auth behavior, ledger, wallet, treasury, payout, proposal execution, bridge, exchange, cash-out, MRWK price, private data, credentials, or secrets behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved validation logic organization by consolidating repeated checks into a centralized helper, enhancing code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->