### PR TITLE
Reject account page type query aliases

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -205,6 +205,11 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
         request: Request, account: str, tx_type: str | None = Query(None)
     ) -> HTMLResponse:
         reject_path_whitespace_padding(account, "account")
+        if request.query_params.getlist("type"):
+            raise HTTPException(
+                status_code=400,
+                detail="type is not supported on account pages; use tx_type",
+            )
         for value in request.query_params.getlist("tx_type"):
             if contains_control_character(value):
                 raise HTTPException(

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -320,6 +320,10 @@ def test_account_page_filters_transactions_by_type(sqlite_url: str) -> None:
     payments = client.get("/accounts/github:alice?tx_type=bounty_payment")
     claims = client.get("/accounts/github:alice?tx_type=github_claim")
     invalid = client.get("/accounts/github:alice?tx_type=bogus")
+    wallet_style_filter = client.get("/accounts/github:alice?type=github_claim")
+    repeated_wallet_style_filter = client.get(
+        "/accounts/github:alice?type=github_claim&type=bounty_payment"
+    )
     control = client.get("/accounts/github:alice?tx_type=%C2%85bounty_payment")
     masked_control = client.get("/accounts/github:alice?tx_type=%C2%85bounty_payment&tx_type=all")
     repeated = client.get("/accounts/github:alice?tx_type=bounty_payment&tx_type=all")
@@ -342,6 +346,15 @@ def test_account_page_filters_transactions_by_type(sqlite_url: str) -> None:
 
     assert invalid.status_code == 400
     assert "transaction type must be one of" in invalid.text
+
+    assert wallet_style_filter.status_code == 400
+    assert wallet_style_filter.json()["detail"] == (
+        "type is not supported on account pages; use tx_type"
+    )
+    assert repeated_wallet_style_filter.status_code == 400
+    assert repeated_wallet_style_filter.json()["detail"] == (
+        "type is not supported on account pages; use tx_type"
+    )
 
     assert control.status_code == 400
     assert control.json()["detail"] == "transaction type must not contain control characters"


### PR DESCRIPTION
## Summary
/claim #798

- Reject wallet-style `type=` transaction filters on public account pages instead of silently rendering the unfiltered account history.
- Keep `tx_type=` as the account page transaction filter and leave valid `tx_type` filtering unchanged.
- Add regression coverage for single and repeated `type=` query aliases returning a clear 400 response.

## Bounty
Bounty #798
Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4635770729
Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4635774680

## Validation
- `python3 -m pytest tests/test_account_routes.py::test_account_page_filters_transactions_by_type -q` -> 1 passed
- `python3 -m ruff check app/accounts.py tests/test_account_routes.py` -> passed
- `python3 -m ruff format --check app/accounts.py tests/test_account_routes.py` -> 2 files already formatted
- `git diff --check` -> clean

Scope: public account page query validation only. No wallet signing, wallet registration, ledger mutation, treasury mutation, payout execution, admin-token behavior, bridge, exchange, cash-out, private data, secrets, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account page now properly rejects unsupported query parameter and returns an error message directing users to use the correct parameter instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->