### PR TITLE
Reject unexpected MCP wallet arguments

### DIFF
--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -151,6 +151,12 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             return bounty_by_issue_number(repo_selector)
         raise ValueError(f"{internal_id_field} or issue_number is required")
 
+    def reject_unexpected_args(tool_name: str, allowed: set[str]) -> None:
+        unexpected = sorted(set(args) - allowed)
+        if unexpected:
+            names = ", ".join(unexpected)
+            raise ValueError(f"{tool_name} received unexpected argument(s): {names}")
+
     with session_scope(database_url) as session:
         if name == "list_bounties":
             status = optional_clean_str_arg("status") or "open"
@@ -221,6 +227,7 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             account = normalized_account(str_arg("account"))
             return f"{account}: {format_mrwk(get_balance(session, account))} MRWK"
         if name == "register_wallet":
+            reject_unexpected_args("register_wallet", {"public_key_hex", "label"})
             wallet = register_wallet(
                 session,
                 public_key_hex=str_arg("public_key_hex"),
@@ -233,6 +240,17 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 return "wallet not found"
             return json.dumps(wallet_to_dict(session, wallet_row))
         if name == "submit_wallet_transfer":
+            reject_unexpected_args(
+                "submit_wallet_transfer",
+                {
+                    "from_address",
+                    "to_address",
+                    "amount_mrwk",
+                    "nonce",
+                    "memo",
+                    "signature_hex",
+                },
+            )
             transfer = submit_wallet_transfer(
                 session,
                 from_address=str_arg("from_address"),

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -2489,3 +2489,58 @@ def test_mcp_can_register_and_fetch_wallet(sqlite_url: str) -> None:
     assert fetched_wallet["address"] == registered_wallet["address"]
     assert fetched_wallet["label"] == "MCP wallet"
     assert fetched_wallet["created_at"] == registered_wallet["created_at"]
+
+
+def test_mcp_wallet_write_tools_reject_unexpected_arguments(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    register_response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "register_wallet",
+                "arguments": {
+                    "public_key_hex": "22" * 32,
+                    "label": "MCP wallet",
+                    "public_key": "22" * 32,
+                },
+            },
+        },
+    )
+
+    assert register_response.status_code == 200
+    assert register_response.json() == {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+    transfer_response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_wallet_transfer",
+                "arguments": {
+                    "from_address": "mrwk1" + "1" * 40,
+                    "to_address": "mrwk1" + "2" * 40,
+                    "amount_mrwk": "1",
+                    "nonce": 1,
+                    "memo": "test",
+                    "signature_hex": "aa" * 64,
+                    "signature": "aa" * 64,
+                },
+            },
+        },
+    )
+
+    assert transfer_response.status_code == 200
+    assert transfer_response.json()["error"] == {
+        "code": -32602,
+        "message": "invalid tool arguments",
+    }


### PR DESCRIPTION
## Summary
- Reject undeclared MCP arguments for wallet write tools: `register_wallet` and `submit_wallet_transfer`.
- Prevent typoed fields such as `public_key` or `signature` from being silently ignored while the tool call succeeds or continues to deeper wallet validation.
- Keep valid wallet registration and transfer argument names, response shapes, signature verification, ledger mutation behavior, and wallet semantics unchanged.

Bounty #844

## Why this fits #844
This is a focused MCP safe argument-error and conformance improvement. Existing read-only MCP tools already reject unexpected arguments in open PR #899; this PR applies the same agent-facing safety expectation to wallet write tools without changing valid write behavior.

## Duplicate / scope check
- #844 public bounty row is open with effective award capacity.
- Open PR search for unexpected MCP wallet arguments, `register_wallet`, and `submit_wallet_transfer` found no same-scope PR.
- This is distinct from #899, which covers read-only selector tools, and does not duplicate #885 `get_balance` structured output, #891 selector docs, #892 `list_bounties` unknown args, or #856 `submit_work_proof` contract work.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py::test_mcp_can_register_and_fetch_wallet tests\test_api_mcp.py::test_mcp_wallet_write_tools_reject_unexpected_arguments -q` -> 2 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py tests\test_mcp_tools.py -q` -> 113 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\python.exe -m ruff check app\mcp_tools.py tests\test_api_mcp.py` -> passed.
- `.\.venv\Scripts\python.exe -m ruff format --check app\mcp_tools.py tests\test_api_mcp.py` -> 2 files already formatted.
- `.\.venv\Scripts\python.exe -m mypy app\mcp_tools.py app\mcp.py` -> success.
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`.

## Scope
MCP argument validation only. No wallet registration semantics, transfer signing, nonce validation, amount handling, ledger writes, treasury behavior, payout execution, proposal execution, admin-token behavior, private data, credentials, secrets, exchange, bridge, cash-out, or MRWK price behavior changed.