### PR TITLE
Expose claimable bounty routing links

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -114,6 +114,27 @@ def _bounties_api_url(
     )
 
 
+def _bounties_summary_api_url(
+    status: str | None,
+    query_text: str,
+    selected_sort: str,
+    limit: int | None,
+    repo: str,
+    issue_number: int | None,
+    selected_availability: str,
+) -> str:
+    return _bounties_url(
+        "/api/v1/bounties/summary",
+        status,
+        query_text,
+        selected_sort,
+        limit,
+        repo,
+        issue_number,
+        selected_availability,
+    )
+
+
 def _bounties_page_url(
     status: str | None,
     query_text: str,
@@ -174,6 +195,25 @@ def public_bounties_context(
             selected_repo,
             issue_number,
             selected_availability,
+        ),
+        "api_summary_url": _bounties_summary_api_url(
+            selected_status,
+            query_text,
+            selected_sort,
+            limit,
+            selected_repo,
+            issue_number,
+            selected_availability,
+        ),
+        "work_discovery_url": "/api/v1/work-discovery",
+        "claimable_now_url": _bounties_page_url(
+            "open",
+            query_text,
+            "reward",
+            limit,
+            selected_repo,
+            issue_number,
+            "effectively_open",
         ),
         "clear_search_url": _bounties_page_url(
             selected_status,

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -71,6 +71,12 @@
 </section>
 <p class="notice">
   <a href="{{ api_results_url }}">View JSON results</a>
+  <span aria-hidden="true">&middot;</span>
+  <a href="{{ api_summary_url }}">View summary JSON</a>
+  <span aria-hidden="true">&middot;</span>
+  <a href="{{ work_discovery_url }}">Work discovery JSON</a>
+  <span aria-hidden="true">&middot;</span>
+  <a href="{{ claimable_now_url }}">Claimable now</a>
 </p>
 <div class="list">
   {% for bounty in bounties %}

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -148,7 +148,9 @@
     <div class="next-steps-actions" aria-label="Bounty action links">
       {% if issue_url %}<a href="{{ issue_url }}" rel="nofollow noopener">Open source issue</a>{% endif %}
       <a href="/bounties?repo={{ bounty.repo | urlencode }}&amp;issue_number={{ bounty.issue_number }}">View source bounty matches</a>
+      <a href="/bounties?status=open&amp;repo={{ bounty.repo | urlencode }}&amp;issue_number={{ bounty.issue_number }}&amp;sort=reward&amp;availability=effectively_open">Check claimable source matches</a>
       <a href="/api/v1/bounties/{{ bounty.id }}">View JSON details</a>
+      <a href="/api/v1/work-discovery">Work discovery JSON</a>
       <a href="{{ requirements.attempt_endpoint }}">Check active attempts</a>
     </div>
   </section>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -64,6 +64,12 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert "Awards open" in all_rows.text
     assert "Open reward pool" in all_rows.text
     assert 'href="/api/v1/bounties">View JSON results</a>' in all_rows.text
+    assert 'href="/api/v1/bounties/summary">View summary JSON</a>' in all_rows.text
+    assert 'href="/api/v1/work-discovery">Work discovery JSON</a>' in all_rows.text
+    assert (
+        'href="/bounties?status=open&amp;sort=reward&amp;availability=effectively_open">'
+        "Claimable now</a>"
+    ) in all_rows.text
     assert "1</strong>" in all_rows.text
     assert "50 MRWK</strong>" in all_rows.text
     assert "50 MRWK still available" in all_rows.text
@@ -75,6 +81,10 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert f'href="/bounties/{paid_bounty.id}"' in paid_rows.text
     assert 'href="/bounties?status=paid"' in paid_rows.text
     assert 'href="/api/v1/bounties?status=paid">View JSON results</a>' in paid_rows.text
+    assert (
+        'href="/api/v1/bounties/summary?status=paid">View summary JSON</a>'
+        in paid_rows.text
+    )
     assert "0 MRWK</strong>" in paid_rows.text
 
     paid_rows_uppercase = client.get("/bounties?status=PAID")
@@ -324,6 +334,14 @@ def test_bounties_page_honors_limit_filter(sqlite_url: str) -> None:
         'href="/api/v1/bounties?q=public&amp;sort=reward&amp;limit=2">View JSON results</a>'
         in filtered_limited_page.text
     )
+    assert (
+        'href="/api/v1/bounties/summary?q=public&amp;sort=reward&amp;limit=2">'
+        "View summary JSON</a>"
+    ) in filtered_limited_page.text
+    assert (
+        'href="/bounties?status=open&amp;q=public&amp;sort=reward&amp;limit=2'
+        '&amp;availability=effectively_open">Claimable now</a>'
+    ) in filtered_limited_page.text
 
     invalid_limit = client.get("/bounties?limit=0")
     assert invalid_limit.status_code == 422
@@ -1322,6 +1340,12 @@ def test_bounty_detail_page_has_back_navigation(sqlite_url: str) -> None:
     assert page.status_code == 200
     assert "Back to bounties" in page.text
     assert 'href="/bounties"' in page.text
+    assert (
+        'href="/bounties?status=open&amp;repo=ramimbo/mergework&amp;issue_number=92'
+        '&amp;sort=reward&amp;availability=effectively_open">'
+        "Check claimable source matches</a>"
+    ) in page.text
+    assert 'href="/api/v1/work-discovery">Work discovery JSON</a>' in page.text
 
     # Detail page should also have a status pill with status-specific class
     assert "status-pill status-open" in page.text

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -56,6 +56,15 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
             "/api/v1/bounties?status=open&q=proof&repo=ramimbo%2Fmergework"
             "&issue_number=649&sort=reward"
         ),
