### PR TITLE
Share staging dry-run response parsing

### DIFF
--- a/scripts/staging_webhook_dry_run.py
+++ b/scripts/staging_webhook_dry_run.py
@@ -24,12 +24,7 @@ def _required_env(name: str) -> str:
 
 def _post_json(url: str, payload: dict[str, object], headers: dict[str, str]) -> dict[str, object]:
     _validate_http_url(url)
-    response = httpx.post(url, json=payload, headers=headers, timeout=20)
-    response.raise_for_status()
-    parsed = response.json()
-    if not isinstance(parsed, dict):
-        raise RuntimeError(f"{url} returned a non-object JSON payload")
-    return parsed
+    return _parse_object_response(url, httpx.post(url, json=payload, headers=headers, timeout=20))
 
 
 def _post_webhook(
@@ -38,17 +33,23 @@ def _post_webhook(
     _validate_http_url(url)
     body = json.dumps(payload, separators=(",", ":")).encode()
     signature = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
-    response = httpx.post(
+    return _parse_object_response(
         url,
-        content=body,
-        headers={
-            "Content-Type": "application/json",
-            "X-GitHub-Delivery": delivery_id,
-            "X-GitHub-Event": "issues",
-            "X-Hub-Signature-256": f"sha256={signature}",
-        },
-        timeout=20,
+        httpx.post(
+            url,
+            content=body,
+            headers={
+                "Content-Type": "application/json",
+                "X-GitHub-Delivery": delivery_id,
+                "X-GitHub-Event": "issues",
+                "X-Hub-Signature-256": f"sha256={signature}",
+            },
+            timeout=20,
+        ),
     )
+
+
+def _parse_object_response(url: str, response: httpx.Response) -> dict[str, object]:
     response.raise_for_status()
     parsed = response.json()
     if not isinstance(parsed, dict):

--- a/tests/test_staging_webhook_dry_run.py
+++ b/tests/test_staging_webhook_dry_run.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import httpx
 import pytest
 
 from scripts.staging_webhook_dry_run import (
     _dry_run_contributor,
     _dry_run_repo,
     _enforce_staging_target,
+    _parse_object_response,
     _validate_http_url,
     main,
 )
@@ -44,6 +46,17 @@ def test_staging_webhook_dry_run_rejects_url_credentials() -> None:
         _validate_http_url("ftp://operator:secret@staging.mrwk.example.test")
 
     _validate_http_url("https://staging.mrwk.example.test")
+
+
+def test_staging_webhook_dry_run_rejects_non_object_json_response() -> None:
+    response = httpx.Response(
+        200,
+        json=["not", "an", "object"],
+        request=httpx.Request("POST", "https://staging.mrwk.example.test/api"),
+    )
+
+    with pytest.raises(RuntimeError, match="returned a non-object JSON payload"):
+        _parse_object_response("https://staging.mrwk.example.test/api", response)
 
 
 def test_staging_webhook_dry_run_uses_valid_default_identity_envs(


### PR DESCRIPTION
﻿Refs #846

Summary:
- extracted shared `_parse_object_response` for staging dry-run HTTP posts
- kept status raising and non-object JSON rejection behavior unchanged
- added focused regression coverage for non-object JSON responses

Validation:
- .\.venv\Scripts\python -m pytest tests/test_staging_webhook_dry_run.py -q
- .\.venv\Scripts\python -m ruff check scripts/staging_webhook_dry_run.py tests/test_staging_webhook_dry_run.py
- .\.venv\Scripts\python -m ruff format --check scripts/staging_webhook_dry_run.py tests/test_staging_webhook_dry_run.py
- .\.venv\Scripts\python -m mypy scripts/staging_webhook_dry_run.py
- git diff --check

Duplicate/scope check:
- checked open PRs before submission; none touched scripts/staging_webhook_dry_run.py or tests/test_staging_webhook_dry_run.py
- no ledger, wallet, treasury, payout, admin-token, private data, bridge/exchange/cash-out, MRWK price, or secret behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated JSON response parsing and validation logic to eliminate code duplication across webhook request handlers.

* **Tests**
  * Added test coverage to verify error handling for non-object JSON responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->