### PR TITLE
Share JSON payload helper parsing

### DIFF
--- a/app/json_payloads.py
+++ b/app/json_payloads.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException, Request
+
+from app.control_chars import contains_control_character
+
+
+async def json_object(request: Request) -> dict[str, Any]:
+    try:
+        data = await request.json()
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid json body") from exc
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=400, detail="json body must be an object")
+    return data
+
+
+def required_str(data: dict[str, Any], field: str) -> str:
+    if field not in data or data[field] is None:
+        raise HTTPException(status_code=400, detail=f"{field} is required")
+    value = data[field]
+    if not isinstance(value, str):
+        raise HTTPException(status_code=400, detail=f"{field} must be a string")
+    return value
+
+
+def optional_str(data: dict[str, Any], field: str, default: str = "") -> str:
+    value = data.get(field, default)
+    if value is None:
+        return default
+    if not isinstance(value, str):
+        raise HTTPException(status_code=400, detail=f"{field} must be a string")
+    return value
+
+
+def _parse_int(value: Any, field: str) -> int:
+    if isinstance(value, bool):
+        raise HTTPException(status_code=400, detail=f"{field} must be an integer")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        if contains_control_character(value):
+            raise HTTPException(
+                status_code=400, detail=f"{field} must not contain control characters"
+            )
+        clean = value.strip()
+        if clean and clean.lstrip("+-").isdigit():
+            try:
+                return int(clean)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=f"{field} must be an integer") from exc
+    raise HTTPException(status_code=400, detail=f"{field} must be an integer")
+
+
+def required_int(data: dict[str, Any], field: str) -> int:
+    value = data.get(field)
+    if value is None:
+        raise HTTPException(status_code=400, detail=f"{field} must be an integer")
+    return _parse_int(value, field)
+
+
+def optional_int(data: dict[str, Any], field: str, default: int) -> int:
+    value = data.get(field, default)
+    if value is None:
+        raise HTTPException(status_code=400, detail=f"{field} must be an integer")
+    return _parse_int(value, field)

--- a/app/main.py
+++ b/app/main.py
@@ -19,9 +19,9 @@ from app.bounty_attempts import (
     register_bounty_attempt_routes,
 )
 from app.config import get_settings
-from app.control_chars import contains_control_character
 from app.db import create_schema, session_scope
 from app.hub import is_ltc_lab_host, ltc_lab_context, mergework_hub_context
+from app.json_payloads import json_object, optional_int, optional_str, required_int, required_str
 from app.ledger.service import ensure_genesis, public_url_or_none
 from app.ledger_views import ledger_entry_to_dict, recent_ledger_entries
 from app.mcp import handle_mcp_request
@@ -114,67 +114,6 @@ def _preserve_forwarded_https_redirect(request: Request, response: Response) -> 
     )
 
 
-async def _json_object(request: Request) -> dict[str, Any]:
-    try:
-        data = await request.json()
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail="invalid json body") from exc
-    if not isinstance(data, dict):
-        raise HTTPException(status_code=400, detail="json body must be an object")
-    return data
-
-
-def _required_str(data: dict[str, Any], field: str) -> str:
-    if field not in data or data[field] is None:
-        raise HTTPException(status_code=400, detail=f"{field} is required")
-    value = data[field]
-    if not isinstance(value, str):
-        raise HTTPException(status_code=400, detail=f"{field} must be a string")
-    return value
-
-
-def _optional_str(data: dict[str, Any], field: str, default: str = "") -> str:
-    value = data.get(field, default)
-    if value is None:
-        return default
-    if not isinstance(value, str):
-        raise HTTPException(status_code=400, detail=f"{field} must be a string")
-    return value
-
-
-def _parse_int(value: Any, field: str) -> int:
-    if isinstance(value, bool):
-        raise HTTPException(status_code=400, detail=f"{field} must be an integer")
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str):
-        if contains_control_character(value):
-            raise HTTPException(
-                status_code=400, detail=f"{field} must not contain control characters"
-            )
-        clean = value.strip()
-        if clean and clean.lstrip("+-").isdigit():
-            try:
-                return int(clean)
-            except ValueError as exc:
-                raise HTTPException(status_code=400, detail=f"{field} must be an integer") from exc
-    raise HTTPException(status_code=400, detail=f"{field} must be an integer")
-
-
-def _required_int(data: dict[str, Any], field: str) -> int:
-    value = data.get(field)
-    if value is None:
-        raise HTTPException(status_code=400, detail=f"{field} must be an integer")
-    return _parse_int(value, field)
-
-
-def _optional_int(data: dict[str, Any], field: str, default: int) -> int:
-    value = data.get(field, default)
-    if value is None:
-        raise HTTPException(status_code=400, detail=f"{field} must be an integer")
-    return _parse_int(value, field)
-
-
 def _csrf_token(action: str, login: str, secret: str) -> str:
     return _signed_value(f"{action}:{login}", secret)
 
