### PR TITLE
Handle missing gh in queue health

### DIFF
--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -324,6 +324,11 @@ def _run_gh_json(args: list[str]) -> Any:
         )
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s: {command}") from exc
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "GitHub CLI executable 'gh' was not found; install gh and ensure it is on PATH "
+            "before using live --repo mode"
+        ) from exc
     except subprocess.CalledProcessError as exc:
         raise RuntimeError(
             "gh command failed "

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -437,6 +437,16 @@ def test_pr_queue_health_wraps_gh_timeouts(monkeypatch) -> None:
         pr_queue_health._run_gh_json(["gh", "pr", "list"])
 
 
+def test_pr_queue_health_reports_missing_github_cli(monkeypatch) -> None:
+    def missing_gh(*args, **kwargs):
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr(pr_queue_health.subprocess, "run", missing_gh)
+
+    with pytest.raises(RuntimeError, match="GitHub CLI executable 'gh' was not found"):
+        pr_queue_health._run_gh_json(["gh", "pr", "list"])
+
+
 def test_pr_queue_health_live_loader_includes_referenced_issue_comments(monkeypatch) -> None:
     viewed_numbers = []
 


### PR DESCRIPTION
## Summary
- Wrap missing GitHub CLI errors in `scripts/pr_queue_health.py` with the same user-friendly RuntimeError style used by the other live queue failure paths.
- Add regression coverage so live `--repo` mode no longer leaks a raw `FileNotFoundError` traceback when `gh` is unavailable.

Bounty #936

## Validation
- `.venv\Scripts\python.exe -m pytest tests\test_pr_queue_health.py` -> 19 passed
- `git diff --check` -> clean

Scope: queue-health script error handling only. No public API, ledger, wallet, treasury, payout, bridge, exchange, cash-out, private data, secrets, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when GitHub CLI is unavailable, now provides a clearer message indicating the tool must be on PATH for live mode.

* **Tests**
  * Added test to validate proper error handling when GitHub CLI is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->