### PR TITLE
Share me page account summary context

### DIFF
--- a/app/me.py
+++ b/app/me.py
@@ -7,16 +7,20 @@ from sqlalchemy.orm import Session
 from app.ledger.service import format_mrwk, get_balance, linked_wallet_for_github
 
 
-def me_page_context(session: Session, login: str | None) -> dict[str, Any]:
-    github_balance_mrwk = "0"
-    linked_wallet_address = ""
-    if login:
-        github_balance_mrwk = format_mrwk(get_balance(session, f"github:{login}"))
-        linked_wallet = linked_wallet_for_github(session, login)
-        if linked_wallet:
-            linked_wallet_address = linked_wallet.address
+def _github_account_summary(session: Session, login: str) -> dict[str, str]:
+    linked_wallet = linked_wallet_for_github(session, login)
     return {
-        "github_login": login,
-        "github_balance_mrwk": github_balance_mrwk,
-        "linked_wallet_address": linked_wallet_address,
+        "github_balance_mrwk": format_mrwk(get_balance(session, f"github:{login}")),
+        "linked_wallet_address": linked_wallet.address if linked_wallet else "",
     }
+
+
+def me_page_context(session: Session, login: str | None) -> dict[str, Any]:
+    context = {
+        "github_login": login,
+        "github_balance_mrwk": "0",
+        "linked_wallet_address": "",
+    }
+    if login:
+        context.update(_github_account_summary(session, login))
+    return context

--- a/tests/test_me_page.py
+++ b/tests/test_me_page.py
@@ -35,6 +35,28 @@ def test_me_page_context_defaults_for_anonymous_user(sqlite_url: str) -> None:
     }
 
 
+def test_me_page_context_reports_balance_without_linked_wallet(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        add_ledger_entry(
+            session,
+            entry_type="test_github_balance",
+            from_account=TREASURY_ACCOUNT,
+            to_account="github:alice",
+            amount_microunits=4_000_000,
+            reference="test-github-balance",
+        )
+
+        context = me_page_context(session, "alice")
+
+    assert context == {
+        "github_login": "alice",
+        "github_balance_mrwk": "4",
+        "linked_wallet_address": "",
+    }
+
+
 def test_me_page_context_reports_balance_and_linked_wallet(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     public_hex = _wallet_public_hex()


### PR DESCRIPTION
## Summary

Refs Bounty #846.

- Extracts a small `_github_account_summary()` helper for the logged-in GitHub account portion of `me_page_context()`.
- Keeps anonymous defaults in the page context and updates them only when a GitHub login is present.
- Adds coverage for a GitHub account with balance but no linked wallet, preserving the empty linked-wallet field.

## Duplicate / Scope Check

- #846 public bounty row 112 is open with effective award capacity and no pending payout proposals at submission time.
- Open PR searches for `me_page_context`, `app/me.py`, and `test_me_page.py` returned no same-scope PR.
- Scope is limited to me-page context construction and focused tests.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests\test_me_page.py -q` -> 3 passed
- `.\.venv\Scripts\python.exe -m pytest tests\test_me_page.py tests\test_wallet_api.py tests\test_account_routes.py -q` -> 55 passed, 1 existing Starlette/httpx warning
- `.\.venv\Scripts\python.exe -m ruff check app\me.py tests\test_me_page.py` -> passed
- `.\.venv\Scripts\python.exe -m ruff format --check app\me.py tests\test_me_page.py` -> 2 files already formatted
- `.\.venv\Scripts\python.exe -m mypy app\me.py` -> success
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`

No wallet registration, wallet signing, balance calculation, ledger mutation, treasury behavior, payout behavior, proposal execution, admin-token behavior, private data, exchange, bridge, cash-out, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub balance is now properly reported for accounts without a linked wallet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->