### PR TITLE
Share webhook control character validation

### DIFF
--- a/app/webhooks/github.py
+++ b/app/webhooks/github.py
@@ -10,6 +10,7 @@ from urllib.error import HTTPError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
 
+from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import (
     LedgerError,
@@ -24,7 +25,6 @@ PROPOSED_WORK_LABEL = "proposed-work"
 PROPOSED_WORK_ACTIONS = {"opened", "edited", "reopened"}
 ISSUE_NUMBER_BOUNDARY = r"(?![A-Za-z0-9_-])"
 MAX_SQLITE_INTEGER = 2**63 - 1
-CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 LINKED_ISSUE_RE = re.compile(
     r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?|bounty|claims?)"
     r"(?:\s+|\s*:\s*)"
@@ -118,7 +118,7 @@ def _payload_object(payload: dict[str, Any], key: str) -> dict[str, Any]:
 def _clean_webhook_string(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
-    if CONTROL_CHAR_RE.search(value):
+    if contains_control_character(value):
         return None
     clean = value.strip()
     return clean or None
@@ -252,7 +252,7 @@ def _handle_proposed_work_issue_label(
     repo_name = _payload_object(payload, "repository").get("full_name")
     repo = _clean_webhook_string(repo_name)
     issue_number = _github_issue_number(issue.get("number"))
-    if isinstance(repo_name, str) and CONTROL_CHAR_RE.search(repo_name):
+    if isinstance(repo_name, str) and contains_control_character(repo_name):
         return _record_status(
             database_url,
             delivery_id,
@@ -325,7 +325,7 @@ def _handle_accepted_issue_label(
     if payload.get("action") != "labeled" or label.lower() != ACCEPTED_LABEL:
         _record_event(database_url, delivery_id, event_type, payload_hash, "ignored")
         return {"status": "ignored"}
-    if isinstance(repo_name, str) and CONTROL_CHAR_RE.search(repo_name):
+    if isinstance(repo_name, str) and contains_control_character(repo_name):
         return _record_status(
             database_url,
             delivery_id,

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1115,6 +1115,12 @@ def test_accepted_label_rejects_control_characters_before_trimming_webhook_ident
             (),
         ),
         (
+            "delivery-c1-repo",
+            {"repository": {"full_name": "\x85ramimbo/mergework"}},
+            "malformed_repository",
+            (),
+        ),
+        (
             "delivery-control-submitter",
             {"issue": {"user": {"login": "\talice"}}},
             "missing_submitter",


### PR DESCRIPTION
## Summary

Bounty #846 focused maintainability cleanup.

- Reuse the shared `contains_control_character()` helper in GitHub webhook identity validation.
- Remove the webhook-local duplicate `CONTROL_CHAR_RE`.
- Add a C1 repository-name regression case while preserving existing malformed repository / missing submitter / missing sender behavior.

## Evidence / Scope

This is a narrow helper reuse in `app/webhooks/github.py`. It preserves the existing behavior that webhook repo, submitter, and sender strings containing raw control characters are rejected before trimming.

Duplicate/current check before submission:
- #846 is live/reserved as bounty id 112 with effective award capacity.
- `gh search prs 'webhooks github CONTROL_CHAR_RE contains_control_character repo:ramimbo/mergework' --state open` returned no open same-scope PR.
- Existing #846 open PRs cover sorting, route wiring, URL helpers, MCP selectors, query/config/account/staging/GitHub issue-finalization helpers, executor/schema/OAuth/wallet/treasury cleanup; none cover `app/webhooks/github.py` control-character helper reuse.

## Validation

- `uv run --python 3.12 --extra dev python -m pytest tests/test_webhooks.py::test_accepted_label_rejects_control_characters_before_trimming_webhook_identity -q` -> 1 passed.
- `uv run --python 3.12 --extra dev python -m pytest tests/test_webhooks.py tests/test_webhook_event_routing.py -q` -> 35 passed.
- `uv run --python 3.12 --extra dev ruff check app/webhooks/github.py tests/test_webhooks.py` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check app/webhooks/github.py tests/test_webhooks.py` -> 2 files already formatted.
- `uv run --python 3.12 --extra dev mypy app/webhooks/github.py` -> success.
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`.

No public API contract, ledger behavior, wallet behavior, treasury behavior, payout behavior, proposal execution, admin-token behavior, private data, credentials, secrets, exchange, bridge, cash-out, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation of GitHub webhook payloads to properly detect and reject malformed repository information containing special characters.

* **Tests**
  * Expanded test coverage for webhook payload validation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->