### PR TITLE
Reject repeated OAuth next parameter

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -12,6 +12,7 @@ from fastapi.responses import RedirectResponse
 
 from app.config import Settings
 from app.control_chars import contains_control_character
+from app.query_validation import reject_repeated_query_param
 
 
 def oauth_configured(settings: Settings) -> bool:
@@ -109,9 +110,12 @@ def register_auth_routes(app: FastAPI, *, settings: Settings) -> AuthService:
     auth = AuthService(settings)
 
     @app.get("/auth/github/login")
-    def auth_github_login(next_path: str | None = Query(None, alias="next")) -> RedirectResponse:
+    def auth_github_login(
+        request: Request, next_path: str | None = Query(None, alias="next")
+    ) -> RedirectResponse:
         if not oauth_configured(settings):
             raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
+        reject_repeated_query_param(request, "next")
         safe_next = safe_next_path(next_path)
         state_value = f"{secrets.token_urlsafe(24)},{safe_next}"
         state = signed_value(state_value, settings.cookie_secret)

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -609,6 +609,19 @@ def test_github_login_redirects_when_oauth_is_configured(sqlite_url: str, monkey
     assert "mrwk_oauth_state" in response.cookies
 
 
+def test_github_login_rejects_repeated_next(sqlite_url: str, monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    monkeypatch.setenv("MERGEWORK_PUBLIC_BASE_URL", "https://mrwk.example.test")
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/auth/github/login?next=/bounties&next=/wallets", follow_redirects=False)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "next must be provided at most once"
+
+
 @pytest.mark.parametrize(
     "next_path",
     (


### PR DESCRIPTION
## Summary

- reject repeated `next` query parameters on `/auth/github/login` before OAuth state is signed
- add a regression test for duplicate `next` handling

## Why

The OAuth login route already rejects external or header-like return targets through `safe_next_path`, but repeated scalar `next` parameters were still accepted. FastAPI exposes one selected value to the route, so a URL such as `?next=/bounties&next=/wallets` silently signs `/wallets` as the post-login return target.

Rejecting repeated `next` values matches the existing scalar query-parameter guard pattern used by other public routes and removes the redirect-target ambiguity.

Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4637054243
Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4637055481

## Validation

- `.\\.venv\\Scripts\\python.exe -m pytest tests/test_wallet_api.py::test_github_login_redirects_when_oauth_is_configured tests/test_wallet_api.py::test_github_login_rejects_repeated_next tests/test_wallet_api.py::test_github_login_stores_safe_default_for_backslash_next -q`
- `.\\.venv\\Scripts\\python.exe -m ruff check app/auth.py tests/test_wallet_api.py`
- `.\\.venv\\Scripts\\python.exe -m ruff format --check app/auth.py tests/test_wallet_api.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub OAuth login now validates the `next` parameter to ensure it is provided at most once. Requests with duplicate `next` parameters are rejected with a 400 error response.

* **Tests**
  * Added test case verifying that duplicate `next` parameters are properly rejected by the GitHub OAuth login endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->