### PR TITLE
Join bounty rows during payout reconciliation

### DIFF
--- a/app/ledger/reconciliation.py
+++ b/app/ledger/reconciliation.py
@@ -65,14 +65,14 @@ class DuplicateAcceptedSourceUrl:
 
 
 def reconcile_accepted_payouts(session: Session) -> list[AcceptedPayoutCheck]:
-    submissions = session.scalars(
-        select(Submission).where(Submission.status == "accepted").order_by(Submission.id)
+    rows = session.execute(
+        select(Submission, Bounty)
+        .join(Bounty, Bounty.id == Submission.bounty_id)
+        .where(Submission.status == "accepted")
+        .order_by(Submission.id)
     ).all()
     checks: list[AcceptedPayoutCheck] = []
-    for submission in submissions:
-        bounty = session.get(Bounty, submission.bounty_id)
-        if bounty is None:
-            continue
+    for submission, bounty in rows:
         evidence = _payout_evidence(session, submission, bounty)
         checks.append(
             AcceptedPayoutCheck(


### PR DESCRIPTION
## Summary
- Load accepted submissions together with their bounty rows in `reconcile_accepted_payouts()`.
- Remove the per-submission `session.get(Bounty, ...)` lookup and reuse the same join shape already used by duplicate source reconciliation.
- Preserve payout evidence matching, ordering, and summary semantics.

Bounty #846

## Duplicate/current check
- #846 public bounty row is live/open with effective award capacity.
- Searched open PRs for `ledger_reconciliation`, `reconcile accepted payouts`, and bounty join cleanup; no same-scope open PR found.
- Current #846 PRs cover sorting, route wiring, public URLs, MCP selectors, query/config/account/staging/GitHub helpers, executor/schema/OAuth/wallet/treasury/webhook/bounty-attempt cleanup, JSON payloads, and bounty-board row rendering, not payout reconciliation row loading.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_ledger_reconciliation.py -q` -> 8 passed
- `uv run --python 3.12 --extra dev python -m pytest tests/test_ledger_reconciliation.py tests/test_bounty_api_routes.py -q` -> 28 passed, 1 existing Starlette/httpx warning
- `uv run --python 3.12 --extra dev python -m pytest tests/test_security.py::test_admin_payout_reconciliation_api_reports_missing_and_duplicate_evidence tests/test_bounty_api.py::TestReconciliationRoute::test_reconciliation_requires_auth -q` -> 2 passed, 1 existing Starlette/httpx warning
- `uv run --python 3.12 --extra dev ruff check app/ledger/reconciliation.py tests/test_ledger_reconciliation.py` -> passed
- `uv run --python 3.12 --extra dev ruff format --check app/ledger/reconciliation.py tests/test_ledger_reconciliation.py` -> already formatted
- `uv run --python 3.12 --extra dev mypy app/ledger/reconciliation.py` -> success
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean merge tree

## Scope safety
- No public API shape changes.
- No payout execution, ledger mutation, treasury mutation, wallet behavior, bounty lifecycle semantics, admin-token behavior, private data, exchange, bridge, cash-out, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized payout reconciliation data retrieval for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->