+        "api_summary_url": (
+            "/api/v1/bounties/summary?status=open&q=proof&repo=ramimbo%2Fmergework"
+            "&issue_number=649&sort=reward"
+        ),
+        "work_discovery_url": "/api/v1/work-discovery",
+        "claimable_now_url": (
+            "/bounties?status=open&q=proof&repo=ramimbo%2Fmergework&issue_number=649"
+            "&sort=reward&availability=effectively_open"
+        ),
         "clear_search_url": (
             "/bounties?status=open&repo=ramimbo%2Fmergework&issue_number=649&sort=reward"
         ),
@@ -82,6 +91,11 @@ def test_public_bounties_context_preserves_limited_json_results_url() -> None:
     context = public_bounties_context([], status=None, q="issue #580", sort="newest", limit=25)
 
     assert context["api_results_url"] == "/api/v1/bounties?q=issue+%23580&limit=25"
+    assert context["api_summary_url"] == "/api/v1/bounties/summary?q=issue+%23580&limit=25"
+    assert context["claimable_now_url"] == (
+        "/bounties?status=open&q=issue%20%23580&sort=reward&limit=25"
+        "&availability=effectively_open"
+    )
     assert (
         context["status_filter_urls"]["open"] == "/bounties?status=open&q=issue%20%23580&limit=25"
     )


### PR DESCRIPTION
## Summary
- Adds public bounty-list routing links for filtered JSON, summary JSON, work-discovery JSON, and a direct claimable-now view.
- Adds bounty detail links that route contributors back to claimable source matches and the work-discovery API.
- Keeps bounty lifecycle semantics unchanged; this is a focused contributor-flow/status-discovery improvement for Bounty #935.

## Validation
- `.venv\Scripts\python.exe -m pytest tests/test_public_routes.py tests/test_bounty_pages.py::test_bounties_page_renders_and_filters_by_status tests/test_bounty_pages.py::test_bounties_page_honors_limit_filter tests/test_bounty_pages.py::test_bounty_detail_page_has_back_navigation` -> 10 passed, 1 existing Starlette/httpx warning
- `git diff --check` -> clean, Windows CRLF warnings only

Refs #935

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced summary JSON view for bounties
  * Added work discovery JSON links to bounty pages
  * Added "Claimable now" filter to discover available bounties
  * Added "Check claimable source matches" link to bounty detail pages

* **Tests**
  * Expanded test coverage for new bounty discovery and summary features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->