### PR TITLE
Share work proof remaining-awards helper

### DIFF
--- a/app/mcp_work_proof.py
+++ b/app/mcp_work_proof.py
@@ -12,11 +12,13 @@ from app.submission_requirements import (
 )
 
 
+def _effective_awards_remaining_from_payload(bounty_data: dict[str, Any]) -> int:
+    return int(bounty_data.get("effective_awards_remaining", bounty_data["awards_remaining"]))
+
+
 def work_proof_guidance(bounty: Bounty, session: Session | None = None) -> str:
     bounty_data = bounty_to_dict(bounty, session=session)
-    remaining_awards = int(
-        bounty_data.get("effective_awards_remaining", bounty_data["awards_remaining"])
-    )
+    remaining_awards = _effective_awards_remaining_from_payload(bounty_data)
     availability = (
         "open for submissions"
         if bounty_data["status"] == "open" and remaining_awards > 0
@@ -50,9 +52,7 @@ def work_proof_guidance(bounty: Bounty, session: Session | None = None) -> str:
 
 
 def _submission_availability(bounty_data: dict[str, Any]) -> SubmissionAvailability:
-    awards_remaining = int(
-        bounty_data.get("effective_awards_remaining", bounty_data["awards_remaining"])
-    )
+    awards_remaining = _effective_awards_remaining_from_payload(bounty_data)
     if bounty_data["status"] == "open":
         return "open" if awards_remaining > 0 else "full"
     return "closed"
@@ -61,11 +61,12 @@ def _submission_availability(bounty_data: dict[str, Any]) -> SubmissionAvailabil
 def work_proof_guidance_json(bounty: Bounty, session: Session | None = None) -> dict[str, Any]:
     bounty_data = bounty_to_dict(bounty, session=session)
     submission_availability = _submission_availability(bounty_data)
+    effective_awards_remaining = _effective_awards_remaining_from_payload(bounty_data)
     can_submit = submission_availability == "open"
     availability_warnings = []
     if bounty_data["status"] != "open":
         availability_warnings.append(f"bounty is {bounty_data['status']}")
-    if bounty_data["effective_awards_remaining"] <= 0:
+    if effective_awards_remaining <= 0:
         availability_warnings.append("bounty has no award slots remaining")
     if bounty_data["availability_state"] not in {"open", "full", bounty_data["status"]}:
         availability_warnings.append(bounty_data["availability_note"])
@@ -77,7 +78,7 @@ def work_proof_guidance_json(bounty: Bounty, session: Session | None = None) -> 
         "can_submit": can_submit,
         "availability_warnings": availability_warnings,
         "awards_remaining": bounty_data["awards_remaining"],
-        "effective_awards_remaining": bounty_data["effective_awards_remaining"],
+        "effective_awards_remaining": effective_awards_remaining,
         "max_awards": bounty_data["max_awards"],
         "awards_paid": bounty_data["awards_paid"],
         "reward_mrwk": bounty_data["reward_mrwk"],

--- a/tests/test_mcp_work_proof.py
+++ b/tests/test_mcp_work_proof.py
@@ -155,6 +155,7 @@ def test_work_proof_guidance_returns_reviewable_text() -> None:
     assert "Bounty #377: Code health boundary" in text
     assert "Repository: ramimbo/mergework" in text
     assert "Status: open (open for submissions); awards remaining: 6 of 6" in text
+    assert "effectively remaining: 6" in text
     assert "Reward: 200 MRWK per accepted award" in text
     assert "Do not include private keys" in text
 


### PR DESCRIPTION
## Summary
- Extract the repeated effective-awards lookup in `app/mcp_work_proof.py` into `_effective_awards_remaining_from_payload()`.
- Reuse the helper for text guidance, submission availability, and structured JSON guidance.
- Add a focused assertion that the text guidance still reports the effective remaining award count.

## Bounty
- Bounty #846: https://github.com/ramimbo/mergework/issues/846
- Public bounty row: https://mrwk.online/bounties/112

## Scope / Safety
- Focused maintainability cleanup only.
- No API shape, MCP tool contract, bounty lifecycle semantics, ledger mutation, wallet behavior, treasury/proposal execution, payout execution, admin-token behavior, private data, credentials, exchange, bridge, cash-out, or MRWK price behavior changed.

## Validation
- `.venv\Scripts\python.exe -m pytest tests\test_mcp_work_proof.py -q` -> 8 passed.
- `.venv\Scripts\python.exe -m ruff check app\mcp_work_proof.py tests\test_mcp_work_proof.py` -> passed.
- `.venv\Scripts\python.exe -m ruff format --check app\mcp_work_proof.py tests\test_mcp_work_proof.py` -> 2 files already formatted.
- `.venv\Scripts\python.exe -m mypy app\mcp_work_proof.py` -> success.
- `.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `9c2767b5a16feff1e787f4f144de44356d168701`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated effective award calculation logic for improved consistency across the application.

* **Tests**
  * Extended test coverage to verify accurate award count information in guidance output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->