### PR TITLE
Accept id alias for MCP attempt lookup

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -28,8 +28,8 @@ MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounty_attempts",
         "description": (
-            "List advisory active-attempt reservations for a bounty by internal bounty_id, "
-            "or by GitHub issue_number with optional repo"
+            "List advisory active-attempt reservations for a bounty by internal bounty_id "
+            "(or id alias), or by GitHub issue_number with optional repo"
         ),
     },
     {

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -153,14 +153,12 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
         repo_selector = optional_repo_selector_arg()
         if len(provided_internal_id_fields) > 1:
             raise ValueError(
-                "use one of "
-                + ", ".join(internal_id_fields)
-                + ", or issue_number, not multiple internal id fields"
+                "use "
+                + " or ".join(provided_internal_id_fields)
+                + ", not multiple internal id fields"
             )
         if has_internal_id and has_issue_number:
-            raise ValueError(
-                "use one of " + ", ".join(internal_id_fields) + ", or issue_number, not both"
-            )
+            raise ValueError(f"use {provided_internal_id_fields[0]} or issue_number, not both")
         if repo_selector is not None and not has_issue_number:
             raise ValueError("repo can only be used with issue_number")
         if has_internal_id:
@@ -225,7 +223,7 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 bounty_data["awards"] = bounty_awards_to_dict(session, bounty.id)
             return json.dumps(bounty_data)
         if name == "list_bounty_attempts":
-            bounty = selected_bounty("bounty_id")
+            bounty = selected_bounty("bounty_id", internal_id_aliases=("id",))
             if bounty is None:
                 return "bounty not found"
             attempt_listing = list_bounty_attempts(

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -266,13 +266,17 @@ from other bounty payloads, or use `issue_number` with `repo` when you start
 from a GitHub issue URL.
 
 Inspect active attempt reservations for a bounty before opening overlapping
-work. Use the internal bounty id from `list_bounties`, or `issue_number` with
-`repo` when you start from a GitHub issue URL:
+work. Use the internal `bounty_id` or the `id` field from `list_bounties`, or
+`issue_number` with `repo` when you start from a GitHub issue URL:
 
 ```bash
 curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_bounty_attempts","arguments":{"bounty_id":11}}}'
+
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"list_bounty_attempts","arguments":{"id":11}}}'
 
 curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -710,14 +710,19 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_bounty","arguments":{"issue_number":404,"repo":"ramimbo/mergework"}}}'
 ```
 
-Call `list_bounty_attempts` with the same internal `bounty_id`, or the GitHub
-`issue_number` plus `repo`, before opening a PR. Omit `include_expired` to see
-only active attempts:
+Call `list_bounty_attempts` with the same internal `bounty_id` (or the `id`
+field returned by `list_bounties`/`get_bounty`), or the GitHub `issue_number`
+plus `repo`, before opening a PR. Omit `include_expired` to see only active
+attempts:
 
 ```bash
 curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"list_bounty_attempts","arguments":{"bounty_id":11,"include_expired":false}}}'
+
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"list_bounty_attempts","arguments":{"id":11,"include_expired":false}}}'
 
 curl -s -X POST "$MCP_HOST/mcp" \
   -H "Content-Type: application/json" \

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -489,6 +489,54 @@ def test_mcp_list_bounty_attempts_accepts_issue_number_selector(sqlite_url: str)
     assert result["attempts"][0]["submitter_account"] == "github:alice"
 
 
+def test_mcp_list_bounty_attempts_accepts_id_alias(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    now = datetime.now(UTC)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=323,
+            issue_url="https://github.com/ramimbo/mergework/issues/323",
+            title="Attempt lookup by id alias",
+            reward_mrwk="250",
+            max_awards=2,
+            acceptance="Agents can reuse the id field from list_bounties.",
+        )
+        session.add(
+            BountyAttempt(
+                bounty_id=bounty.id,
+                submitter_account="github:alice",
+                source_url="https://github.com/ramimbo/mergework/pull/523",
+                status="active",
+                expires_at=now + timedelta(hours=1),
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    result = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 25,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounty_attempts",
+                "arguments": {"id": bounty_id},
+            },
+        },
+    ).json()["result"]["structuredContent"]
+
+    assert result["bounty_id"] == bounty_id
+    assert result["issue_number"] == 323
+    assert result["attempts"][0]["submitter_account"] == "github:alice"
+
+
 def test_mcp_list_bounty_attempts_rejects_invalid_arguments(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -523,6 +571,44 @@ def test_mcp_list_bounty_attempts_rejects_invalid_arguments(sqlite_url: str) -> 
     assert response.json() == {
         "jsonrpc": "2.0",
         "id": 23,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
+def test_mcp_list_bounty_attempts_rejects_mixed_id_aliases(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=324,
+            issue_url="https://github.com/ramimbo/mergework/issues/324",
+            title="Attempt alias ambiguity",
+            reward_mrwk="250",
+            acceptance="Agents should not mix internal id aliases.",
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 26,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounty_attempts",
+                "arguments": {"bounty_id": bounty_id, "id": bounty_id},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 26,
         "error": {"code": -32602, "message": "invalid tool arguments"},
     }
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -74,6 +74,29 @@ def test_call_mcp_tool_preserves_argument_validation_errors(
         call_mcp_tool(sqlite_url, tool_name, arguments)
 
 
+def test_call_mcp_tool_reports_attempt_id_alias_issue_number_mix(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=391,
+            issue_url="https://github.com/ramimbo/mergework/issues/391",
+            title="Attempt alias issue-number conflict",
+            reward_mrwk="200",
+            acceptance="Agents should get actionable selector errors.",
+        )
+        bounty_id = bounty.id
+
+    with pytest.raises(ValueError, match="use id or issue_number, not both"):
+        call_mcp_tool(
+            sqlite_url,
+            "list_bounty_attempts",
+            {"id": bounty_id, "issue_number": 391},
+        )
+
+
 def test_call_mcp_tool_rejects_c1_status_before_normalizing(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Bounty #844

## Summary
- lets `list_bounty_attempts` accept `id` as an alias for the existing internal `bounty_id` selector;
- rejects mixed `bounty_id` + `id` selectors to keep internal bounty lookup unambiguous;
- updates `tools/list` wording and agent/API docs so agents can reuse the `id` field returned by `list_bounties` or `get_bounty` before opening overlapping work.

## Duplicate / Scope Check
- distinct from #908: this does not change `get_bounty`; it covers `list_bounty_attempts` selector usability.
- distinct from #893: no proof or ledger selector alias changes.
- distinct from #899/#892: this does not add broad unexpected-argument guards; it defines one valid alias for an existing read-only selector.
- distinct from #738: no broad `tools/list` input schema work.
- no wallet registration, wallet transfer signing, ledger mutation, bounty payout, treasury mutation, admin-token behavior, exchange, bridge, cash-out, MRWK price behavior, private data, credentials, or secrets are changed.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_api_mcp.py::test_mcp_tools_list_and_call tests/test_api_mcp.py::test_mcp_list_bounty_attempts_reports_active_and_expired tests/test_api_mcp.py::test_mcp_list_bounty_attempts_accepts_issue_number_selector tests/test_api_mcp.py::test_mcp_list_bounty_attempts_accepts_id_alias tests/test_api_mcp.py::test_mcp_list_bounty_attempts_rejects_invalid_arguments tests/test_api_mcp.py::test_mcp_list_bounty_attempts_rejects_mixed_id_aliases -q` -> 6 passed, 1 existing warning.
- `uv run --python 3.12 --extra dev python -m pytest tests/test_api_mcp.py tests/test_mcp_tools.py tests/test_docs_public_urls.py -q` -> 149 passed, 1 existing warning.
- `uv run --python 3.12 --extra dev ruff check app/mcp_tools.py app/mcp.py tests/test_api_mcp.py docs/api-examples.md docs/agent-guide.md` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check app/mcp_tools.py app/mcp.py tests/test_api_mcp.py` -> 3 files already formatted.
- `uv run --python 3.12 --extra dev mypy app/mcp_tools.py app/mcp.py` -> success.
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * list_bounty_attempts accepts an alternate internal id field (`id`) as an alternative to `bounty_id`.
  * Selection enforces mutual exclusivity: you cannot mix internal-id selectors with each other or with an `issue_number`.

* **Documentation**
  * Guidance and examples updated to show using either `bounty_id` or `id` when listing bounty attempts.

* **Tests**
  * Added tests for `id` alias acceptance and rejection of ambiguous/mixed selectors; error messages now name the provided conflicting fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->