### PR TITLE
Add source filter reset link on bounties page

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -137,6 +137,15 @@ def public_bounties_context(
             issue_number,
             selected_availability,
         ),
+        "clear_source_filter_url": _bounties_page_url(
+            selected_status,
+            query_text,
+            selected_sort,
+            limit,
+            "",
+            None,
+            selected_availability,
+        ),
         "status_filter_urls": {
             "all": _bounties_page_url(
                 None,

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -37,7 +37,7 @@
 </nav>
 {% if query_text %}<p>Showing matches for “{{ query_text }}”.</p>{% endif %}
 {% if selected_repo or selected_issue_number %}
-<p>Source filter:{% if selected_repo %} {{ selected_repo }}{% endif %}{% if selected_issue_number %} #{{ selected_issue_number }}{% endif %}.</p>
+<p>Source filter:{% if selected_repo %} {{ selected_repo }}{% endif %}{% if selected_issue_number %} #{{ selected_issue_number }}{% endif %}. <a href="{{ clear_source_filter_url | safe }}">Clear source filter</a></p>
 {% endif %}
 <section class="bounty-list-summary" aria-label="Bounty list summary">
   <article>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -452,6 +452,7 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     leading_zero_limit_page = client.get("/bounties?limit=01")
     assert source_filter_page.status_code == 200
     assert "Source filter: ramimbo/mergework #64." in source_filter_page.text
+    assert 'href="/bounties">Clear source filter</a>' in source_filter_page.text
     assert "Improve public bounty discovery" in source_filter_page.text
     assert "Other repo same issue" not in source_filter_page.text
     assert (

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -59,6 +59,7 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
         "clear_search_url": (
             "/bounties?status=open&repo=ramimbo%2Fmergework&issue_number=649&sort=reward"
         ),
+        "clear_source_filter_url": "/bounties?status=open&q=proof&sort=reward",
         "status_filter_urls": {
             "all": ("/bounties?q=proof&repo=ramimbo%2Fmergework&issue_number=649&sort=reward"),
             "open": (
@@ -83,6 +84,23 @@ def test_public_bounties_context_preserves_limited_json_results_url() -> None:
     assert context["api_results_url"] == "/api/v1/bounties?q=issue+%23580&limit=25"
     assert (
         context["status_filter_urls"]["open"] == "/bounties?status=open&q=issue%20%23580&limit=25"
+    )
+
+
+def test_public_bounties_context_clear_source_filter_preserves_other_filters() -> None:
+    context = public_bounties_context(
+        [],
+        status="open",
+        q="proof",
+        sort="reward",
+        limit=25,
+        repo="ramimbo/mergework",
+        issue_number=649,
+        availability="effectively_open",
+    )
+
+    assert context["clear_source_filter_url"] == (
+        "/bounties?status=open&q=proof&sort=reward&limit=25&availability=effectively_open"
     )
 
 


### PR DESCRIPTION
Refs #845

## What changed

- Added a `clear_source_filter_url` to the public bounties page context.
- Shows a `Clear source filter` link when the list is filtered by source repo and/or issue number.
- Preserves other contributor filters such as status, query text, sort, limit, and availability when clearing only the source lane.
- Added direct regression coverage for preserving `limit` and `availability` after CodeRabbit review feedback.

## Why

Source-filtered bounty list links are useful for routing contributors from a GitHub issue to matching public bounty rows, but the page previously only described the active source filter. This gives contributors a direct way back to the broader filtered bounty list without manually editing the URL.

## Validation

- `uv run --python 3.12 --extra dev python -m pytest tests/test_bounty_pages.py tests/test_public_routes.py -q` -> 25 passed, 1 existing Starlette/httpx warning
- `uv run --python 3.12 --extra dev ruff check app/public_routes.py tests/test_public_routes.py tests/test_bounty_pages.py` -> passed
- `uv run --python 3.12 --extra dev ruff format --check app/public_routes.py tests/test_public_routes.py tests/test_bounty_pages.py` -> 3 files already formatted
- `uv run --python 3.12 --extra dev mypy app/public_routes.py` -> success
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `38fcf622f7e1a428f17a13830dda90e828042614`

Scope: public bounty list contributor navigation only. No ledger, wallet, treasury, payout, proposal execution, admin-token behavior, private data, exchange, bridge, cash-out, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Clear source filter" link on the bounties page. When a repository or issue number filter is applied, users can remove it while preserving other active search preferences (search text, status, sort, limit, and availability).
* **Tests**
  * Updated and added tests to verify the clear-source behavior and that other filters are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->