### PR TITLE
Share OpenAPI JSON content schema helper

### DIFF
--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 from typing import Any
 
 
+def _json_content(schema: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "application/json": {
+            "schema": schema,
+        },
+    }
+
+
 def _request_body(schema: dict[str, Any], *, required: bool = True) -> dict[str, Any]:
     body: dict[str, Any] = {
-        "content": {
-            "application/json": {
-                "schema": schema,
-            },
-        },
+        "content": _json_content(schema),
     }
     if required:
         body["required"] = True
@@ -21,11 +25,7 @@ def _json_response(
 ) -> dict[str, Any]:
     return {
         "description": description,
-        "content": {
-            "application/json": {
-                "schema": schema,
-            },
-        },
+        "content": _json_content(schema),
     }
 
 


### PR DESCRIPTION
Bounty #846

## Summary
- add one private helper for the repeated `application/json` schema content wrapper
- reuse it for both OpenAPI request bodies and JSON responses
- preserve the generated OpenAPI field constraints and response schemas

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_openapi_request_bodies.py -q` -> 8 passed, 1 existing Starlette/httpx warning
- `uv run --python 3.12 --extra dev ruff check app/openapi_request_bodies.py tests/test_openapi_request_bodies.py` -> passed
- `uv run --python 3.12 --extra dev ruff format --check app/openapi_request_bodies.py tests/test_openapi_request_bodies.py` -> 2 files already formatted
- `uv run --python 3.12 --extra dev mypy app/openapi_request_bodies.py` -> success
- `git diff --check upstream/main...HEAD` -> clean
- `python3 /Users/ssr/.codex/bounty-radar/automation/scan_hidden_unicode.py --repo $PWD --changed-files-from-git upstream/main...HEAD` -> ok, 1 path scanned

Scope: maintainability-only OpenAPI schema helper cleanup. No runtime API behavior, ledger behavior, wallet behavior, treasury behavior, payout behavior, proposal execution, private data, exchange, bridge, cash-out, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure for OpenAPI schema handling to enhance maintainability and reduce code duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->