### PR TITLE
Share public path status metadata

### DIFF
--- a/app/status.py
+++ b/app/status.py
@@ -26,6 +26,7 @@ FUTURE_PATH_BOUNDARY = (
     "Future public snapshots, bridges, and onchain claims require separate "
     "maintainer/contributor discussion before implementation."
 )
+FUTURE_PATH = "public snapshots, bridges, and onchain claims"
 
 
 def ledger_height(session: Session) -> int:
@@ -42,6 +43,16 @@ def health_status(session: Session) -> dict[str, Any]:
     }
 
 
+def public_path_status() -> dict[str, Any]:
+    return {
+        "current_transfer_paths": list(CURRENT_TRANSFER_PATHS),
+        "unsupported_public_paths": list(UNSUPPORTED_PUBLIC_PATHS),
+        "unsupported_public_paths_summary": UNSUPPORTED_PUBLIC_PATHS_SUMMARY,
+        "future_path": FUTURE_PATH,
+        "future_path_boundary": FUTURE_PATH_BOUNDARY,
+    }
+
+
 def system_status(session: Session) -> dict[str, Any]:
     active_bounties = session.scalar(
         select(func.count()).select_from(Bounty).where(Bounty.status == "open")
@@ -54,9 +65,5 @@ def system_status(session: Session) -> dict[str, Any]:
         "ledger_height": ledger_height(session),
         "active_bounties": int(active_bounties or 0),
         "treasury_balance_mrwk": format_mrwk(treasury_balance),
-        "current_transfer_paths": list(CURRENT_TRANSFER_PATHS),
-        "unsupported_public_paths": list(UNSUPPORTED_PUBLIC_PATHS),
-        "unsupported_public_paths_summary": UNSUPPORTED_PUBLIC_PATHS_SUMMARY,
-        "future_path": "public snapshots, bridges, and onchain claims",
-        "future_path_boundary": FUTURE_PATH_BOUNDARY,
+        **public_path_status(),
     }

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -12,7 +12,7 @@ from app.ledger.service import (
     pay_bounty,
 )
 from app.models import LedgerEntry
-from app.status import health_status, system_status
+from app.status import health_status, public_path_status, system_status
 
 
 def test_health_status_reports_current_ledger_height(sqlite_url: str) -> None:
@@ -94,3 +94,23 @@ def test_system_status_counts_only_open_bounties(sqlite_url: str) -> None:
         "Future public snapshots, bridges, and onchain claims require separate "
         "maintainer/contributor discussion before implementation."
     )
+
+
+def test_public_path_status_returns_independent_lists() -> None:
+    first = public_path_status()
+    first["current_transfer_paths"].append("changed")
+    first["unsupported_public_paths"].append("changed")
+
+    assert public_path_status()["current_transfer_paths"] == [
+        "github:* balance claims into a linked wallet",
+        "payouts to linked mrwk1 wallets",
+        "signed wallet-to-wallet transfers between registered wallets",
+    ]
+    assert public_path_status()["unsupported_public_paths"] == [
+        "BTC",
+        "USDC",
+        "fiat",
+        "bridge",
+        "exchange",
+        "off-ramp",
+    ]


### PR DESCRIPTION
## Summary
- add a small `public_path_status()` helper for the public transfer/unsupported-path status metadata
- reuse that helper from `system_status()` so `/api/v1/status` keeps one source for current paths, unsupported paths, and future-path boundary text
- add regression coverage that the returned path lists are independent copies

Refs #846

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_status.py tests/test_hub.py -q` -> 7 passed
- `uv run --python 3.12 --extra dev ruff check app/status.py tests/test_status.py` -> passed
- `uv run --python 3.12 --extra dev ruff format --check app/status.py tests/test_status.py` -> 2 files already formatted
- `uv run --python 3.12 --extra dev mypy app/status.py` -> success
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `7f9ba3b620652a1e64dbb270c5fab365fd718128`

Scope: maintainability-only status metadata cleanup. No ledger, wallet, treasury, payout, proposal execution, admin-token behavior, private data, exchange, bridge, cash-out, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized status reporting logic for better code structure.

* **Tests**
  * Added test coverage to verify status reporting functions work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->