### PR TITLE
Guard claim inventory live collection caps

### DIFF
--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -20,7 +20,9 @@ from scripts.bounty_refs import BOUNTY_REF_RE
 
 DEFAULT_API_HOST = "https://api.mrwk.online"
 GH_TIMEOUT_SECONDS = 30
-GH_LIMIT = 200
+GH_PUBLIC_API_LIMIT = 200
+GH_ISSUE_SAFETY_CAP = 200
+GH_PR_SAFETY_CAP = 200
 GITHUB_URL_RE = re.compile(
     r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/"
     r"(?:issues|pull)/\d+(?:#[A-Za-z0-9_.-]+)?"
@@ -581,8 +583,8 @@ def _get_json(url: str) -> Any:
 
 def load_public_api_state(api_host: str) -> dict[str, Any]:
     host = api_host.rstrip("/")
-    bounties = _get_json(f"{host}/api/v1/bounties?limit={GH_LIMIT}")
-    activity = _get_json(f"{host}/api/v1/activity?limit={GH_LIMIT}")
+    bounties = _get_json(f"{host}/api/v1/bounties?limit={GH_PUBLIC_API_LIMIT}")
+    activity = _get_json(f"{host}/api/v1/activity?limit={GH_PUBLIC_API_LIMIT}")
     data: dict[str, Any] = {}
     if isinstance(bounties, list):
         data["bounties"] = bounties
@@ -607,11 +609,16 @@ def load_live_inventory(repo: str, api_host: str) -> dict[str, Any]:
             "--state",
             "open",
             "--limit",
-            str(GH_LIMIT),
+            str(GH_ISSUE_SAFETY_CAP),
             "--json",
             "number,title,url,labels,author",
         ]
     )
+    if len(issue_list) >= GH_ISSUE_SAFETY_CAP:
+        raise RuntimeError(
+            f"gh issue list reached the {GH_ISSUE_SAFETY_CAP} item safety cap; "
+            "use an API-paginated collector before trusting this live inventory"
+        )
     issues: list[dict[str, Any]] = []
     for issue in issue_list:
         if (
@@ -643,11 +650,16 @@ def load_live_inventory(repo: str, api_host: str) -> dict[str, Any]:
             "--state",
             "open",
             "--limit",
-            str(GH_LIMIT),
+            str(GH_PR_SAFETY_CAP),
             "--json",
             "number,title,url,body,author,labels",
         ]
     )
+    if len(prs) >= GH_PR_SAFETY_CAP:
+        raise RuntimeError(
+            f"gh pr list reached the {GH_PR_SAFETY_CAP} item safety cap; "
+            "use an API-paginated collector before trusting this live inventory"
+        )
     pull_requests: list[dict[str, Any]] = []
     for pr in prs:
         if not isinstance(pr, dict) or not isinstance(pr.get("number"), int):

--- a/tests/test_claim_inventory.py
+++ b/tests/test_claim_inventory.py
@@ -430,6 +430,51 @@ def test_run_gh_json_reports_missing_gh(monkeypatch) -> None:
         raise AssertionError("expected missing gh RuntimeError")
 
 
+def test_claim_inventory_live_mode_fails_fast_when_issue_fetch_hits_cap(monkeypatch) -> None:
+    def fake_run_gh_json(args: list[str]) -> object:
+        if args[:3] == ["gh", "issue", "list"]:
+            return [
+                {
+                    "number": number,
+                    "title": "MRWK bounty: many",
+                    "url": f"https://github.com/ramimbo/mergework/issues/{number}",
+                    "labels": [{"name": "mrwk:bounty"}],
+                    "author": {"login": "ramimbo"},
+                }
+                for number in range(1, claim_inventory.GH_ISSUE_SAFETY_CAP + 1)
+            ]
+        raise AssertionError(args)
+
+    monkeypatch.setattr(claim_inventory, "_run_gh_json", fake_run_gh_json)
+
+    with pytest.raises(RuntimeError, match="issue list reached the 200 item safety cap"):
+        claim_inventory.load_live_inventory("ramimbo/mergework", "https://api.example.test")
+
+
+def test_claim_inventory_live_mode_fails_fast_when_pr_fetch_hits_cap(monkeypatch) -> None:
+    def fake_run_gh_json(args: list[str]) -> object:
+        if args[:3] == ["gh", "issue", "list"]:
+            return []
+        if args[:3] == ["gh", "pr", "list"]:
+            return [
+                {
+                    "number": number,
+                    "title": "Open PR",
+                    "url": f"https://github.com/ramimbo/mergework/pull/{number}",
+                    "body": "Refs #1",
+                    "author": {"login": "contributor"},
+                    "labels": [],
+                }
+                for number in range(1, claim_inventory.GH_PR_SAFETY_CAP + 1)
+            ]
+        raise AssertionError(args)
+
+    monkeypatch.setattr(claim_inventory, "_run_gh_json", fake_run_gh_json)
+
+    with pytest.raises(RuntimeError, match="pr list reached the 200 item safety cap"):
+        claim_inventory.load_live_inventory("ramimbo/mergework", "https://api.example.test")
+
+
 def test_claim_inventory_script_entrypoint_loads_shared_parser() -> None:
     result = subprocess.run(
         [sys.executable, "scripts/claim_inventory.py", "--help"],

--- a/tests/test_claim_inventory.py
+++ b/tests/test_claim_inventory.py
@@ -447,7 +447,10 @@ def test_claim_inventory_live_mode_fails_fast_when_issue_fetch_hits_cap(monkeypa
 
     monkeypatch.setattr(claim_inventory, "_run_gh_json", fake_run_gh_json)
 
-    with pytest.raises(RuntimeError, match="issue list reached the 200 item safety cap"):
+    with pytest.raises(
+        RuntimeError,
+        match=rf"issue list reached the {claim_inventory.GH_ISSUE_SAFETY_CAP} item safety cap",
+    ):
         claim_inventory.load_live_inventory("ramimbo/mergework", "https://api.example.test")
 
 
@@ -471,7 +474,10 @@ def test_claim_inventory_live_mode_fails_fast_when_pr_fetch_hits_cap(monkeypatch
 
     monkeypatch.setattr(claim_inventory, "_run_gh_json", fake_run_gh_json)
 
-    with pytest.raises(RuntimeError, match="pr list reached the 200 item safety cap"):
+    with pytest.raises(
+        RuntimeError,
+        match=rf"pr list reached the {claim_inventory.GH_PR_SAFETY_CAP} item safety cap",
+    ):
         claim_inventory.load_live_inventory("ramimbo/mergework", "https://api.example.test")
 
 


### PR DESCRIPTION
Bounty #936

Related proposed-work context: #978

## Summary
- separate public API read limit from GitHub live-collection safety caps in `claim_inventory.py`
- fail fast when live issue or PR collection reaches the configured cap instead of producing a potentially incomplete inventory
- add regression coverage for issue-list and PR-list cap saturation

## Validation
- `.venv\Scripts\python.exe -m pytest tests/test_claim_inventory.py` -> 9 passed
- `git diff --check` -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added safety caps to live GitHub inventory fetching for issues and pull requests to prevent truncated results and excessive retrieval.
  * Now fails fast with clear error messages when a safety cap is reached, directing users to use a paginated API collector instead of relying on truncated live lists.

* **Tests**
  * Added tests validating safety-cap enforcement and corresponding error messages for issue and pull request retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->