### PR TITLE
Reuse account page summary context

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -107,8 +107,7 @@ def account_transfer_status(account: str) -> str:
     return "MRWK wallet transfers require a registered mrwk1 address."
 
 
-def account_api_context(session: Session, account: str) -> dict[str, Any]:
-    account = normalized_account(account)
+def _account_api_context_for_normalized_account(session: Session, account: str) -> dict[str, Any]:
     account_row = session.get(Account, account)
     pending_payouts = safe_pending_payouts_for_account(session, account)
     return {
@@ -122,6 +121,10 @@ def account_api_context(session: Session, account: str) -> dict[str, Any]:
         "pending_summary": pending_payout_summary(pending_payouts),
         "pending_payouts": pending_payouts,
     }
+
+
+def account_api_context(session: Session, account: str) -> dict[str, Any]:
+    return _account_api_context_for_normalized_account(session, normalized_account(account))
 
 
 def account_accepted_work_context(session: Session, account: str) -> dict[str, Any]:
@@ -158,13 +161,13 @@ def account_page_context(
 ) -> dict[str, Any]:
     account = normalized_account(account)
     selected_transaction_type, transaction_filter = _transaction_type_filter(transaction_type)
-    pending_payouts = safe_pending_payouts_for_account(session, account)
+    account_context = _account_api_context_for_normalized_account(session, account)
     return {
-        "account": account_api_context(session, account),
-        "accepted_summary": safe_account_accepted_summary(session, account),
+        "account": account_context,
+        "accepted_summary": account_context["accepted_work"],
         "accepted_work": safe_accepted_work_for_account(session, account),
-        "pending_summary": pending_payout_summary(pending_payouts),
-        "pending_payouts": pending_payouts,
+        "pending_summary": account_context["pending_summary"],
+        "pending_payouts": account_context["pending_payouts"],
         "selected_transaction_type": selected_transaction_type,
         "transaction_type_options": ACCOUNT_TRANSACTION_TYPE_OPTIONS,
         "transactions": account_ledger_transactions(

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-from fastapi.testclient import TestClient
+from typing import Any
 
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+import app.accounts as accounts_module
 import app.serializers as serializers_module
 from app.accounts import account_api_context, account_page_context, normalized_account
 from app.db import create_schema, session_scope
@@ -219,6 +223,36 @@ def test_account_pages_fall_back_when_pending_payouts_fail(sqlite_url: str, monk
     assert api_context["pending_payouts"] == []
     assert page_context["pending_summary"] == api_context["pending_summary"]
     assert page_context["pending_payouts"] == []
+
+
+def test_account_page_context_reuses_api_summary_context(sqlite_url: str, monkeypatch) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    calls = {"accepted": 0, "pending": 0}
+    real_accepted_summary = accounts_module.safe_account_accepted_summary
+    real_pending_payouts = accounts_module.safe_pending_payouts_for_account
+
+    def count_accepted_summary(session: Session, account: str) -> dict[str, Any]:
+        calls["accepted"] += 1
+        return real_accepted_summary(session, account)
+
+    def count_pending_payouts(session: Session, account: str) -> list[dict[str, Any]]:
+        calls["pending"] += 1
+        return real_pending_payouts(session, account)
+
+    monkeypatch.setattr(accounts_module, "safe_account_accepted_summary", count_accepted_summary)
+    monkeypatch.setattr(accounts_module, "safe_pending_payouts_for_account", count_pending_payouts)
+
+    with session_scope(sqlite_url) as session:
+        page_context = account_page_context(session, " GitHub:Alice ")
+
+    assert calls == {"accepted": 1, "pending": 1}
+    assert page_context["account"]["account"] == "github:alice"
+    assert page_context["accepted_summary"] == page_context["account"]["accepted_work"]
+    assert page_context["pending_summary"] == page_context["account"]["pending_summary"]
+    assert page_context["pending_payouts"] == page_context["account"]["pending_payouts"]
 
 
 def test_account_page_filters_transactions_by_type(sqlite_url: str) -> None:


### PR DESCRIPTION
Refs #846

## Summary
- Add an internal account API context helper for already-normalized account ids.
- Reuse that account context from the account page so accepted/pending summaries are built once and shared with the rendered page context.
- Add regression coverage that the page summary fields reuse the API context values while preserving account normalization.

## Duplicate check
- Searched open PRs for account page summary/context reuse, `accepted_summary`, `pending_summary`, and `accounts.py` overlap.
- Existing open PRs cover account row limits, query validation, or activity/account filters, not account page summary context reuse.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_account_routes.py tests/test_account_validation.py -q` -> 52 passed, 1 existing Starlette/httpx warning.
- `uv run --python 3.12 --extra dev ruff check .` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check .` -> 111 files already formatted.
- `uv run --python 3.12 --extra dev mypy app` -> success across 42 source files.
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `4af20c2477f9b25e51a0780c138a38dd3e15a3b7`.

## Scope
Account page/API context maintainability only. No ledger mutation, wallet registration, transfer signing, payout/proof execution, treasury/proposal mutation, admin-token API, exchange, bridge, cash-out, MRWK price behavior, private data, or secrets behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and efficiency by consolidating account context computation logic.

* **Tests**
  * Added test coverage to verify consistency of internal context reuse patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->