### PR TITLE
Flag due pending create discovery rows

### DIFF
--- a/app/work_discovery.py
+++ b/app/work_discovery.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy import select
@@ -17,6 +18,9 @@ MAX_OPEN_BOUNTY_SCAN_ROWS = 500
 STATE_DEFINITIONS = {
     "live_bounty": "Public bounty row is open and has positive effective_awards_remaining.",
     "pending_create": "Public treasury proposal exists but the bounty row is not live yet.",
+    "pending_create_due": (
+        "Public treasury proposal is past executes_after but the bounty row is not live yet."
+    ),
     "pending_payout": "Accepted work has a pending pay_bounty proposal, not proof-backed payment.",
     "closed_or_exhausted": "Bounty is closed, paid, or has no effective award capacity.",
     "proposed_work": (
@@ -73,10 +77,17 @@ def _not_claimable_state(row: dict[str, Any]) -> str:
     return "closed_or_exhausted"
 
 
+def _db_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
 def _pending_create_item(proposal: TreasuryProposal) -> dict[str, Any]:
     payload = proposal_payload(proposal)
+    execution_due = _db_utc(proposal.executes_after) <= datetime.now(UTC)
     return {
-        "availability_state": "pending_create",
+        "availability_state": "pending_create_due" if execution_due else "pending_create",
         "proposal_id": int(proposal.id),
         "issue_number": int(payload["issue_number"]),
         "title": str(payload["title"]),
@@ -85,6 +96,7 @@ def _pending_create_item(proposal: TreasuryProposal) -> dict[str, Any]:
         "max_awards": int(payload["max_awards"]),
         "effective_awards_remaining": 0,
         "executes_after": public_utc_timestamp(proposal.executes_after),
+        "execution_due": execution_due,
         "source_urls": {
             "proposal": f"/api/v1/treasury/proposals/{proposal.id}",
             "github_issue": str(payload["issue_url"]),

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -163,6 +163,7 @@ non-claimable states out of the claimable list, and accepts optional
   "state_definitions": {
     "live_bounty": "Public bounty row is open and has positive effective_awards_remaining.",
     "pending_create": "Public treasury proposal exists but the bounty row is not live yet.",
+    "pending_create_due": "Public treasury proposal is past executes_after but the bounty row is not live yet.",
     "pending_payout": "Accepted work has a pending pay_bounty proposal, not proof-backed payment.",
     "closed_or_exhausted": "Bounty is closed, paid, or has no effective award capacity.",
     "proposed_work": "GitHub proposed-work issue is intake only until a create_bounty proposal executes.",
@@ -198,6 +199,7 @@ non-claimable states out of the claimable list, and accepts optional
       "max_awards": 8,
       "effective_awards_remaining": 0,
       "executes_after": "2026-06-03T11:41:52Z",
+      "execution_due": false,
       "source_urls": {
         "proposal": "/api/v1/treasury/proposals/125",
         "github_issue": "https://github.com/ramimbo/mergework/issues/798"

--- a/tests/test_work_discovery.py
+++ b/tests/test_work_discovery.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 
 from fastapi.testclient import TestClient
 
@@ -77,6 +77,9 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
     assert body["state_definitions"]["pending_create"] == (
         "Public treasury proposal exists but the bounty row is not live yet."
     )
+    assert body["state_definitions"]["pending_create_due"] == (
+        "Public treasury proposal is past executes_after but the bounty row is not live yet."
+    )
     assert body["state_definitions"]["board_or_index"] == (
         "Index issues help discovery but are not claimable bounty work."
     )
@@ -115,6 +118,7 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
             "max_awards": 2,
             "effective_awards_remaining": 0,
             "executes_after": pending_create_executes_after,
+            "execution_due": False,
             "source_urls": {
                 "proposal": f"/api/v1/treasury/proposals/{pending_create.id}",
                 "github_issue": "https://github.com/ramimbo/mergework/issues/900",
@@ -125,6 +129,58 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
     assert datetime.fromisoformat(pending_create_executes_after.replace("Z", "+00:00"))
     assert body["not_claimable"][0]["availability_state"] == "closed_or_exhausted"
     assert body["not_claimable"][0]["issue_number"] == 761
+
+
+def test_work_discovery_flags_due_pending_create_without_making_it_claimable(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        future_pending = propose_treasury_action(
+            session,
+            action="create_bounty",
+            payload={
+                "repo": "ramimbo/mergework",
+                "issue_number": 930,
+                "issue_url": "https://github.com/ramimbo/mergework/issues/930",
+                "title": "Future pending create",
+                "reward_mrwk": "25",
+                "max_awards": 1,
+                "acceptance": "Future pending create stays ordinary opening soon.",
+            },
+            proposed_by="maintainer",
+        )
+        due_pending = propose_treasury_action(
+            session,
+            action="create_bounty",
+            payload={
+                "repo": "ramimbo/mergework",
+                "issue_number": 931,
+                "issue_url": "https://github.com/ramimbo/mergework/issues/931",
+                "title": "Due pending create",
+                "reward_mrwk": "25",
+                "max_awards": 1,
+                "acceptance": "Due pending create should be visible but not claimable.",
+            },
+            proposed_by="maintainer",
+        )
+        due_pending.executes_after = datetime.now(UTC) - timedelta(minutes=5)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    body = client.get("/api/v1/work-discovery").json()
+    by_issue = {item["issue_number"]: item for item in body["opening_soon"]}
+
+    assert by_issue[930]["proposal_id"] == future_pending.id
+    assert by_issue[930]["availability_state"] == "pending_create"
+    assert by_issue[930]["execution_due"] is False
+    assert by_issue[930]["effective_awards_remaining"] == 0
+    assert by_issue[931]["proposal_id"] == due_pending.id
+    assert by_issue[931]["availability_state"] == "pending_create_due"
+    assert by_issue[931]["execution_due"] is True
+    assert by_issue[931]["effective_awards_remaining"] == 0
+    assert body["summary"]["claimable_now_count"] == 0
 
 
 def test_work_discovery_limit_caps_public_buckets(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- add an explicit `pending_create_due` work-discovery state for pending create-bounty proposals whose `executes_after` time has passed
- expose `execution_due` on opening-soon rows while keeping due proposals non-claimable with `effective_awards_remaining: 0`
- document the new state/field in the public API examples

## Bounty
Bounty #935
Related proposed-work context: #983

## Validation
- `.venv\Scripts\python.exe -m pytest tests\test_work_discovery.py tests\test_docs_public_urls.py::test_docs_document_public_work_discovery_endpoint` -> 6 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `.venv\Scripts\python.exe -m ruff check app\work_discovery.py tests\test_work_discovery.py` -> All checks passed
- `.venv\Scripts\python.exe -m ruff format --check app\work_discovery.py tests\test_work_discovery.py` -> 2 files already formatted
- `git diff --check` -> clean, Windows CRLF warnings only

## Scope notes
No treasury execution, payout execution, wallet, admin-token, bridge, exchange, off-ramp, or cash-out behavior changes. Due pending-create rows remain non-claimable until a public bounty row exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pending_create_due` availability state to distinguish overdue pending create proposals in work discovery.
  * Added `execution_due` field to work-discovery proposals, indicating whether a pending creation has passed its execution deadline.

* **Documentation**
  * Updated API examples with the new availability state and field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->