### PR TITLE
Share wallet control character validation

### DIFF
--- a/app/wallets.py
+++ b/app/wallets.py
@@ -8,10 +8,11 @@ from typing import Any
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
+from app.control_chars import contains_control_character
+
 ADDRESS_RE = re.compile(r"^mrwk1[0-9a-f]{40}$")
 PUBLIC_KEY_RE = re.compile(r"^[0-9a-f]{64}$")
 SIGNATURE_RE = re.compile(r"^[0-9a-f]{128}$")
-CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
 
 class WalletError(ValueError):
@@ -23,7 +24,7 @@ def canonical_wallet_json(payload: dict[str, Any]) -> str:
 
 
 def _reject_control_characters(value: str, field: str) -> None:
-    if CONTROL_CHAR_RE.search(value):
+    if contains_control_character(value):
         raise WalletError(f"{field} must not contain control characters")
 
 

--- a/tests/test_wallets.py
+++ b/tests/test_wallets.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -20,7 +22,14 @@ from app.ledger.service import (
     wallet_transfer_payload,
 )
 from app.models import Wallet
-from app.wallets import address_from_public_key_hex, canonical_wallet_json
+from app.wallets import (
+    WalletError,
+    address_from_public_key_hex,
+    canonical_wallet_json,
+    normalize_public_key_hex,
+    normalize_signature_hex,
+    normalize_wallet_address,
+)
 
 
 def _keypair() -> tuple[Ed25519PrivateKey, str, str]:
@@ -44,6 +53,21 @@ def test_wallet_address_is_derived_from_public_key() -> None:
     assert address.startswith("mrwk1")
     assert len(address) == 45
     assert address_from_public_key_hex(public_hex) == address
+
+
+@pytest.mark.parametrize(
+    ("normalizer", "value", "message"),
+    [
+        (normalize_public_key_hex, "a" * 63 + "\x85", "public key"),
+        (normalize_signature_hex, "b" * 127 + "\x85", "signature"),
+        (normalize_wallet_address, "mrwk1" + "c" * 39 + "\x85", "MRWK wallet address"),
+    ],
+)
+def test_wallet_normalizers_reject_c1_control_characters(
+    normalizer: Callable[[str], str], value: str, message: str
+) -> None:
+    with pytest.raises(WalletError, match=f"{message} must not contain control characters"):
+        normalizer(value)
 
 
 def test_wallet_registration_rejects_oversized_label(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary

Refs #846.

This is a focused maintainability cleanup for wallet input validation:

- reuse the shared `contains_control_character()` helper in `app/wallets.py`;
- remove the duplicate wallet-local control-character regex;
- add focused regression coverage that public key, signature, and wallet address normalizers still reject C1 control characters before hex/address validation.

## Scope

Behavior is intended to stay unchanged. The PR only changes the internal control-character helper used by wallet normalizers and adds tests around the preserved error boundary. It does not change wallet formats, signatures, ledger behavior, account linking, transfer behavior, treasury behavior, payout behavior, private data handling, exchange/bridge/cash-out behavior, or MRWK price behavior.

## Duplicate/current check

- #846 public bounty row 112 is live/open with effective award capacity.
- `gh search prs 'wallets.py control characters Bounty #846 repo:ramimbo/mergework' --state open` -> no results.
- `gh search prs 'normalize_wallet_address contains_control_character repo:ramimbo/mergework' --state open` -> no results.
- `gh pr list --repo ramimbo/mergework --state open --search 'wallets.py'` -> no results.
- Existing #846 PRs cover sorting, route wiring, public URLs, MCP selectors, query/config/account/staging/GitHub helpers, executor/schema/OAuth cleanup; I did not find an open PR covering wallet normalizer control-character helper reuse.

## Validation

- `uv run --python 3.12 --extra dev python -m pytest tests/test_wallets.py tests/test_wallet_api.py -q` -> 59 passed, 1 existing Starlette/httpx warning.
- `uv run --python 3.12 --extra dev ruff check app/wallets.py tests/test_wallets.py` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check app/wallets.py tests/test_wallets.py` -> 2 files already formatted.
- `uv run --python 3.12 --extra dev mypy app/wallets.py` -> success.
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced control character detection consistency in wallet operations.

* **Tests**
  * Expanded test suite with parametrized tests for wallet normalizers, validating control character rejection in public key, signature, and address normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->