### PR TITLE
Share executor config env specs

### DIFF
--- a/app/treasury_executor_config.py
+++ b/app/treasury_executor_config.py
@@ -22,6 +22,32 @@ class ExecutorConfig:
     bounty_board_refresh_interval_seconds: int
 
 
+@dataclass(frozen=True)
+class _PositiveIntEnv:
+    name: str
+    default: int
+    minimum: int
+    maximum: int | None = None
+
+
+_INTERVAL_SECONDS_ENV = _PositiveIntEnv(
+    "MERGEWORK_TREASURY_EXECUTOR_INTERVAL_SECONDS",
+    DEFAULT_INTERVAL_SECONDS,
+    MIN_INTERVAL_SECONDS,
+)
+_BATCH_LIMIT_ENV = _PositiveIntEnv(
+    "MERGEWORK_TREASURY_EXECUTOR_BATCH_LIMIT",
+    DEFAULT_BATCH_LIMIT,
+    1,
+    MAX_BATCH_LIMIT,
+)
+_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS_ENV = _PositiveIntEnv(
+    "MERGEWORK_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS",
+    DEFAULT_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS,
+    MIN_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS,
+)
+
+
 def _enabled_from_env(value: str | None) -> bool:
     normalized = (value or "").strip().lower()
     if normalized in TRUE_VALUES:
@@ -31,18 +57,16 @@ def _enabled_from_env(value: str | None) -> bool:
     raise ValueError("MERGEWORK_TREASURY_EXECUTOR_ENABLED must be true or false")
 
 
-def _positive_int_from_env(
-    env: Mapping[str, str], name: str, default: int, *, minimum: int, maximum: int | None = None
-) -> int:
-    raw = env.get(name, str(default)).strip()
+def _positive_int_from_env(env: Mapping[str, str], setting: _PositiveIntEnv) -> int:
+    raw = env.get(setting.name, str(setting.default)).strip()
     try:
         value = int(raw)
     except ValueError as exc:
-        raise ValueError(f"{name} must be an integer") from exc
-    if value < minimum:
-        raise ValueError(f"{name} must be at least {minimum}")
-    if maximum is not None and value > maximum:
-        raise ValueError(f"{name} must be at most {maximum}")
+        raise ValueError(f"{setting.name} must be an integer") from exc
+    if value < setting.minimum:
+        raise ValueError(f"{setting.name} must be at least {setting.minimum}")
+    if setting.maximum is not None and value > setting.maximum:
+        raise ValueError(f"{setting.name} must be at most {setting.maximum}")
     return value
 
 
@@ -52,21 +76,14 @@ def executor_config_from_env(env: Mapping[str, str] | None = None) -> ExecutorCo
         enabled=_enabled_from_env(source.get("MERGEWORK_TREASURY_EXECUTOR_ENABLED")),
         interval_seconds=_positive_int_from_env(
             source,
-            "MERGEWORK_TREASURY_EXECUTOR_INTERVAL_SECONDS",
-            DEFAULT_INTERVAL_SECONDS,
-            minimum=MIN_INTERVAL_SECONDS,
+            _INTERVAL_SECONDS_ENV,
         ),
         batch_limit=_positive_int_from_env(
             source,
-            "MERGEWORK_TREASURY_EXECUTOR_BATCH_LIMIT",
-            DEFAULT_BATCH_LIMIT,
-            minimum=1,
-            maximum=MAX_BATCH_LIMIT,
+            _BATCH_LIMIT_ENV,
         ),
         bounty_board_refresh_interval_seconds=_positive_int_from_env(
             source,
-            "MERGEWORK_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS",
-            DEFAULT_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS,
-            minimum=MIN_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS,
+            _BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS_ENV,
         ),
     )

--- a/tests/test_treasury_executor_config.py
+++ b/tests/test_treasury_executor_config.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from app.treasury_executor_config import (
+    executor_config_from_env,
+)
+
+
+def test_executor_config_uses_shared_positive_int_specs() -> None:
+    config = executor_config_from_env({})
+
+    assert config.interval_seconds == 300
+    assert config.batch_limit == 25
+    assert config.bounty_board_refresh_interval_seconds == 60
+
+
+def test_positive_int_spec_preserves_validation_messages() -> None:
+    with pytest.raises(
+        ValueError, match="MERGEWORK_TREASURY_EXECUTOR_INTERVAL_SECONDS must be at least 15"
+    ):
+        executor_config_from_env({"MERGEWORK_TREASURY_EXECUTOR_INTERVAL_SECONDS": "14"})
+
+    with pytest.raises(
+        ValueError, match="MERGEWORK_TREASURY_EXECUTOR_BATCH_LIMIT must be at most 200"
+    ):
+        executor_config_from_env({"MERGEWORK_TREASURY_EXECUTOR_BATCH_LIMIT": "201"})
+
+    with pytest.raises(
+        ValueError, match="MERGEWORK_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS must be an integer"
+    ):
+        executor_config_from_env({"MERGEWORK_BOUNTY_BOARD_REFRESH_INTERVAL_SECONDS": "notanumber"})


### PR DESCRIPTION
## Summary
- Introduce a small `_PositiveIntEnv` spec object for treasury executor integer env settings.
- Route interval, batch limit, and bounty-board refresh parsing through the shared spec helper.
- Add focused public-behavior tests for defaults and validation messages without touching the existing executor script test file.

## Bounty scope / duplicate check
Refs #846.

This is a low-conflict maintainability slice for the paid shared-logic bounty. I checked the open PR queue for `app/treasury_executor_config.py` before opening this PR and found no open PRs touching this file. I also avoided `tests/test_treasury_executor_script.py` because an existing open PR touches that test file.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_treasury_executor_config.py tests/test_treasury_executor_script.py::test_executor_config_defaults_to_disabled tests/test_treasury_executor_script.py::test_executor_config_reads_explicit_production_settings tests/test_treasury_executor_script.py::test_executor_config_accepts_bounds tests/test_treasury_executor_script.py::test_executor_config_rejects_invalid_numbers -q`
- `uv run --python 3.12 --extra dev ruff check app/treasury_executor_config.py tests/test_treasury_executor_config.py`
- `uv run --python 3.12 --extra dev ruff format --check app/treasury_executor_config.py tests/test_treasury_executor_config.py`
- `uv run --python 3.12 --extra dev mypy app/treasury_executor_config.py`
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py`
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved environment configuration validation with centralized rules for enhanced consistency and clearer error messaging.

* **Tests**
  * Added tests validating configuration defaults and validation constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->