### PR TITLE
Reject unsupported hub query params

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -37,7 +37,11 @@ from app.path_params import (
     proof_hash_from_path,
 )
 from app.public_routes import register_public_routes
-from app.query_validation import reject_noncanonical_int_query_param, reject_repeated_query_param
+from app.query_validation import (
+    reject_noncanonical_int_query_param,
+    reject_repeated_query_param,
+    reject_unsupported_query_params,
+)
 from app.status import health_status, system_status
 from app.treasury_routes import register_treasury_routes
 from app.wallet_api import register_wallet_api_routes
@@ -312,6 +316,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     @app.get("/", response_class=HTMLResponse)
     def hub(request: Request) -> HTMLResponse:
+        reject_unsupported_query_params(request, set())
         if is_ltc_lab_host(request.headers.get("host", "")):
             return templates.TemplateResponse(
                 request,

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -59,3 +59,13 @@ def reject_repeated_query_param(request: Request, name: str) -> None:
             status_code=400,
             detail=f"{name} must be provided at most once",
         )
+
+
+def reject_unsupported_query_params(request: Request, allowed: set[str]) -> None:
+    """Reject query parameters that have no meaning on the current endpoint."""
+    for name in request.query_params:
+        if name not in allowed:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} is not supported on this endpoint",
+            )

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -100,3 +100,14 @@ def test_mergework_hub_renders_contributor_starting_points(sqlite_url: str) -> N
     assert 'href="/activity"' in response.text
     assert "Current bounty JSON" in response.text
     assert 'href="/api/v1/bounties?status=open&amp;availability=effectively_open"' in response.text
+
+
+def test_mergework_hub_rejects_unsupported_query_params(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    for name in ("limit", "offset", "status", "q", "account", "repo"):
+        response = client.get(f"/?{name}=1")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == f"{name} is not supported on this endpoint"


### PR DESCRIPTION
## Summary
- reject unsupported query parameters on the root hub page `/`
- use the shared unsupported-query helper with an empty allowlist
- add regression coverage for list/search/account/repo-style query parameters on the hub route

## Bounty / report
- Bounty: #798
- Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4637351984
- Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4637352503

## Evidence
Production repro before fix showed `/` returning the same 200 response body for unsupported filters including `limit`, `status`, `q`, `account`, and `repo`. This PR fails closed for any query parameter because the root hub has no documented query surface.

## Validation
- `uv run --extra dev pytest tests/test_hub.py::test_mergework_hub_renders_contributor_starting_points tests/test_hub.py::test_mergework_hub_rejects_unsupported_query_params -q` -> 2 passed
- `uv run --extra dev pytest tests/test_hub.py -q` -> 6 passed
- `uv run --extra dev ruff check app/main.py app/query_validation.py tests/test_hub.py` -> passed
- `uv run --extra dev ruff format --check app/main.py app/query_validation.py tests/test_hub.py` -> already formatted
- `uv run --extra dev mypy app/main.py app/query_validation.py` -> success
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD -- app/main.py app/query_validation.py tests/test_hub.py` -> clean

## Scope
Public root hub query validation only. No admin APIs, wallet material, credentials, ledger mutation, treasury mutation, payout execution, exchange, bridge, cash-out, MRWK price behavior, or private security details were used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Hub endpoint now validates query parameters and rejects unsupported ones with informative error messages.

* **Tests**
  * Added test coverage for query parameter validation on the hub endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->