### PR TITLE
Reject non-origin report API hosts

### DIFF
--- a/scripts/api_host_args.py
+++ b/scripts/api_host_args.py
@@ -11,4 +11,8 @@ def public_api_host(value: str) -> str:
     parsed = urllib.parse.urlparse(clean)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise argparse.ArgumentTypeError("api host must be an absolute HTTP(S) URL")
+    if parsed.username or parsed.password:
+        raise argparse.ArgumentTypeError("api host must not include userinfo")
+    if parsed.path not in {"", "/"} or parsed.params or parsed.query or parsed.fragment:
+        raise argparse.ArgumentTypeError("api host must be an origin URL without path or query")
     return clean

--- a/tests/test_claim_inventory.py
+++ b/tests/test_claim_inventory.py
@@ -429,7 +429,16 @@ def test_claim_inventory_script_entrypoint_loads_shared_parser() -> None:
 
 
 def test_claim_inventory_rejects_invalid_api_host(capsys) -> None:
-    for bad in ("", "   ", "/relative", "ftp://api.example.test"):
+    for bad in (
+        "",
+        "   ",
+        "/relative",
+        "ftp://api.example.test",
+        "https://api.example.test/v1",
+        "https://api.example.test?debug=1",
+        "https://api.example.test#fragment",
+        "https://user:pass@api.example.test",
+    ):
         with pytest.raises(SystemExit) as excinfo:
             main(["--repo", "ramimbo/mergework", "--api-host", bad])
         assert excinfo.value.code == 2

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -775,7 +775,16 @@ def test_proposed_work_triage_rejects_non_integer_limit(capsys) -> None:
 
 
 def test_proposed_work_triage_rejects_invalid_api_host(capsys) -> None:
-    for bad in ("", "   ", "/relative", "ftp://api.example.test"):
+    for bad in (
+        "",
+        "   ",
+        "/relative",
+        "ftp://api.example.test",
+        "https://api.example.test/v1",
+        "https://api.example.test?debug=1",
+        "https://api.example.test#fragment",
+        "https://user:pass@api.example.test",
+    ):
         with pytest.raises(SystemExit) as excinfo:
             main(["--repo", "ramimbo/mergework", "--api-host", bad])
         assert excinfo.value.code == 2

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -1390,7 +1390,16 @@ def test_quality_gate_cli_rejects_negative_max_maintainer_age_days(tmp_path, cap
 def test_quality_gate_cli_rejects_invalid_api_host(tmp_path, capsys) -> None:
     draft = tmp_path / "draft.md"
     draft.write_text("Summary: work\n\nRefs #319\n\nValidation: pytest passed", encoding="utf-8")
-    for bad in ("", "   ", "/relative", "ftp://api.example.test"):
+    for bad in (
+        "",
+        "   ",
+        "/relative",
+        "ftp://api.example.test",
+        "https://api.example.test/v1",
+        "https://api.example.test?debug=1",
+        "https://api.example.test#fragment",
+        "https://user:pass@api.example.test",
+    ):
         with pytest.raises(SystemExit) as excinfo:
             main(["--text-file", str(draft), "--api-host", bad])
         assert excinfo.value.code == 2


### PR DESCRIPTION
## Summary
- Tightens shared CLI `--api-host` parsing so report scripts accept only clean HTTP(S) origin URLs.
- Rejects userinfo, path, params, query, and fragment components that can make downstream API URL construction surprising.
- Extends existing invalid-host regression coverage across claim inventory, proposed-work triage, and submission quality gate scripts.

## Bounty
Refs #936

## Validation
- `.venv\Scripts\python.exe -m pytest tests/test_claim_inventory.py::test_claim_inventory_rejects_invalid_api_host tests/test_proposed_work_triage.py::test_proposed_work_triage_rejects_invalid_api_host tests/test_submission_quality_gate.py::test_quality_gate_cli_rejects_invalid_api_host` -> 3 passed
- `git diff --check main..codex/strict-api-host-origin-936` -> clean

## Notes
Public behavior is intentionally narrowed only for script API host selectors: callers must pass an origin like `https://api.mrwk.online`, not a URL with path/query/userinfo. Ledger, wallet, treasury, payout, and bounty lifecycle behavior are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened API host URL validation to reject malformed inputs including embedded credentials, paths, query strings, and fragments. The API host argument now requires a properly-formatted origin URL only.

* **Tests**
  * Expanded test coverage for API host validation with additional invalid input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->