### PR TITLE
Expose submission requirements in work discovery

### DIFF
--- a/app/work_discovery.py
+++ b/app/work_discovery.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.models import Bounty, TreasuryProposal
 from app.serializers import bounties_to_dict, public_utc_timestamp
+from app.submission_requirements import work_proof_submission_requirements
 from app.treasury import proposal_payload
 
 DEFAULT_WORK_DISCOVERY_LIMIT = 50
@@ -64,6 +65,7 @@ def _bounty_work_item(row: dict[str, Any], availability_state: str) -> dict[str,
         "bounty_availability_state": str(row["availability_state"]),
         "pending_payout_awards": int(row["pending_payout_awards"]),
         "source_urls": _bounty_source_urls(row),
+        "submission_requirements": row["submission_requirements"],
     }
 
 
@@ -89,6 +91,13 @@ def _pending_create_item(proposal: TreasuryProposal) -> dict[str, Any]:
             "proposal": f"/api/v1/treasury/proposals/{proposal.id}",
             "github_issue": str(payload["issue_url"]),
         },
+        "submission_requirements": work_proof_submission_requirements(
+            bounty_id=None,
+            issue_number=int(payload["issue_number"]),
+            availability="unknown",
+            title=str(payload["title"]),
+            acceptance=str(payload.get("acceptance", "")),
+        ),
     }
 
 

--- a/tests/test_work_discovery.py
+++ b/tests/test_work_discovery.py
@@ -84,6 +84,11 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
     assert body["non_claimable_issue_states"][1]["availability_state"] == "board_or_index"
     assert body["non_claimable_issue_states"][1]["issue_number"] == 785
 
+    live_requirements = body["claimable_now"][0]["submission_requirements"]
+    assert live_requirements["reference_formats"] == ["Bounty #800", "Refs #800"]
+    assert live_requirements["attempt_endpoint"] == f"/api/v1/bounties/{live_bounty.id}/attempts"
+    assert live_requirements["next_actions"][0]["id"] == "confirm_award_slot"
+
     assert body["claimable_now"] == [
         {
             "availability_state": "live_bounty",
@@ -101,9 +106,19 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
                 "attempts": f"/api/v1/bounties/{live_bounty.id}/attempts",
                 "github_issue": "https://github.com/ramimbo/mergework/issues/800",
             },
+            "submission_requirements": live_requirements,
         }
     ]
     pending_create_executes_after = body["opening_soon"][0]["executes_after"]
+    pending_create_requirements = body["opening_soon"][0]["submission_requirements"]
+    assert pending_create_requirements["reference_formats"] == [
+        "Bounty #900",
+        "Refs #900",
+    ]
+    assert pending_create_requirements["attempt_endpoint"] == (
+        "/api/v1/bounties/<bounty_id>/attempts"
+    )
+    assert pending_create_requirements["next_actions"][0]["id"] == "select_bounty"
     assert body["opening_soon"] == [
         {
             "availability_state": "pending_create",
@@ -119,6 +134,7 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
                 "proposal": f"/api/v1/treasury/proposals/{pending_create.id}",
                 "github_issue": "https://github.com/ramimbo/mergework/issues/900",
             },
+            "submission_requirements": pending_create_requirements,
         }
     ]
     assert pending_create_executes_after.endswith("Z")


### PR DESCRIPTION
## Summary
- Adds shared `submission_requirements` to `/api/v1/work-discovery` live bounty rows so contributors can see reference formats, the attempt endpoint, evidence expectations, and duplicate-scope checks from the discovery payload.
- Adds pending-create guidance that keeps opening-soon items distinct from claimable live bounty rows.
- Extends work discovery tests for both live and pending-create payloads.

## Bounty
Bounty #935

## Evidence
- Confusion addressed: `/api/v1/work-discovery` previously exposed bounty rows without the same structured submission guidance available from bounty detail and MCP proof guidance surfaces.
- Bounty capacity check: #935 is a live MergeWork bounty with multiple awards available at submission time.
- Intended files: work discovery response code and focused work discovery tests.
- Expected PR size: small, read-only response shape and focused regression coverage.
- Out of scope: ledger mutation, wallet custody, treasury execution, payouts, admin-token behavior, price claims, bridge, exchange, cash-out behavior, private data, and secrets.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_work_discovery.py`
- `.\.venv\Scripts\python.exe -m pytest tests\test_work_discovery.py tests\test_bounty_api_routes.py::test_bounty_api_reports_issue_submission_requirements tests\test_mcp_work_proof.py`
- `.\.venv\Scripts\python.exe -m ruff check app\work_discovery.py tests\test_work_discovery.py`
- `.\.venv\Scripts\python.exe -m py_compile app\work_discovery.py tests\test_work_discovery.py`
- `git diff --check`
- PR title/body and added-line public identity hygiene scans