### PR TITLE
Share queue duplicate-scope formatting

### DIFF
--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -251,6 +251,12 @@ def has_queue_issues(report: dict[str, Any]) -> bool:
     )
 
 
+def _format_duplicate_scope_group(item: dict[str, Any], *, normalize_scope: bool = False) -> str:
+    prs = ", ".join(f"#{number}" for number in item["pull_requests"])
+    scope = _single_line(item["scope"]) if normalize_scope else item["scope"]
+    return f"- Bounty #{item['bounty']}: {scope} ({prs})"
+
+
 def format_text_report(report: dict[str, Any]) -> str:
     lines = ["PR queue health summary"]
     for key, value in report["summary"].items():
@@ -269,8 +275,7 @@ def format_text_report(report: dict[str, Any]) -> str:
         lines.append("")
         lines.append("Likely duplicate bounty scope")
         for item in report["duplicate_scope_groups"]:
-            prs = ", ".join(f"#{number}" for number in item["pull_requests"])
-            lines.append(f"- Bounty #{item['bounty']}: {item['scope']} ({prs})")
+            lines.append(_format_duplicate_scope_group(item))
     return "\n".join(lines)
 
 
@@ -305,8 +310,7 @@ def format_markdown_report(report: dict[str, Any]) -> str:
         lines.append("")
         lines.append("### Likely duplicate bounty scope")
         for item in report["duplicate_scope_groups"]:
-            prs = ", ".join(f"#{number}" for number in item["pull_requests"])
-            lines.append(f"- Bounty #{item['bounty']}: {_single_line(item['scope'])} ({prs})")
+            lines.append(_format_duplicate_scope_group(item, normalize_scope=True))
     return "\n".join(lines)
 
 

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -82,6 +82,10 @@ def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
             "pull_requests": [3, 4],
         }
     ]
+    assert (
+        "- Bounty #292: guard mcp bounty search oversized numeric query (#3, #4)"
+        in format_text_report(report)
+    )
 
     input_path = tmp_path / "queue.json"
     input_path.write_text(json.dumps(fixture), encoding="utf-8")
@@ -385,6 +389,7 @@ def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     assert "PR has mrwk:needs-info label" in markdown
     assert "### Likely duplicate bounty scope" in markdown
     assert "- Bounty #292: guard mcp bounty search oversized numeric query (#3, #4)" in markdown
+    assert markdown.count("guard mcp bounty search oversized numeric query (#3, #4)") == 1
 
 
 def test_pr_queue_health_markdown_no_issues_output_is_pasteable(tmp_path, capsys) -> None:


### PR DESCRIPTION
## Summary
- Centralize duplicate bounty-scope report rendering in `scripts/pr_queue_health.py` so text and Markdown reports share the same bounty/PR formatting path.
- Add focused regression assertions for the text duplicate-scope line and the Markdown duplicate-scope line.

Bounty #936

## Validation
- `python3 -m pytest tests/test_pr_queue_health.py` -> 18 passed
- `python3 -m ruff check scripts/pr_queue_health.py tests/test_pr_queue_health.py` -> All checks passed
- `python3 -m ruff format --check scripts/pr_queue_health.py tests/test_pr_queue_health.py` -> 2 files already formatted
- `git diff --check` -> clean

Scope: queue-health report formatting cleanup only. Public API, ledger, wallet, treasury, payout, bridge, exchange, cash-out, private data, secrets, and MRWK price behavior are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced consistency in how duplicate scope information is displayed across report formats.
  * Strengthened test coverage for duplicate scope detection to prevent duplicate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->