### PR TITLE
Reject proof detail query filters

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -37,7 +37,11 @@ from app.path_params import (
     proof_hash_from_path,
 )
 from app.public_routes import register_public_routes
-from app.query_validation import reject_noncanonical_int_query_param, reject_repeated_query_param
+from app.query_validation import (
+    reject_noncanonical_int_query_param,
+    reject_repeated_query_param,
+    reject_unsupported_query_params,
+)
 from app.status import health_status, system_status
 from app.treasury_routes import register_treasury_routes
 from app.wallet_api import register_wallet_api_routes
@@ -269,8 +273,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 raise HTTPException(status_code=404, detail="ledger entry not found")
             return entry
 
-    @app.get("/api/v1/proofs/{proof_hash}")
-    def api_proof(proof_hash: str) -> dict[str, Any]:
+    def proof_payload(proof_hash: str) -> dict[str, Any]:
         proof_hash = proof_hash_from_path(proof_hash)
         with session_scope(db_url) as session:
             proof = session.get(Proof, proof_hash)
@@ -283,6 +286,11 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             if not isinstance(data, dict):
                 raise HTTPException(status_code=500, detail="invalid proof payload")
             return data
+
+    @app.get("/api/v1/proofs/{proof_hash}")
+    def api_proof(request: Request, proof_hash: str) -> dict[str, Any]:
+        reject_unsupported_query_params(request, allowed=set())
+        return proof_payload(proof_hash)
 
     register_activity_routes(app, db_url=db_url, templates=templates)
 
@@ -333,7 +341,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         api_bounty=api_bounty,
         api_ledger=ledger_rows,
         api_ledger_entry=api_ledger_entry,
-        api_proof=api_proof,
+        api_proof=proof_payload,
     )
 
     @app.get("/me", response_class=HTMLResponse)

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -26,6 +26,7 @@ from app.query_validation import (
     reject_control_char_query_param,
     reject_noncanonical_int_query_param,
     reject_repeated_query_param,
+    reject_unsupported_query_params,
 )
 from app.serializers import bounty_list_summary, wallet_to_dict
 from app.status import (
@@ -419,6 +420,7 @@ def register_public_routes(
 
     @app.get("/proofs/{proof_hash}", response_class=HTMLResponse)
     def proof_page(request: Request, proof_hash: str) -> HTMLResponse:
+        reject_unsupported_query_params(request, allowed=set())
         normalized_proof_hash = proof_hash_from_path(proof_hash)
         return templates.TemplateResponse(
             request,

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -59,3 +59,13 @@ def reject_repeated_query_param(request: Request, name: str) -> None:
             status_code=400,
             detail=f"{name} must be provided at most once",
         )
+
+
+def reject_unsupported_query_params(request: Request, allowed: set[str]) -> None:
+    """Reject query parameters that have no meaning on the current endpoint."""
+    for name in request.query_params:
+        if name not in allowed:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} is not supported on this endpoint",
+            )

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -1124,6 +1124,13 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert f'href="/activity?q={proof_hash}"' in proof_page.text
     assert f'href="/activity?q={bounty.id}"' in proof_page.text
     assert 'href="/activity?q=https%3A//github.com/ramimbo/mergework/pull/99"' in proof_page.text
+    for name in ("limit", "status", "repo", "offset", "q"):
+        api_response = client.get(f"/api/v1/proofs/{proof_hash}?{name}=1")
+        assert api_response.status_code == 400
+        assert api_response.json()["detail"] == f"{name} is not supported on this endpoint"
+        page_response = client.get(f"/proofs/{proof_hash}?{name}=1")
+        assert page_response.status_code == 400
+        assert page_response.json()["detail"] == f"{name} is not supported on this endpoint"
 
     uppercase_proof_page = client.get(f"/proofs/{proof_hash.upper()}")
     assert uppercase_proof_page.status_code == 200


### PR DESCRIPTION
## Summary
- Reject unsupported query parameters on `/api/v1/proofs/{proof_hash}` instead of silently returning an unfiltered proof payload.
- Reject unsupported list/search filters on `/proofs/{proof_hash}`.
- Share the proof payload lookup between the API route and public page after each route validates its own query surface.

Bounty #798
Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4637411548
Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4637412252

## Production evidence
Using proof `304e35ee2138c83593890a651d025aa9bc9490b45b906e41261df622b3f52064`:

- `/api/v1/proofs/{hash}`, `?limit=1`, `?status=open`, `?repo=ramimbo/mergework`, `?offset=1`, and `?q=x` all returned HTTP 200 with identical 475-byte response body and SHA-256 `304e35ee2138c83593890a651d025aa9bc9490b45b906e41261df622b3f52064`.
- `/proofs/{hash}`, `?limit=1`, `?status=open`, `?repo=ramimbo/mergework`, `?offset=1`, and `?q=x` all returned HTTP 200 with identical 3972-byte response body and SHA-256 `6a15641fdf763333447d027459b84ce5f016459032f99ebbafb2b8d0a852c2ea`.

## Validation
- `uv run --extra dev pytest tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable -q` -> 1 passed, 1 warning.
- `uv run --extra dev pytest tests/test_bounty_pages.py -q` -> 19 passed, 1 warning.
- `uv run --extra dev ruff check app/main.py app/public_routes.py app/query_validation.py tests/test_bounty_pages.py` -> passed.
- `uv run --extra dev ruff format --check app/main.py app/public_routes.py app/query_validation.py tests/test_bounty_pages.py` -> 4 files already formatted.
- `uv run --extra dev mypy app/main.py app/public_routes.py app/query_validation.py` -> success.
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD -- app/main.py app/public_routes.py app/query_validation.py tests/test_bounty_pages.py` -> clean.

## Scope
Public proof detail API/page query validation only. No admin-token APIs, payout execution, treasury mutation, ledger mutation, wallet material, secrets, bridge/exchange/cash-out behavior, MRWK price behavior, or private data is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Proof API and page endpoints now reject unsupported query parameters with HTTP 400 errors, improving endpoint validation.

* **Refactor**
  * Internal refactoring of proof request handling to consolidate validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->