### PR TITLE
Document get_balance MCP account selectors

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -32,7 +32,14 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "or by GitHub issue_number with optional repo"
         ),
     },
-    {"name": "get_balance", "description": "Get an account balance"},
+    {
+        "name": "get_balance",
+        "description": (
+            "Get an account balance by selector: a GitHub login (github:<login>), "
+            "an MRWK wallet address (mrwk1...), the treasury account (treasury:mrwk), "
+            "or a bounty reserve (reserve:bounty:<id>)"
+        ),
+    },
     {
         "name": "register_wallet",
         "description": "Register an MRWK wallet public key",

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -291,9 +291,7 @@ def test_mcp_get_balance_description_documents_account_selectors(sqlite_url: str
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
     tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()
-    balance_tool = next(
-        tool for tool in tools["result"]["tools"] if tool["name"] == "get_balance"
-    )
+    balance_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_balance")
     description = balance_tool["description"]
     assert "github:" in description
     assert "mrwk1" in description

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -283,6 +283,24 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert "structuredContent" not in balance["result"]
 
 
+def test_mcp_get_balance_description_documents_account_selectors(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()
+    balance_tool = next(
+        tool for tool in tools["result"]["tools"] if tool["name"] == "get_balance"
+    )
+    description = balance_tool["description"]
+    assert "github:" in description
+    assert "mrwk1" in description
+    assert "treasury:mrwk" in description
+    assert "reserve:bounty:" in description
+
+
 def test_mcp_list_bounty_attempts_reports_active_and_expired(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     now = datetime.now(UTC)


### PR DESCRIPTION
## Summary
- Document the supported `get_balance` MCP account selector formats in the tool description.
- Add regression coverage so `tools/list` keeps exposing selector guidance for `github:<login>`, `mrwk1...`, `treasury:mrwk`, and `reserve:bounty:<id>`.

## Test Plan
- `./.venv/bin/python -m pytest tests/test_api_mcp.py`
- `./.venv/bin/python -m pytest`
- `./.venv/bin/python -m ruff check app/mcp.py tests/test_api_mcp.py`
- `./.venv/bin/python -m mypy app/mcp.py`

## Bounty
- Bounty #844: https://github.com/ramimbo/mergework/issues/844
- Public bounty row: https://mrwk.online/bounties/110

## Caveats / Scope
- Description/test-only MCP usability change.
- No ledger, wallet, treasury, payout, admin, bridge, exchange, cash-out, or MRWK price behavior changed.
- This does not duplicate #885's structured `get_balance` response work; it only documents the existing selector formats exposed through `tools/list`.

This fix was solved by Hermes, Rulislim's autonomous coding agent, on behalf of Rulislim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the balance lookup tool description to include detailed examples of supported account selector formats (GitHub logins, address-style IDs, treasury accounts, and bounty reserve selectors).

* **Tests**
  * Added a test to confirm the tool listing exposes the updated description and includes the account selector examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->