### PR TITLE
Share ledger exporter argv testing

### DIFF
--- a/scripts/export_ledger_snapshot.py
+++ b/scripts/export_ledger_snapshot.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -33,7 +33,7 @@ def read_only_session_scope(database_url: str) -> Iterator[Session]:
         engine.dispose()
 
 
-def main() -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Export a read-only MRWK ledger snapshot.")
     parser.add_argument("--database-url", help="Database URL. Defaults to MERGEWORK_DATABASE_URL.")
     parser.add_argument("--source-host", help="Public source host/origin for snapshot metadata.")
@@ -47,7 +47,7 @@ def main() -> int:
         action="store_true",
         help="Print the ledger snapshot JSON Schema instead of a live snapshot.",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     if args.schema:
         sys.stdout.write(ledger_snapshot_schema_json())
         return 0

--- a/tests/test_ledger_snapshot.py
+++ b/tests/test_ledger_snapshot.py
@@ -20,6 +20,7 @@ from app.ledger.snapshot import (
     ledger_snapshot_schema_json,
 )
 from app.models import LedgerEntry
+from scripts.export_ledger_snapshot import main as export_ledger_snapshot_main
 from scripts.export_ledger_snapshot import read_only_session_scope
 
 
@@ -159,6 +160,41 @@ def test_exporter_read_only_session_rolls_back_writes(sqlite_url: str) -> None:
 
     with session_scope(sqlite_url) as session:
         assert session.get(LedgerEntry, 1) is None
+
+
+def test_exporter_main_accepts_schema_argv(capsys) -> None:
+    assert export_ledger_snapshot_main(["--schema"]) == 0
+
+    schema = json.loads(capsys.readouterr().out)
+
+    assert schema["$id"] == LEDGER_SNAPSHOT_SCHEMA
+
+
+def test_exporter_main_accepts_snapshot_argv(sqlite_url: str, capsys) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    assert (
+        export_ledger_snapshot_main(
+            [
+                "--database-url",
+                sqlite_url,
+                "--source-host",
+                "https://mrwk.example",
+                "--source-mode",
+                "test",
+            ]
+        )
+        == 0
+    )
+
+    snapshot = json.loads(capsys.readouterr().out)
+
+    assert snapshot["source"] == {"mode": "test", "host": "https://mrwk.example"}
+    assert snapshot["ledger_anchor"]["latest_sequence"] == 1
+    assert snapshot["verification"]["hash_chain_ok"] is True
 
 
 def test_ledger_snapshot_schema_is_deterministic_json() -> None:


### PR DESCRIPTION
Refs #846

## Summary
- Allow `scripts/export_ledger_snapshot.py` to accept an optional `argv` sequence in `main()`, matching the pattern used by the other report/utility scripts.
- Add direct CLI-path tests for `--schema` and a live snapshot export with explicit `--database-url`, `--source-host`, and `--source-mode` arguments.
- Preserve normal command-line behavior because `main()` still defaults to parsing `sys.argv` when no argument list is supplied.

## Duplicate/current check
- Before opening this PR, I checked the current open PR file list and found no open PR touching `scripts/export_ledger_snapshot.py` or `tests/test_ledger_snapshot.py`.
- Scope is limited to the ledger snapshot exporter entry point and direct tests.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_ledger_snapshot.py -q` -> 8 passed
- `uv run --python 3.12 --extra dev ruff check scripts/export_ledger_snapshot.py tests/test_ledger_snapshot.py` -> passed
- `uv run --python 3.12 --extra dev ruff format --check scripts/export_ledger_snapshot.py tests/test_ledger_snapshot.py` -> 2 files already formatted
- `uv run --python 3.12 --extra dev mypy scripts/export_ledger_snapshot.py` -> success
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `3e15c535bf70486caaad0b609d1f9a913409bb69`

Scope: maintainability/testability only. No ledger snapshot schema, ledger entries, balances, wallet behavior, treasury behavior, payout behavior, public API fields, exchange, bridge, cash-out, or MRWK price behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated the ledger snapshot export script to support flexible argument injection for improved testing capabilities.

* **Tests**
  * Added tests verifying the `--schema` flag output and snapshot argument handling work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->