### PR TITLE
Accept bounty_id alias for MCP get_bounty

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -21,8 +21,8 @@ MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "get_bounty",
         "description": (
-            "Get a bounty by internal id, or by GitHub issue_number with optional repo, "
-            "optionally with accepted awards"
+            "Get a bounty by internal id or bounty_id alias, or by GitHub issue_number "
+            "with optional repo, optionally with accepted awards"
         ),
     },
     {

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -137,16 +137,32 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             raise ValueError("issue_number matches multiple bounties")
         return bounties[0]
 
-    def selected_bounty(internal_id_field: str) -> Bounty | None:
-        has_internal_id = internal_id_field in args and args.get(internal_id_field) is not None
+    def selected_bounty(
+        internal_id_field: str,
+        *,
+        internal_id_aliases: tuple[str, ...] = (),
+    ) -> Bounty | None:
+        internal_id_fields = (internal_id_field, *internal_id_aliases)
+        provided_internal_id_fields = [
+            field for field in internal_id_fields if field in args and args.get(field) is not None
+        ]
+        has_internal_id = bool(provided_internal_id_fields)
         has_issue_number = "issue_number" in args and args.get("issue_number") is not None
         repo_selector = optional_repo_selector_arg()
+        if len(provided_internal_id_fields) > 1:
+            raise ValueError(
+                "use one of "
+                + ", ".join(internal_id_fields)
+                + ", or issue_number, not multiple internal id fields"
+            )
         if has_internal_id and has_issue_number:
-            raise ValueError(f"use {internal_id_field} or issue_number, not both")
+            raise ValueError(
+                "use one of " + ", ".join(internal_id_fields) + ", or issue_number, not both"
+            )
         if repo_selector is not None and not has_issue_number:
             raise ValueError("repo can only be used with issue_number")
         if has_internal_id:
-            return session.get(Bounty, positive_int_arg(internal_id_field))
+            return session.get(Bounty, positive_int_arg(provided_internal_id_fields[0]))
         if has_issue_number:
             return bounty_by_issue_number(repo_selector)
         raise ValueError(f"{internal_id_field} or issue_number is required")
@@ -193,7 +209,7 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             )
             return json.dumps(sorted_bounties[:limit])
         if name == "get_bounty":
-            bounty = selected_bounty("id")
+            bounty = selected_bounty("id", internal_id_aliases=("bounty_id",))
             if bounty is None:
                 return "bounty not found"
             bounty_data = bounty_to_dict(bounty, session=session)

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -260,8 +260,13 @@ Use `{"availability":"effectively_open"}` with `list_bounties` when you only wan
 raw-open bounties that still have positive effective award capacity after
 pending payout or close proposals are considered.
 
+Inspect a bounty with `get_bounty` before preparing evidence. Use the `id`
+from `list_bounties`, pass the same value as `bounty_id` when reusing fields
+from other bounty payloads, or use `issue_number` with `repo` when you start
+from a GitHub issue URL.
+
 Inspect active attempt reservations for a bounty before opening overlapping
-work. Use the internal `bounty_id` from `list_bounties`, or `issue_number` with
+work. Use the internal bounty id from `list_bounties`, or `issue_number` with
 `repo` when you start from a GitHub issue URL:
 
 ```bash

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -690,14 +690,19 @@ curl -s -X POST "$MCP_HOST/mcp" \
 Pass `{"availability":"effectively_open"}` to `list_bounties` when an agent only
 wants bounty rows with positive effective award capacity.
 
-Call `get_bounty` with the internal bounty `id` returned by `list_bounties`,
-or use the GitHub `issue_number` with `repo` when your workflow starts from an
-issue URL:
+Call `get_bounty` with the internal bounty `id` returned by `list_bounties`.
+Agents may also pass the same value as `bounty_id` when reusing fields from
+other bounty or attempt payloads. Use the GitHub `issue_number` with `repo` when
+your workflow starts from an issue URL:
 
 ```bash
 curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_bounty","arguments":{"id":11}}}'
