### PR TITLE
Share bounty board row rendering

### DIFF
--- a/app/github_bounty_board.py
+++ b/app/github_bounty_board.py
@@ -61,6 +61,18 @@ def _unavailable_bounties(open_bounties: Sequence[dict[str, Any]]) -> list[dict[
     ]
 
 
+def _bounty_table_row(bounty: dict[str, Any]) -> str:
+    return " | ".join(
+        [
+            f"| {_issue_link(bounty.get('issue_number'), bounty.get('issue_url'))}",
+            _work_lane(bounty.get("title")),
+            f"{_markdown_cell(bounty.get('reward_mrwk'))} MRWK",
+            str(_int_value(bounty.get("effective_awards_remaining"))),
+            f"{_markdown_cell(bounty.get('availability_note'))} |",
+        ]
+    )
+
+
 def _claimable_table(open_bounties: Sequence[dict[str, Any]]) -> list[str]:
     rows = [
         "| Issue | Work lane | Reward | Effective slots | Status |",
@@ -73,17 +85,7 @@ def _claimable_table(open_bounties: Sequence[dict[str, Any]]) -> list[str]:
             _int_value(item.get("issue_number")),
         ),
     ):
-        rows.append(
-            " | ".join(
-                [
-                    f"| {_issue_link(bounty.get('issue_number'), bounty.get('issue_url'))}",
-                    _work_lane(bounty.get("title")),
-                    f"{_markdown_cell(bounty.get('reward_mrwk'))} MRWK",
-                    str(_int_value(bounty.get("effective_awards_remaining"))),
-                    f"{_markdown_cell(bounty.get('availability_note'))} |",
-                ]
-            )
-        )
+        rows.append(_bounty_table_row(bounty))
     if len(rows) == 2:
         rows.append(
             "| - | No live bounty currently has effective capacity. | - | 0 | Check opening soon. |"
@@ -102,17 +104,7 @@ def _unavailable_table(open_bounties: Sequence[dict[str, Any]]) -> list[str]:
         "| --- | --- | ---: | ---: | --- |",
     ]
     for bounty in sorted(unavailable, key=lambda item: _int_value(item.get("issue_number"))):
-        rows.append(
-            " | ".join(
-                [
-                    f"| {_issue_link(bounty.get('issue_number'), bounty.get('issue_url'))}",
-                    _work_lane(bounty.get("title")),
-                    f"{_markdown_cell(bounty.get('reward_mrwk'))} MRWK",
-                    str(_int_value(bounty.get("effective_awards_remaining"))),
-                    f"{_markdown_cell(bounty.get('availability_note'))} |",
-                ]
-            )
-        )
+        rows.append(_bounty_table_row(bounty))
     return rows
 
 


### PR DESCRIPTION
## Summary
- Extract the duplicated GitHub bounty board table-row rendering into a private `_bounty_table_row()` helper.
- Keep the claimable and unavailable board tables on the same formatting path without changing their output, sorting, or availability rules.

## Bounty fit
- Refs #846 as a focused maintainability cleanup.
- Checked the live bounty capacity before starting.
- Checked open PRs for this exact `github_bounty_board` row-rendering scope; no same-scope open PR found.

## Scope safety
- No public API changes.
- No bounty lifecycle, GitHub issue update, treasury, payout, ledger, wallet, admin-token, private-data, exchange, bridge, cash-out, or MRWK price changes.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_github_bounty_board.py -q` -> 6 passed
- `uv run --python 3.12 --extra dev ruff check app/github_bounty_board.py tests/test_github_bounty_board.py` -> passed
- `uv run --python 3.12 --extra dev mypy app/github_bounty_board.py` -> success
- `uv run --python 3.12 --extra dev ruff format --check app/github_bounty_board.py tests/test_github_bounty_board.py` -> already formatted
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean merge tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements for maintainability with no visible impact to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->