### PR TITLE
Reject unknown MCP bounty list arguments

### DIFF
--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -126,6 +126,11 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             raise ValueError(f"{field} must be a boolean")
         return value
 
+    def reject_unexpected_args(allowed: set[str]) -> None:
+        unexpected = sorted(set(args) - allowed)
+        if unexpected:
+            raise ValueError(f"unexpected argument: {unexpected[0]}")
+
     def bounty_by_issue_number(repo_selector: str | None) -> Bounty | None:
         issue_query = select(Bounty).where(Bounty.issue_number == positive_int_arg("issue_number"))
         if repo_selector is not None:
@@ -153,6 +158,7 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
 
     with session_scope(database_url) as session:
         if name == "list_bounties":
+            reject_unexpected_args({"availability", "limit", "q", "sort", "status"})
             status = optional_clean_str_arg("status") or "open"
             normalized_status = status.lower()
             if normalized_status not in {"open", "paid", "closed"}:

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -688,7 +688,9 @@ curl -s -X POST "$MCP_HOST/mcp" \
 ```
 
 Pass `{"availability":"effectively_open"}` to `list_bounties` when an agent only
-wants bounty rows with positive effective award capacity.
+wants bounty rows with positive effective award capacity. `list_bounties`
+rejects unknown argument names so typos fail instead of silently falling back to
+the default open-bounty query.
 
 Call `get_bounty` with the internal bounty `id` returned by `list_bounties`,
 or use the GitHub `issue_number` with `repo` when your workflow starts from an

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -697,6 +697,7 @@ def test_mcp_list_bounties_filters_effective_availability(sqlite_url: str) -> No
         ({"limit": 101}, 35),
         ({"sort": "invalid"}, 36),
         ({"availability": "maybe"}, 37),
+        ({"statuz": "paid"}, 38),
     ],
 )
 def test_mcp_list_bounties_rejects_invalid_filters(

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -83,6 +83,15 @@ def test_call_mcp_tool_rejects_c1_status_before_normalizing(sqlite_url: str) -> 
         call_mcp_tool(sqlite_url, "list_bounties", {"status": "\u0085open"})
 
 
+def test_call_mcp_tool_rejects_unknown_list_bounties_arguments(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    with pytest.raises(ValueError, match="unexpected argument: statuz"):
+        call_mcp_tool(sqlite_url, "list_bounties", {"statuz": "paid"})
+
+
 def test_call_mcp_tool_rejects_c1_nonce_before_integer_parsing(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Bounty #844

## Summary
- reject undeclared `list_bounties` MCP arguments before applying defaults;
- prevent typoed agent calls like `{ statuz: paid }` from silently returning the default open-bounty query;
- document the stricter `list_bounties` argument behavior in MCP examples.

## Duplicate / Scope Check
- distinct from #891: this does not change `get_balance` wording or selector guidance;
- distinct from #862: this does not change `q` length or search validation;
- distinct from #856: this does not touch `submit_work_proof` argument handling;
- distinct from #738: this is a narrow runtime guard for `list_bounties`, not a broad `tools/list` inputSchema PR, and #738 is currently dirty/needs-info;
- no ledger, wallet, treasury, payout, proposal execution, admin-token behavior, exchange, bridge, cash-out, MRWK price behavior, private data, credentials, or secrets are changed.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_mcp_tools.py tests/test_api_mcp.py::test_mcp_list_bounties_rejects_invalid_filters -q` -> 16 passed, 1 existing warning.
- `uv run --python 3.12 --extra dev python -m pytest tests/test_api_mcp.py tests/test_mcp_tools.py -q` -> 114 passed, 1 existing warning.
- `uv run --python 3.12 --extra dev ruff check app/mcp_tools.py tests/test_api_mcp.py tests/test_mcp_tools.py` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check app/mcp_tools.py tests/test_api_mcp.py tests/test_mcp_tools.py` -> 3 files already formatted.
- `uv run --python 3.12 --extra dev mypy app/mcp_tools.py app/mcp.py` -> success.
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `ed74afeb10150b5eb6f0814bf1cba01cf0d541b9`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `list_bounties` tool now validates input arguments and rejects typos or unexpected parameters, providing clear error messages instead of silently ignoring invalid inputs.

* **Documentation**
  * Updated API examples to clarify that unknown argument names are rejected during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->