### PR TITLE
Reject ledger detail query filters

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -37,7 +37,11 @@ from app.path_params import (
     proof_hash_from_path,
 )
 from app.public_routes import register_public_routes
-from app.query_validation import reject_noncanonical_int_query_param, reject_repeated_query_param
+from app.query_validation import (
+    reject_noncanonical_int_query_param,
+    reject_repeated_query_param,
+    reject_unsupported_query_params,
+)
 from app.status import health_status, system_status
 from app.treasury_routes import register_treasury_routes
 from app.wallet_api import register_wallet_api_routes
@@ -249,6 +253,14 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         with session_scope(db_url) as session:
             return recent_ledger_entries(session, limit, offset)
 
+    def ledger_entry_detail(sequence: int | str) -> dict[str, Any]:
+        sequence_id = positive_ledger_sequence(sequence)
+        with session_scope(db_url) as session:
+            entry = ledger_entry_to_dict(session, sequence_id)
+            if entry is None:
+                raise HTTPException(status_code=404, detail="ledger entry not found")
+            return entry
+
     @app.get("/api/v1/ledger")
     def api_ledger(
         request: Request,
@@ -261,13 +273,13 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         return ledger_rows(limit, offset)
 
     @app.get("/api/v1/ledger/{sequence}")
-    def api_ledger_entry(sequence: int | str) -> dict[str, Any]:
-        sequence_id = positive_ledger_sequence(sequence)
-        with session_scope(db_url) as session:
-            entry = ledger_entry_to_dict(session, sequence_id)
-            if entry is None:
-                raise HTTPException(status_code=404, detail="ledger entry not found")
-            return entry
+    def api_ledger_entry(request: Request, sequence: int | str) -> dict[str, Any]:
+        reject_unsupported_query_params(
+            request,
+            ("limit", "offset", "account", "q", "type", "status"),
+            target="ledger entry detail",
+        )
+        return ledger_entry_detail(sequence)
 
     @app.get("/api/v1/proofs/{proof_hash}")
     def api_proof(proof_hash: str) -> dict[str, Any]:
@@ -332,7 +344,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         list_bounties_by_status=list_bounties_by_status,
         api_bounty=api_bounty,
         api_ledger=ledger_rows,
-        api_ledger_entry=api_ledger_entry,
+        api_ledger_entry=ledger_entry_detail,
         api_proof=api_proof,
     )
 

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -26,6 +26,7 @@ from app.query_validation import (
     reject_control_char_query_param,
     reject_noncanonical_int_query_param,
     reject_repeated_query_param,
+    reject_unsupported_query_params,
 )
 from app.serializers import bounty_list_summary, wallet_to_dict
 from app.status import (
@@ -384,6 +385,11 @@ def register_public_routes(
 
     @app.get("/ledger/{sequence}", response_class=HTMLResponse)
     def ledger_entry_page(request: Request, sequence: str) -> HTMLResponse:
+        reject_unsupported_query_params(
+            request,
+            ("limit", "offset", "account", "q", "type", "status"),
+            target="ledger entry detail",
+        )
         return templates.TemplateResponse(
             request, "ledger_entry.html", ledger_entry_page_context(sequence, api_ledger_entry)
         )

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 
 from fastapi import HTTPException, Request
 
@@ -59,3 +60,18 @@ def reject_repeated_query_param(request: Request, name: str) -> None:
             status_code=400,
             detail=f"{name} must be provided at most once",
         )
+
+
+def reject_unsupported_query_params(
+    request: Request,
+    names: Iterable[str],
+    *,
+    target: str,
+) -> None:
+    """Reject list/search parameters on detail endpoints that cannot honor them."""
+    for name in names:
+        if _query_param_values(request, name):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} is not supported on {target}",
+            )

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -1060,6 +1060,20 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
         'href="https://github.com/ramimbo/mergework/pull/99" rel="nofollow noopener"'
         in ledger_entry_page.text
     )
+    for query, field in (
+        ("limit=1", "limit"),
+        ("offset=1", "offset"),
+        ("account=github:alice", "account"),
+        ("q=payment", "q"),
+        ("type=bounty_payment", "type"),
+        ("status=paid", "status"),
+    ):
+        api_detail = client.get(f"/api/v1/ledger/{payment_sequence}?{query}")
+        assert api_detail.status_code == 400
+        assert api_detail.json()["detail"] == f"{field} is not supported on ledger entry detail"
+        html_detail = client.get(f"/ledger/{payment_sequence}?{query}")
+        assert html_detail.status_code == 400
+        assert html_detail.json()["detail"] == f"{field} is not supported on ledger entry detail"
     genesis_page = client.get("/ledger/1")
     assert genesis_page.status_code == 200
     assert 'href="/ledger">All ledger entries</a>' in genesis_page.text


### PR DESCRIPTION
## Summary

/claim #798

- Reject ledger-list/search query filters on `/api/v1/ledger/<sequence>` and `/ledger/<sequence>` instead of silently returning byte-identical default detail responses.
- Keep normal unfiltered ledger entry detail lookups unchanged.
- Add a small shared query helper for detail endpoints that cannot honor list/search parameters.
- Add regression coverage for `limit`, `offset`, `account`, `q`, `type`, and `status` on both JSON and HTML ledger detail surfaces.

## Bounty

Bounty #798
Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636481853
Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636483362

## Validation

- `python3 -m pytest tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable -q` -> 1 passed
- `python3 -m pytest tests/test_bounty_pages.py -q` -> 19 passed
- `python3 -m pytest tests/test_api_mcp.py::test_ledger_api_rejects_noncanonical_limit tests/test_api_mcp.py::test_ledger_api_honors_offset tests/test_api_mcp.py::test_ledger_api_applies_default_limit_when_omitted -q` -> 6 passed
- `python3 -m ruff check app/main.py app/public_routes.py app/query_validation.py tests/test_bounty_pages.py` -> passed
- `python3 -m ruff format --check app/main.py app/public_routes.py app/query_validation.py tests/test_bounty_pages.py` -> 4 files already formatted
- `python3 -m mypy app/query_validation.py app/public_routes.py` -> success
- `git diff --check` -> clean

Additional local note: `python3 -m mypy app/main.py app/public_routes.py app/query_validation.py` reports existing unrelated errors in `app/webhooks/github.py` and `app/admin.py`; those files are not touched by this PR.

## Scope

Public ledger detail query validation only. No admin APIs, wallet signatures, private keys, secrets, payout execution, treasury mutation, ledger mutation, bridge, exchange, cash-out, MRWK price, or private security detail is involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The ledger entry detail endpoint now properly rejects unsupported query parameters with HTTP 400 errors. Attempting to pass invalid parameters (such as `limit`, `offset`, `account`, `q`, `type`, or `status`) will now return clear error messages indicating which fields are not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->