### PR TITLE
Honor ledger API offset

### DIFF
--- a/app/ledger_views.py
+++ b/app/ledger_views.py
@@ -26,9 +26,9 @@ def ledger_entries_to_dicts(
     return [ledger_to_dict(entry, proofs.get(entry.sequence)) for entry in entries]
 
 
-def recent_ledger_entries(session: Session, limit: int) -> list[dict[str, Any]]:
+def recent_ledger_entries(session: Session, limit: int, offset: int = 0) -> list[dict[str, Any]]:
     entries = session.scalars(
-        select(LedgerEntry).order_by(LedgerEntry.sequence.desc()).limit(limit)
+        select(LedgerEntry).order_by(LedgerEntry.sequence.desc()).offset(offset).limit(limit)
     ).all()
     return ledger_entries_to_dicts(session, entries)
 

--- a/app/main.py
+++ b/app/main.py
@@ -306,18 +306,20 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         post_only_route=post_only_route,
     )
 
-    def ledger_rows(limit: int = 50) -> list[dict[str, Any]]:
+    def ledger_rows(limit: int = 50, offset: int = 0) -> list[dict[str, Any]]:
         with session_scope(db_url) as session:
-            return recent_ledger_entries(session, limit)
+            return recent_ledger_entries(session, limit, offset)
 
     @app.get("/api/v1/ledger")
     def api_ledger(
         request: Request,
         limit: Annotated[int, Query(ge=1, le=200)] = 50,
+        offset: Annotated[int, Query(ge=0, le=SQLITE_INTEGER_MAX)] = 0,
     ) -> list[dict[str, Any]]:
-        reject_repeated_query_param(request, "limit")
-        reject_noncanonical_int_query_param(request, "limit")
-        return ledger_rows(limit)
+        for name in ("limit", "offset"):
+            reject_repeated_query_param(request, name)
+            reject_noncanonical_int_query_param(request, name)
+        return ledger_rows(limit, offset)
 
     @app.get("/api/v1/ledger/{sequence}")
     def api_ledger_entry(sequence: int | str) -> dict[str, Any]:

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -318,11 +318,12 @@ Read recent ledger entries and inspect one entry:
 
 ```bash
 curl -s "$API_HOST/api/v1/ledger?limit=10"
+curl -s "$API_HOST/api/v1/ledger?limit=10&offset=10"
 curl -s "$API_HOST/api/v1/ledger/<sequence>"
 ```
 
 Ledger entries use the internal immutable sequence number as the API path key.
-Recent-list and single-entry responses share the same shape:
+Recent-list queries accept `limit` from `1` to `200` and `offset` from `0` through SQLite's signed integer maximum. Recent-list and single-entry responses share the same shape:
 
 ```json
 {

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -102,6 +102,56 @@ def test_ledger_api_rejects_repeated_limit_before_using_later_value(sqlite_url: 
     assert response.json()["detail"] == "limit must be provided at most once"
 
 
+def test_ledger_api_honors_offset(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        older_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=201,
+            issue_url="https://github.com/ramimbo/mergework/issues/201",
+            title="Older ledger row",
+            reward_mrwk="25",
+            acceptance="Ledger offset should skip newest rows.",
+        )
+        newer_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=202,
+            issue_url="https://github.com/ramimbo/mergework/issues/202",
+            title="Newer ledger row",
+            reward_mrwk="25",
+            acceptance="Ledger offset should return later pages.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    newest = client.get("/api/v1/ledger?limit=1")
+    shifted = client.get("/api/v1/ledger?limit=1&offset=1")
+    exhausted = client.get("/api/v1/ledger?limit=1&offset=99")
+    max_valid = client.get("/api/v1/ledger?offset=9223372036854775807")
+    negative = client.get("/api/v1/ledger?offset=-1")
+    oversized = client.get("/api/v1/ledger?offset=9999999999999999999999999999999999999999")
+    noncanonical = client.get("/api/v1/ledger?offset=01")
+    repeated = client.get("/api/v1/ledger?offset=1&offset=2")
+
+    assert newest.status_code == 200
+    assert shifted.status_code == 200
+    assert [entry["reference"] for entry in newest.json()] == [newer_bounty.issue_url]
+    assert [entry["reference"] for entry in shifted.json()] == [older_bounty.issue_url]
+    assert exhausted.status_code == 200
+    assert exhausted.json() == []
+    assert max_valid.status_code == 200
+    assert max_valid.json() == []
+    assert negative.status_code == 422
+    assert oversized.status_code == 422
+    assert noncanonical.status_code == 400
+    assert noncanonical.json()["detail"] == "offset must be a canonical positive integer"
+    assert repeated.status_code == 400
+    assert repeated.json()["detail"] == "offset must be provided at most once"
+
+
 def test_head_requests_match_get_routes_without_body(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -94,6 +94,7 @@ def test_api_examples_document_ledger_response_shape() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 
     assert "/api/v1/ledger?limit=10" in examples
+    assert "/api/v1/ledger?limit=10&offset=10" in examples
     assert "/api/v1/ledger/<sequence>" in examples
     assert '"sequence": 329' in examples
     assert '"type": "bounty_reserve"' in examples
@@ -105,6 +106,7 @@ def test_api_examples_document_ledger_response_shape() -> None:
     )
     assert '"proof_hash": null' in examples
     assert "bounty-payment ledger entries" in examples
+    assert "offset` from `0` through SQLite's signed integer maximum" in examples
 
 
 def test_api_examples_document_auth_me_response_shape() -> None:


### PR DESCRIPTION
## Summary
- Add bounded `offset=0..SQLITE_INTEGER_MAX` support to `/api/v1/ledger`.
- Apply the offset after newest-first ledger ordering so callers can page immutable ledger history.
- Validate repeated and non-canonical `offset` values with the same scalar query guards used by `limit`.
- Document the ledger offset query example and guard it with docs coverage.

Bounty #799
Source report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4621977133

## Production behavior before fix
- `GET https://api.mrwk.online/api/v1/ledger?limit=1` -> sequence `[1178]`.
- `GET https://api.mrwk.online/api/v1/ledger?limit=1&offset=1` -> sequence `[1178]` again.
- `GET https://api.mrwk.online/api/v1/ledger?offset=1` -> default first page starting `[1178, 1177, 1176]`.
- `GET https://api.mrwk.online/api/v1/ledger?limit=01` -> HTTP 400, so nearby integer query handling is already strict.

## Validation
- `python -m pytest tests\test_api_mcp.py::test_ledger_api_honors_offset -q`
- `python -m pytest tests\test_docs_public_urls.py::test_api_examples_document_ledger_response_shape -q`
- `python -m pytest tests\test_api_mcp.py tests\test_docs_public_urls.py -q`
- `python -m ruff check app\main.py app\ledger_views.py tests\test_api_mcp.py tests\test_docs_public_urls.py`
- `python -m ruff format --check app\main.py app\ledger_views.py tests\test_api_mcp.py tests\test_docs_public_urls.py`
- `python -m mypy app\main.py app\ledger_views.py`
- `python scripts\docs_smoke.py`
- `git diff --check`
- `git merge-tree --write-tree origin/main HEAD`

## Scope
Public ledger list pagination only. No ledger writes, proof generation, payout execution, treasury mutation, wallet behavior, private data, secrets, bridge/exchange/cash-out behavior, or MRWK price behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The ledger API endpoint now supports offset-based pagination. Users can use the new `offset` query parameter in combination with `limit` to retrieve paginated ledger entries.

* **Documentation**
  * Updated API documentation with examples of offset pagination, including accepted parameter ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->