### PR TITLE
Validate review candidate CLI count

### DIFF
--- a/scripts/review_bounty_candidates.py
+++ b/scripts/review_bounty_candidates.py
@@ -350,6 +350,16 @@ def _require_non_empty_arg(parser: argparse.ArgumentParser, option_name: str, va
     return value
 
 
+def _positive_int_arg(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"expected an integer, got {value!r}") from None
+    if parsed < 1:
+        raise argparse.ArgumentTypeError(f"must be >= 1, got {parsed}")
+    return parsed
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Rank open PRs for reviewer-specific review-bounty work."
@@ -358,7 +368,7 @@ def main(argv: list[str] | None = None) -> int:
     source.add_argument("--input", help="Read candidate data from a JSON fixture file.")
     source.add_argument("--repo", help="Collect live open PR data with gh.")
     parser.add_argument("--reviewer", required=True, help="GitHub login of the reviewer.")
-    parser.add_argument("--sufficient-reviews", type=int, default=1)
+    parser.add_argument("--sufficient-reviews", type=_positive_int_arg, default=1)
     parser.add_argument("--format", choices=["json", "markdown", "text"], default="text")
     args = parser.parse_args(argv)
 

--- a/tests/test_review_bounty_candidates.py
+++ b/tests/test_review_bounty_candidates.py
@@ -257,6 +257,48 @@ def test_review_bounty_candidates_rejects_invalid_sufficient_reviews(
     assert captured.out == ""
 
 
+def test_review_bounty_candidates_accepts_minimum_sufficient_reviews(
+    tmp_path,
+    capsys,
+) -> None:
+    fixture = {
+        "pull_requests": [
+            {
+                "number": 10,
+                "title": "Ready for review",
+                "author": {"login": "alice"},
+                "headRefOid": "h10",
+                "mergeStateStatus": "CLEAN",
+                "labels": [],
+                "statusCheckRollup": _quality_check(),
+                "reviews": [],
+            }
+        ]
+    }
+    input_path = tmp_path / "candidates.json"
+    input_path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    exit_code = main(
+        [
+            "--input",
+            str(input_path),
+            "--reviewer",
+            "reviewer",
+            "--sufficient-reviews",
+            "1",
+            "--format",
+            "json",
+        ]
+    )
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    output = json.loads(captured.out)
+    assert output["summary"]["pull_requests"] == 1
+    assert output["pull_requests"][0]["state"] == "candidate_for_fresh_review"
+
+
 def test_review_bounty_candidate_reports_are_pasteable() -> None:
     report = analyze_candidates(
         {

--- a/tests/test_review_bounty_candidates.py
+++ b/tests/test_review_bounty_candidates.py
@@ -226,6 +226,37 @@ def test_analyze_candidates_rejects_invalid_arguments() -> None:
         analyze_candidates(data, reviewer="reviewer", sufficient_reviews=0)
 
 
+@pytest.mark.parametrize(
+    ("value", "expected_message"),
+    (
+        ("0", "must be >= 1"),
+        ("abc", "expected an integer"),
+    ),
+)
+def test_review_bounty_candidates_rejects_invalid_sufficient_reviews(
+    value: str,
+    expected_message: str,
+    capsys,
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "--input",
+                "tests/fixtures/missing.json",
+                "--reviewer",
+                "reviewer",
+                "--sufficient-reviews",
+                value,
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    captured = capsys.readouterr()
+    assert expected_message in captured.err
+    assert "Traceback" not in captured.err
+    assert captured.out == ""
+
+
 def test_review_bounty_candidate_reports_are_pasteable() -> None:
     report = analyze_candidates(
         {


### PR DESCRIPTION
Bounty #936

## Summary
- validate `--sufficient-reviews` as a positive integer during argparse parsing
- keep `analyze_candidates()` validation intact for library callers
- add CLI regression coverage so invalid values fail cleanly without a traceback

## Validation
- `.venv\Scripts\python.exe -m pytest tests/test_review_bounty_candidates.py` -> 14 passed
- `git diff --check` -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI handling for `--sufficient-reviews` by enforcing that it must be a positive integer (minimum 1). Invalid values now return a proper argument error with a clear message, rather than proceeding with an incorrect value.

* **Tests**
  * Added CLI-focused test coverage to confirm invalid inputs (e.g., non-numeric and zero) fail with the expected exit code and clean error output, and that the minimum valid value succeeds and produces the expected JSON report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->