### PR TITLE
Reject wallet tx_type query aliases

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -403,6 +403,10 @@ def register_public_routes(
         type: str | None = Query(None),  # noqa: A002
     ) -> HTMLResponse:
         reject_path_whitespace_padding(address, "MRWK wallet address")
+        if request.query_params.getlist("tx_type"):
+            raise HTTPException(
+                status_code=400, detail="tx_type is not supported on wallet pages; use type"
+            )
         for value in request.query_params.getlist("type"):
             if contains_control_character(value):
                 raise HTTPException(

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -736,10 +736,12 @@ def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
 
     search_response = client.get("/wallets", params={"q": "\u0085Main"})
     type_response = client.get(f"/wallets/{address}", params={"type": "test_funding\t"})
+    tx_type_response = client.get(f"/wallets/{address}?tx_type=test_funding")
     masked_search_response = client.get("/wallets?q=%C2%85Main&q=Main")
     repeated_search_response = client.get("/wallets?q=Main&q=smoke")
     masked_type_response = client.get(f"/wallets/{address}?type=%C2%85test_funding&type=all")
     repeated_type_response = client.get(f"/wallets/{address}?type=test_funding&type=all")
+    repeated_tx_type_response = client.get(f"/wallets/{address}?tx_type=test_funding&tx_type=all")
     max_length_search_response = client.get("/wallets", params={"q": "a" * 500})
     oversized_search_response = client.get("/wallets", params={"q": "a" * 501})
 
@@ -747,6 +749,8 @@ def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
     assert search_response.json()["detail"] == "q must not contain control characters"
     assert type_response.status_code == 400
     assert type_response.json()["detail"] == "transaction type must not contain control characters"
+    assert tx_type_response.status_code == 400
+    assert tx_type_response.json()["detail"] == "tx_type is not supported on wallet pages; use type"
     assert masked_search_response.status_code == 400
     assert masked_search_response.json()["detail"] == "q must not contain control characters"
     assert repeated_search_response.status_code == 400
@@ -758,6 +762,11 @@ def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
     )
     assert repeated_type_response.status_code == 400
     assert repeated_type_response.json()["detail"] == "type must be provided at most once"
+    assert repeated_tx_type_response.status_code == 400
+    assert (
+        repeated_tx_type_response.json()["detail"]
+        == "tx_type is not supported on wallet pages; use type"
+    )
     assert max_length_search_response.status_code == 200
     assert oversized_search_response.status_code == 400
     assert oversized_search_response.json()["detail"] == "q must be at most 500 characters"


### PR DESCRIPTION
## Summary

/claim #798

- Reject account-style `tx_type` query parameters on public wallet detail pages.
- Keep the existing wallet-page `type` transaction filter unchanged.
- Add regression coverage for single and repeated `tx_type` inputs.

## Bounty context

Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4635997076

Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636003520

Production issue: `/wallets/<address>?tx_type=...` currently returns HTTP 200 with the byte-identical default wallet page, while `/wallets/<address>?type=...` is the working transaction filter.

## Validation

- `python3 -m pytest tests/test_wallet_api.py::test_wallet_pages_reject_control_character_filters -q`
- `python3 -m pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows tests/test_wallet_api.py::test_wallet_pages_reject_control_character_filters -q`
- `python3 -m ruff check app/public_routes.py tests/test_wallet_api.py`
- `python3 -m ruff format --check app/public_routes.py tests/test_wallet_api.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wallet detail pages now explicitly reject the `tx_type` query parameter with a 400 error response, directing users to use the correct `type` parameter instead through an informative error message.

* **Tests**
  * Extended test coverage to validate query parameter handling on wallet pages, including scenarios with the deprecated `tx_type` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->