### PR TITLE
Reject control-padded MCP work proof format

### DIFF
--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -97,6 +97,8 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             return "text"
         if not isinstance(value, str):
             raise ValueError("format must be a string")
+        if contains_control_character(value):
+            raise ValueError("format must not contain control characters")
         normalized = value.strip().lower()
         if normalized not in {"text", "json"}:
             raise ValueError("format must be text or json")

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1989,6 +1989,7 @@ def test_mcp_submit_work_proof_scopes_issue_number_by_repo(sqlite_url: str) -> N
         ({"bounty_id": 1, "issue_number": 1}, 25),
         ({"format": "xml"}, 26),
         ({"format": 1}, 27),
+        ({"format": "\u0085json"}, 28),
         ({"repo": "ramimbo/mergework"}, 29),
         ({"bounty_id": 1, "repo": "ramimbo/mergework"}, 30),
         ({"issue_number": 1, "repo": 1}, 31),


### PR DESCRIPTION
## Summary

Bounty #844
Refs #819

- reject raw control characters in the MCP `submit_work_proof` `format` argument before trimming/lowercasing
- add regression coverage for a C1-control-padded `format` value that previously normalized to `json`
- preserve existing valid `text`, `json`, and omitted/null format behavior

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py -q` -> 106 passed, 1 existing Starlette/httpx warning
- `.\.venv\Scripts\python.exe -m ruff check app\mcp_tools.py tests\test_api_mcp.py` -> passed
- `.\.venv\Scripts\python.exe -m ruff format --check app\mcp_tools.py tests\test_api_mcp.py` -> 2 files already formatted

## Scope safety

No wallet registration, wallet transfer signing, ledger mutation, bounty payout, treasury mutation, admin-token behavior, private data, credentials, secrets, exchange, bridge, cash-out, or MRWK price/liquidity behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of format arguments to reject inputs containing control characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->