### PR TITLE
Honor activity API pagination

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
@@ -10,17 +10,26 @@ from sqlalchemy.orm import Session
 from app.accounts import normalized_account
 from app.control_chars import contains_control_character
 from app.db import session_scope
-from app.query_validation import reject_control_char_query_param, reject_repeated_query_param
+from app.query_validation import (
+    reject_control_char_query_param,
+    reject_noncanonical_int_query_param,
+    reject_repeated_query_param,
+)
 from app.serializers import activity_to_dict
 
 
 def activity_context(
-    session: Session, query: str | None = None, account: str | None = None
+    session: Session,
+    query: str | None = None,
+    account: str | None = None,
+    *,
+    limit: int = 100,
+    offset: int = 0,
 ) -> dict[str, Any]:
     if query is not None and contains_control_character(query):
         raise HTTPException(status_code=400, detail="q must not contain control characters")
     normalized = normalized_account(account) if account is not None else None
-    return activity_to_dict(session, query, account=normalized)
+    return activity_to_dict(session, query, account=normalized, limit=limit, offset=offset)
 
 
 def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
@@ -29,13 +38,19 @@ def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Temp
         request: Request,
         q: str | None = Query(None),
         account: str | None = Query(None),
+        limit: Annotated[int, Query(ge=1, le=200)] = 100,
+        offset: Annotated[int, Query(ge=0, le=10_000)] = 0,
     ) -> dict[str, Any]:
         reject_control_char_query_param(request, "q")
         reject_repeated_query_param(request, "q")
         reject_control_char_query_param(request, "account")
         reject_repeated_query_param(request, "account")
+        reject_repeated_query_param(request, "limit")
+        reject_noncanonical_int_query_param(request, "limit")
+        reject_repeated_query_param(request, "offset")
+        reject_noncanonical_int_query_param(request, "offset")
         with session_scope(db_url) as session:
-            return activity_context(session, q, account)
+            return activity_context(session, q, account, limit=limit, offset=offset)
 
     @app.get("/activity", response_class=HTMLResponse)
     def activity_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:

--- a/app/activity.py
+++ b/app/activity.py
@@ -45,8 +45,10 @@ def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Temp
         reject_repeated_query_param(request, "q")
         reject_control_char_query_param(request, "account")
         reject_repeated_query_param(request, "account")
+        reject_control_char_query_param(request, "limit")
         reject_repeated_query_param(request, "limit")
         reject_noncanonical_int_query_param(request, "limit")
+        reject_control_char_query_param(request, "offset")
         reject_repeated_query_param(request, "offset")
         reject_noncanonical_int_query_param(request, "offset")
         with session_scope(db_url) as session:

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -617,7 +617,12 @@ def pending_activity_rows(
 
 
 def activity_to_dict(
-    session: Session, query: str | None = None, *, account: str | None = None
+    session: Session,
+    query: str | None = None,
+    *,
+    account: str | None = None,
+    limit: int = 100,
+    offset: int = 0,
 ) -> dict[str, Any]:
     """Build the public activity feed and contributor totals."""
     search_query = _activity_search_query(query)
@@ -691,9 +696,11 @@ def activity_to_dict(
             "pending_mrwk": format_mrwk(pending_microunits),
         },
         "query": search_query,
-        "contributors": contributors,
-        "pending_payouts": pending_payouts[:100],
-        "recent": recent[:100],
+        "limit": limit,
+        "offset": offset,
+        "contributors": contributors[offset : offset + limit],
+        "pending_payouts": pending_payouts[offset : offset + limit],
+        "recent": recent[offset : offset + limit],
     }
     if account is not None:
         activity["account"] = account

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -348,6 +348,7 @@ Read accepted-work activity summarized from proof-backed bounty payments:
 curl -s "$API_HOST/api/v1/activity"
 curl -s "$API_HOST/api/v1/activity?q=p3xill"
 curl -s "$API_HOST/api/v1/activity?account=github%3Ap3xill"
