### PR TITLE
Prioritize already-reviewed PRs in review candidates

### DIFF
--- a/scripts/review_bounty_candidates.py
+++ b/scripts/review_bounty_candidates.py
@@ -171,6 +171,9 @@ def _classify_pr(
     if pr_author == reviewer:
         state = "self_authored"
         reason = "reviewer authored this PR"
+    elif current_reviewer_reviews:
+        state = "already_reviewed_current_head_by_reviewer"
+        reason = "reviewer already reviewed current head"
     elif "mrwk:needs-info" in normalized_labels:
         state = "needs_info"
         reason = "PR has mrwk:needs-info label"
@@ -180,9 +183,6 @@ def _classify_pr(
     elif quality_state != "success":
         state = "missing_standard_quality_check"
         reason = f"standard quality check is {quality_state}"
-    elif current_reviewer_reviews:
-        state = "already_reviewed_current_head_by_reviewer"
-        reason = "reviewer already reviewed current head"
     elif changes_requested:
         state = "waiting_for_author_update"
         reason = "current-head human review already requested changes"

--- a/tests/test_review_bounty_candidates.py
+++ b/tests/test_review_bounty_candidates.py
@@ -84,6 +84,16 @@ def test_review_bounty_candidates_classifies_review_states(tmp_path, capsys) -> 
                 "reviews": [],
             },
             {
+                "number": 10,
+                "title": "Already reviewed without standard CI",
+                "author": {"login": "alice"},
+                "headRefOid": "h10",
+                "mergeStateStatus": "CLEAN",
+                "labels": [],
+                "statusCheckRollup": [],
+                "reviews": [_review("reviewer", "APPROVED", "h10")],
+            },
+            {
                 "number": 6,
                 "title": "Needs info",
                 "author": {"login": "alice"},
@@ -135,6 +145,7 @@ def test_review_bounty_candidates_classifies_review_states(tmp_path, capsys) -> 
         3: "candidate_for_fresh_review",
         4: "dirty_or_conflicted",
         5: "missing_standard_quality_check",
+        10: "already_reviewed_current_head_by_reviewer",
         6: "needs_info",
         7: "waiting_for_author_update",
         8: "already_has_sufficient_current_head_human_reviews",
@@ -157,7 +168,7 @@ def test_review_bounty_candidates_classifies_review_states(tmp_path, capsys) -> 
     )
     assert exit_code == 0
     output = json.loads(capsys.readouterr().out)
-    assert output["summary"]["pull_requests"] == 9
+    assert output["summary"]["pull_requests"] == 10
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- classify PRs already reviewed by the requested reviewer on the current head before workflow/mergeability buckets
- prevents the review-bounty candidate scanner from re-suggesting a reviewer’s own current-head review when the PR is still missing the standard quality check
- adds regression coverage for a current-head reviewer approval with missing standard CI

## Bounty
Bounty #936

## Validation
- `.venv\Scripts\python.exe -m pytest tests\test_review_bounty_candidates.py` -> 12 passed
- `.venv\Scripts\python.exe -m ruff check scripts\review_bounty_candidates.py tests\test_review_bounty_candidates.py` -> All checks passed
- `.venv\Scripts\python.exe -m ruff format --check scripts\review_bounty_candidates.py tests\test_review_bounty_candidates.py` -> 2 files already formatted
- `git diff --check` -> clean
- Live smoke: `scripts\review_bounty_candidates.py --repo ramimbo/mergework --reviewer elianguitarra --format json` now classifies PR #982 as `already_reviewed_current_head_by_reviewer` even though its standard quality check is missing

## Scope notes
Focused scanner maintainability fix only; no app runtime, ledger, wallet, treasury, payout, admin-token, bridge, exchange, off-ramp, or cash-out behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized pull request review state classification to prioritize already-reviewed submissions earlier in the evaluation process, improving candidate prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->