### PR TITLE
Add MCP schemas for proof and ledger lookups

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -194,8 +194,40 @@ MCP_TOOLS: list[dict[str, Any]] = [
         "name": "submit_wallet_transfer",
         "description": "Submit a signed MRWK wallet transfer",
     },
-    {"name": "get_ledger_entry", "description": "Get a ledger entry"},
-    {"name": "get_proof", "description": "Get a public proof by hash"},
+    {
+        "name": "get_ledger_entry",
+        "description": "Get a ledger entry by immutable ledger sequence",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "sequence": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Immutable public ledger sequence number.",
+                },
+            },
+            "required": ["sequence"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "get_proof",
+        "description": "Get a public proof by hash",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "hash": {
+                    "type": "string",
+                    "pattern": "^[0-9a-fA-F]{64}$",
+                    "description": (
+                        "Public proof hash returned by ledger, activity, or bounty APIs."
+                    ),
+                },
+            },
+            "required": ["hash"],
+            "additionalProperties": False,
+        },
+    },
     {
         "name": "submit_work_proof",
         "description": (

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -316,6 +316,10 @@ Tools:
 - `submit_work_proof` (`format: "json"` returns structuredContent; `tools/list`
   advertises the selector and format schema)
 
+`tools/list` advertises required selector schemas for proof and ledger lookups:
+`get_proof` requires a 64-character proof `hash`, and `get_ledger_entry`
+requires a positive integer `sequence`.
+
 Successful MCP tools that return JSON objects or lists include both the
 backward-compatible JSON string in `result.content[0].text` and parsed
 `result.structuredContent`. Prefer `structuredContent` when present, and fall

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -377,6 +377,18 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert balance_schema["additionalProperties"] is False
     assert balance_schema["properties"]["account"]["minLength"] == 1
     assert "github:<login>" in balance_schema["properties"]["account"]["description"]
+    ledger_tool = next(
+        tool for tool in tools["result"]["tools"] if tool["name"] == "get_ledger_entry"
+    )
+    ledger_schema = ledger_tool["inputSchema"]
+    assert ledger_schema["required"] == ["sequence"]
+    assert ledger_schema["additionalProperties"] is False
+    assert ledger_schema["properties"]["sequence"]["minimum"] == 1
+    proof_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_proof")
+    proof_schema = proof_tool["inputSchema"]
+    assert proof_schema["required"] == ["hash"]
+    assert proof_schema["additionalProperties"] is False
+    assert proof_schema["properties"]["hash"]["pattern"] == "^[0-9a-fA-F]{64}$"
 
     balance = client.post(
         "/mcp",


### PR DESCRIPTION
Bounty #934

## Summary
- Add `tools/list` input schemas for `get_ledger_entry` and `get_proof`.
- Document the required `sequence` and `hash` selectors for agent callers.
- Add MCP test coverage so the advertised schemas stay aligned with runtime lookup requirements.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_api_mcp.py::test_mcp_tools_list_and_call tests/test_api_mcp.py::test_mcp_get_ledger_entry_includes_payment_proof_hash tests/test_api_mcp.py::test_mcp_get_proof_returns_public_proof_details -q`
- `uv run --python 3.12 --extra dev ruff check app/mcp.py tests/test_api_mcp.py`
- `uv run --python 3.12 --extra dev ruff format --check app/mcp.py tests/test_api_mcp.py`
- `uv run --python 3.12 --extra dev mypy app/mcp.py`
- `uv run --python 3.12 --extra dev python scripts/docs_smoke.py`
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

## Scope
This is limited to MCP tool schema/docs/tests. It does not change ledger, wallet, treasury, payout, admin, or price behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced input validation for MCP tools with schema-based constraints on parameters (sequence for ledger entries, hex-formatted hashes for proofs).

* **Documentation**
  * Updated agent guide with clarified input requirements for proof and ledger lookup operations.

* **Tests**
  * Added validation testing for MCP tool input schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->