### PR TITLE
Share treasury control character validation

### DIFF
--- a/app/treasury.py
+++ b/app/treasury.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from app.control_chars import contains_control_character
 from app.ledger.service import (
     MICRO_UNITS,
     TREASURY_ACCOUNT,
@@ -69,14 +70,10 @@ def _required_payload_value(payload: dict[str, Any], field: str) -> Any:
     return value
 
 
-def _contains_control_character(value: str) -> bool:
-    return any(ord(char) < 32 or ord(char) == 127 or 0x80 <= ord(char) <= 0x9F for char in value)
-
-
 def _clean_string(value: Any, field: str, max_length: int = 500) -> str:
     if not isinstance(value, str):
         raise LedgerError(f"{field} must be a string")
-    if _contains_control_character(value):
+    if contains_control_character(value):
         raise LedgerError(f"{field} must not contain control characters")
     clean = value.strip()
     if not clean:
@@ -98,7 +95,7 @@ def _payload_int(value: Any, field: str) -> int:
     if isinstance(value, int):
         return value
     if isinstance(value, str):
-        if _contains_control_character(value):
+        if contains_control_character(value):
             raise LedgerError(f"{field} must not contain control characters")
         clean = value.strip()
         if clean and clean.lstrip("+-").isdigit():

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -703,6 +703,16 @@ def test_direct_proposal_creation_requires_admin_token(
             },
             "title must not contain control characters",
         ),
+        (
+            {
+                "action": "create_bounty",
+                "payload": {
+                    **_bounty_payload(issue_number=182),
+                    "acceptance": "Accepted\x85work.",
+                },
+            },
+            "acceptance must not contain control characters",
+        ),
     ],
 )
 def test_treasury_proposal_creation_rejects_raw_control_characters(


### PR DESCRIPTION
## Summary

Refs #846.

Focused maintainability cleanup for treasury proposal payload validation:

- reuse the shared `contains_control_character()` helper in `app/treasury.py`;
- remove the treasury-local ordinal scan helper;
- add focused coverage that `create_bounty` proposal `acceptance` text still rejects C1 control characters before proposal creation.

## Scope

Behavior is intended to stay unchanged. This only changes the internal control-character helper used by treasury proposal payload cleanup. It does not change bounty creation semantics, proposal execution, payouts, ledger mutation, wallet behavior, admin-token behavior, private data handling, exchange/bridge/cash-out behavior, or MRWK price behavior.

## Duplicate/current check

- #846 public bounty row 112 is live/open with effective award capacity.
- `gh search prs 'treasury.py contains_control_character repo:ramimbo/mergework' --state open` -> no results.
- `gh search prs '_contains_control_character treasury repo:ramimbo/mergework' --state open` -> no results.
- Broader `treasury control character helper` search only surfaced other control-character helper work in wallet/path/query/auth surfaces, not treasury proposal payload validation.

## Validation

- `uv run --python 3.12 --extra dev python -m pytest tests/test_treasury_proposals.py::test_treasury_proposal_creation_rejects_raw_control_characters tests/test_treasury_proposals.py::test_treasury_proposals_list_rejects_invalid_filters -q` -> 15 passed, 1 existing Starlette/httpx warning.
- `uv run --python 3.12 --extra dev python -m pytest tests/test_treasury_proposals.py tests/test_security.py -q` -> 116 passed, 1 existing Starlette/httpx warning.
- `uv run --python 3.12 --extra dev ruff check app/treasury.py tests/test_treasury_proposals.py` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check app/treasury.py tests/test_treasury_proposals.py` -> 2 files already formatted.
- `uv run --python 3.12 --extra dev mypy app/treasury.py` -> success.
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Treasury proposal creation now properly validates the `acceptance` field to reject inputs containing control characters, returning a clear error message when invalid input is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->