### PR TITLE
Share bounty list query validation

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -186,6 +186,14 @@ def register_bounty_api_routes(
                 return sorted_bounties[:limit]
             return sorted_bounties
 
+    def _validate_bounty_list_request(request: Request) -> None:
+        for name in ("status", "q", "limit", "sort", "repo", "issue_number", "availability"):
+            reject_repeated_query_param(request, name)
+        for name in ("status", "q", "sort", "repo", "availability"):
+            reject_control_char_query_param(request, name)
+        for name in ("limit", "issue_number"):
+            reject_noncanonical_int_query_param(request, name)
+
     @app.get("/api/v1/bounties")
     def api_bounties(
         request: Request,
@@ -197,12 +205,7 @@ def register_bounty_api_routes(
         issue_number: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
         availability: str | None = Query(None),
     ) -> list[dict[str, Any]]:
-        for name in ("status", "q", "limit", "sort", "repo", "issue_number", "availability"):
-            reject_repeated_query_param(request, name)
-        for name in ("status", "q", "sort", "repo", "availability"):
-            reject_control_char_query_param(request, name)
-        for name in ("limit", "issue_number"):
-            reject_noncanonical_int_query_param(request, name)
+        _validate_bounty_list_request(request)
         return _list_bounties_by_status(
             status,
             q,
@@ -224,12 +227,7 @@ def register_bounty_api_routes(
         issue_number: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
         availability: str | None = Query(None),
     ) -> dict[str, Any]:
-        for name in ("status", "q", "limit", "sort", "repo", "issue_number", "availability"):
-            reject_repeated_query_param(request, name)
-        for name in ("status", "q", "sort", "repo", "availability"):
-            reject_control_char_query_param(request, name)
-        for name in ("limit", "issue_number"):
-            reject_noncanonical_int_query_param(request, name)
+        _validate_bounty_list_request(request)
         return bounty_list_summary(
             _list_bounties_by_status(
                 status,


### PR DESCRIPTION
## Summary
- extract the repeated `/api/v1/bounties` and `/api/v1/bounties/summary` query-parameter guard sequence into one internal `_validate_bounty_list_request()` helper
- keep the existing repeated-parameter, control-character, and noncanonical integer checks unchanged for both list and summary routes

## Bounty
Bounty #846

## Evidence
- Duplicate/scope check: this is limited to `app/bounty_api.py` and does not overlap with open work-discovery, MCP, activity, treasury, wallet, or public string-padding PRs.
- Behavior preserved: the two public bounty list routes still call the same validators in the same order before the existing list/summary serialization path.
- Out of scope: no bounty creation, proposal execution, payout, ledger, wallet, treasury mutation, admin-token behavior, private data, exchange, bridge, cash-out, or MRWK price behavior changed.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_bounty_api.py tests/test_bounty_api_routes.py -q` -> 46 passed, 1 existing Starlette/httpx warning
- `uv run --python 3.12 --extra dev ruff check app/bounty_api.py` -> passed
- `uv run --python 3.12 --extra dev ruff format --check app/bounty_api.py` -> 1 file already formatted
- `uv run --python 3.12 --extra dev mypy app/bounty_api.py` -> success
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `7d5e112d4f1f3d23db6efd5d04cbd8bcc94bcc73`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for bounty-related API endpoints by consolidating request validation logic, reducing code duplication and enhancing system maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->