### PR TITLE
Add get_wallet MCP input schema

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -37,7 +37,22 @@ MCP_TOOLS: list[dict[str, Any]] = [
         "name": "register_wallet",
         "description": "Register an MRWK wallet public key",
     },
-    {"name": "get_wallet", "description": "Get an MRWK wallet by address"},
+    {
+        "name": "get_wallet",
+        "description": "Get an MRWK wallet by address",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string",
+                    "pattern": "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$",
+                    "description": "MRWK wallet address, using the mrwk1 prefix and 40 hex chars.",
+                },
+            },
+            "required": ["address"],
+            "additionalProperties": False,
+        },
+    },
     {
         "name": "submit_wallet_transfer",
         "description": "Submit a signed MRWK wallet transfer",

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -268,6 +268,13 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
         tool for tool in tools["result"]["tools"] if tool["name"] == "list_bounty_attempts"
     )
     assert "active-attempt reservations" in attempt_tool["description"]
+    wallet_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_wallet")
+    wallet_schema = wallet_tool["inputSchema"]
+    assert wallet_schema["required"] == ["address"]
+    assert wallet_schema["additionalProperties"] is False
+    assert wallet_schema["properties"]["address"]["pattern"] == (
+        "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$"
+    )
 
     balance = client.post(
         "/mcp",


### PR DESCRIPTION
## Summary
- Add an MCP `inputSchema` for the `get_wallet` tool so agents can discover the required `address` argument from `tools/list`.
- Document the canonical `mrwk1` + 40 hex character address shape in the schema while preserving the existing `tools/call` behavior.
- Add regression coverage to keep the schema exposed through the MCP tool list.

## Test Plan
- `uv run --python 3.12 --extra dev pytest tests/test_api_mcp.py::test_mcp_tools_list_and_call tests/test_api_mcp.py::test_mcp_get_wallet_returns_not_found_for_unregistered_wallet`
- `uv run --python 3.12 --extra dev ruff check app/mcp.py tests/test_api_mcp.py`
- `uv run --python 3.12 --extra dev ruff format --check app/mcp.py tests/test_api_mcp.py`

## Bounty
- Bounty #844: https://github.com/ramimbo/mergework/issues/844
- Public bounty row: https://mrwk.online/bounties/110

## Scope
- MCP metadata and tests only.
- No runtime validation, ledger, transfer, wallet custody, treasury, payout, bridge, exchange, off-ramp, or cash-out behavior changed.
- This avoids the broader stale schema work in #738 and focuses only on the currently unschematized `get_wallet` tool metadata.