+
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_bounty","arguments":{"bounty_id":11}}}'
 
 curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -920,6 +920,42 @@ def test_mcp_get_bounty_accepts_issue_number_selector(sqlite_url: str) -> None:
     assert payload["issue_number"] == 286
 
 
+def test_mcp_get_bounty_accepts_bounty_id_alias(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=289,
+            issue_url="https://github.com/ramimbo/mergework/issues/289",
+            title="MCP bounty id alias",
+            reward_mrwk="75",
+            acceptance="Agents may reuse bounty_id fields from other MCP payloads.",
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "get_bounty",
+                "arguments": {"bounty_id": bounty_id},
+            },
+        },
+    ).json()
+
+    payload = json.loads(result["result"]["content"][0]["text"])
+    assert result["result"]["structuredContent"] == payload
+    assert payload["id"] == bounty_id
+    assert payload["issue_number"] == 289
+
+
 def test_mcp_get_bounty_rejects_ambiguous_issue_number_selector(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -1001,6 +1037,44 @@ def test_mcp_get_bounty_rejects_mixed_selectors(sqlite_url: str) -> None:
     assert response.json() == {
         "jsonrpc": "2.0",
         "id": 5,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
+def test_mcp_get_bounty_rejects_mixed_internal_id_aliases(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=290,
+            issue_url="https://github.com/ramimbo/mergework/issues/290",
+            title="MCP internal selector validation",
+            reward_mrwk="75",
+            acceptance="Agents should pass one internal bounty selector.",
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": {
+                "name": "get_bounty",
+                "arguments": {"id": bounty_id, "bounty_id": bounty_id},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 6,
         "error": {"code": -32602, "message": "invalid tool arguments"},
     }
 


### PR DESCRIPTION
## Summary

Bounty #844

- let MCP `get_bounty` accept `bounty_id` as an alias for the existing internal `id` selector;
- reject calls that pass both `id` and `bounty_id` so agents do not get ambiguous selector behavior;
- update `tools/list` wording plus agent/API docs to mention the alias.

## Evidence / duplicate check

- This is a focused MCP selector-usability improvement for agents reusing `bounty_id` fields from related bounty/attempt payloads.
- Open PR searches for `get_bounty bounty_id`, `bounty_id alias`, and `get_bounty id` found no same-scope open PR.
- Distinct from #893 proof/ledger selector aliases, #899 unexpected read-tool argument rejection, #892 `list_bounties` argument guard, and #856 `submit_work_proof` contract alignment.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py tests\test_mcp_tools.py tests\test_docs_public_urls.py -q` -> 149 passed, 1 existing Starlette/httpx warning
- `.\.venv\Scripts\python.exe -m ruff check app\mcp.py app\mcp_tools.py tests\test_api_mcp.py docs\api-examples.md docs\agent-guide.md tests\test_docs_public_urls.py` -> passed
- `.\.venv\Scripts\python.exe -m ruff format --check app\mcp.py app\mcp_tools.py tests\test_api_mcp.py tests\test_docs_public_urls.py` -> 4 files already formatted
- `.\.venv\Scripts\python.exe -m mypy app\mcp.py app\mcp_tools.py` -> success
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `de3fc5c4bd73b62ff49fee9ca013f9dfcb3cf65e`

## Scope safety

No wallet registration, wallet transfer signing, ledger mutation, bounty payout, treasury mutation, admin-token behavior, private data, credentials, secrets, exchange, bridge, cash-out, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `get_bounty` tool now accepts `bounty_id` as an alternative parameter for bounty retrieval, enabling more flexible lookup options.

* **Documentation**
  * Updated agent guide with instructions to inspect bounties via `get_bounty` before preparing evidence submissions.
  * Expanded API examples demonstrating `bounty_id` parameter usage alongside existing lookup methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->