### PR TITLE
Add get_balance MCP input schema

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -32,7 +32,25 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "or by GitHub issue_number with optional repo"
         ),
     },
-    {"name": "get_balance", "description": "Get an account balance"},
+    {
+        "name": "get_balance",
+        "description": "Get an account balance",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "account": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Account selector such as github:<login>, treasury:mrwk, "
+                        "reserve:bounty:<id>, or an mrwk1 wallet address."
+                    ),
+                },
+            },
+            "required": ["account"],
+            "additionalProperties": False,
+        },
+    },
     {
         "name": "register_wallet",
         "description": "Register an MRWK wallet public key",

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -268,6 +268,12 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
         tool for tool in tools["result"]["tools"] if tool["name"] == "list_bounty_attempts"
     )
     assert "active-attempt reservations" in attempt_tool["description"]
+    balance_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_balance")
+    balance_schema = balance_tool["inputSchema"]
+    assert balance_schema["required"] == ["account"]
+    assert balance_schema["additionalProperties"] is False
+    assert balance_schema["properties"]["account"]["minLength"] == 1
+    assert "github:<login>" in balance_schema["properties"]["account"]["description"]
 
     balance = client.post(
         "/mcp",


### PR DESCRIPTION
## Summary
- Add `inputSchema` metadata for the existing `get_balance` MCP tool.
- Document the required `account` selector shape in `tools/list` so agents can discover it before calling the tool.
- Extend the existing MCP tools/list test while preserving current `get_balance` runtime behavior and response text.

## Bounty scope / duplicate check
Bounty #844.

This is a focused MCP schema/usability improvement for a read-only tool. Existing useful open #844 work covers get_balance structured output (#885), selector description wording (#891), broad/stale input-schema work (#738), list_bounties argument guards (#892), proof/bounty/attempt aliases, and wallet schema work (#926). This PR only adds machine-readable `inputSchema` metadata for the existing `get_balance.account` argument and does not change the dispatcher, balance calculation, response shape, or wallet/ledger/treasury behavior.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_api_mcp.py::test_mcp_tools_list_and_call tests/test_api_mcp.py::test_wallet_account_views_normalize_mixed_case_addresses tests/test_api_mcp.py::test_github_account_views_normalize_mixed_case_logins -q` -> 3 passed, 1 existing Starlette/httpx warning
- `uv run --python 3.12 --extra dev python -m pytest tests/test_api_mcp.py tests/test_mcp_tools.py -q` -> 112 passed, 1 existing Starlette/httpx warning
- `uv run --python 3.12 --extra dev ruff check app/mcp.py tests/test_api_mcp.py` -> passed
- `uv run --python 3.12 --extra dev ruff format --check app/mcp.py tests/test_api_mcp.py` -> 2 files already formatted
- `uv run --python 3.12 --extra dev mypy app/mcp.py` -> success
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened input validation for balance queries by introducing an explicit schema: required account field, minimum length, and disallowing extra properties.

* **Tests**
  * Expanded test coverage for the balance tool schema, verifying required fields, length constraints, and prevention of additional properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->