### PR TITLE
Reject treasury status query filters

### DIFF
--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -101,6 +101,15 @@ def _proposal_payload_matches(
     )
 
 
+def _reject_treasury_status_filters(request: Request) -> None:
+    for name in ("limit", "offset", "action", "status", "to_account", "bounty_id"):
+        if request.query_params.getlist(name):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} is not supported on treasury status",
+            )
+
+
 def register_treasury_routes(
     app: FastAPI,
     *,
@@ -177,7 +186,8 @@ def register_treasury_routes(
             return proposals
 
     @app.get("/api/v1/treasury/status")
-    def api_treasury_status() -> dict[str, Any]:
+    def api_treasury_status(request: Request) -> dict[str, Any]:
+        _reject_treasury_status_filters(request)
         with session_scope(db_url) as session:
             return treasury_status(session)
 

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -243,6 +243,25 @@ def test_treasury_status_reports_reserve_capacity_and_pending_create_proposals(
     ]
 
 
+def test_treasury_status_rejects_proposal_list_filters(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = _client(sqlite_url, monkeypatch)
+
+    assert client.get("/api/v1/treasury/status").status_code == 200
+    for query, field in (
+        ("limit=1", "limit"),
+        ("offset=1", "offset"),
+        ("status=pending", "status"),
+        ("action=create_bounty", "action"),
+        ("to_account=github:alice", "to_account"),
+        ("bounty_id=1", "bounty_id"),
+    ):
+        response = client.get(f"/api/v1/treasury/status?{query}")
+        assert response.status_code == 400
+        assert response.json()["detail"] == f"{field} is not supported on treasury status"
+
+
 def test_treasury_status_includes_reserve_at_exact_24h_boundary(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

/claim #798

- Reject proposal-list query filters on `/api/v1/treasury/status` instead of silently returning the byte-identical default treasury status response.
- Keep normal unfiltered treasury status lookups unchanged.
- Add regression coverage for `limit`, `offset`, `status`, `action`, `to_account`, and `bounty_id`.

## Bounty

Bounty #798
Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636434536
Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636439232

## Validation

- `python3 -m pytest tests/test_treasury_proposals.py::test_treasury_status_rejects_proposal_list_filters tests/test_treasury_proposals.py::test_treasury_status_reports_reserve_capacity_and_pending_create_proposals -q` -> 2 passed
- `python3 -m pytest tests/test_treasury_proposals.py -q` -> 61 passed
- `python3 -m ruff check app/treasury_routes.py tests/test_treasury_proposals.py` -> passed
- `python3 -m ruff format --check app/treasury_routes.py tests/test_treasury_proposals.py` -> 2 files already formatted
- `python3 -m mypy app/treasury_routes.py` -> success
- `git diff --check` -> clean

## Scope

Public treasury status query validation only. No admin APIs, wallet signatures, private keys, secrets, payout execution, treasury mutation, ledger mutation, bridge, exchange, cash-out, MRWK price, or private security detail is involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The treasury status endpoint now validates query parameters and rejects unsupported filters with HTTP 400 errors instead of silently ignoring them.

* **Tests**
  * Added test coverage for query parameter validation on the treasury status endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->