### PR TITLE
Reject unsupported docs query params

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -26,6 +26,7 @@ from app.query_validation import (
     reject_control_char_query_param,
     reject_noncanonical_int_query_param,
     reject_repeated_query_param,
+    reject_unsupported_query_params,
 )
 from app.serializers import bounty_list_summary, wallet_to_dict
 from app.status import (
@@ -428,6 +429,7 @@ def register_public_routes(
 
     @app.get("/docs", response_class=HTMLResponse)
     def docs_page(request: Request) -> HTMLResponse:
+        reject_unsupported_query_params(request, set())
         return templates.TemplateResponse(
             request,
             "docs.html",

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -59,3 +59,13 @@ def reject_repeated_query_param(request: Request, name: str) -> None:
             status_code=400,
             detail=f"{name} must be provided at most once",
         )
+
+
+def reject_unsupported_query_params(request: Request, allowed: set[str]) -> None:
+    """Reject query parameters that have no meaning on the current endpoint."""
+    for name in request.query_params:
+        if name not in allowed:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} is not supported on this endpoint",
+            )

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -16,6 +16,11 @@ publish request and response schemas for attempt reservations, wallet actions,
 transfers, and treasury challenges so clients can discover payload and result
 fields without reading source code.
 
+The human-readable contributor docs page at `https://mrwk.online/docs` is a
+static page and must be requested without query parameters. Requests such as
+`/docs?limit=1` or `/docs?status=open` return HTTP 400 because the page does not
+support list, search, account, repository, or status filters.
+
 ## Status And Bounties
 
 Check service status and list bounties:

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -562,6 +562,15 @@ def test_api_examples_document_activity_response_shape() -> None:
     assert "/api/v1/proofs/<proof_hash>" in examples
 
 
+def test_api_examples_document_docs_page_query_rejection() -> None:
+    examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
+
+    assert "https://mrwk.online/docs" in examples
+    assert "/docs?limit=1" in examples
+    assert "/docs?status=open" in examples
+    assert "return HTTP 400" in examples
+
+
 def test_api_examples_document_accepted_work_bounty_context() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -134,6 +134,16 @@ def test_docs_page_marks_static_github_links_as_untrusted(sqlite_url: str) -> No
         assert f'href="{url}"' in page.text
 
 
+def test_docs_page_rejects_unsupported_query_params(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    for name in ("limit", "offset", "status", "q", "account", "repo"):
+        response = client.get(f"/docs?{name}=1")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == f"{name} is not supported on this endpoint"
+
+
 def test_ltc_lab_header_marks_github_nav_link_as_untrusted(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 


### PR DESCRIPTION
## Summary
- reject unsupported query parameters on the static `/docs` page
- add a shared unsupported-query helper for explicit query allowlists
- add regression coverage for list/search/account/repo-style query parameters on `/docs`

## Bounty / report
- Bounty: #798
- Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4637308212
- Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4637308950

## Evidence
Production repro before fix showed `/docs` returning the same 200 response body for unsupported filters including `limit`, `status`, `q`, `account`, and `repo`. This PR fails closed for any query parameter because `/docs` has no documented query surface.

## Validation
- `uv run --extra dev pytest tests/test_public_routes.py::test_docs_page_marks_static_github_links_as_untrusted tests/test_public_routes.py::test_docs_page_rejects_unsupported_query_params -q` -> 2 passed
- `uv run --extra dev pytest tests/test_public_routes.py -q` -> 8 passed
- `uv run --extra dev ruff check app/public_routes.py app/query_validation.py tests/test_public_routes.py` -> passed
- `uv run --extra dev ruff format --check app/public_routes.py app/query_validation.py tests/test_public_routes.py` -> already formatted
- `uv run --extra dev mypy app/public_routes.py app/query_validation.py` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD -- app/public_routes.py app/query_validation.py tests/test_public_routes.py` -> clean

## Scope
Public docs page query validation only. No admin APIs, wallet material, credentials, ledger mutation, treasury mutation, payout execution, exchange, bridge, cash-out, MRWK price behavior, or private security details were used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Docs endpoint now rejects unsupported query parameters and returns clear HTTP 400 error messages.

* **Documentation**
  * Clarified that the human-readable docs page is static and must be requested without query parameters (e.g., /docs?limit=1 returns HTTP 400).

* **Tests**
  * Added tests ensuring the docs page rejects unsupported query parameters and reports appropriate errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->