### PR TITLE
Add MCP selector input schemas

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -24,6 +24,43 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "Get a bounty by internal id or bounty_id alias, or by GitHub issue_number "
             "with optional repo, optionally with accepted awards"
         ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Internal MRWK bounty id. Use one bounty selector.",
+                },
+                "bounty_id": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Alias for the internal MRWK bounty id.",
+                },
+                "issue_number": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "GitHub issue number for an MRWK bounty.",
+                },
+                "repo": {
+                    "type": "string",
+                    "maxLength": 200,
+                    "description": "Optional owner/name repository scope for issue_number lookups.",
+                },
+                "include_awards": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Include accepted award records in the bounty payload.",
+                },
+            },
+            "oneOf": [
+                {"required": ["id"]},
+                {"required": ["bounty_id"]},
+                {"required": ["issue_number"]},
+            ],
+            "dependentRequired": {"repo": ["issue_number"]},
+            "additionalProperties": False,
+        },
     },
     {
         "name": "list_bounty_attempts",
@@ -31,6 +68,44 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "List advisory active-attempt reservations for a bounty by internal bounty_id, "
             "or by GitHub issue_number with optional repo"
         ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "bounty_id": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Internal MRWK bounty id.",
+                },
+                "issue_number": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "GitHub issue number for an MRWK bounty.",
+                },
+                "repo": {
+                    "type": "string",
+                    "maxLength": 200,
+                    "description": "Optional owner/name repository scope for issue_number lookups.",
+                },
+                "include_expired": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Include expired advisory attempts as well as active ones.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "Maximum attempt records to return.",
+                },
+            },
+            "oneOf": [
+                {"required": ["bounty_id"]},
+                {"required": ["issue_number"]},
+            ],
+            "dependentRequired": {"repo": ["issue_number"]},
+            "additionalProperties": False,
+        },
     },
     {
         "name": "get_balance",

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -317,10 +317,37 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert submit_schema["not"] == {"required": ["bounty_id", "issue_number"]}
     bounty_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_bounty")
     assert "accepted awards" in bounty_tool["description"]
+    bounty_schema = bounty_tool["inputSchema"]
+    assert bounty_schema["additionalProperties"] is False
+    assert bounty_schema["properties"]["id"]["minimum"] == 1
+    assert bounty_schema["properties"]["bounty_id"]["minimum"] == 1
+    assert bounty_schema["properties"]["issue_number"]["minimum"] == 1
+    assert bounty_schema["properties"]["repo"]["maxLength"] == 200
+    assert bounty_schema["properties"]["include_awards"]["default"] is False
+    assert bounty_schema["oneOf"] == [
+        {"required": ["id"]},
+        {"required": ["bounty_id"]},
+        {"required": ["issue_number"]},
+    ]
+    assert bounty_schema["dependentRequired"] == {"repo": ["issue_number"]}
     attempt_tool = next(
         tool for tool in tools["result"]["tools"] if tool["name"] == "list_bounty_attempts"
     )
     assert "active-attempt reservations" in attempt_tool["description"]
+    attempt_schema = attempt_tool["inputSchema"]
+    assert attempt_schema["additionalProperties"] is False
+    assert attempt_schema["properties"]["bounty_id"]["minimum"] == 1
+    assert attempt_schema["properties"]["issue_number"]["minimum"] == 1
+    assert attempt_schema["properties"]["repo"]["maxLength"] == 200
+    assert attempt_schema["properties"]["include_expired"]["default"] is False
+    assert attempt_schema["properties"]["limit"]["minimum"] == 1
+    assert attempt_schema["properties"]["limit"]["maximum"] == 100
+    assert attempt_schema["properties"]["limit"]["default"] == 25
+    assert attempt_schema["oneOf"] == [
+        {"required": ["bounty_id"]},
+        {"required": ["issue_number"]},
+    ]
+    assert attempt_schema["dependentRequired"] == {"repo": ["issue_number"]}
     wallet_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_wallet")
     wallet_schema = wallet_tool["inputSchema"]
     assert wallet_schema["required"] == ["address"]


### PR DESCRIPTION
Bounty #844

Summary:
- adds `tools/list` `inputSchema` metadata for `get_bounty`, covering `id`, `bounty_id`, `issue_number`, optional `repo`, and `include_awards`;
- adds `tools/list` `inputSchema` metadata for `list_bounty_attempts`, covering `bounty_id`, `issue_number`, optional `repo`, `include_expired`, and bounded `limit`;
- preserves existing `tools/call` runtime behavior and response payloads.

Duplicate/current check:
- #844 public bounty row is open with 2 effective award slots remaining.
- Existing paid schema slices cover `get_wallet` (#926) and `get_balance` (#937); this PR covers the remaining bounty selector/attempt selector discovery surface.
- Distinct from #908/#916 selector alias runtime changes and #899 unexpected-argument runtime guards; this PR only adds machine-readable `tools/list` schemas.
- #738 is a broad stale input-schema PR; this is a narrow current-head schema slice matching the recent accepted pattern.

Validation:
- `python -m pytest tests\test_api_mcp.py -q` -> 110 passed, 1 existing Starlette/httpx warning
- `python -m ruff check app\mcp.py tests\test_api_mcp.py` -> passed
- `python -m ruff format --check app\mcp.py tests\test_api_mcp.py` -> 2 files already formatted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded validation coverage for bounty-related tool input schemas.

* **Improvements**
  * Enhanced input validation for bounty retrieval and listing operations with structured schemas, field constraints, configurable filtering options, and stricter requirement enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->