### PR TITLE
Reject status query filters

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -185,10 +185,22 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         with session_scope(db_url) as session:
             return health_status(session)
 
-    @app.get("/api/v1/status")
-    def api_status() -> dict[str, Any]:
+    def reject_status_query_filters(request: Request) -> None:
+        for name in ("limit", "offset", "status", "q", "account", "repo"):
+            if request.query_params.getlist(name):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"{name} is not supported on status",
+                )
+
+    def status_detail() -> dict[str, Any]:
         with session_scope(db_url) as session:
             return system_status(session)
+
+    @app.get("/api/v1/status")
+    def api_status(request: Request) -> dict[str, Any]:
+        reject_status_query_filters(request)
+        return status_detail()
 
     _bounty_api = register_bounty_api_routes(
         app,
@@ -318,7 +330,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 "ltc_lab.html",
                 ltc_lab_context(),
             )
-        status_data = api_status()
+        status_data = status_detail()
         return templates.TemplateResponse(
             request,
             "hub.html",

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from fastapi.testclient import TestClient
 from sqlalchemy import func, select
 
 from app.db import create_schema, session_scope
@@ -11,6 +12,7 @@ from app.ledger.service import (
     get_balance,
     pay_bounty,
 )
+from app.main import create_app
 from app.models import LedgerEntry
 from app.status import health_status, public_path_status, system_status
 
@@ -94,6 +96,26 @@ def test_system_status_counts_only_open_bounties(sqlite_url: str) -> None:
         "Future public snapshots, bridges, and onchain claims require separate "
         "maintainer/contributor discussion before implementation."
     )
+
+
+def test_status_api_rejects_list_query_filters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    assert client.get("/api/v1/status").status_code == 200
+    for query, field in (
+        ("limit=1", "limit"),
+        ("offset=1", "offset"),
+        ("status=open", "status"),
+        ("q=bounty", "q"),
+        ("account=github:alice", "account"),
+        ("repo=ramimbo/mergework", "repo"),
+    ):
+        response = client.get(f"/api/v1/status?{query}")
+        assert response.status_code == 400
+        assert response.json()["detail"] == f"{field} is not supported on status"
 
 
 def test_public_path_status_returns_independent_lists() -> None:


### PR DESCRIPTION
## Summary

/claim #798

- Reject list/search query filters on `/api/v1/status` instead of silently returning the byte-identical global status object.
- Keep normal unfiltered status lookups and the hub page status context unchanged.
- Add regression coverage for `limit`, `offset`, `status`, `q`, `account`, and `repo`.

## Bounty

Bounty #798
Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636612927
Corrected claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636614349

## Validation

- `python3 -m pytest tests/test_status.py::test_status_api_rejects_list_query_filters -q` -> 1 passed
- `python3 -m pytest tests/test_status.py tests/test_hub.py -q` -> 9 passed
- `python3 -m ruff check app/main.py tests/test_status.py` -> passed
- `python3 -m ruff format --check app/main.py tests/test_status.py` -> 2 files already formatted
- `python3 -m py_compile app/main.py tests/test_status.py` -> passed
- `git diff --check` -> clean

Additional local note: `python3 -m mypy tests/test_status.py` reports existing unrelated errors in `app/webhooks/github.py` and `app/admin.py`; those files are not touched by this PR.

## Scope

Public system status query validation only. No admin APIs, wallet signatures, private keys, secrets, payout execution, treasury mutation, ledger mutation, bridge, exchange, cash-out, MRWK price, or private security detail is involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status API endpoint now properly rejects unsupported query parameters (limit, offset, status, q, account, repo) with HTTP 400 errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->