### PR TITLE
Align MCP bounty sort schema with runtime

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -35,7 +35,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
                 },
                 "sort": {
                     "type": "string",
-                    "enum": ["newest", "reward"],
+                    "enum": ["newest", "reward", "available", "awards"],
                     "default": "newest",
                     "description": "Sort order for returned bounties.",
                 },

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -307,6 +307,12 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert list_bounties_schema["additionalProperties"] is False
     assert list_bounties_schema["properties"]["q"]["maxLength"] == 500
     assert list_bounties_schema["properties"]["limit"]["maximum"] == 100
+    assert list_bounties_schema["properties"]["sort"]["enum"] == [
+        "newest",
+        "reward",
+        "available",
+        "awards",
+    ]
     submit_tool = next(
         tool for tool in tools["result"]["tools"] if tool["name"] == "submit_work_proof"
     )


### PR DESCRIPTION
## Summary
- Expands the MCP `list_bounties` input schema so the advertised `sort` enum matches the runtime-supported bounty sort values.
- Keeps behavior unchanged; `available` and `awards` were already accepted by `normalize_bounty_sort`, but `tools/list` only advertised `newest` and `reward`.
- Adds coverage to prevent the schema from drifting away from runtime-supported sort modes again.

## Validation
- `.venv\Scripts\python.exe -m pytest tests/test_api_mcp.py::test_mcp_tools_list_and_call tests/test_api_mcp.py::test_mcp_list_bounties_honors_sort_argument` -> 2 passed, 1 existing Starlette/httpx warning
- `git diff --check` -> clean, Windows CRLF warnings only

Refs #934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new sorting options for bounties: sort by availability and awards, in addition to existing criteria.

* **Tests**
  * Expanded test coverage to validate the bounties sorting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->