### PR TITLE
Reject account detail list filters

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -15,7 +15,7 @@ from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
 from app.ledger_views import account_ledger_transactions
 from app.models import Account
 from app.path_params import SQLITE_INTEGER_MAX, reject_path_whitespace_padding
-from app.query_validation import reject_repeated_query_param
+from app.query_validation import reject_repeated_query_param, reject_unsupported_query_params
 from app.serializers import (
     accepted_work_for_account,
     account_accepted_summary,
@@ -189,8 +189,9 @@ def account_page_context(
 
 def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
     @app.get("/api/v1/accounts/{account}")
-    def api_account(account: str) -> dict[str, Any]:
+    def api_account(request: Request, account: str) -> dict[str, Any]:
         reject_path_whitespace_padding(account, "account")
+        reject_unsupported_query_params(request, allowed=set())
         with session_scope(db_url) as session:
             return account_api_context(session, account)
 
@@ -205,6 +206,7 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
         request: Request, account: str, tx_type: str | None = Query(None)
     ) -> HTMLResponse:
         reject_path_whitespace_padding(account, "account")
+        reject_unsupported_query_params(request, allowed={"tx_type"})
         for value in request.query_params.getlist("tx_type"):
             if contains_control_character(value):
                 raise HTTPException(

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -59,3 +59,13 @@ def reject_repeated_query_param(request: Request, name: str) -> None:
             status_code=400,
             detail=f"{name} must be provided at most once",
         )
+
+
+def reject_unsupported_query_params(request: Request, allowed: set[str]) -> None:
+    """Reject query parameters that have no meaning on the current endpoint."""
+    for name in request.query_params:
+        if name not in allowed:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} is not supported on this endpoint",
+            )

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -116,6 +116,36 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     assert f'href="/proofs/{proof.hash}"' in page_response.text
 
 
+def test_account_api_rejects_unsupported_query_params(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    for name in ("limit", "status", "repo", "offset"):
+        response = client.get(f"/api/v1/accounts/github:alice?{name}=1")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == f"{name} is not supported on this endpoint"
+
+
+def test_account_page_rejects_unsupported_query_params(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    assert client.get("/accounts/github:alice?tx_type=genesis").status_code == 200
+
+    for name in ("limit", "status", "repo", "offset"):
+        response = client.get(f"/accounts/github:alice?{name}=1")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == f"{name} is not supported on this endpoint"
+
+
 def test_account_action_urls_escape_query_accounts() -> None:
     assert account_action_urls("github:alice") == {
         "account_json": "/api/v1/accounts/github:alice",


### PR DESCRIPTION
## Summary
- Reject unsupported query parameters on `/api/v1/accounts/{account}` instead of silently returning an unfiltered account detail response.
- Reject unsupported list/search filters on `/accounts/{account}` while preserving the supported `tx_type` page filter.
- Add a shared unsupported-query helper and focused account route regression coverage.

Bounty #798
Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4637384685
Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4637385218

## Production evidence
- `/api/v1/accounts/github:floofy6`, `?limit=1`, `?status=open`, `?repo=ramimbo/mergework`, and `?offset=1` all returned HTTP 200 with identical 783-byte response body and SHA-256 `57cf74d34b5d9fa28234d3267d5f451076d945e2e772191f4803b330318c188c`.
- `/accounts/github:floofy6`, `?limit=1`, `?status=open`, `?repo=ramimbo/mergework`, and `?offset=1` all returned HTTP 200 with identical 9641-byte response body and SHA-256 `9770bdf02221be49e526f36757e92e7b1ad21e8931f2aa93cc6ec12ac8df740c`.

## Validation
- `uv run --extra dev pytest tests/test_account_routes.py::test_account_api_rejects_unsupported_query_params tests/test_account_routes.py::test_account_page_rejects_unsupported_query_params -q` -> 2 passed, 1 warning.
- `uv run --extra dev pytest tests/test_account_routes.py -q` -> 11 passed, 1 warning.
- `uv run --extra dev ruff check app/accounts.py app/query_validation.py tests/test_account_routes.py` -> passed.
- `uv run --extra dev ruff format --check app/accounts.py app/query_validation.py tests/test_account_routes.py` -> 3 files already formatted.
- `uv run --extra dev mypy app/accounts.py app/query_validation.py` -> success.
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD -- app/accounts.py app/query_validation.py tests/test_account_routes.py` -> clean.

## Scope
Public account detail API/page query validation only. No admin-token APIs, payout execution, treasury mutation, ledger mutation, wallet material, secrets, bridge/exchange/cash-out behavior, MRWK price behavior, or private data is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account endpoints now enforce stricter query parameter validation, rejecting unsupported parameters with HTTP 400 errors. Only whitelisted parameters are accepted per endpoint.

* **Tests**
  * Added test coverage for query parameter validation on account endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->