+curl -s "$API_HOST/api/v1/activity?limit=25&offset=25"
 ```
 
 Use `account=github:<login>` or `account=mrwk1...` for an exact account-scoped
@@ -357,6 +358,9 @@ activity rows. `q` filters proof-backed and pending activity rows by account,
 amount, submission URL, proof hash, proposal id, bounty repo, bounty issue URL,
 internal bounty id, or GitHub issue number. In other words, the same search can
 match bounty repo, bounty issue URL, proposal, proof, or submission evidence.
+Use `limit` from `1` to `200` and `offset` from `0` upward to page the
+`contributors`, `pending_payouts`, and `recent` arrays after filtering; aggregate
+totals still describe the full matching activity set.
 The response groups
 matching proof-backed bounty payments into `totals`, contributor rollups, and
 the most recent payment rows. Accepted-but-not-yet-executed `pay_bounty`
@@ -376,6 +380,8 @@ execution creates a ledger proof:
     "pending_mrwk": "50"
   },
   "query": "p3xill",
+  "limit": 25,
+  "offset": 0,
   "contributors": [
     {
       "account": "github:p3xill",

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -348,7 +348,7 @@ Read accepted-work activity summarized from proof-backed bounty payments:
 curl -s "$API_HOST/api/v1/activity"
 curl -s "$API_HOST/api/v1/activity?q=p3xill"
 curl -s "$API_HOST/api/v1/activity?account=github%3Ap3xill"
-curl -s "$API_HOST/api/v1/activity?limit=25&offset=25"
+curl -s "$API_HOST/api/v1/activity?q=p3xill&limit=25"
 ```
 
 Use `account=github:<login>` or `account=mrwk1...` for an exact account-scoped
