### PR TITLE
Reject unsupported auth status query params

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -37,7 +37,11 @@ from app.path_params import (
     proof_hash_from_path,
 )
 from app.public_routes import register_public_routes
-from app.query_validation import reject_noncanonical_int_query_param, reject_repeated_query_param
+from app.query_validation import (
+    reject_noncanonical_int_query_param,
+    reject_repeated_query_param,
+    reject_unsupported_query_params,
+)
 from app.status import health_status, system_status
 from app.treasury_routes import register_treasury_routes
 from app.wallet_api import register_wallet_api_routes
@@ -230,6 +234,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/api/v1/auth/me")
     def api_auth_me(request: Request) -> dict[str, Any]:
+        reject_unsupported_query_params(request, set())
         login = auth.github_login_from_request(request)
         return {"authenticated": login is not None, "github_login": login}
 

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -59,3 +59,12 @@ def reject_repeated_query_param(request: Request, name: str) -> None:
             status_code=400,
             detail=f"{name} must be provided at most once",
         )
+
+
+def reject_unsupported_query_params(request: Request, allowed: set[str]) -> None:
+    for name in request.query_params:
+        if name not in allowed:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} is not supported on this endpoint",
+            )

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -594,6 +594,28 @@ def test_auth_routes_exist_when_oauth_is_unconfigured(sqlite_url: str) -> None:
     assert client.get("/api/v1/auth/me").json()["authenticated"] is False
 
 
+@pytest.mark.parametrize(
+    "query",
+    (
+        "limit=1",
+        "offset=1",
+        "status=open",
+        "q=bounty",
+        "account=github:alice",
+        "repo=ramimbo/mergework",
+        "type=bounty_payment",
+        "tx_type=bounty_payment",
+    ),
+)
+def test_auth_me_rejects_unsupported_query_params(sqlite_url: str, query: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(f"/api/v1/auth/me?{query}")
+
+    assert response.status_code == 400
+    assert response.json()["detail"].endswith("is not supported on this endpoint")
+
+
 def test_github_login_redirects_when_oauth_is_configured(sqlite_url: str, monkeypatch) -> None:
     monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_ID", "client-id")
     monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", "client-secret")


### PR DESCRIPTION
## Summary
- reject unsupported query parameters on `/api/v1/auth/me`
- add regression coverage for list/search/account/repo/transaction filters on the auth status endpoint

## Bounty context
Bounty #798

Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4637240882

This fixes the reported production behavior where `/api/v1/auth/me` returned the same auth status response for unrelated query filters such as `limit`, `offset`, `status`, `q`, `account`, `repo`, `type`, and `tx_type`.

## Validation
- `uv run --extra dev pytest tests/test_wallet_api.py::test_auth_routes_exist_when_oauth_is_unconfigured tests/test_wallet_api.py::test_auth_me_rejects_unsupported_query_params tests/test_wallet_api.py::test_github_login_redirects_when_oauth_is_configured -q`
- `uv run --extra dev ruff check app/main.py app/query_validation.py tests/test_wallet_api.py`
- `uv run --extra dev ruff format --check app/main.py app/query_validation.py tests/test_wallet_api.py`
- `uv run --extra dev mypy app/main.py app/query_validation.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `/api/v1/auth/me` endpoint now validates query parameters and rejects unsupported ones with a descriptive error message.

* **Tests**
  * Added test coverage for query parameter validation on the authentication endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->