### PR TITLE
Clarify bounty contributor routing

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -275,6 +275,18 @@ code.hash { overflow-wrap: anywhere; }
 .next-steps-card li + li {
   margin-top: 8px;
 }
+.claimability-checklist {
+  border-top: 1px solid var(--line);
+  margin-top: 18px;
+  padding-top: 14px;
+}
+.claimability-checklist p {
+  margin: 0 0 8px;
+}
+.claimability-checklist ul {
+  margin: 0;
+  padding-left: 22px;
+}
 .next-steps-actions {
   display: flex;
   flex-wrap: wrap;

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -69,8 +69,9 @@
     <p class="eyebrow">Contributor next steps</p>
     <h2 id="bounty-next-steps-heading">Before you start</h2>
     <ol>
-      <li>Confirm the source issue is still open and your change is not already covered by another PR.</li>
-      <li>Keep the PR focused, link the source issue as <strong>Bounty #{{ bounty.issue_number }}</strong>, and include test or smoke-check evidence.</li>
+      <li>Confirm the linked GitHub issue is still open, has <code>mrwk:bounty</code>, and includes a <code>Reserved on MergeWork</code> claims-open comment.</li>
+      <li>Confirm your change is not already covered by another useful open PR for this bounty.</li>
+      <li>Keep the PR focused, reference the GitHub bounty issue as <strong>Bounty #{{ bounty.issue_number }}</strong> or <strong>Refs #{{ bounty.issue_number }}</strong>, and include test or smoke-check evidence.</li>
       <li>Check active attempt reservations if you need to coordinate before opening a PR; attempts are advisory only and do not reserve MRWK, acceptance, or payment.</li>
       <li>
         {% if bounty.effective_awards_remaining %}
@@ -86,6 +87,15 @@
         {% endif %}
       </li>
     </ol>
+    <div class="claimability-checklist" aria-label="Claimability checklist">
+      <p><strong>Claimability checklist</strong></p>
+      <ul>
+        <li>Public bounty row status: <strong>{{ bounty.status }}</strong>.</li>
+        <li>Effective award capacity after pending proposals: <strong>{{ bounty.effective_awards_remaining }}</strong>.</li>
+        <li>Visible award capacity before pending proposals: <strong>{{ bounty.awards_remaining }}</strong>.</li>
+        <li>Use <code>Closes #{{ bounty.issue_number }}</code> only when maintainers want this bounty issue closed by your PR.</li>
+      </ul>
+    </div>
     <div class="next-steps-actions" aria-label="Bounty action links">
       {% if issue_url %}<a href="{{ issue_url }}" rel="nofollow noopener">Open source issue</a>{% endif %}
       <a href="/api/v1/bounties/{{ bounty.id }}">View JSON details</a>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -239,6 +239,42 @@ def test_bounties_page_shows_effective_capacity_after_pending_close(
     ) in detail.text
 
 
+def test_bounty_detail_clarifies_claimability_and_pr_reference(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=845,
+            issue_url="https://github.com/ramimbo/mergework/issues/845",
+            title="Contributor routing bounty",
+            reward_mrwk="150",
+            max_awards=6,
+            acceptance="Contributor routing should distinguish live, pending, and paid work.",
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    detail = client.get(f"/bounties/{bounty_id}")
+
+    assert detail.status_code == 200
+    assert "Confirm the linked GitHub issue is still open" in detail.text
+    assert "<code>mrwk:bounty</code>" in detail.text
+    assert "<code>Reserved on MergeWork</code>" in detail.text
+    assert "<strong>Bounty #845</strong> or <strong>Refs #845</strong>" in detail.text
+    assert "Claimability checklist" in detail.text
+    assert "Public bounty row status: <strong>open</strong>" in detail.text
+    assert "Effective award capacity after pending proposals: <strong>6</strong>" in detail.text
+    assert "Visible award capacity before pending proposals: <strong>6</strong>" in detail.text
+    assert "<code>Closes #845</code> only when maintainers want this bounty issue closed" in (
+        detail.text
+    )
+
+
 def test_bounties_page_honors_limit_filter(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -695,9 +731,14 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert "Focused PR improves status, reward, issue link, and acceptance text." in response.text
     assert "Contributor next steps" in response.text
     assert "Before you start" in response.text
-    assert "Confirm the source issue is still open" in response.text
+    assert "Confirm the linked GitHub issue is still open" in response.text
+    assert "<code>mrwk:bounty</code>" in response.text
+    assert "<code>Reserved on MergeWork</code>" in response.text
     assert bounty.id != bounty.issue_number
-    assert "link the source issue as <strong>Bounty #4</strong>" in response.text
+    assert "<strong>Bounty #4</strong> or <strong>Refs #4</strong>" in response.text
+    assert "<code>Closes #4</code> only when maintainers want this bounty issue closed" in (
+        response.text
+    )
     assert (
         "attempts are advisory only and do not reserve MRWK, acceptance, or payment"
         in response.text


### PR DESCRIPTION
## Summary
- clarify the bounty detail next-steps copy so contributors verify the live GitHub issue signals before starting
- make the PR reference guidance explicit: use `Bounty #...` or `Refs #...`, and reserve `Closes #...` for cases where maintainers want the bounty issue closed
- add a claimability checklist for public status, effective award capacity after pending proposals, and visible capacity before pending proposals

Bounty #845

## Validation
- `UV_CACHE_DIR=.uv-cache uv run pytest tests/test_bounty_pages.py -q` -> 19 passed
- `UV_CACHE_DIR=.uv-cache uv run ruff check tests/test_bounty_pages.py` -> passed
- `UV_CACHE_DIR=.uv-cache uv run ruff format --check tests/test_bounty_pages.py` -> passed
- `git diff --check` -> passed

## Scope notes
- no bounty creation, payout, ledger, wallet, admin-token, or API mutation changes
- only touches the public bounty detail page copy, small supporting CSS, and focused page tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Claimability checklist" section on bounty detail pages displaying relevant capacity and status information
  * Updated "Before you start" guidance with checks for GitHub issue state and reservation details

* **Improvements**
  * Enhanced clarity on award capacity visibility and PR reference formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->