### PR TITLE
Surface contributor starting points on the hub

### DIFF
--- a/app/hub.py
+++ b/app/hub.py
@@ -24,6 +24,26 @@ LTC_LAB_PROJECTS = (
     },
 )
 
+MERGEWORK_CONTRIBUTOR_STARTING_POINTS = (
+    {
+        "title": "Effectively open bounties",
+        "href": "/bounties?status=open&availability=effectively_open",
+        "description": "Start from live bounty rows that still have effective award capacity.",
+    },
+    {
+        "title": "Accepted work activity",
+        "href": "/activity",
+        "description": (
+            "Check proof-backed paid work and pending payout queues before claiming payment."
+        ),
+    },
+    {
+        "title": "Current bounty JSON",
+        "href": "/api/v1/bounties?status=open&availability=effectively_open",
+        "description": "Use the public API to verify live status, capacity, and requirements.",
+    },
+)
+
 
 def host_without_port(host_header: str) -> str:
     return host_header.split(":", 1)[0].lower()
@@ -44,4 +64,7 @@ def mergework_hub_context(status: dict[str, Any], public_base_url: str) -> dict[
     return {
         "status": status,
         "public_base_url": public_base_url,
+        "contributor_starting_points": [
+            dict(point) for point in MERGEWORK_CONTRIBUTOR_STARTING_POINTS
+        ],
     }

--- a/app/templates/hub.html
+++ b/app/templates/hub.html
@@ -34,4 +34,22 @@
   <h2>Accounts and payouts</h2>
   <p>Accepted work can be paid to a linked native wallet address. Wallets use public keys and signed transfer transactions to move MRWK inside the ledger.</p>
 </section>
+<section>
+  <h2>Contributor starting points</h2>
+  <p>Use these public paths to confirm a bounty is live, effectively open, and not merely pending or already paid.</p>
+  <div class="list">
+    {% for point in contributor_starting_points %}
+    <article class="ledger-row">
+      <div class="ledger-entry-card">
+        <div class="ledger-card-head">
+          <div class="ledger-card-title">
+            <a class="ledger-entry-link" href="{{ point.href }}">{{ point.title }}</a>
+          </div>
+        </div>
+        <p>{{ point.description }}</p>
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+</section>
 {% endblock %}

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from fastapi.testclient import TestClient
+
+from app.db import create_schema, session_scope
 from app.hub import (
     host_without_port,
     is_ltc_lab_host,
     ltc_lab_context,
     mergework_hub_context,
 )
+from app.ledger.service import ensure_genesis
+from app.main import create_app
 
 
 def test_host_without_port_normalizes_host_headers() -> None:
@@ -46,7 +51,52 @@ def test_mergework_hub_context_preserves_status_and_base_url() -> None:
 
     context = mergework_hub_context(status, "https://mrwk.online")
 
-    assert context == {
-        "status": status,
-        "public_base_url": "https://mrwk.online",
-    }
+    assert context["status"] is status
+    assert context["public_base_url"] == "https://mrwk.online"
+    assert context["contributor_starting_points"] == [
+        {
+            "title": "Effectively open bounties",
+            "href": "/bounties?status=open&availability=effectively_open",
+            "description": "Start from live bounty rows that still have effective award capacity.",
+        },
+        {
+            "title": "Accepted work activity",
+            "href": "/activity",
+            "description": (
+                "Check proof-backed paid work and pending payout queues before claiming payment."
+            ),
+        },
+        {
+            "title": "Current bounty JSON",
+            "href": "/api/v1/bounties?status=open&availability=effectively_open",
+            "description": "Use the public API to verify live status, capacity, and requirements.",
+        },
+    ]
+
+    context["contributor_starting_points"][0]["title"] = "changed"
+
+    assert (
+        mergework_hub_context(status, "https://mrwk.online")["contributor_starting_points"][0][
+            "title"
+        ]
+        == "Effectively open bounties"
+    )
+
+
+def test_mergework_hub_renders_contributor_starting_points(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "Contributor starting points" in response.text
+    assert "Effectively open bounties" in response.text
+    assert 'href="/bounties?status=open&amp;availability=effectively_open"' in response.text
+    assert "Accepted work activity" in response.text
+    assert 'href="/activity"' in response.text
+    assert "Current bounty JSON" in response.text
+    assert 'href="/api/v1/bounties?status=open&amp;availability=effectively_open"' in response.text


### PR DESCRIPTION
﻿Bounty #845

## Summary
- Adds a focused "Contributor starting points" section to the MergeWork hub page.
- Links contributors directly to effectively open bounties, accepted-work activity, and the current open-bounty JSON feed.
- Keeps the distinction between live/effectively open work, proof-backed paid work, pending payout queues, and already-paid rows visible before contributors start or claim work.

## Why this fits #845
This is a small contributor-routing improvement on the first public MergeWork page. It points contributors and agents to existing public surfaces that confirm whether a bounty is live, effectively open, pending, or already paid before they start work.

## Duplicate / current check
- Public bounty API row #111 for issue #845 is open with 5 effective award slots remaining.
- PR #920 is already accepted/paid, but it adds bounty-list card actions; this PR is the hub-page starting-points counterpart and does not touch the bounty list card scope.
- Current open PR file checks found no open PR touching `app/hub.py`, `app/templates/hub.html`, or `tests/test_hub.py`.
- This PR does not duplicate the open #845 PRs for bounty detail pages, bounty list source filters, pending proposal detail visibility, list capacity counters, or docs preflight guidance.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_hub.py -q` -> 5 passed, 1 existing Starlette/httpx warning.
- `uv run --python 3.12 --extra dev ruff check app/hub.py tests/test_hub.py` -> passed.
- `uv run --python 3.12 --extra dev ruff format --check app/hub.py tests/test_hub.py` -> 2 files already formatted.
- `uv run --python 3.12 --extra dev mypy app/hub.py` -> success.
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- Open PR duplicate file check -> no open PR touching the hub files.

## Scope
Public hub-page routing only. No bounty API shape, attempt creation, payout execution, treasury mutation, wallet behavior, ledger mutation, admin-token behavior, private data, exchange, bridge, cash-out, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Contributor starting points" section to the hub page displaying a curated list of entry links with titles and descriptions in a styled card layout.

* **Tests**
  * Added tests to verify the contributor starting points section renders correctly with proper link handling and HTML escaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->