### PR TITLE
Show capacity reduction counters on bounty list

### DIFF
--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -60,6 +60,14 @@
     <span>Effectively available</span>
     <strong>{{ summary.effective_open_pool_mrwk }} MRWK</strong>
   </article>
+  <article>
+    <span>Capacity reduced</span>
+    <strong>{{ summary.reduced_capacity_bounties }}</strong>
+  </article>
+  <article>
+    <span>Effectively unavailable</span>
+    <strong>{{ summary.effectively_unavailable_bounties }}</strong>
+  </article>
 </section>
 <p class="notice">
   <a href="{{ api_results_url }}">View JSON results</a>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 
 from fastapi.testclient import TestClient
 
@@ -182,6 +183,10 @@ def test_bounties_page_shows_effective_capacity_after_pending_payout(
     assert page.status_code == 200
     assert "Effectively open" in page.text
     assert "Effectively available" in page.text
+    assert "Capacity reduced" in page.text
+    assert "Effectively unavailable" in page.text
+    assert re.search(r"Capacity reduced</span>\s*<strong>1</strong>", page.text)
+    assert re.search(r"Effectively unavailable</span>\s*<strong>0</strong>", page.text)
     assert "50 MRWK still available before pending proposals" in page.text
     assert "25 MRWK effectively available" in page.text
     assert "1 award covered by pending payout proposal" in page.text
@@ -228,6 +233,8 @@ def test_bounties_page_shows_effective_capacity_after_pending_close(
     detail = client.get(f"/bounties/{bounty_id}")
 
     assert page.status_code == 200
+    assert re.search(r"Capacity reduced</span>\s*<strong>1</strong>", page.text)
+    assert re.search(r"Effectively unavailable</span>\s*<strong>1</strong>", page.text)
     assert "90 MRWK still available before pending proposals" in page.text
     assert "0 MRWK effectively available" in page.text
     assert "A pending close proposal would make this bounty unavailable if executed." in page.text


### PR DESCRIPTION
## Summary
- Surface existing bounty summary counters for reduced capacity and effectively unavailable rows on the public /bounties page.
- Add regression coverage for pending payout and pending close cases so contributors can see when visible capacity differs from effective capacity.

## Bounty
Refs #845

## Validation
- .\.venv\Scripts\python.exe -m pytest tests/test_bounty_pages.py -q -> 18 passed, 1 existing Starlette/httpx warning.
- .\.venv\Scripts\python.exe -m ruff check tests/test_bounty_pages.py -> passed.
- .\.venv\Scripts\python.exe -m ruff format --check tests/test_bounty_pages.py -> 1 file already formatted.

## Scope
No ledger, wallet, treasury execution, payout execution, admin-token, exchange, bridge, cash-out, MRWK price, private data, credentials, or secrets behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The bounties page now provides enhanced visibility into bounty capacity status. Two new summary metrics have been added: one displaying reduced capacity bounties and another showing effectively unavailable bounties. This allows users to better understand bounty availability at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->