@@ -255,11 +194,11 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         app,
         db_url=db_url,
         require_admin_token=auth.require_admin_token,
-        json_object=_json_object,
-        required_str=_required_str,
-        optional_str=_optional_str,
-        optional_int=_optional_int,
-        required_int=_required_int,
+        json_object=json_object,
+        required_str=required_str,
+        optional_str=optional_str,
+        optional_int=optional_int,
+        required_int=required_int,
         settings=settings,
     )
     list_bounties_by_status = _bounty_api["list_bounties_by_status"]
@@ -269,9 +208,9 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         app,
         db_url=db_url,
         require_github_login=auth.require_github_login,
-        json_object=_json_object,
-        required_str=_required_str,
-        optional_int=_optional_int,
+        json_object=json_object,
+        required_str=required_str,
+        optional_int=optional_int,
         normalized_account=normalized_account,
         positive_bounty_id=positive_bounty_id,
         sqlite_integer_max=SQLITE_INTEGER_MAX,
@@ -284,7 +223,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         public_base_url=settings.public_base_url,
         require_admin_token=auth.require_admin_token,
         require_github_login=auth.require_github_login,
-        json_object=_json_object,
+        json_object=json_object,
     )
 
     register_account_routes(app, db_url=db_url, templates=templates)
@@ -298,10 +237,10 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         app,
         db_url=db_url,
         require_github_login=auth.require_github_login,
-        json_object=_json_object,
-        required_str=_required_str,
-        required_int=_required_int,
-        optional_str=_optional_str,
+        json_object=json_object,
+        required_str=required_str,
+        required_int=required_int,
+        optional_str=optional_str,
         normalized_wallet_address=normalized_wallet_address,
         post_only_route=post_only_route,
     )

--- a/tests/test_json_payloads.py
+++ b/tests/test_json_payloads.py
@@ -1,13 +1,49 @@
 from __future__ import annotations
 
-import pytest
-from fastapi import HTTPException
+import asyncio
+from typing import Any, cast
 
-from app.json_payloads import optional_int, optional_str, required_int, required_str
+import pytest
+from fastapi import HTTPException, Request
+
+from app.json_payloads import json_object, optional_int, optional_str, required_int, required_str
+
+
+class _JsonRequest:
+    def __init__(self, payload: Any = None, *, error: Exception | None = None) -> None:
+        self.payload = payload
+        self.error = error
+
+    async def json(self) -> Any:
+        if self.error is not None:
+            raise self.error
+        return self.payload
 
 
 def _detail(exc_info: pytest.ExceptionInfo[HTTPException]) -> str:
     return str(exc_info.value.detail)
+
+
+def _status_code(exc_info: pytest.ExceptionInfo[HTTPException]) -> int:
+    return int(exc_info.value.status_code)
+
+
+def _request(payload: Any = None, *, error: Exception | None = None) -> Request:
+    return cast(Request, _JsonRequest(payload, error=error))
+
+
+def test_json_object_preserves_invalid_and_non_object_errors() -> None:
+    assert asyncio.run(json_object(_request({"ok": True}))) == {"ok": True}
+
+    with pytest.raises(HTTPException) as invalid:
+        asyncio.run(json_object(_request(error=ValueError("bad json"))))
+    with pytest.raises(HTTPException) as non_object:
+        asyncio.run(json_object(_request(["not", "an", "object"])))
+
+    assert _status_code(invalid) == 400
+    assert _detail(invalid) == "invalid json body"
+    assert _status_code(non_object) == 400
+    assert _detail(non_object) == "json body must be an object"
 
 
 def test_json_payload_string_helpers_preserve_required_and_type_errors() -> None:
@@ -20,7 +56,9 @@ def test_json_payload_string_helpers_preserve_required_and_type_errors() -> None
     with pytest.raises(HTTPException) as typed:
         optional_str({"source": 1}, "source")
 
+    assert _status_code(missing) == 400
     assert _detail(missing) == "title is required"
+    assert _status_code(typed) == 400
     assert _detail(typed) == "source must be a string"
 
 
