### PR TITLE
Reject bounty detail list filters

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -31,6 +31,7 @@ from app.query_validation import (
     reject_control_char_query_param,
     reject_noncanonical_int_query_param,
     reject_repeated_query_param,
+    reject_unsupported_query_params,
 )
 from app.serializers import (
     bounties_to_dict,
@@ -210,6 +211,13 @@ def register_bounty_api_routes(
         for name in ("limit", "issue_number"):
             reject_noncanonical_int_query_param(request, name)
 
+    def _reject_bounty_detail_list_filters(request: Request) -> None:
+        reject_unsupported_query_params(
+            request,
+            ("status", "q", "limit", "offset", "sort", "repo", "issue_number", "availability"),
+            context="bounty detail",
+        )
+
     @app.get("/api/v1/bounties")
     def api_bounties(
         request: Request,
@@ -313,8 +321,7 @@ def register_bounty_api_routes(
                 raise _ledger_http_error(exc) from exc
             return proposal_to_dict(proposal)
 
-    @app.get("/api/v1/bounties/{bounty_id}")
-    def api_bounty(bounty_id: str) -> dict[str, Any]:
+    def get_bounty_detail(bounty_id: str) -> dict[str, Any]:
         bounty_id_int = positive_bounty_id(bounty_id)
         with session_scope(db_url) as session:
             bounty = session.get(Bounty, bounty_id_int)
@@ -323,6 +330,11 @@ def register_bounty_api_routes(
             result = bounty_to_dict(bounty, session=session)
             result["accepted_awards"] = bounty_awards_to_dict(session, bounty.id)
             return result
+
+    @app.get("/api/v1/bounties/{bounty_id}")
+    def api_bounty(request: Request, bounty_id: str) -> dict[str, Any]:
+        _reject_bounty_detail_list_filters(request)
+        return get_bounty_detail(bounty_id)
 
     @app.get("/api/v1/reconciliation/payouts")
     def api_payout_reconciliation(
@@ -425,5 +437,5 @@ def register_bounty_api_routes(
 
     return {
         "list_bounties_by_status": _list_bounties_by_status,
-        "get_bounty_detail": api_bounty,
+        "get_bounty_detail": get_bounty_detail,
     }

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -26,6 +26,7 @@ from app.query_validation import (
     reject_control_char_query_param,
     reject_noncanonical_int_query_param,
     reject_repeated_query_param,
+    reject_unsupported_query_params,
 )
 from app.serializers import bounty_list_summary, wallet_to_dict
 from app.status import (
@@ -369,6 +370,11 @@ def register_public_routes(
 
     @app.get("/bounties/{bounty_id}", response_class=HTMLResponse)
     def bounty_page(request: Request, bounty_id: str) -> HTMLResponse:
+        reject_unsupported_query_params(
+            request,
+            ("status", "q", "limit", "offset", "sort", "repo", "issue_number", "availability"),
+            context="bounty detail",
+        )
         return templates.TemplateResponse(
             request, "bounty_detail.html", {"bounty": api_bounty(bounty_id)}
         )

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -59,3 +59,15 @@ def reject_repeated_query_param(request: Request, name: str) -> None:
             status_code=400,
             detail=f"{name} must be provided at most once",
         )
+
+
+def reject_unsupported_query_params(
+    request: Request, names: tuple[str, ...], *, context: str
+) -> None:
+    """Reject query parameters that are valid elsewhere but unsupported here."""
+    for name in names:
+        if _query_param_values(request, name):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} is not supported on {context}",
+            )

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -960,6 +960,40 @@ def test_bounty_detail_skips_malformed_award_proof_payloads(sqlite_url: str) -> 
     assert "No accepted work has been paid for this bounty yet." in page.text
 
 
+def test_bounty_detail_rejects_list_query_filters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=166,
+            issue_url="https://github.com/ramimbo/mergework/issues/166",
+            title="Detail query filters",
+            reward_mrwk="100",
+            acceptance="Bounty detail routes should not silently accept list filters.",
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    assert client.get(f"/api/v1/bounties/{bounty_id}").status_code == 200
+    assert client.get(f"/bounties/{bounty_id}").status_code == 200
+    for query, field in (
+        ("limit=1", "limit"),
+        ("status=open", "status"),
+        ("q=review", "q"),
+        ("offset=1", "offset"),
+    ):
+        api_response = client.get(f"/api/v1/bounties/{bounty_id}?{query}")
+        page_response = client.get(f"/bounties/{bounty_id}?{query}")
+
+        assert api_response.status_code == 400
+        assert api_response.json()["detail"] == f"{field} is not supported on bounty detail"
+        assert page_response.status_code == 400
+        assert page_response.json()["detail"] == f"{field} is not supported on bounty detail"
+
+
 def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
## Summary

/claim #798

- Reject bounty-board/list query filters on JSON bounty detail responses.
- Reject the same filters on HTML bounty detail pages.
- Add a shared unsupported-query helper and regression coverage for `limit`, `status`, `q`, and `offset`.

## Bounty context

Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636236527

Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636243241

Production issue: `/api/v1/bounties/{bounty_id}` and `/bounties/{bounty_id}` currently return HTTP 200 with byte-identical default detail responses when bounty-list filters such as `limit`, `status`, `q`, or `offset` are supplied.

## Validation

- `python3 -m pytest tests/test_bounty_pages.py::test_bounty_detail_rejects_list_query_filters -q`
- `python3 -m pytest tests/test_bounty_pages.py -q`
- `python3 -m ruff check app/query_validation.py app/bounty_api.py app/public_routes.py tests/test_bounty_pages.py`
- `python3 -m ruff format --check app/query_validation.py app/bounty_api.py app/public_routes.py tests/test_bounty_pages.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bounty detail endpoints now reject unsupported query parameters (limit, status, q, offset) with proper HTTP 400 error messages instead of silently ignoring them.

* **Tests**
  * Added test coverage for bounty detail query parameter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->