### PR TITLE
Reject unsupported health query params

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -37,7 +37,11 @@ from app.path_params import (
     proof_hash_from_path,
 )
 from app.public_routes import register_public_routes
-from app.query_validation import reject_noncanonical_int_query_param, reject_repeated_query_param
+from app.query_validation import (
+    reject_noncanonical_int_query_param,
+    reject_repeated_query_param,
+    reject_unsupported_query_params,
+)
 from app.status import health_status, system_status
 from app.treasury_routes import register_treasury_routes
 from app.wallet_api import register_wallet_api_routes
@@ -181,7 +185,8 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     auth = auth_module.register_auth_routes(app, settings=settings)
 
     @app.get("/health")
-    def health() -> dict[str, Any]:
+    def health(request: Request) -> dict[str, Any]:
+        reject_unsupported_query_params(request, set())
         with session_scope(db_url) as session:
             return health_status(session)
 

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -59,3 +59,13 @@ def reject_repeated_query_param(request: Request, name: str) -> None:
             status_code=400,
             detail=f"{name} must be provided at most once",
         )
+
+
+def reject_unsupported_query_params(request: Request, allowed: set[str]) -> None:
+    """Reject query parameters that have no meaning on the current endpoint."""
+    for name in request.query_params:
+        if name not in allowed:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} is not supported on this endpoint",
+            )

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -64,6 +64,21 @@ def _fund_wallet(sqlite_url: str, address: str, amount_microunits: int = 10_000_
         )
 
 
+def test_health_endpoint_rejects_unsupported_query_params(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    ok_response = client.get("/health")
+    assert ok_response.status_code == 200
+    assert ok_response.json()["ok"] is True
+
+    for name in ("limit", "offset", "status", "q", "account", "repo", "type", "tx_type"):
+        response = client.get(f"/health?{name}=1")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == f"{name} is not supported on this endpoint"
+
+
 def test_wallet_api_register_lookup_and_transfer(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     sender_key, sender_public, sender_address = _keypair()


### PR DESCRIPTION
## Summary
- reject unsupported query parameters on the zero-query `/health` endpoint
- add a shared unsupported-query helper on `app.query_validation` for endpoints with explicit query allowlists
- add regression coverage that keeps plain `/health` successful and rejects cross-surface filters

## Bounty / report
- Bounty: #798
- Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4637265959
- Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4637266364

## Evidence
Production repro before fix showed `/health` returning the same 200 status body for unsupported filters including `limit`, `offset`, `status`, `q`, `account`, and `repo`. This PR fails closed for any query parameter because `/health` has no documented query surface.

## Validation
- `uv run --extra dev pytest tests/test_wallet_api.py::test_health_endpoint_rejects_unsupported_query_params -q` -> 1 passed
- `uv run --extra dev pytest tests/test_wallet_api.py -q` -> 46 passed
- `uv run --extra dev ruff check app/main.py app/query_validation.py tests/test_wallet_api.py` -> passed
- `uv run --extra dev ruff format --check app/main.py app/query_validation.py tests/test_wallet_api.py` -> already formatted
- `uv run --extra dev mypy app/main.py app/query_validation.py` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD -- app/main.py app/query_validation.py tests/test_wallet_api.py` -> clean

## Scope
Public health endpoint query validation only. No private data, credentials, wallet material, ledger mutation, treasury mutation, payout execution, exchange, bridge, cash-out, MRWK price behavior, or private security details were used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `/health` endpoint now includes query parameter validation. Any request containing unsupported query parameters will be rejected with a 400 Bad Request response that provides a descriptive error message identifying which parameters are not accepted by the endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->