### PR TITLE
Reject unsupported bounty attempts query parameters

### DIFF
--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -24,6 +24,7 @@ from app.query_validation import (
 DEFAULT_ATTEMPT_TTL_SECONDS = 24 * 60 * 60
 MIN_ATTEMPT_TTL_SECONDS = 60
 MAX_ATTEMPT_TTL_SECONDS = 7 * 24 * 60 * 60
+SUPPORTED_ATTEMPT_LIST_QUERY_PARAMS = {"include_expired", "limit"}
 
 JsonObjectLoader = Callable[[Request], Awaitable[dict[str, Any]]]
 LoginDependency = Callable[[Request], str]
@@ -53,6 +54,15 @@ async def _optional_json_object(request: Request, json_object: JsonObjectLoader)
     if not (await request.body()).strip():
         return {}
     return await json_object(request)
+
+
+def _reject_unsupported_attempt_list_query_params(request: Request) -> None:
+    for name in request.query_params:
+        if name not in SUPPORTED_ATTEMPT_LIST_QUERY_PARAMS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} is not a supported query parameter",
+            )
 
 
 def bounty_attempt_to_dict(attempt: BountyAttempt, now: datetime | None = None) -> dict[str, Any]:
@@ -256,6 +266,7 @@ def register_bounty_attempt_routes(
         include_expired: str | None = Query(None),
         limit: Annotated[int | None, Query(ge=1, le=100)] = None,
     ) -> dict[str, Any]:
+        _reject_unsupported_attempt_list_query_params(request)
         for name in ("include_expired", "limit"):
             reject_repeated_query_param(request, name)
         reject_noncanonical_bool_query_param(request, "include_expired")

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -123,6 +123,16 @@ def test_bounty_attempts_register_list_duplicate_and_release(sqlite_url: str, mo
         "github:bob"
     ]
 
+    for unsupported_query in ("offset=1", "status=active", "q=alice", "repo=ramimbo%2Fmergework"):
+        unsupported = client.get(
+            f"/api/v1/bounties/{bounty.id}/attempts?limit=1&{unsupported_query}"
+        )
+        assert unsupported.status_code == 400
+        assert (
+            unsupported.json()["detail"]
+            == f"{unsupported_query.split('=', 1)[0]} is not a supported query parameter"
+        )
+
     assert client.get(f"/api/v1/bounties/{bounty.id}/attempts?limit=0").status_code == 422
     assert client.get(f"/api/v1/bounties/{bounty.id}/attempts?limit=101").status_code == 422
     noncanonical_limits = {


### PR DESCRIPTION
## Summary
- Reject unsupported `GET /api/v1/bounties/{bounty_id}/attempts` query parameters instead of silently ignoring filter-like inputs.
- Keep `include_expired` and `limit` as the endpoint's supported query parameters and preserve existing repeated/canonical validation.
- Add regression coverage for `offset`, `status`, `q`, and `repo` returning HTTP 400.

## Bounty
Bounty: #798
Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4634729247
Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4634729380

## Validation
- `python -m pytest tests/test_bounty_attempts.py -q`
- `python -m ruff check app/bounty_attempts.py tests/test_bounty_attempts.py`
- `python -m ruff format --check app/bounty_attempts.py tests/test_bounty_attempts.py`
- `python -m mypy app/bounty_attempts.py`

Scope: public bounty attempts list query validation only. No attempt creation/release semantics, ledger mutation, payout, treasury execution, wallet, bridge, exchange, cash-out, private data, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The bounty attempts listing endpoint now properly validates query parameters and rejects unsupported ones with a 400 error response.

* **Tests**
  * Added test coverage for query parameter validation on the bounty attempts endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->