### PR TITLE
Reject OAuth unsupported query filters

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -12,6 +12,7 @@ from fastapi.responses import RedirectResponse
 
 from app.config import Settings
 from app.control_chars import contains_control_character
+from app.query_validation import reject_unsupported_query_params
 
 
 def oauth_configured(settings: Settings) -> bool:
@@ -109,7 +110,10 @@ def register_auth_routes(app: FastAPI, *, settings: Settings) -> AuthService:
     auth = AuthService(settings)
 
     @app.get("/auth/github/login")
-    def auth_github_login(next_path: str | None = Query(None, alias="next")) -> RedirectResponse:
+    def auth_github_login(
+        request: Request, next_path: str | None = Query(None, alias="next")
+    ) -> RedirectResponse:
+        reject_unsupported_query_params(request, allowed={"next"})
         if not oauth_configured(settings):
             raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
         safe_next = safe_next_path(next_path)
@@ -133,6 +137,7 @@ def register_auth_routes(app: FastAPI, *, settings: Settings) -> AuthService:
 
     @app.get("/auth/github/callback")
     async def auth_github_callback(request: Request, code: str, state: str) -> RedirectResponse:
+        reject_unsupported_query_params(request, allowed={"code", "state"})
         if not oauth_configured(settings):
             raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
         cookie_state = request.cookies.get("mrwk_oauth_state")

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -59,3 +59,13 @@ def reject_repeated_query_param(request: Request, name: str) -> None:
             status_code=400,
             detail=f"{name} must be provided at most once",
         )
+
+
+def reject_unsupported_query_params(request: Request, allowed: set[str]) -> None:
+    """Reject query parameters that have no meaning on the current endpoint."""
+    for name in request.query_params:
+        if name not in allowed:
+            raise HTTPException(
+                status_code=400,
+                detail=f"{name} is not supported on this endpoint",
+            )

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -609,6 +609,38 @@ def test_github_login_redirects_when_oauth_is_configured(sqlite_url: str, monkey
     assert "mrwk_oauth_state" in response.cookies
 
 
+def test_github_login_rejects_unsupported_query_filters(sqlite_url: str, monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    monkeypatch.setenv("MERGEWORK_PUBLIC_BASE_URL", "https://mrwk.example.test")
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    for name in ("limit", "status", "repo", "offset", "q", "account"):
+        response = client.get(f"/auth/github/login?{name}=1", follow_redirects=False)
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == f"{name} is not supported on this endpoint"
+        assert "location" not in response.headers
+        assert "mrwk_oauth_state" not in response.cookies
+
+
+def test_github_callback_rejects_unsupported_query_filters(sqlite_url: str, monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    monkeypatch.setenv("MERGEWORK_PUBLIC_BASE_URL", "https://mrwk.example.test")
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    for name in ("limit", "status", "repo", "offset", "q", "account"):
+        response = client.get(
+            f"/auth/github/callback?code=abc&state=bad&{name}=1", follow_redirects=False
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == f"{name} is not supported on this endpoint"
+
+
 @pytest.mark.parametrize(
     "next_path",
     (


### PR DESCRIPTION
## Summary
- Reject unsupported query parameters on `/auth/github/login` before creating OAuth state or redirecting to GitHub.
- Reject unsupported query parameters on `/auth/github/callback` before state validation or token exchange.
- Add focused route regression coverage for allowed OAuth parameters versus unsupported list/search/account filters.

Bounty #798
Report: https://github.com/ramimbo/mergework/issues/798#issuecomment-4637453812
Claim: https://github.com/ramimbo/mergework/issues/798#issuecomment-4637454132

## Production evidence
- `/auth/github/login`, `?limit=1`, `?status=open`, `?repo=ramimbo/mergework`, `?offset=1`, `?q=x`, and `?account=github:floofy6` all returned HTTP 302 with empty body SHA-256 `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`, continuing into the GitHub OAuth authorize flow and generating OAuth state even though only `next` is meaningful on this route.
- Existing PRs #825 and #963 cover repeated scalar OAuth parameters; this fix covers unsupported query names.

## Validation
- `uv run --extra dev pytest tests/test_wallet_api.py::test_github_login_rejects_unsupported_query_filters tests/test_wallet_api.py::test_github_callback_rejects_unsupported_query_filters -q` -> 2 passed, 1 warning.
- `uv run --extra dev pytest tests/test_wallet_api.py::test_github_login_redirects_when_oauth_is_configured tests/test_wallet_api.py::test_github_login_stores_safe_default_for_backslash_next tests/test_wallet_api.py::test_github_login_rejects_unsupported_query_filters tests/test_wallet_api.py::test_github_callback_rejects_unsupported_query_filters -q` -> 4 passed, 1 warning.
- `uv run --extra dev pytest tests/test_wallet_api.py -q` -> 47 passed, 1 warning.
- `uv run --extra dev ruff check app/auth.py app/query_validation.py tests/test_wallet_api.py` -> passed.
- `uv run --extra dev ruff format --check app/auth.py app/query_validation.py tests/test_wallet_api.py` -> 3 files already formatted.
- `uv run --extra dev mypy app/auth.py app/query_validation.py` -> success.
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD -- app/auth.py app/query_validation.py tests/test_wallet_api.py` -> clean.

## Scope
Public OAuth login/callback query validation only. No admin-token APIs, payout execution, treasury mutation, ledger mutation, wallet material, secrets, bridge/exchange/cash-out behavior, MRWK price behavior, or private data is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GitHub OAuth security and robustness by implementing stricter query parameter validation that rejects unsupported parameters during login and callback flows, restricting access to only explicitly allowed parameters

* **Tests**
  * Added comprehensive tests to verify that unsupported query parameters are properly rejected with HTTP 400 responses and appropriate error details across GitHub OAuth endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->