### PR TITLE
Reject bounty list cross-surface filters

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -209,6 +209,12 @@ def register_bounty_api_routes(
             reject_control_char_query_param(request, name)
         for name in ("limit", "issue_number"):
             reject_noncanonical_int_query_param(request, name)
+        for name in ("account", "type", "tx_type"):
+            if request.query_params.getlist(name):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"{name} is not supported on bounty list endpoints",
+                )
 
     @app.get("/api/v1/bounties")
     def api_bounties(

--- a/tests/test_bounty_api_routes.py
+++ b/tests/test_bounty_api_routes.py
@@ -473,6 +473,30 @@ def test_bounty_api_rejects_repeated_scalar_filters(
     assert response.json()["detail"] == detail
 
 
+@pytest.mark.parametrize("base_path", ["/api/v1/bounties", "/api/v1/bounties/summary"])
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("account", "github:alice"),
+        ("type", "bounty_payment"),
+        ("tx_type", "bounty_payment"),
+    ],
+)
+def test_bounty_api_rejects_cross_surface_filters(
+    sqlite_url: str, base_path: str, name: str, value: str
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(base_path, params={name: value})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == f"{name} is not supported on bounty list endpoints"
+
+
 def test_bounty_api_limit_caps_filtered_rows(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
/claim #798

Fixes one live bug-bounty report: unsupported wallet-style filters were silently ignored by the bounty list APIs.

Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636855118
Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4636856434

What changed:
- reject account, type, and tx_type on /api/v1/bounties and /api/v1/bounties/summary with HTTP 400
- add coverage for both endpoints

Validation:
- python3 -m pytest tests/test_bounty_api_routes.py::test_bounty_api_rejects_cross_surface_filters tests/test_bounty_api_routes.py::test_bounty_api_rejects_repeated_scalar_filters tests/test_bounty_api_routes.py::test_bounty_api_limit_caps_filtered_rows -q -> 14 passed
- python3 -m pytest tests/test_bounty_api_routes.py -q -> 27 passed
- python3 -m ruff check app/bounty_api.py tests/test_bounty_api_routes.py -> passed
- python3 -m ruff format --check app/bounty_api.py tests/test_bounty_api_routes.py -> passed
- git diff --check -> clean

Note:
- python3 -m mypy app/bounty_api.py currently fails on existing origin/main app/admin.py:72 typing, outside this patch scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Bounty list API endpoints now properly validate incoming requests and reject unsupported query parameters (account, type, and tx_type) with HTTP 400 error responses containing specific error detail messages identifying the unsupported parameters.

## Tests
* Added parametrized test cases to verify proper validation and error handling behavior across bounty list and summary endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->