### PR TITLE
Share claim inventory pending field mapping

### DIFF
--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -251,6 +251,48 @@ def _duplicate_key(text: str, source_url: str, bounty_issue: int | None) -> str:
     return f"{bounty_issue or 'unknown'}:{core}"
 
 
+def _pending_row_fields(pending_details: dict[str, Any] | None) -> dict[str, Any]:
+    if pending_details is None:
+        return {
+            "pending_proposal_id": None,
+            "pending_proposal_url": None,
+            "pending_executes_after": None,
+            "pending_to_account": None,
+            "pending_bounty_id": None,
+            "pending_accepted_by": None,
+            "pending_submission_url": None,
+        }
+    return {
+        "pending_proposal_id": _int_or_none(pending_details.get("pending_proposal_id")),
+        "pending_proposal_url": (
+            str(pending_details.get("pending_proposal_url"))
+            if pending_details.get("pending_proposal_url")
+            else None
+        ),
+        "pending_executes_after": (
+            str(pending_details.get("pending_executes_after"))
+            if pending_details.get("pending_executes_after")
+            else None
+        ),
+        "pending_to_account": (
+            str(pending_details.get("pending_to_account"))
+            if pending_details.get("pending_to_account")
+            else None
+        ),
+        "pending_bounty_id": _int_or_none(pending_details.get("pending_bounty_id")),
+        "pending_accepted_by": (
+            str(pending_details.get("pending_accepted_by"))
+            if pending_details.get("pending_accepted_by")
+            else None
+        ),
+        "pending_submission_url": (
+            str(pending_details.get("pending_submission_url"))
+            if pending_details.get("pending_submission_url")
+            else None
+        ),
+    }
+
+
 def _surface_row(
     *,
     text: str,
@@ -297,37 +339,7 @@ def _surface_row(
         duplicate_key=duplicate_key,
         likely_status=likely_status,
         proof_url=proof_url,
-        pending_proposal_id=(
-            _int_or_none(pending_details.get("pending_proposal_id")) if pending_details else None
-        ),
-        pending_proposal_url=(
-            str(pending_details.get("pending_proposal_url"))
-            if pending_details and pending_details.get("pending_proposal_url")
-            else None
-        ),
-        pending_executes_after=(
-            str(pending_details.get("pending_executes_after"))
-            if pending_details and pending_details.get("pending_executes_after")
-            else None
-        ),
-        pending_to_account=(
-            str(pending_details.get("pending_to_account"))
-            if pending_details and pending_details.get("pending_to_account")
-            else None
-        ),
-        pending_bounty_id=(
-            _int_or_none(pending_details.get("pending_bounty_id")) if pending_details else None
-        ),
-        pending_accepted_by=(
-            str(pending_details.get("pending_accepted_by"))
-            if pending_details and pending_details.get("pending_accepted_by")
-            else None
-        ),
-        pending_submission_url=(
-            str(pending_details.get("pending_submission_url"))
-            if pending_details and pending_details.get("pending_submission_url")
-            else None
-        ),
+        **_pending_row_fields(pending_details),
     )
 
 

--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -252,6 +252,7 @@ def _duplicate_key(text: str, source_url: str, bounty_issue: int | None) -> str:
 
 
 def _pending_row_fields(pending_details: dict[str, Any] | None) -> dict[str, Any]:
+    """Return normalized pending-payout fields for a claim inventory row."""
     if pending_details is None:
         return {
             "pending_proposal_id": None,

--- a/tests/test_claim_inventory.py
+++ b/tests/test_claim_inventory.py
@@ -218,6 +218,7 @@ def test_claim_inventory_classifies_required_statuses(tmp_path, capsys) -> None:
     assert (
         rows["https://github.com/ramimbo/mergework/pull/582"]["likely_status"] == "unpaid_candidate"
     )
+    assert rows["https://github.com/ramimbo/mergework/pull/582"]["pending_proposal_id"] is None
     assert (
         rows["https://github.com/ramimbo/mergework/issues/578#issuecomment-3"]["source_type"]
         == "bounty_issue_comment"


### PR DESCRIPTION
Refs #846.

## Summary
- extracts claim-inventory pending payout field mapping into one internal helper;
- keeps the existing `ClaimRow` output fields and likely-status behavior unchanged;
- adds a regression assertion that non-pending claim rows keep pending proposal fields empty.

## Duplicate / scope check
- Bounty #846 is live/open with effective award capacity according to the public API.
- I checked current open PR file lists before submission; none touched `scripts/claim_inventory.py` or `tests/test_claim_inventory.py`.
- Scope is maintainability-only in the claim inventory script. No ledger, wallet, treasury, payout execution, proposal execution, exchange, bridge, cash-out, MRWK price behavior, private data, credentials, or secrets changed.

## Validation
- `python -m pytest tests/test_claim_inventory.py -q` -> 6 passed
- `python -m ruff check scripts/claim_inventory.py tests/test_claim_inventory.py` -> passed
- `python -m ruff format --check scripts/claim_inventory.py tests/test_claim_inventory.py` -> 2 files already formatted
- `python -m mypy scripts/claim_inventory.py` -> success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of pending proposal/payout data so items without a pending proposal are represented as absent (None) rather than erroneous values, improving display and classification of claim rows.
* **Tests**
  * Added a test assertion to ensure items with no pending proposal are treated as absent, preventing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->