### PR TITLE
Reject API detail transaction filters

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -189,8 +189,13 @@ def account_page_context(
 
 def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
     @app.get("/api/v1/accounts/{account}")
-    def api_account(account: str) -> dict[str, Any]:
+    def api_account(request: Request, account: str) -> dict[str, Any]:
         reject_path_whitespace_padding(account, "account")
+        if request.query_params.getlist("type") or request.query_params.getlist("tx_type"):
+            raise HTTPException(
+                status_code=400,
+                detail="transaction filters are not supported on account JSON detail",
+            )
         with session_scope(db_url) as session:
             return account_api_context(session, account)
 

--- a/app/wallet_api.py
+++ b/app/wallet_api.py
@@ -67,8 +67,13 @@ def register_wallet_api_routes(
         post_only_route()
 
     @app.get("/api/v1/wallets/{address}")
-    def api_wallet(address: str) -> dict[str, Any]:
+    def api_wallet(request: Request, address: str) -> dict[str, Any]:
         reject_path_whitespace_padding(address, "MRWK wallet address")
+        if request.query_params.getlist("type") or request.query_params.getlist("tx_type"):
+            raise HTTPException(
+                status_code=400,
+                detail="transaction filters are not supported on wallet JSON detail",
+            )
         address = normalized_wallet_address(address)
         with session_scope(db_url) as session:
             wallet = session.get(Wallet, address)

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -97,12 +97,22 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
     api_response = client.get("/api/v1/accounts/GitHub:Bob")
+    api_type_filter_response = client.get("/api/v1/accounts/github:bob?type=github_claim")
+    api_tx_type_filter_response = client.get("/api/v1/accounts/github:bob?tx_type=github_claim")
     accepted_response = client.get("/api/v1/accounts/github:bob/accepted-work")
     page_response = client.get("/accounts/github:bob")
 
     assert api_response.status_code == 200
     assert api_response.json()["account"] == "github:bob"
     assert api_response.json()["accepted_work"]["latest_proof_hash"] == proof.hash
+    assert api_type_filter_response.status_code == 400
+    assert api_type_filter_response.json()["detail"] == (
+        "transaction filters are not supported on account JSON detail"
+    )
+    assert api_tx_type_filter_response.status_code == 400
+    assert api_tx_type_filter_response.json()["detail"] == (
+        "transaction filters are not supported on account JSON detail"
+    )
     assert accepted_response.status_code == 200
     assert accepted_response.json()["summary"]["accepted_mrwk"] == "25"
     assert accepted_response.json()["accepted_work"][0]["submission_url"].endswith("/pull/178")

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -100,6 +100,23 @@ def test_wallet_api_register_lookup_and_transfer(sqlite_url: str) -> None:
     assert transfer["type"] == "wallet_transfer"
     assert transfer["amount_mrwk"] == "3"
     assert client.get(f"/api/v1/wallets/{receiver_address}").json()["balance_mrwk"] == "3"
+    type_filter = client.get(f"/api/v1/wallets/{receiver_address}?type=github_claim")
+    tx_type_filter = client.get(f"/api/v1/wallets/{receiver_address}?tx_type=github_claim")
+    repeated_type_filter = client.get(
+        f"/api/v1/wallets/{receiver_address}?type=github_claim&type=bounty_payment"
+    )
+    assert type_filter.status_code == 400
+    assert type_filter.json()["detail"] == (
+        "transaction filters are not supported on wallet JSON detail"
+    )
+    assert tx_type_filter.status_code == 400
+    assert tx_type_filter.json()["detail"] == (
+        "transaction filters are not supported on wallet JSON detail"
+    )
+    assert repeated_type_filter.status_code == 400
+    assert repeated_type_filter.json()["detail"] == (
+        "transaction filters are not supported on wallet JSON detail"
+    )
 
 
 def test_wallet_transfer_api_rejects_replayed_signed_body(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary

/claim #798

- Reject page-style transaction filters on JSON account detail responses.
- Reject page-style transaction filters on JSON wallet detail responses.
- Add regression coverage for `type` and `tx_type` query parameters while preserving normal detail lookups.

## Bounty context

Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636115155

Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636122343

Production issue: `/api/v1/accounts/<account>` and `/api/v1/wallets/<address>` currently return HTTP 200 with byte-identical default summary objects when page-style transaction filters such as `type=` or `tx_type=` are supplied.

## Validation

- `python3 -m pytest tests/test_account_routes.py::test_registered_account_routes_preserve_api_and_page_shapes tests/test_wallet_api.py::test_wallet_api_register_lookup_and_transfer -q`
- `python3 -m pytest tests/test_account_routes.py tests/test_wallet_api.py -q`
- `python3 -m ruff check app/accounts.py app/wallet_api.py tests/test_account_routes.py tests/test_wallet_api.py`
- `python3 -m ruff format --check app/accounts.py app/wallet_api.py tests/test_account_routes.py tests/test_wallet_api.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Account and wallet JSON endpoints now properly reject requests with transaction filter query parameters (`type` and `tx_type`), returning HTTP 400 errors. These filters are not supported on these detail endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->