@@ -35,6 +73,9 @@ def test_json_payload_integer_helpers_preserve_string_and_control_char_errors() 
     with pytest.raises(HTTPException) as controlled:
         optional_int({"ttl_seconds": "\x851"}, "ttl_seconds", 3600)
 
+    assert _status_code(boolean) == 400
     assert _detail(boolean) == "nonce must be an integer"
+    assert _status_code(decimal) == 400
     assert _detail(decimal) == "nonce must be an integer"
+    assert _status_code(controlled) == 400
     assert _detail(controlled) == "ttl_seconds must not contain control characters"

--- a/tests/test_json_payloads.py
+++ b/tests/test_json_payloads.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.json_payloads import optional_int, optional_str, required_int, required_str
+
+
+def _detail(exc_info: pytest.ExceptionInfo[HTTPException]) -> str:
+    return str(exc_info.value.detail)
+
+
+def test_json_payload_string_helpers_preserve_required_and_type_errors() -> None:
+    assert required_str({"title": "Bounty"}, "title") == "Bounty"
+    assert optional_str({}, "source", "github") == "github"
+    assert optional_str({"source": None}, "source", "github") == "github"
+
+    with pytest.raises(HTTPException) as missing:
+        required_str({}, "title")
+    with pytest.raises(HTTPException) as typed:
+        optional_str({"source": 1}, "source")
+
+    assert _detail(missing) == "title is required"
+    assert _detail(typed) == "source must be a string"
+
+
+def test_json_payload_integer_helpers_preserve_string_and_control_char_errors() -> None:
+    assert required_int({"nonce": " 42 "}, "nonce") == 42
+    assert optional_int({}, "ttl_seconds", 3600) == 3600
+
+    with pytest.raises(HTTPException) as boolean:
+        required_int({"nonce": True}, "nonce")
+    with pytest.raises(HTTPException) as decimal:
+        required_int({"nonce": "1.5"}, "nonce")
+    with pytest.raises(HTTPException) as controlled:
+        optional_int({"ttl_seconds": "\x851"}, "ttl_seconds", 3600)
+
+    assert _detail(boolean) == "nonce must be an integer"
+    assert _detail(decimal) == "nonce must be an integer"
+    assert _detail(controlled) == "ttl_seconds must not contain control characters"


### PR DESCRIPTION
Bounty #846

## Summary
- move shared JSON body/string/integer payload parsing helpers out of app startup wiring into `app/json_payloads.py`
- keep existing route injection points in `app/main.py` but make the startup module responsible only for assembly
- add direct helper coverage for required/optional strings, integer parsing, and C1 control-character rejection messages

## Duplicate check
- searched open PRs for `json_payloads`, payload helpers, and related helper extraction; no same-scope open PR found
- current #846 PRs cover sorting, route wiring, public URLs, MCP selectors, query/config/account/staging/GitHub helpers, executor/schema/OAuth/wallet/treasury/webhook/bounty-attempt cleanup, not this shared JSON payload helper split

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_json_payloads.py tests/test_bounty_attempts.py tests/test_wallet_api.py -q` -> 59 passed, 1 existing Starlette/httpx warning
- `uv run --python 3.12 --extra dev python -m pytest tests/test_security.py::test_admin_bounty_api_rejects_fractional_integer_fields tests/test_wallet_api.py::test_wallet_transfer_api_rejects_c1_nonce_before_integer_parsing -q` -> 2 passed, 1 existing Starlette/httpx warning
- `uv run --python 3.12 --extra dev python -m pytest tests/test_bounty_api_routes.py tests/test_security.py::test_admin_bounty_api_rejects_fractional_integer_fields -q` -> 21 passed, 1 existing Starlette/httpx warning
- `uv run --python 3.12 --extra dev ruff check app/json_payloads.py app/main.py tests/test_json_payloads.py` -> passed
- `uv run --python 3.12 --extra dev ruff format --check app/json_payloads.py app/main.py tests/test_json_payloads.py` -> 3 files already formatted
- `uv run --python 3.12 --extra dev mypy app/json_payloads.py app/main.py` -> success
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`

Scope: maintainability-only helper relocation for request payload parsing. No public API contract, ledger behavior, wallet behavior, treasury behavior, payout behavior, proposal execution, admin-token behavior, private data, exchange, bridge, cash-out, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated JSON request parsing and validation into a dedicated component for clearer behavior and reuse.

* **Tests**
  * Added comprehensive tests covering JSON body handling, string and integer field validation, defaults, and error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->