### PR TITLE
Share bounty sorting key helpers

### DIFF
--- a/app/bounty_sorting.py
+++ b/app/bounty_sorting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from decimal import Decimal
 from typing import Any
 
@@ -15,6 +16,37 @@ BOUNTY_SORT_LABELS = {
 }
 BOUNTY_SORT_OPTIONS = tuple(BOUNTY_SORT_LABELS)
 BOUNTY_SORT_ERROR = f"sort must be one of: {', '.join(BOUNTY_SORT_OPTIONS)}"
+_BountySortKey = Callable[[dict[str, Any]], Any]
+
+
+def _bounty_id(bounty: dict[str, Any]) -> int:
+    return int(bounty["id"])
+
+
+def _reward_sort_key(bounty: dict[str, Any]) -> tuple[Decimal, int]:
+    return Decimal(str(bounty["reward_mrwk"])), _bounty_id(bounty)
+
+
+def _available_sort_key(bounty: dict[str, Any]) -> tuple[Decimal, int]:
+    return (
+        Decimal(str(bounty.get("effective_available_mrwk", bounty["available_mrwk"]))),
+        _bounty_id(bounty),
+    )
+
+
+def _awards_sort_key(bounty: dict[str, Any]) -> tuple[int, int]:
+    return (
+        int(bounty.get("effective_awards_remaining", bounty["awards_remaining"])),
+        _bounty_id(bounty),
+    )
+
+
+_BOUNTY_SORT_KEYS: dict[str, _BountySortKey] = {
+    "newest": _bounty_id,
+    "reward": _reward_sort_key,
+    "available": _available_sort_key,
+    "awards": _awards_sort_key,
+}
 
 
 def normalize_bounty_sort(sort: str | None) -> str:
@@ -31,28 +63,4 @@ def normalize_bounty_sort(sort: str | None) -> str:
 
 def sort_bounties(bounties: list[dict[str, Any]], sort: str | None) -> list[dict[str, Any]]:
     normalized_sort = normalize_bounty_sort(sort)
-    if normalized_sort == "newest":
-        return sorted(bounties, key=lambda bounty: int(bounty["id"]), reverse=True)
-    if normalized_sort == "reward":
-        return sorted(
-            bounties,
-            key=lambda bounty: (Decimal(str(bounty["reward_mrwk"])), int(bounty["id"])),
-            reverse=True,
-        )
-    if normalized_sort == "available":
-        return sorted(
-            bounties,
-            key=lambda bounty: (
-                Decimal(str(bounty.get("effective_available_mrwk", bounty["available_mrwk"]))),
-                int(bounty["id"]),
-            ),
-            reverse=True,
-        )
-    return sorted(
-        bounties,
-        key=lambda bounty: (
-            int(bounty.get("effective_awards_remaining", bounty["awards_remaining"])),
-            int(bounty["id"]),
-        ),
-        reverse=True,
-    )
+    return sorted(bounties, key=_BOUNTY_SORT_KEYS[normalized_sort], reverse=True)

--- a/tests/test_bounty_sorting.py
+++ b/tests/test_bounty_sorting.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from app.bounty_sorting import normalize_bounty_sort, sort_bounties
+
+
+def _bounty(
+    bounty_id: int,
+    *,
+    reward_mrwk: str = "10",
+    available_mrwk: str = "10",
+    awards_remaining: int = 1,
+    effective_available_mrwk: str | None = None,
+    effective_awards_remaining: int | None = None,
+) -> dict[str, object]:
+    bounty: dict[str, object] = {
+        "id": bounty_id,
+        "reward_mrwk": reward_mrwk,
+        "available_mrwk": available_mrwk,
+        "awards_remaining": awards_remaining,
+    }
+    if effective_available_mrwk is not None:
+        bounty["effective_available_mrwk"] = effective_available_mrwk
+    if effective_awards_remaining is not None:
+        bounty["effective_awards_remaining"] = effective_awards_remaining
+    return bounty
+
+
+def _ids(bounties: list[dict[str, object]]) -> list[int]:
+    return [int(bounty["id"]) for bounty in bounties]
+
+
+def test_normalize_bounty_sort_defaults_and_validates() -> None:
+    assert normalize_bounty_sort(None) == "newest"
+    assert normalize_bounty_sort(" Reward ") == "reward"
+
+    with pytest.raises(ValueError, match="sort must not contain control characters"):
+        normalize_bounty_sort("\x85reward")
+
+    with pytest.raises(ValueError, match="sort must be one of"):
+        normalize_bounty_sort("oldest")
+
+
+def test_sort_bounties_uses_shared_sort_keys() -> None:
+    bounties = [
+        _bounty(1, reward_mrwk="25", available_mrwk="75", awards_remaining=3),
+        _bounty(3, reward_mrwk="10", available_mrwk="90", awards_remaining=4),
+        _bounty(
+            2,
+            reward_mrwk="25",
+            available_mrwk="50",
+            awards_remaining=5,
+            effective_available_mrwk="10",
+            effective_awards_remaining=1,
+        ),
+    ]
+
+    assert _ids(sort_bounties(bounties, "newest")) == [3, 2, 1]
+    assert _ids(sort_bounties(bounties, "reward")) == [2, 1, 3]
+    assert _ids(sort_bounties(bounties, "available")) == [3, 1, 2]
+    assert _ids(sort_bounties(bounties, "awards")) == [3, 1, 2]


### PR DESCRIPTION
Refs #846.

## Summary
- Extract bounty list sort key construction into named helpers and a shared internal mapping.
- Keep the existing `newest`, `reward`, `available`, and `awards` ordering semantics unchanged.
- Add direct tests for sort normalization and all shared sort keys, including effective availability/award fallbacks.

## Duplicate / scope check
- I checked the current open PR file list before starting. No open PR was touching `app/bounty_sorting.py` or `tests/test_bounty_sorting.py`.
- This is intentionally limited to the shared bounty sorting helper and direct unit coverage.
- It does not change API/MCP route behavior, database state, bounty serialization, or public templates.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_bounty_sorting.py tests/test_bounty_api.py::TestBountyListRoutes -q` -> 11 passed, 1 existing Starlette/httpx warning.
- `uv run --python 3.12 --extra dev ruff check app/bounty_sorting.py tests/test_bounty_sorting.py` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check app/bounty_sorting.py tests/test_bounty_sorting.py` -> 2 files already formatted.
- `uv run --python 3.12 --extra dev mypy app/bounty_sorting.py` -> success.
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `abda6f4c7b8cc6d19c1ef4bc0fd2711b121cfce1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal organization of bounty sorting logic for better maintainability and consistency.

* **Tests**
  * Added comprehensive test coverage for bounty sorting functionality, including validation of sort parameters and sorting behavior across multiple sort modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->