### PR TITLE
Expose public work discovery routes

### DIFF
--- a/app/work_discovery.py
+++ b/app/work_discovery.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlencode
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -48,11 +49,28 @@ def _bounty_source_urls(row: dict[str, Any]) -> dict[str, str]:
     return {
         "bounty": f"/api/v1/bounties/{bounty_id}",
         "attempts": f"/api/v1/bounties/{bounty_id}/attempts",
+        "public_bounty_page": f"/bounties/{bounty_id}",
         "github_issue": str(row["issue_url"]),
     }
 
 
+def _claimable_matches_url(row: dict[str, Any]) -> str:
+    query = urlencode(
+        {
+            "status": "open",
+            "repo": str(row["repo"]),
+            "issue_number": int(row["issue_number"]),
+            "sort": "reward",
+            "availability": "effectively_open",
+        }
+    )
+    return f"/bounties?{query}"
+
+
 def _bounty_work_item(row: dict[str, Any], availability_state: str) -> dict[str, Any]:
+    source_urls = _bounty_source_urls(row)
+    if availability_state == "live_bounty":
+        source_urls["claimable_matches"] = _claimable_matches_url(row)
     return {
         "availability_state": availability_state,
         "bounty_id": int(row["id"]),
@@ -64,7 +82,7 @@ def _bounty_work_item(row: dict[str, Any], availability_state: str) -> dict[str,
         "effective_awards_remaining": int(row["effective_awards_remaining"]),
         "bounty_availability_state": str(row["availability_state"]),
         "pending_payout_awards": int(row["pending_payout_awards"]),
-        "source_urls": _bounty_source_urls(row),
+        "source_urls": source_urls,
         "submission_requirements": row["submission_requirements"],
     }
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -183,6 +183,8 @@ non-claimable states out of the claimable list, and accepts optional
       "source_urls": {
         "bounty": "/api/v1/bounties/108",
         "attempts": "/api/v1/bounties/108/attempts",
+        "public_bounty_page": "/bounties/108",
+        "claimable_matches": "/bounties?status=open&repo=ramimbo%2Fmergework&issue_number=800&sort=reward&availability=effectively_open",
         "github_issue": "https://github.com/ramimbo/mergework/issues/800"
       }
     }
@@ -219,6 +221,7 @@ non-claimable states out of the claimable list, and accepts optional
       "source_urls": {
         "bounty": "/api/v1/bounties/102",
         "attempts": "/api/v1/bounties/102/attempts",
+        "public_bounty_page": "/bounties/102",
         "github_issue": "https://github.com/ramimbo/mergework/issues/761"
       }
     }

--- a/tests/test_work_discovery.py
+++ b/tests/test_work_discovery.py
@@ -104,6 +104,11 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
             "source_urls": {
                 "bounty": f"/api/v1/bounties/{live_bounty.id}",
                 "attempts": f"/api/v1/bounties/{live_bounty.id}/attempts",
+                "public_bounty_page": f"/bounties/{live_bounty.id}",
+                "claimable_matches": (
+                    "/bounties?status=open&repo=ramimbo%2Fmergework&issue_number=800"
+                    "&sort=reward&availability=effectively_open"
+                ),
                 "github_issue": "https://github.com/ramimbo/mergework/issues/800",
             },
             "submission_requirements": live_requirements,
@@ -137,10 +142,15 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
             "submission_requirements": pending_create_requirements,
         }
     ]
+    assert "public_bounty_page" not in body["opening_soon"][0]["source_urls"]
     assert pending_create_executes_after.endswith("Z")
     assert datetime.fromisoformat(pending_create_executes_after.replace("Z", "+00:00"))
     assert body["not_claimable"][0]["availability_state"] == "closed_or_exhausted"
     assert body["not_claimable"][0]["issue_number"] == 761
+    assert body["not_claimable"][0]["source_urls"]["public_bounty_page"] == (
+        f"/bounties/{paid_bounty.id}"
+    )
+    assert "claimable_matches" not in body["not_claimable"][0]["source_urls"]
 
 
 def test_work_discovery_limit_caps_public_buckets(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #935

Related proposed-work context: #975

## Summary
- add human public bounty page links to `GET /api/v1/work-discovery` bounty rows
- add filtered `claimable_matches` links for live bounty rows so agents can jump from API discovery to the claimable public list lane
- keep pending-create rows from exposing a fake public bounty page before a public bounty row exists
- update API examples with the JSON vs human-review URL distinction

## Validation
- `.venv\Scripts\python.exe -m pytest tests/test_work_discovery.py tests/test_docs_public_urls.py::test_docs_document_public_work_discovery_endpoint` -> 5 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Work discovery API responses now include extra source URLs for live bounties — direct public bounty pages and a claimable-matches search URL to help users find available opportunities.

* **Documentation**
  * API examples updated to show the new source URL fields.

* **Tests**
  * Test coverage expanded to validate the new source URL fields and expected buckets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->