### PR TITLE
Reuse path control-character validation helper

### DIFF
--- a/app/path_params.py
+++ b/app/path_params.py
@@ -4,6 +4,8 @@ import re
 
 from fastapi import HTTPException
 
+from app.control_chars import contains_control_character
+
 SQLITE_INTEGER_MAX = 2**63 - 1
 HEX_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
 POSITIVE_INTEGER_RE = re.compile(r"^[0-9]+$")
@@ -11,7 +13,7 @@ POSITIVE_INTEGER_RE = re.compile(r"^[0-9]+$")
 
 def reject_path_whitespace_padding(value: str, field: str) -> None:
     """Reject leading or trailing path whitespace before identifier normalization."""
-    if any(ord(char) < 32 or 127 <= ord(char) < 160 for char in value):
+    if contains_control_character(value):
         return
     if value.strip() and value != value.strip():
         raise HTTPException(

--- a/tests/test_path_params.py
+++ b/tests/test_path_params.py
@@ -7,6 +7,7 @@ from app.path_params import (
     positive_ledger_sequence,
     positive_proposal_id,
     proof_hash_from_path,
+    reject_path_whitespace_padding,
 )
 
 
@@ -32,6 +33,10 @@ def test_issue_number_search_value_rejects_non_numeric_or_overflow_query():
     assert issue_number_search_value(" #340") is None
     assert issue_number_search_value("340a") is None
     assert issue_number_search_value(str(SQLITE_INTEGER_MAX + 1)) is None
+
+
+def test_reject_path_whitespace_padding_defers_control_characters():
+    reject_path_whitespace_padding("\u0085github:alice", "account")
 
 
 def test_positive_bounty_id_and_ledger_sequence_validate_bounds():


### PR DESCRIPTION
Bounty #846

## Summary
- reuse the shared `contains_control_character` helper inside path parameter whitespace-padding validation
- add focused coverage that control characters still defer to the dedicated downstream validators instead of being reported as whitespace padding

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_path_params.py tests/test_account_validation.py -q` -> 50 passed, 1 existing Starlette/httpx warning
- `uv run --python 3.12 --extra dev ruff check app/path_params.py tests/test_path_params.py` -> passed
- `uv run --python 3.12 --extra dev ruff format --check app/path_params.py tests/test_path_params.py` -> 2 files already formatted
- `uv run --python 3.12 --extra dev mypy app/path_params.py` -> success
- `git diff --check upstream/main...HEAD` -> clean
- `python3 /Users/ssr/.codex/bounty-radar/automation/scan_hidden_unicode.py --repo $PWD --changed-files-from-git upstream/main...HEAD` -> ok, 2 paths scanned

Scope: maintainability-only path parameter cleanup. No public route contract, ledger behavior, wallet behavior, treasury behavior, payout behavior, proposal execution, private data, exchange, bridge, cash-out, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for character validation logic.

* **Tests**
  * Added test coverage for control character handling in path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->