@@ -433,7 +433,7 @@ execution creates a ledger proof:
 ```
 
 `contributors` is sorted by accepted MRWK amount, while `recent` is sorted by
-newest ledger sequence and capped to the latest 100 matching rows. Use
+newest ledger sequence and paginated using `limit` and `offset`. Use
 `proof_hash` with `/api/v1/proofs/<proof_hash>` to inspect the public proof
 payload for a payment.
 

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -293,6 +293,130 @@ def test_activity_api_filters_by_exact_account(sqlite_url: str) -> None:
     assert missing["recent"] == []
 
 
+def test_activity_api_honors_limit_and_offset(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        for issue_number, account, reward in (
+            (180, "github:alice", "10"),
+            (181, "github:bob", "20"),
+            (182, "github:carol", "30"),
+        ):
+            bounty = create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=issue_number,
+                issue_url=f"https://github.com/ramimbo/mergework/issues/{issue_number}",
+                title=f"Activity pagination bounty {issue_number}",
+                reward_mrwk=reward,
+                acceptance="Activity pagination should page public rows.",
+            )
+            pay_bounty(
+                session,
+                bounty_id=bounty.id,
+                to_account=account,
+                submission_url=f"https://github.com/ramimbo/mergework/pull/{issue_number}",
+                accepted_by="maintainer",
+                verifier_result={"label": "mrwk:accepted"},
+            )
+
+        pending_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=183,
+            issue_url="https://github.com/ramimbo/mergework/issues/183",
+            title="Activity pending pagination bounty",
+            reward_mrwk="5",
+            acceptance="Pending activity rows should page public rows.",
+        )
+        propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": pending_bounty.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/183",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    first_page = client.get("/api/v1/activity?limit=1")
+    second_page = client.get("/api/v1/activity?limit=1&offset=1")
+    offset_only = client.get("/api/v1/activity?offset=1")
+
+    assert first_page.status_code == 200
+    assert second_page.status_code == 200
+    assert offset_only.status_code == 200
+
+    first_payload = first_page.json()
+    second_payload = second_page.json()
+    offset_payload = offset_only.json()
+
+    assert first_payload["limit"] == 1
+    assert first_payload["offset"] == 0
+    assert first_payload["totals"] == {
+        "accepted_awards": 3,
+        "accepted_mrwk": "60",
+        "contributors": 3,
+    }
+    assert first_payload["pending_totals"] == {
+        "pending_awards": 1,
+        "pending_mrwk": "5",
+    }
+    assert [row["account"] for row in first_payload["contributors"]] == ["github:carol"]
+    assert [row["account"] for row in first_payload["recent"]] == ["github:carol"]
+    assert [row["account"] for row in first_payload["pending_payouts"]] == ["github:alice"]
+
+    assert second_payload["limit"] == 1
+    assert second_payload["offset"] == 1
+    assert second_payload["totals"] == first_payload["totals"]
+    assert second_payload["pending_totals"] == first_payload["pending_totals"]
+    assert [row["account"] for row in second_payload["contributors"]] == ["github:bob"]
+    assert [row["account"] for row in second_payload["recent"]] == ["github:bob"]
+    assert second_payload["pending_payouts"] == []
+
+    assert offset_payload["limit"] == 100
+    assert offset_payload["offset"] == 1
+    assert [row["account"] for row in offset_payload["contributors"]] == [
+        "github:bob",
+        "github:alice",
+    ]
+    assert [row["account"] for row in offset_payload["recent"]] == [
+        "github:bob",
+        "github:alice",
+    ]
+    assert offset_payload["pending_payouts"] == []
+
+
+def test_activity_api_rejects_invalid_pagination_queries(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    noncanonical_limit = client.get("/api/v1/activity?limit=01")
+    repeated_limit = client.get("/api/v1/activity?limit=1&limit=2")
+    too_small_limit = client.get("/api/v1/activity?limit=0")
+    noncanonical_offset = client.get("/api/v1/activity?offset=01")
+    repeated_offset = client.get("/api/v1/activity?offset=1&offset=2")
+    negative_offset = client.get("/api/v1/activity?offset=-1")
+    controlled_offset = client.get("/api/v1/activity?offset=%C2%851")
+
+    assert noncanonical_limit.status_code == 400
+    assert noncanonical_limit.json()["detail"] == "limit must be a canonical positive integer"
+    assert repeated_limit.status_code == 400
+    assert repeated_limit.json()["detail"] == "limit must be provided at most once"
+    assert too_small_limit.status_code == 422
+    assert noncanonical_offset.status_code == 400
+    assert noncanonical_offset.json()["detail"] == "offset must be a canonical positive integer"
+    assert repeated_offset.status_code == 400
+    assert repeated_offset.json()["detail"] == "offset must be provided at most once"
+    assert negative_offset.status_code == 422
+    assert controlled_offset.status_code == 400
+    assert controlled_offset.json()["detail"] == "offset must not contain control characters"
+
+
 def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -398,16 +398,23 @@ def test_activity_api_rejects_invalid_pagination_queries(sqlite_url: str) -> Non
     noncanonical_limit = client.get("/api/v1/activity?limit=01")
     repeated_limit = client.get("/api/v1/activity?limit=1&limit=2")
     too_small_limit = client.get("/api/v1/activity?limit=0")
+    controlled_limit = client.get("/api/v1/activity?limit=%C2%851")
+    masked_controlled_limit = client.get("/api/v1/activity?limit=%C2%851&limit=2")
     noncanonical_offset = client.get("/api/v1/activity?offset=01")
     repeated_offset = client.get("/api/v1/activity?offset=1&offset=2")
     negative_offset = client.get("/api/v1/activity?offset=-1")
     controlled_offset = client.get("/api/v1/activity?offset=%C2%851")
+    masked_controlled_offset = client.get("/api/v1/activity?offset=%C2%851&offset=2")
 
     assert noncanonical_limit.status_code == 400
     assert noncanonical_limit.json()["detail"] == "limit must be a canonical positive integer"
     assert repeated_limit.status_code == 400
     assert repeated_limit.json()["detail"] == "limit must be provided at most once"
     assert too_small_limit.status_code == 422
+    assert controlled_limit.status_code == 400
+    assert controlled_limit.json()["detail"] == "limit must not contain control characters"
+    assert masked_controlled_limit.status_code == 400
+    assert masked_controlled_limit.json()["detail"] == "limit must not contain control characters"
     assert noncanonical_offset.status_code == 400
     assert noncanonical_offset.json()["detail"] == "offset must be a canonical positive integer"
     assert repeated_offset.status_code == 400
@@ -415,6 +422,8 @@ def test_activity_api_rejects_invalid_pagination_queries(sqlite_url: str) -> Non
     assert negative_offset.status_code == 422
     assert controlled_offset.status_code == 400
     assert controlled_offset.json()["detail"] == "offset must not contain control characters"
+    assert masked_controlled_offset.status_code == 400
+    assert masked_controlled_offset.json()["detail"] == "offset must not contain control characters"
 
 
 def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:

--- a/tests/test_activity_routes.py
+++ b/tests/test_activity_routes.py
@@ -22,4 +22,6 @@ def test_activity_context_preserves_empty_feed_shape(sqlite_url: str) -> None:
             "contributors": [],
             "pending_payouts": [],
             "recent": [],
+            "limit": 100,
+            "offset": 0,
         }

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -399,6 +399,8 @@ def test_activity_serializers_skip_malformed_public_proofs(sqlite_url: str) -> N
         "totals": {"accepted_awards": 0, "accepted_mrwk": "0", "contributors": 0},
         "pending_totals": {"pending_awards": 0, "pending_mrwk": "0"},
         "query": "",
+        "limit": 100,
+        "offset": 0,
         "contributors": [],
         "pending_payouts": [],
         "recent": [],


### PR DESCRIPTION
Bounty #799

Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4628797946

## Summary
- Adds bounded canonical `limit` and `offset` support to the public `/api/v1/activity` endpoint.
- Applies pagination after the existing query/account filtering while keeping `totals` and `pending_totals` representative of the full matching activity set.
- Rejects repeated and non-canonical `limit`/`offset` query values before silently treating them as canonical intent.
- Documents activity pagination fields and examples.

## Production evidence before fix
Read-only checks against current production on 2026-06-05 UTC:

```text
/api/v1/activity?limit=1 -> HTTP 200, contributors=150, first accounts [github:ckeplinger199, github:tatelyman, github:eliasx45], bytes=128283, sha256=8ee90b1eafb8
/api/v1/activity?limit=1&offset=1 -> HTTP 200, contributors=150, first accounts [github:ckeplinger199, github:tatelyman, github:eliasx45], bytes=128283, sha256=8ee90b1eafb8
/api/v1/activity?offset=1 -> HTTP 200, contributors=150, first accounts [github:ckeplinger199, github:tatelyman, github:eliasx45], bytes=128283, sha256=8ee90b1eafb8
/api/v1/activity?limit=01 -> HTTP 200, contributors=150, first accounts [github:ckeplinger199, github:tatelyman, github:eliasx45], bytes=128283, sha256=8ee90b1eafb8
```

## Duplicate / scope check
- I searched open PRs for `activity pagination limit offset` and found no current open PR covering both `limit` and `offset` on `/api/v1/activity`.
- PR #751 is the known older activity `limit` PR from #656, but it is currently `DIRTY`/`mrwk:needs-info`, tied to the exhausted #656 route, and does not implement `offset` or the latest #798 report's full pagination surface.
- This PR stays on current `main` and fixes the source report above in one focused API slice. It does not touch the `/activity` HTML page, payout execution, treasury mutation, wallet behavior, ledger mutation, admin-token behavior, private data, exchange, bridge, cash-out, or MRWK price behavior.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_activity.py tests/test_activity_routes.py tests/test_docs_public_urls.py -q` -> 45 passed, 1 existing Starlette/httpx warning.
- `uv run --python 3.12 --extra dev ruff check app/activity.py app/serializers.py tests/test_activity.py tests/test_activity_routes.py docs/api-examples.md` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check app/activity.py app/serializers.py tests/test_activity.py tests/test_activity_routes.py` -> 4 files already formatted.
- `uv run --python 3.12 --extra dev mypy app/activity.py app/serializers.py` -> success.
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity API supports paginated results via limit/offset (default page size 100) and returns pagination metadata.

* **Improvements**
  * Activity lists (contributors, pending payouts, recent) are now served according to pagination parameters; totals still reflect the full filtered set.

* **Documentation**
  * API examples updated to show pagination and multi-page retrieval.

* **Tests**
  * Added tests for pagination behavior and for rejecting invalid/non-canonical pagination queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->