### PR TITLE
Reject treasury proposal detail filters

### DIFF
--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -101,6 +101,15 @@ def _proposal_payload_matches(
     )
 
 
+def _reject_treasury_proposal_detail_filters(request: Request) -> None:
+    for name in ("limit", "offset", "action", "status", "to_account", "bounty_id"):
+        if request.query_params.getlist(name):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} is not supported on treasury proposal detail",
+            )
+
+
 def register_treasury_routes(
     app: FastAPI,
     *,
@@ -182,7 +191,8 @@ def register_treasury_routes(
             return treasury_status(session)
 
     @app.get("/api/v1/treasury/proposals/{proposal_id}")
-    def api_treasury_proposal(proposal_id: str) -> dict[str, Any]:
+    def api_treasury_proposal(request: Request, proposal_id: str) -> dict[str, Any]:
+        _reject_treasury_proposal_detail_filters(request)
         proposal_id_int = positive_proposal_id(proposal_id)
         with session_scope(db_url) as session:
             proposal = session.get(TreasuryProposal, proposal_id_int)

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -114,6 +114,20 @@ def test_admin_bounty_creation_creates_public_delayed_proposal(
     assert [proposal["id"] for proposal in listed.json()] == [body["id"]]
     assert detail.status_code == 200
     assert detail.json()["payload_hash"] == body["payload_hash"]
+    for query, field in (
+        ("limit=1", "limit"),
+        ("offset=1", "offset"),
+        ("status=pending", "status"),
+        ("action=create_bounty", "action"),
+        ("to_account=github:alice", "to_account"),
+        ("bounty_id=1", "bounty_id"),
+    ):
+        filtered_detail = client.get(f"/api/v1/treasury/proposals/{body['id']}?{query}")
+        assert filtered_detail.status_code == 400
+        assert (
+            filtered_detail.json()["detail"]
+            == f"{field} is not supported on treasury proposal detail"
+        )
     for noncanonical_id in (f"{body['id']}.0", f"+{body['id']}", f"%C2%85{body['id']}"):
         noncanonical_detail = client.get(f"/api/v1/treasury/proposals/{noncanonical_id}")
         assert noncanonical_detail.status_code == 400


### PR DESCRIPTION
## Summary

/claim #798

- Reject proposal-list query filters on treasury proposal detail responses.
- Preserve normal proposal detail lookup behavior.
- Add regression coverage for `limit`, `offset`, `status`, `action`, `to_account`, and `bounty_id`.

## Bounty context

Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636332640

Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636336913

Production issue: `/api/v1/treasury/proposals/{proposal_id}` currently returns HTTP 200 with a byte-identical default detail response when proposal-list filters such as `limit`, `offset`, `status`, `action`, `to_account`, or `bounty_id` are supplied.

## Validation

- `python3 -m pytest tests/test_treasury_proposals.py::test_admin_bounty_creation_creates_public_delayed_proposal -q`
- `python3 -m pytest tests/test_treasury_proposals.py::test_admin_bounty_creation_creates_public_delayed_proposal tests/test_treasury_proposals.py::test_treasury_proposals_list_honors_limit tests/test_treasury_proposals.py::test_treasury_proposals_list_honors_offset tests/test_treasury_proposals.py::test_treasury_proposals_list_filters_by_action_status_and_bounty_id -q`
- `python3 -m ruff check app/treasury_routes.py tests/test_treasury_proposals.py`
- `python3 -m ruff format --check app/treasury_routes.py tests/test_treasury_proposals.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Treasury proposal detail endpoint now validates query parameters and properly rejects unsupported ones (limit, offset, status, action, to_account, bounty_id) with HTTP 400 responses and descriptive error messages.

* **Tests**
  * Enhanced test coverage to verify unsupported query parameters are correctly rejected on treasury proposal detail requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->