### PR TITLE
Reject transfer page query filters

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -415,6 +415,12 @@ def register_public_routes(
 
     @app.get("/transfer", response_class=HTMLResponse)
     def transfer_page(request: Request) -> HTMLResponse:
+        for name in ("limit", "offset", "status", "q", "account", "repo", "type", "tx_type"):
+            if request.query_params.getlist(name):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"{name} is not supported on transfer page",
+                )
         return templates.TemplateResponse(request, "transfer.html")
 
     @app.get("/proofs/{proof_hash}", response_class=HTMLResponse)

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -763,6 +763,30 @@ def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
     assert oversized_search_response.json()["detail"] == "q must be at most 500 characters"
 
 
+def test_transfer_page_rejects_unsupported_query_filters(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/transfer")
+
+    assert response.status_code == 200
+    assert "Signed transfer" in response.text
+    for name, value in {
+        "limit": "1",
+        "offset": "1",
+        "status": "open",
+        "q": "bounty",
+        "account": "github:alice",
+        "repo": "ramimbo/mergework",
+        "type": "bounty_payment",
+        "tx_type": "bounty_payment",
+    }.items():
+        unsupported_response = client.get("/transfer", params={name: value})
+        assert unsupported_response.status_code == 400
+        assert unsupported_response.json()["detail"] == (
+            f"{name} is not supported on transfer page"
+        )
+
+
 def test_me_page_shows_signed_in_github_claim_balance(sqlite_url: str, monkeypatch) -> None:
     monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
     create_schema(sqlite_url)


### PR DESCRIPTION
Reject unsupported query filters on the public `/transfer` page.

/claim #798

Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636805253
Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636806817

What changed:
- Reject unsupported `/transfer` query filters: `limit`, `offset`, `status`, `q`, `account`, `repo`, `type`, `tx_type`.
- Keep the normal unfiltered transfer page unchanged.
- Add regression coverage for each unsupported query name.

Validation:
- `python3 -m pytest tests/test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows tests/test_wallet_api.py::test_transfer_page_rejects_unsupported_query_filters -q`
- `python3 -m pytest tests/test_wallet_api.py -q`
- `python3 -m ruff check app/public_routes.py tests/test_wallet_api.py`
- `python3 -m ruff format --check app/public_routes.py tests/test_wallet_api.py`
- `python3 -m mypy app/public_routes.py`
- `git diff --check`

Scope: public transfer page query validation only. No transfer signing, wallet material, ledger mutation, payout execution, treasury mutation, bridge/exchange/cash-out behavior, MRWK price behavior, private data, or secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `/transfer` page now validates incoming query parameters and rejects unsupported ones with a clear error message (HTTP 400), ensuring only valid filters are accepted.

* **Tests**
  * Added comprehensive test coverage for transfer page query parameter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->