### PR TITLE
Share ledger snapshot totals calculation

### DIFF
--- a/app/ledger/snapshot.py
+++ b/app/ledger/snapshot.py
@@ -122,11 +122,7 @@ def ledger_snapshot(
     generated = generated_at or datetime.now(UTC)
     entries = list(session.scalars(select(LedgerEntry).order_by(LedgerEntry.sequence)).all())
     latest_entry = entries[-1] if entries else None
-    credited_microunits = sum(entry.amount_microunits for entry in entries)
-    debited_microunits = sum(
-        entry.amount_microunits for entry in entries if entry.from_account is not None
-    )
-    net_supply_microunits = credited_microunits - debited_microunits
+    totals = _ledger_totals(entries)
     return {
         "schema": LEDGER_SNAPSHOT_SCHEMA,
         "schema_version": LEDGER_SNAPSHOT_SCHEMA_VERSION,
@@ -145,11 +141,7 @@ def ledger_snapshot(
         },
         "genesis_supply_microunits": GENESIS_SUPPLY_MICRO,
         "accounts": _account_balances(entries),
-        "totals": {
-            "credited_microunits": credited_microunits,
-            "debited_microunits": debited_microunits,
-            "net_supply_microunits": net_supply_microunits,
-        },
+        "totals": totals,
         "verification": {
             "hash_chain_ok": verify_hash_chain(session),
             "supply_conservation_ok": verify_supply_conservation(session),
@@ -171,6 +163,18 @@ def ledger_snapshot_schema_json() -> str:
         )
         + "\n"
     )
+
+
+def _ledger_totals(entries: list[LedgerEntry]) -> dict[str, int]:
+    credited_microunits = sum(entry.amount_microunits for entry in entries)
+    debited_microunits = sum(
+        entry.amount_microunits for entry in entries if entry.from_account is not None
+    )
+    return {
+        "credited_microunits": credited_microunits,
+        "debited_microunits": debited_microunits,
+        "net_supply_microunits": credited_microunits - debited_microunits,
+    }
 
 
 def _account_balances(entries: list[LedgerEntry]) -> list[dict[str, Any]]:


### PR DESCRIPTION
Bounty #846

## Summary
- collect ledger snapshot credited/debited/net supply calculations in a single private helper
- keep the exported snapshot JSON fields and values unchanged
- leave account balance calculation and verification semantics untouched

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_ledger_snapshot.py -q` -> 6 passed
- `uv run --python 3.12 --extra dev ruff check app/ledger/snapshot.py tests/test_ledger_snapshot.py` -> passed
- `uv run --python 3.12 --extra dev ruff format --check app/ledger/snapshot.py tests/test_ledger_snapshot.py` -> 2 files already formatted
- `uv run --python 3.12 --extra dev mypy app/ledger/snapshot.py` -> success
- `git diff --check upstream/main...HEAD` -> clean
- `python3 /Users/ssr/.codex/bounty-radar/automation/scan_hidden_unicode.py --repo $PWD --changed-files-from-git upstream/main...HEAD` -> ok, 1 path scanned

Scope: maintainability-only cleanup in read-only ledger snapshot serialization. No ledger mutation, wallet behavior, treasury behavior, payout behavior, proposal execution, public route contract, private data, exchange, bridge, cash-out, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of ledger snapshot calculation logic for improved code maintainability.

*Note: This release contains no user-facing changes or new features.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->