### PR TITLE
Honor ledger page offset

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -330,7 +330,7 @@ def register_public_routes(
         list[dict[str, Any]],
     ],
     api_bounty: Callable[[str], dict[str, Any]],
-    api_ledger: Callable[[int], list[dict[str, Any]]],
+    api_ledger: Callable[[int, int], list[dict[str, Any]]],
     api_ledger_entry: Callable[[str], dict[str, Any]],
     api_proof: Callable[[str], dict[str, Any]],
 ) -> None:
@@ -377,10 +377,14 @@ def register_public_routes(
     def ledger_page(
         request: Request,
         limit: Annotated[int, Query(ge=1, le=200)] = 50,
+        offset: Annotated[int, Query(ge=0, le=SQLITE_INTEGER_MAX)] = 0,
     ) -> HTMLResponse:
-        reject_repeated_query_param(request, "limit")
-        reject_noncanonical_int_query_param(request, "limit")
-        return templates.TemplateResponse(request, "ledger.html", {"entries": api_ledger(limit)})
+        for name in ("limit", "offset"):
+            reject_repeated_query_param(request, name)
+            reject_noncanonical_int_query_param(request, name)
+        return templates.TemplateResponse(
+            request, "ledger.html", {"entries": api_ledger(limit, offset)}
+        )
 
     @app.get("/ledger/{sequence}", response_class=HTMLResponse)
     def ledger_entry_page(request: Request, sequence: str) -> HTMLResponse:

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -1039,12 +1039,26 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert limited_ledger_page.text.count('class="ledger-row ledger-row--') == 1
     assert f'href="/ledger/{unsafe_payment_sequence}"' in limited_ledger_page.text
     assert f'href="/ledger/{payment_sequence}"' not in limited_ledger_page.text
+    offset_ledger_page = client.get("/ledger?limit=1&offset=1")
+    assert offset_ledger_page.status_code == 200
+    assert offset_ledger_page.text.count('class="ledger-row ledger-row--') == 1
+    expected_shifted = client.get("/api/v1/ledger?limit=1&offset=1")
+    assert expected_shifted.status_code == 200
+    expected_sequence = expected_shifted.json()[0]["sequence"]
+    assert f'href="/ledger/{expected_sequence}"' in offset_ledger_page.text
+    assert f'href="/ledger/{unsafe_payment_sequence}"' not in offset_ledger_page.text
     noncanonical_limit = client.get("/ledger?limit=01")
     repeated_limit = client.get("/ledger?limit=1&limit=2")
+    noncanonical_offset = client.get("/ledger?offset=01")
+    repeated_offset = client.get("/ledger?offset=1&offset=2")
     assert noncanonical_limit.status_code == 400
     assert noncanonical_limit.json()["detail"] == "limit must be a canonical positive integer"
     assert repeated_limit.status_code == 400
     assert repeated_limit.json()["detail"] == "limit must be provided at most once"
+    assert noncanonical_offset.status_code == 400
+    assert noncanonical_offset.json()["detail"] == "offset must be a canonical positive integer"
+    assert repeated_offset.status_code == 400
+    assert repeated_offset.json()["detail"] == "offset must be provided at most once"
 
     ledger_entry_page = client.get(f"/ledger/{payment_sequence}")
     assert ledger_entry_page.status_code == 200


### PR DESCRIPTION
## Summary

/claim #798

- Make the public HTML `/ledger` page honor `offset` the same way `/api/v1/ledger` does.
- Validate repeated and non-canonical `offset` values before rendering.
- Add regression coverage showing `/ledger?limit=1&offset=1` renders a different row than `/ledger?limit=1`.

## Bounty

Bounty #798
Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636528372
Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636529850

## Validation

- `python3 -m pytest tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable -q` -> 1 passed
- `python3 -m pytest tests/test_bounty_pages.py -q` -> 19 passed
- `python3 -m ruff check app/public_routes.py tests/test_bounty_pages.py` -> passed
- `python3 -m ruff format --check app/public_routes.py tests/test_bounty_pages.py` -> 2 files already formatted
- `python3 -m mypy app/public_routes.py` -> success
- `git diff --check` -> clean

## Scope

Public HTML ledger pagination only. No admin APIs, wallet signatures, private keys, secrets, payout execution, treasury mutation, ledger mutation, bridge, exchange, cash-out, MRWK price, or private security detail is involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `offset` query parameter to the ledger page for paginated browsing alongside `limit`.

* **Bug Fixes / Validation**
  * Stronger validation for `limit` and `offset`, returning errors for non-canonical or repeated parameters.

* **Tests**
  * Expanded tests to cover offset pagination, validation behavior, and rendered ledger row correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->