### PR TITLE
Show bounty submission requirements on detail page

### DIFF
--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -68,6 +68,27 @@
   <section class="next-steps-card" aria-labelledby="bounty-next-steps-heading">
     <p class="eyebrow">Contributor next steps</p>
     <h2 id="bounty-next-steps-heading">Before you start</h2>
+    {% set requirements = bounty.submission_requirements %}
+    <div class="submission-requirements" aria-label="Submission requirements">
+      <dl>
+        <div>
+          <dt>Claim command</dt>
+          <dd><code>{{ requirements.claim_command }}</code></dd>
+        </div>
+        <div>
+          <dt>Reference formats</dt>
+          <dd>
+            {% for reference_format in requirements.reference_formats %}
+            <code>{{ reference_format }}</code>{% if not loop.last %}, {% endif %}
+            {% endfor %}
+          </dd>
+        </div>
+        <div>
+          <dt>Expected artifact</dt>
+          <dd>{{ requirements.expected_artifact }}</dd>
+        </div>
+      </dl>
+    </div>
     <ol>
       <li>Confirm the source issue is still open and your change is not already covered by another PR.</li>
       <li>Keep the PR focused, link the source issue as <strong>Bounty #{{ bounty.issue_number }}</strong>, and include test or smoke-check evidence.</li>
@@ -89,7 +110,7 @@
     <div class="next-steps-actions" aria-label="Bounty action links">
       {% if issue_url %}<a href="{{ issue_url }}" rel="nofollow noopener">Open source issue</a>{% endif %}
       <a href="/api/v1/bounties/{{ bounty.id }}">View JSON details</a>
-      <a href="/api/v1/bounties/{{ bounty.id }}/attempts">Check active attempts</a>
+      <a href="{{ requirements.attempt_endpoint }}">Check active attempts</a>
     </div>
   </section>
 </section>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -695,6 +695,14 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert "Focused PR improves status, reward, issue link, and acceptance text." in response.text
     assert "Contributor next steps" in response.text
     assert "Before you start" in response.text
+    assert "Submission requirements" in response.text
+    assert "<dt>Claim command</dt>" in response.text
+    assert "<code>/claim</code>" in response.text
+    assert "<dt>Reference formats</dt>" in response.text
+    assert "<code>Bounty #4</code>" in response.text
+    assert "<code>Refs #4</code>" in response.text
+    assert "<dt>Expected artifact</dt>" in response.text
+    assert "focused PR, issue, report, or evidence URL" in response.text
     assert "Confirm the source issue is still open" in response.text
     assert bounty.id != bounty.issue_number
     assert "link the source issue as <strong>Bounty #4</strong>" in response.text
@@ -736,6 +744,35 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert oversized_api_response.json()["detail"] == "bounty id is too large"
     oversized_page_response = client.get(f"/bounties/{oversized_bounty_id}")
     assert oversized_page_response.status_code == 400
+
+
+def test_bounty_detail_shows_issue_submission_requirements(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=649,
+            issue_url="https://github.com/ramimbo/mergework/issues/649",
+            title="Queue proposed-work requests",
+            reward_mrwk="40",
+            acceptance=(
+                "Accepted work is a new proposed-work issue with clear evidence, "
+                "duplicate search, and acceptance notes."
+            ),
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(f"/bounties/{bounty.id}")
+
+    assert response.status_code == 200
+    assert "<code>/claim #649</code>" in response.text
+    assert "<code>Bounty #649</code>" in response.text
+    assert "<code>Refs #649</code>" in response.text
+    assert "<code>Linked bounty: #649</code>" in response.text
+    assert "new proposed-work GitHub issue URL" in response.text
 
 
 def test_bounty_detail_warns_when_no_awards_remain(sqlite_url: str) -> None:


### PR DESCRIPTION
Refs #845

## Summary
- Surface the existing structured `submission_requirements` on bounty detail pages.
- Show the exact claim command, accepted reference formats, and expected artifact before the existing contributor checklist.
- Reuse `submission_requirements.attempt_endpoint` for the active-attempt action link.

## Duplicate check
- Not duplicating #840: no new work-discovery endpoint or grouped queue behavior.
- Not duplicating #874: no active-attempt pressure/card display changes.
- Not duplicating #883: not docs/API-example preflight guidance.
- Not duplicating #884: not source-match routing; this exposes existing structured submission metadata on the detail page.
- Searched open PRs for submission requirements, claim command, reference formats, and bounty detail overlap; no same-scope PR found.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_bounty_pages.py tests/test_public_routes.py -q` -> 24 passed, 1 existing Starlette/httpx warning.
- `uv run --python 3.12 --extra dev ruff check .` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check .` -> 111 files already formatted.
- `uv run --python 3.12 --extra dev mypy app` -> success across 42 source files.
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `02eae5dd9df3521c623ee28326dd9627463da75b`.

## Scope
Bounty detail template and page regression coverage only. No bounty creation, proposal execution, payout execution, ledger mutation, wallet behavior, admin-token APIs, exchange, bridge, off-ramp, cash-out, MRWK price behavior, private data, or secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounty detail pages now show a dedicated "Submission requirements" section with claim command instructions, accepted reference formats, and expected artifact guidance.

* **Improvements**
  * Action links for checking attempts use configurable endpoints, ensuring the correct attempt checks are used for each bounty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->