### PR TITLE
Reject wallets page query filters

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -390,6 +390,12 @@ def register_public_routes(
 
     @app.get("/wallets", response_class=HTMLResponse)
     def wallets_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:
+        for name in ("limit", "offset", "status", "account", "repo", "type"):
+            if request.query_params.getlist(name):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"{name} is not supported on wallets page",
+                )
         reject_control_char_query_param(request, "q")
         reject_repeated_query_param(request, "q")
         with session_scope(db_url) as session:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -738,6 +738,14 @@ def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
     type_response = client.get(f"/wallets/{address}", params={"type": "test_funding\t"})
     masked_search_response = client.get("/wallets?q=%C2%85Main&q=Main")
     repeated_search_response = client.get("/wallets?q=Main&q=smoke")
+    unsupported_wallet_list_filters = {
+        "limit": "1",
+        "offset": "1",
+        "status": "open",
+        "account": "github:alice",
+        "repo": "ramimbo/mergework",
+        "type": "test_funding",
+    }
     masked_type_response = client.get(f"/wallets/{address}?type=%C2%85test_funding&type=all")
     repeated_type_response = client.get(f"/wallets/{address}?type=test_funding&type=all")
     max_length_search_response = client.get("/wallets", params={"q": "a" * 500})
@@ -751,6 +759,12 @@ def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
     assert masked_search_response.json()["detail"] == "q must not contain control characters"
     assert repeated_search_response.status_code == 400
     assert repeated_search_response.json()["detail"] == "q must be provided at most once"
+    for name, value in unsupported_wallet_list_filters.items():
+        unsupported_filter_response = client.get("/wallets", params={name: value})
+        assert unsupported_filter_response.status_code == 400
+        assert unsupported_filter_response.json()["detail"] == (
+            f"{name} is not supported on wallets page"
+        )
     assert masked_type_response.status_code == 400
     assert (
         masked_type_response.json()["detail"]


### PR DESCRIPTION
Fixes another `/wallets` page query mismatch from bounty #798.

/claim #798

Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636673616
Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636675222

What changed:
- Reject unsupported `/wallets` query filters: `limit`, `offset`, `status`, `account`, `repo`, `type`.
- Keep supported `q` wallet search behavior unchanged.
- Add regression coverage for unsupported list filters.

Validation:
- `python3 -m pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows tests/test_wallet_api.py::test_wallet_pages_reject_control_character_filters -q`
- `python3 -m pytest tests/test_wallet_api.py -q`
- `python3 -m ruff check app/public_routes.py tests/test_wallet_api.py`
- `python3 -m ruff format --check app/public_routes.py tests/test_wallet_api.py`
- `python3 -m mypy app/public_routes.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The wallets page now properly validates incoming query parameters and rejects unsupported filters (`limit`, `offset`, `status`, `account`, `repo`, `type`) with HTTP 400 error responses. Users attempting to use these parameters will receive clear error messages explaining that each parameter is not supported on the wallets page, improving API robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->