### PR TITLE
Link bounty list action surfaces

### DIFF
--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -88,6 +88,11 @@
     <p class="notice">{{ bounty.availability_note }}</p>
     {% endif %}
     <p>{{ bounty.acceptance }}</p>
+    <div class="next-steps-actions" aria-label="Bounty action links for {{ bounty.id }}">
+      <a href="/bounties/{{ bounty.id }}">View details</a>
+      <a href="/api/v1/bounties/{{ bounty.id }}">JSON details</a>
+      <a href="/api/v1/bounties/{{ bounty.id }}/attempts">Active attempts</a>
+    </div>
   </article>
   {% else %}
   {% if query_text or selected_status or selected_availability != "all" %}

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -50,7 +50,7 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert "Open public bounty" in all_rows.text
     assert "Paid public bounty" in all_rows.text
     assert f'href="/bounties/{open_bounty.id}"' in all_rows.text
-    assert 'aria-label="Bounty action links for ' in all_rows.text
+    assert f'aria-label="Bounty action links for {open_bounty.id}"' in all_rows.text
     assert f'href="/api/v1/bounties/{open_bounty.id}">JSON details</a>' in all_rows.text
     assert f'href="/api/v1/bounties/{open_bounty.id}/attempts">Active attempts</a>' in all_rows.text
     assert (

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -50,6 +50,9 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert "Open public bounty" in all_rows.text
     assert "Paid public bounty" in all_rows.text
     assert f'href="/bounties/{open_bounty.id}"' in all_rows.text
+    assert 'aria-label="Bounty action links for ' in all_rows.text
+    assert f'href="/api/v1/bounties/{open_bounty.id}">JSON details</a>' in all_rows.text
+    assert f'href="/api/v1/bounties/{open_bounty.id}/attempts">Active attempts</a>' in all_rows.text
     assert (
         'href="https://github.com/ramimbo/mergework/issues/50" rel="nofollow noopener"'
         in all_rows.text


### PR DESCRIPTION
Bounty #845

## Summary
- Adds contributor-flow action links to each public bounty list card.
- Exposes direct card-level links to the bounty detail page, JSON detail row, and active attempt list.
- Keeps existing source issue, search, sorting, availability, and capacity display behavior unchanged.

## Why this fits #845
The bounty list already shows source issue and capacity context, while the detail page exposes JSON details and active attempt checks. This PR brings those same low-risk routing actions onto the list cards so contributors and agents can move directly from discovery to preflight/duplicate checking without opening each detail page first.

## Duplicate / scope check
- Open PR searches for `bounty list action links attempts JSON details`, `bounties page attempts link`, and `Check active attempts` found no open PR adding card-level list actions.
- PR #890 covers contributor next steps on the bounty detail page; this PR is the list-page counterpart and does not change #890's detail-page content.
- Scope is public page routing only. No bounty API shape, attempt creation, payout execution, treasury mutation, wallet behavior, ledger mutation, admin-token behavior, private data, exchange, bridge, cash-out, or MRWK price behavior changed.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_bounty_pages.py -q` -> 18 passed, 1 existing Starlette/httpx warning.
- `uv run --python 3.12 --extra dev ruff check tests/test_bounty_pages.py` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check tests/test_bounty_pages.py` -> 1 file already formatted.
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bounty cards show a "next steps" actions block with links: "View details", "JSON details", and "Active attempts". The action group includes an ARIA label scoped to the bounty ID for improved accessibility.

* **Tests**
  * Updated tests to verify the bounty action links render correctly, include the ARIA-scoped action group, and point to the expected detail and attempts endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->