### PR TITLE
Share submission requirement action construction

### DIFF
--- a/app/submission_requirements.py
+++ b/app/submission_requirements.py
@@ -5,6 +5,10 @@ from typing import Any, Literal
 SubmissionAvailability = Literal["open", "full", "closed", "unknown"]
 
 
+def _next_action(action_id: str, text: str, *, required: bool = True) -> dict[str, Any]:
+    return {"id": action_id, "required": required, "text": text}
+
+
 def work_proof_submission_requirements(
     *,
     bounty_id: int | None,
@@ -32,16 +36,14 @@ def work_proof_submission_requirements(
             "duplicate search and out-of-scope notes",
         ]
         mode_actions = [
-            {
-                "id": "open_proposed_work_issue",
-                "required": True,
-                "text": "Open a concrete proposed-work issue before claiming this bounty.",
-            },
-            {
-                "id": "link_bounty_issue",
-                "required": True,
-                "text": f"Link bounty #{issue_ref} from the proposed-work issue or bounty thread.",
-            },
+            _next_action(
+                "open_proposed_work_issue",
+                "Open a concrete proposed-work issue before claiming this bounty.",
+            ),
+            _next_action(
+                "link_bounty_issue",
+                f"Link bounty #{issue_ref} from the proposed-work issue or bounty thread.",
+            ),
         ]
     else:
         submission_mode = "pr_or_evidence"
@@ -56,45 +58,39 @@ def work_proof_submission_requirements(
             "tests, command output, screenshots, or reproduction steps when relevant",
         ]
         mode_actions = [
-            {
-                "id": "keep_scope_focused",
-                "required": True,
-                "text": "Keep changes directly tied to one bounty issue.",
-            },
-            {
-                "id": "include_bounty_reference",
-                "required": True,
-                "text": f"Include Bounty #{issue_ref} or Refs #{issue_ref} in the submission.",
-            },
+            _next_action(
+                "keep_scope_focused",
+                "Keep changes directly tied to one bounty issue.",
+            ),
+            _next_action(
+                "include_bounty_reference",
+                f"Include Bounty #{issue_ref} or Refs #{issue_ref} in the submission.",
+            ),
         ]
 
     if availability == "open":
-        first_action = {
-            "id": "confirm_award_slot",
-            "required": True,
-            "text": "Confirm this bounty is open and has at least one award slot remaining.",
-        }
+        first_action = _next_action(
+            "confirm_award_slot",
+            "Confirm this bounty is open and has at least one award slot remaining.",
+        )
     elif availability == "full":
-        first_action = {
-            "id": "watch_for_award_slot",
-            "required": True,
-            "text": (
+        first_action = _next_action(
+            "watch_for_award_slot",
+            (
                 "This bounty is open but has no award slots remaining; check for new "
                 "capacity before submitting new work."
             ),
-        }
+        )
     elif availability == "closed":
-        first_action = {
-            "id": "choose_open_bounty",
-            "required": True,
-            "text": "Do not open or claim new work for this bounty unless a maintainer reopens it.",
-        }
+        first_action = _next_action(
+            "choose_open_bounty",
+            "Do not open or claim new work for this bounty unless a maintainer reopens it.",
+        )
     else:
-        first_action = {
-            "id": "select_bounty",
-            "required": True,
-            "text": "Select a concrete open bounty before submitting work proof.",
-        }
+        first_action = _next_action(
+            "select_bounty",
+            "Select a concrete open bounty before submitting work proof.",
+        )
 
     return {
         "submission_mode": submission_mode,
@@ -116,25 +112,22 @@ def work_proof_submission_requirements(
         ],
         "next_actions": [
             first_action,
-            {
-                "id": "check_duplicate_scope",
-                "required": True,
-                "text": "Confirm no active claim or duplicate PR already covers the same scope.",
-            },
+            _next_action(
+                "check_duplicate_scope",
+                "Confirm no active claim or duplicate PR already covers the same scope.",
+            ),
             *mode_actions,
-            {
-                "id": "include_review_evidence",
-                "required": True,
-                "text": "Include reviewable validation evidence before claiming.",
-            },
-            {
-                "id": "wait_for_maintainer_acceptance",
-                "required": True,
-                "text": (
+            _next_action(
+                "include_review_evidence",
+                "Include reviewable validation evidence before claiming.",
+            ),
+            _next_action(
+                "wait_for_maintainer_acceptance",
+                (
                     "Payment requires mrwk:accepted or an admin payout; merge or CI "
                     "alone is not acceptance."
                 ),
-            },
+            ),
         ],
     }
 

--- a/tests/test_mcp_work_proof.py
+++ b/tests/test_mcp_work_proof.py
@@ -57,6 +57,33 @@ def test_work_proof_submission_requirements_choose_open_bounty_for_closed_state(
     assert "price claims" in requirements["public_metadata_must_avoid"]
 
 
+def test_work_proof_submission_requirements_reports_open_pr_mode_actions() -> None:
+    requirements = work_proof_submission_requirements(
+        bounty_id=7,
+        issue_number=377,
+        availability="open",
+    )
+
+    assert [action["id"] for action in requirements["next_actions"]] == [
+        "confirm_award_slot",
+        "check_duplicate_scope",
+        "keep_scope_focused",
+        "include_bounty_reference",
+        "include_review_evidence",
+        "wait_for_maintainer_acceptance",
+    ]
+    assert _action(requirements, "confirm_award_slot") == {
+        "id": "confirm_award_slot",
+        "required": True,
+        "text": "Confirm this bounty is open and has at least one award slot remaining.",
+    }
+    assert _action(requirements, "include_bounty_reference") == {
+        "id": "include_bounty_reference",
+        "required": True,
+        "text": "Include Bounty #377 or Refs #377 in the submission.",
+    }
+
+
 def test_work_proof_submission_requirements_marks_issue_mode() -> None:
     requirements = work_proof_submission_requirements(
         bounty_id=96,


### PR DESCRIPTION
## Summary
- add a small internal `_next_action()` helper for submission requirement action dictionaries
- reuse it across open/full/closed/unknown availability actions and issue-vs-PR submission mode actions
- add focused coverage for open PR/evidence mode action ordering and text

## Bounty
Bounty #846

## Duplicate/scope check
- Public bounty API showed #846 live/open with effective award capacity.
- Open PR file-overlap checks found no open PR touching `app/submission_requirements.py`.
- Searches for `submission_requirements.py` + `next_actions` and `work_proof_submission_requirements` + `next_actions` returned no same-scope open PR.
- This is distinct from open page/API/MCP/helper PRs; it only consolidates the internal submission-requirements action dict construction.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_mcp_work_proof.py tests\test_api_mcp.py::test_mcp_submit_work_proof_returns_structured_bounty_guidance tests\test_api_mcp.py::test_mcp_submit_work_proof_returns_structured_generic_guidance tests\test_api_mcp.py::test_mcp_submit_work_proof_structures_terminal_bounty_availability -q` -> 12 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\python.exe -m pytest tests\test_mcp_work_proof.py tests\test_serializers.py tests\test_bounty_api_routes.py tests\test_api_mcp.py -q` -> 145 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\python.exe -m pytest -q` -> 791 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\python.exe -m ruff check .` -> passed.
- `.\.venv\Scripts\python.exe -m ruff format --check .` -> 111 files already formatted.
- `.\.venv\Scripts\python.exe -m mypy app` -> success across 42 source files.
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `bc3fbdda2d6aa283a9aff3365ef91c355aded568`.

## Scope
Maintainability-only helper extraction in `app/submission_requirements.py` plus focused tests. No public submission-requirements text, bounty lifecycle behavior, ledger behavior, wallet behavior, treasury behavior, payout behavior, proposal execution, admin-token behavior, private data, exchange, bridge, cash-out, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure for submission requirements handling.

* **Tests**
  * Added test coverage for work proof submission requirements validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->