### PR TITLE
Reject unsupported work discovery query parameters

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -31,6 +31,7 @@ from app.query_validation import (
     reject_control_char_query_param,
     reject_noncanonical_int_query_param,
     reject_repeated_query_param,
+    reject_unknown_query_params,
 )
 from app.serializers import (
     bounties_to_dict,
@@ -264,6 +265,7 @@ def register_bounty_api_routes(
             Query(ge=1, le=MAX_WORK_DISCOVERY_LIMIT),
         ] = DEFAULT_WORK_DISCOVERY_LIMIT,
     ) -> dict[str, Any]:
+        reject_unknown_query_params(request, {"limit"})
         reject_repeated_query_param(request, "limit")
         reject_noncanonical_int_query_param(request, "limit")
         with session_scope(db_url) as session:

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -52,6 +52,16 @@ def reject_noncanonical_bool_query_param(request: Request, name: str) -> None:
             )
 
 
+def reject_unknown_query_params(request: Request, allowed_names: set[str]) -> None:
+    """Reject unsupported query parameters before FastAPI ignores them."""
+    for name in request.query_params:
+        if name not in allowed_names:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} is not a supported query parameter",
+            )
+
+
 def reject_repeated_query_param(request: Request, name: str) -> None:
     """Reject ambiguous scalar query parameters before FastAPI chooses one value."""
     if len(_query_param_values(request, name)) > 1:

--- a/tests/test_query_validation.py
+++ b/tests/test_query_validation.py
@@ -8,6 +8,7 @@ from app.query_validation import (
     reject_noncanonical_bool_query_param,
     reject_noncanonical_int_query_param,
     reject_repeated_query_param,
+    reject_unknown_query_params,
 )
 
 
@@ -63,3 +64,13 @@ def test_query_guards_keep_canonical_and_repeated_boundaries() -> None:
         reject_repeated_query_param(request, "status")
     assert repeated_error.value.status_code == 400
     assert repeated_error.value.detail == "status must be provided at most once"
+
+
+def test_unknown_query_guard_rejects_unsupported_names() -> None:
+    request = _request("limit=1&status=open")
+
+    with pytest.raises(HTTPException) as exc_info:
+        reject_unknown_query_params(request, {"limit"})
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "status is not a supported query parameter"

--- a/tests/test_work_discovery.py
+++ b/tests/test_work_discovery.py
@@ -166,6 +166,17 @@ def test_work_discovery_limit_caps_public_buckets(sqlite_url: str) -> None:
     assert len(body["opening_soon"]) == 1
 
 
+def test_work_discovery_rejects_unsupported_filter_query_params(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    for name in ("status", "availability", "repo", "q"):
+        response = client.get(f"/api/v1/work-discovery?limit=1&{name}=ignored")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == f"{name} is not a supported query parameter"
+
+
 def test_work_discovery_limit_keeps_older_claimable_bounty_visible(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
## Summary
- Reject unsupported `/api/v1/work-discovery` query parameters instead of silently ignoring filter-like inputs.
- Keep `limit` as the endpoint's only supported query parameter and preserve existing repeated/canonical integer validation.
- Add regression coverage for `status`, `availability`, `repo`, and `q` returning HTTP 400.

## Bounty
Bounty: #798
Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4634544543

## Validation
- `python -m pytest tests/test_work_discovery.py tests/test_query_validation.py -q`
- `python -m ruff check app/query_validation.py app/bounty_api.py tests/test_query_validation.py tests/test_work_discovery.py`
- `python -m ruff format --check app/query_validation.py app/bounty_api.py tests/test_query_validation.py tests/test_work_discovery.py`
- `python -m mypy app/query_validation.py app/bounty_api.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Changes**
  * Work discovery endpoint now validates query parameters and rejects unsupported ones with HTTP 400 error
  * Invalid requests include clear error messages identifying unsupported parameters

* **Tests**
  * Added tests to validate query parameter handling and error responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->