### PR TITLE
Share bounty attempt control character validation

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -10,8 +10,9 @@ from sqlalchemy import func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app.control_chars import contains_control_character
 from app.db import session_scope
-from app.ledger.service import CONTROL_CHAR_RE, LedgerError, validate_public_url
+from app.ledger.service import LedgerError, validate_public_url
 from app.models import Bounty, BountyAttempt
 from app.openapi_request_bodies import OPTIONAL_ATTEMPT_BODY, OPTIONAL_ATTEMPT_RELEASE_BODY
 from app.query_validation import (
@@ -281,7 +282,7 @@ def register_bounty_attempt_routes(
             source = ""
         if not isinstance(source, str):
             raise HTTPException(status_code=400, detail="source_url must be a string")
-        if CONTROL_CHAR_RE.search(source):
+        if contains_control_character(source):
             raise HTTPException(
                 status_code=400, detail="source_url must not contain control characters"
             )

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -163,6 +163,16 @@ def test_bounty_attempts_register_list_duplicate_and_release(sqlite_url: str, mo
         control_char_bool.json()["detail"] == "include_expired must not contain control characters"
     )
 
+    control_char_source = client.post(
+        f"/api/v1/bounties/{bounty.id}/attempts",
+        json={
+            "submitter_account": "github:bob",
+            "source_url": "\x85https://github.com/ramimbo/mergework/pull/501",
+        },
+    )
+    assert control_char_source.status_code == 400
+    assert control_char_source.json()["detail"] == "source_url must not contain control characters"
+
     wrong_submitter = client.post(
         f"/api/v1/bounty-attempts/{first_attempt['id']}/release",
         json={"submitter_account": "github:bob"},


### PR DESCRIPTION
## Summary

Bounty #846 focused maintainability cleanup.

- Reuse the shared `contains_control_character()` helper for bounty-attempt `source_url` validation.
- Stop importing the ledger service's `CONTROL_CHAR_RE` into `app/bounty_attempts.py` just for this read-only route guard.
- Add a C1 `source_url` regression case while preserving the existing validation error.

## Evidence / Scope

This keeps the attempt route behavior unchanged while reducing cross-module coupling between bounty attempts and ledger internals.

Duplicate/current check before submission:
- #846 public bounty row 112 is open with effective award capacity.
- `gh search prs 'bounty_attempts CONTROL_CHAR_RE contains_control_character source_url repo:ramimbo/mergework' --state open` returned no same-scope PR.
- Existing open `app/bounty_attempts.py` PRs I found are older needs-info / broader surfaces and do not cover this focused source_url control-character helper reuse.

## Validation

- `uv run --python 3.12 --extra dev python -m pytest tests/test_bounty_attempts.py::test_bounty_attempts_register_list_duplicate_and_release -q` -> 1 passed, 1 existing Starlette/httpx warning.
- `uv run --python 3.12 --extra dev python -m pytest tests/test_bounty_attempts.py tests/test_bounty_api_routes.py -q` -> 32 passed, 1 existing Starlette/httpx warning.
- `uv run --python 3.12 --extra dev ruff check app/bounty_attempts.py tests/test_bounty_attempts.py` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check app/bounty_attempts.py tests/test_bounty_attempts.py` -> 2 files already formatted.
- `uv run --python 3.12 --extra dev mypy app/bounty_attempts.py` -> success.
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`.

No public API contract, ledger behavior, wallet behavior, treasury behavior, payout behavior, proposal execution, admin-token behavior, private data, credentials, secrets, exchange, bridge, cash-out, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the validation logic for source URLs to more reliably detect and reject control characters, returning HTTP 400 with clear, descriptive error messaging to users.

* **Tests**
  * Added comprehensive test coverage to ensure that bounty attempt registrations with control characters in the source URL field are properly rejected with HTTP 400 status and detailed validation error information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->