### PR TITLE
Share duplicate attempt response

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -211,6 +211,22 @@ def expire_stale_bounty_attempts(
     session.execute(query.values(status="expired", updated_at=now))
 
 
+def _duplicate_active_attempt_response(
+    session: Session,
+    bounty: Bounty,
+    attempt: BountyAttempt,
+    now: datetime,
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=409,
+        content={
+            "status": "duplicate_active_attempt",
+            "attempt": bounty_attempt_to_dict(attempt, now),
+            "warnings": bounty_attempt_warnings(session, bounty, now),
+        },
+    )
+
+
 def register_bounty_attempt_routes(
     app: FastAPI,
     *,
@@ -319,14 +335,7 @@ def register_bounty_attempt_routes(
                 .limit(1)
             )
             if existing is not None:
-                return JSONResponse(
-                    status_code=409,
-                    content={
-                        "status": "duplicate_active_attempt",
-                        "attempt": bounty_attempt_to_dict(existing, now),
-                        "warnings": bounty_attempt_warnings(session, bounty, now),
-                    },
-                )
+                return _duplicate_active_attempt_response(session, bounty, existing, now)
             attempt = BountyAttempt(
                 bounty_id=bounty_id_int,
                 submitter_account=submitter_account,
@@ -355,14 +364,7 @@ def register_bounty_attempt_routes(
                     raise HTTPException(
                         status_code=409, detail="active attempt already exists"
                     ) from None
-                return JSONResponse(
-                    status_code=409,
-                    content={
-                        "status": "duplicate_active_attempt",
-                        "attempt": bounty_attempt_to_dict(existing, now),
-                        "warnings": bounty_attempt_warnings(session, bounty, now),
-                    },
-                )
+                return _duplicate_active_attempt_response(session, bounty, existing, now)
             return JSONResponse(
                 status_code=201,
                 content={


### PR DESCRIPTION
Bounty #846

## Summary
- Extract the duplicated `duplicate_active_attempt` 409 JSON response into a private helper in `app/bounty_attempts.py`.
- Reuse that helper for both the normal active-attempt duplicate path and the `IntegrityError` fallback path.
- Preserve the existing response shape, warning calculation, and attempt serialization behavior.

## Why this fits #846
This is a focused maintainability cleanup: the route currently builds the same duplicate-attempt response in two places. Sharing the response construction keeps the two duplicate paths in sync without changing the public API contract.

## Duplicate / scope check
- #846 public bounty row is open with effective award capacity.
- `gh pr list --repo ramimbo/mergework --state open --search "duplicate_active_attempt OR active attempt duplicate OR IntegrityError bounty_attempts"` did not show a same-scope open PR.
- `gh search prs "duplicate_active_attempt bounty_attempts repo:ramimbo/mergework" --state open` returned no same-scope PR.
- This does not duplicate #912, which is about source URL control-character validation, or #916, which is MCP attempt selector usability.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_bounty_attempts.py::test_bounty_attempts_register_list_duplicate_and_release -q`
- `uv run --python 3.12 --extra dev python -m pytest tests/test_bounty_attempts.py tests/test_bounty_api_routes.py -q`
- `uv run --python 3.12 --extra dev ruff check app/bounty_attempts.py`
- `uv run --python 3.12 --extra dev ruff format --check app/bounty_attempts.py`
- `uv run --python 3.12 --extra dev mypy app/bounty_attempts.py`
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py`
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`

## Scope
No public API contract, attempt lifecycle state, bounty availability logic, ledger behavior, wallet behavior, treasury behavior, payout behavior, proposal execution, admin-token behavior, private data, credentials, secrets, exchange, bridge, cash-out, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for bounty attempt error handling. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->