### PR TITLE
Share treasury executor pass runner

### DIFF
--- a/scripts/treasury_executor.py
+++ b/scripts/treasury_executor.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import logging
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 from app.config import get_settings
 from app.github_bounty_board import refresh_bounty_board_issue
@@ -39,6 +39,18 @@ def _sleep_until(next_run_at: float) -> None:
     time.sleep(delay)
 
 
+def _run_logged_pass(
+    runner: Callable[[], dict[str, object]], *, success_message: str, failure_message: str
+) -> bool:
+    try:
+        report = runner()
+    except Exception:
+        logging.exception(failure_message)
+        return False
+    logging.info("%s %s", success_message, json.dumps(report, sort_keys=True))
+    return True
+
+
 def run_enabled_loop(config: ExecutorConfig, *, once: bool) -> int:
     next_executor_at = 0.0
     next_board_refresh_at = 0.0
@@ -46,13 +58,13 @@ def run_enabled_loop(config: ExecutorConfig, *, once: bool) -> int:
     while True:
         now = time.monotonic()
         if now >= next_executor_at:
-            try:
-                report = run_once(config)
-                logging.info("treasury executor report %s", json.dumps(report, sort_keys=True))
-            except Exception:
-                logging.exception("treasury executor pass failed")
-                if once:
-                    return 1
+            success = _run_logged_pass(
+                lambda: run_once(config),
+                success_message="treasury executor report",
+                failure_message="treasury executor pass failed",
+            )
+            if once and not success:
+                return 1
             if once:
                 return 0
             now = time.monotonic()
@@ -62,11 +74,11 @@ def run_enabled_loop(config: ExecutorConfig, *, once: bool) -> int:
             continue
 
         if now >= next_board_refresh_at:
-            try:
-                report = run_bounty_board_refresh_once()
-                logging.info("bounty board refresh report %s", json.dumps(report, sort_keys=True))
-            except Exception:
-                logging.exception("bounty board refresh failed")
+            _run_logged_pass(
+                run_bounty_board_refresh_once,
+                success_message="bounty board refresh report",
+                failure_message="bounty board refresh failed",
+            )
             now = time.monotonic()
             next_board_refresh_at = now + config.bounty_board_refresh_interval_seconds
 

--- a/tests/test_treasury_executor_script.py
+++ b/tests/test_treasury_executor_script.py
@@ -157,6 +157,51 @@ def test_enabled_loop_refreshes_board_between_executor_passes(
     assert events == [("executor", 0.0), ("board", 60.0)]
 
 
+def test_enabled_loop_continues_after_board_refresh_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = ExecutorConfig(
+        enabled=True,
+        interval_seconds=300,
+        batch_limit=1,
+        bounty_board_refresh_interval_seconds=60,
+    )
+    now = 0.0
+    events: list[tuple[str, float]] = []
+
+    def fake_monotonic() -> float:
+        return now
+
+    def fake_sleep(seconds: float) -> None:
+        nonlocal now
+        now += seconds
+
+    def fake_run_once(config: ExecutorConfig) -> dict[str, object]:
+        events.append(("executor", now))
+        return {"status": "ok"}
+
+    def fake_board_refresh_once() -> dict[str, object]:
+        events.append(("board", now))
+        if len(events) == 2:
+            raise RuntimeError("refresh failed")
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(executor_script.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(executor_script.time, "sleep", fake_sleep)
+    monkeypatch.setattr(executor_script, "run_once", fake_run_once)
+    monkeypatch.setattr(
+        executor_script,
+        "run_bounty_board_refresh_once",
+        fake_board_refresh_once,
+        raising=False,
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        executor_script.run_enabled_loop(config, once=False)
+
+    assert events == [("executor", 0.0), ("board", 60.0), ("board", 120.0)]
+
+
 def test_executor_once_returns_failure_when_pass_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_run_once(config: ExecutorConfig) -> dict[str, object]:
         raise RuntimeError("executor failed")


### PR DESCRIPTION
Bounty #846

## Summary
- add a shared private `_run_logged_pass()` helper for treasury executor pass and bounty-board refresh logging/error handling
- keep the existing success/failure log messages, once-mode failure exit, and board-refresh exception swallowing behavior unchanged
- add regression coverage that a board-refresh failure is swallowed and the scheduler continues to the next refresh window

## Duplicate check
- #846 is live/open on the public bounty API with effective award capacity before submission
- `gh search prs treasury_executor --repo ramimbo/mergework --state open` -> no results
- `gh search prs "bounty board refresh" --repo ramimbo/mergework --state open` -> no results
- `gh search prs "treasury executor" --repo ramimbo/mergework --state open` -> only unrelated #828 public bounty-board MCP resource work

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_treasury_executor_script.py -q` -> 9 passed
- `.\.venv\Scripts\python.exe -m pytest tests\test_treasury_executor_script.py tests\test_treasury_executor.py -q` -> 17 passed
- `.\.venv\Scripts\python.exe -m ruff check scripts\treasury_executor.py tests\test_treasury_executor_script.py` -> passed
- `.\.venv\Scripts\python.exe -m ruff format --check scripts\treasury_executor.py tests\test_treasury_executor_script.py` -> 2 files already formatted
- `.\.venv\Scripts\python.exe -m mypy scripts\treasury_executor.py` -> success
- `git diff --check` -> clean

Scope: maintainability-only cleanup in the read/write scheduler wrapper. No proposal execution semantics, bounty board payloads, ledger behavior, wallet behavior, treasury mutation rules, payout behavior, admin-token behavior, private data, exchange, bridge, cash-out, or MRWK price behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization by centralizing execution and logging logic for treasury operations, reducing code duplication.

* **Tests**
  * Enhanced test coverage to verify the treasury executor's resilience, ensuring it continues operating normally when board refresh operations encounter errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->