### PR TITLE
Hide deployment server headers

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -10,6 +10,9 @@ ltclab.site, www.ltclab.site, mrwk.online, www.mrwk.online, api.mrwk.online, mcp
 		?X-Content-Type-Options nosniff
 		?X-Frame-Options DENY
 		?Referrer-Policy no-referrer
+		-Server
 	}
-	reverse_proxy app:8000
+	reverse_proxy app:8000 {
+		header_down -Server
+	}
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ RUN useradd --uid 10001 --create-home --shell /usr/sbin/nologin mergework \
 
 USER mergework
 EXPOSE 8000
-CMD ["sh", "-c", "python scripts/check_deploy_ready.py && uvicorn app.main:app --host 0.0.0.0 --port 8000"]
+CMD ["sh", "-c", "python scripts/check_deploy_ready.py && uvicorn app.main:app --host 0.0.0.0 --port 8000 --no-server-header"]

--- a/tests/test_caddyfile.py
+++ b/tests/test_caddyfile.py
@@ -19,6 +19,13 @@ def test_caddy_security_headers_are_fallback_defaults() -> None:
         assert f"\n\t\t{header}" not in caddyfile
 
 
+def test_caddy_removes_public_server_headers() -> None:
+    caddyfile = Path("Caddyfile").read_text(encoding="utf-8")
+
+    assert "\n\t\t-Server\n" in caddyfile
+    assert "\n\t\theader_down -Server\n" in caddyfile
+
+
 def test_caddy_serves_canonical_and_legacy_mergework_hosts() -> None:
     caddyfile = Path("Caddyfile").read_text(encoding="utf-8")
 

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -12,3 +12,9 @@ def test_docker_compose_defines_treasury_executor_service() -> None:
     assert "      - .env" in compose
     assert "      - /srv/mergework/data:/srv/mergework/data" in compose
     assert "restart: unless-stopped" in compose
+
+
+def test_dockerfile_disables_uvicorn_server_header() -> None:
+    dockerfile = Path("Dockerfile").read_text(encoding="utf-8")
+
+    assert "uvicorn app.main:app --host 0.0.0.0 --port 8000 --no-server-header" in dockerfile


### PR DESCRIPTION
## Summary

- Remove public `Server` response headers at the Caddy edge with `header -Server`.
- Strip upstream `Server` headers from proxied app responses with `header_down -Server`.
- Start uvicorn with `--no-server-header` so the app container does not emit the upstream header in the first place.
- Add deployment-config regression tests for the Caddy and Dockerfile guardrails.

Bounty #799
Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4620928323

## Production evidence before fix

Current public responses expose implementation details from both the edge proxy and upstream ASGI server:

```text
GET https://api.mrwk.online/api/v1/status
server: Caddy
server: uvicorn

GET https://mrwk.online/
server: Caddy
server: uvicorn
```

## Duplicate/current check

- Public bounty API before submission: #799 is open with 5 effective awards remaining and 0 active attempts.
- Open PR search for `server header`, `Caddy`, `uvicorn`, `header_down -Server`, and `no-server-header` found no open PR covering this report.
- Existing nearby PRs cover security headers, MCP content type, and canonical hosts, not public `Server` header suppression.

## Validation

- `uv run --extra dev pytest tests/test_caddyfile.py tests/test_docker_compose.py -q` -> 5 passed
- `uv run --extra dev pytest tests/test_security.py::test_browser_responses_set_security_headers tests/test_caddyfile.py tests/test_docker_compose.py -q` -> 6 passed, 1 existing Starlette/httpx warning
- `uv run --extra dev pytest tests/test_security.py::test_api_docs_allow_external_assets_under_csp tests/test_caddyfile.py tests/test_docker_compose.py -q` -> 7 passed, 1 existing Starlette/httpx warning
- `uv run --extra dev ruff check tests/test_caddyfile.py tests/test_docker_compose.py` -> passed
- `uv run --extra dev ruff format --check tests/test_caddyfile.py tests/test_docker_compose.py` -> passed
- `git diff --check` -> clean

Docker is installed locally, but the Docker daemon is not running, so I could not run a containerized `caddy validate` command in this environment.

## Scope

Deployment header configuration only. No app routes, auth, ledger, wallet, treasury, payout, admin-token behavior, private data, bridge/exchange/cash-out behavior, or MRWK price behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Server response headers are no longer exposed in HTTP responses from the application and reverse proxy.

* **Tests**
  * Added tests to verify Server header removal configuration and application startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->