### PR TITLE
Fix proposed-work triage live payment defaults

### DIFF
--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -82,7 +82,7 @@ STOPWORDS = {
 GH_TIMEOUT_SECONDS = 30
 HTTP_TIMEOUT_SECONDS = 30
 DEFAULT_API_HOST = "https://api.mrwk.online"
-DEFAULT_PAYMENT_BOUNTY_ISSUE_NUMBERS = (649, 722)
+DEFAULT_PAYMENT_BOUNTY_ISSUE_NUMBERS = (932, 722, 649)
 LIVE_ISSUE_SEARCHES = (
     "label:proposed-work",
     '"proposed work"',
@@ -384,6 +384,7 @@ def _run_gh(args: list[str]) -> Any:
         result = subprocess.run(
             ["gh", *args],
             capture_output=True,
+            encoding="utf-8",
             text=True,
             timeout=GH_TIMEOUT_SECONDS,
             check=False,

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -430,6 +430,8 @@ def test_proposed_work_triage_live_mode_uses_read_only_gh(monkeypatch, capsys) -
     def fake_urlopen(request, timeout):  # noqa: ANN001, ANN202, ARG001
         url = request.full_url
         loaded_urls.append(url)
+        if url.endswith("/api/v1/bounties?issue_number=932&limit=5"):
+            return FakeResponse([])
         if url.endswith("/api/v1/bounties?issue_number=649&limit=5"):
             return FakeResponse([])
         if url.endswith("/api/v1/bounties?issue_number=722&limit=5"):
@@ -458,8 +460,9 @@ def test_proposed_work_triage_live_mode_uses_read_only_gh(monkeypatch, capsys) -
     output = json.loads(capsys.readouterr().out)
     assert output["summary"]["proposed_work_issues"] == 2
     assert output["summary"]["payment_counts"] == {"none": 1, "pending": 1}
-    assert any(url.endswith("/api/v1/bounties?issue_number=649&limit=5") for url in loaded_urls)
+    assert any(url.endswith("/api/v1/bounties?issue_number=932&limit=5") for url in loaded_urls)
     assert any(url.endswith("/api/v1/bounties?issue_number=722&limit=5") for url in loaded_urls)
+    assert any(url.endswith("/api/v1/bounties?issue_number=649&limit=5") for url in loaded_urls)
     pending = next(item for item in output["proposals"] if item["number"] == 672)
     unlabeled = next(item for item in output["proposals"] if item["number"] == 673)
     assert "accepted_pending_payout" in pending["warnings"]
@@ -656,8 +659,9 @@ def test_proposed_work_triage_live_mode_warns_when_payment_state_is_incomplete(
 
     assert output["summary"]["payment_counts"] == {"none": 1}
     assert output["summary"]["data_warnings"] == [
-        "payment_state_incomplete: failed to load public bounty list for issue #649 (URLError)",
+        "payment_state_incomplete: failed to load public bounty list for issue #932 (URLError)",
         "payment_state_incomplete: failed to load public bounty list for issue #722 (URLError)",
+        "payment_state_incomplete: failed to load public bounty list for issue #649 (URLError)",
     ]
     markdown = format_markdown(output)
     assert "data warning: payment_state_incomplete" in markdown
@@ -683,6 +687,8 @@ def test_proposed_work_triage_live_mode_warns_when_bounty_detail_fetch_fails(
         return subprocess.CompletedProcess(args, 0, stdout=stdout, stderr="")
 
     def fake_urlopen(request, timeout):  # noqa: ANN001, ANN202, ARG001
+        if request.full_url.endswith("/api/v1/bounties?issue_number=932&limit=5"):
+            return FakeResponse([])
         if request.full_url.endswith("/api/v1/bounties?issue_number=649&limit=5"):
             return FakeResponse([{"id": 96}])
         if request.full_url.endswith("/api/v1/bounties?issue_number=722&limit=5"):
@@ -705,6 +711,15 @@ def test_proposed_work_triage_live_mode_warns_when_bounty_detail_fetch_fails(
 
 
 def test_run_gh_reports_timeout_and_invalid_json(monkeypatch) -> None:
+    def fake_utf8_json(args, **kwargs):  # noqa: ANN001, ANN202
+        assert kwargs["encoding"] == "utf-8"
+        return subprocess.CompletedProcess(
+            args, 0, stdout='{"title":"Fixed \u201csmart quotes\u201d"}', stderr=""
+        )
+
+    monkeypatch.setattr("scripts.proposed_work_triage.subprocess.run", fake_utf8_json)
+    assert _run_gh(["issue", "view", "1"]) == {"title": "Fixed \u201csmart quotes\u201d"}
+
     def fake_timeout(args, **kwargs):  # noqa: ANN001, ANN202, ARG001
         raise subprocess.TimeoutExpired(args, timeout=15)
 


### PR DESCRIPTION
## Summary
- include the current accepted proposed-work payment bounty (#932) in the live triage defaults while preserving prior transition rounds
- force gh JSON subprocess output to decode as UTF-8 so live mode works on Windows when issue text contains smart quotes or other Unicode
- extend tests for the #932 default and UTF-8 gh decoding

## Validation
- .\\.venv\\Scripts\\python.exe -m pytest tests\\test_proposed_work_triage.py
- .\\.venv\\Scripts\\ruff.exe check scripts\\proposed_work_triage.py tests\\test_proposed_work_triage.py
- .\\.venv\\Scripts\\python.exe scripts\\proposed_work_triage.py --repo ramimbo/mergework --format json --limit 10

For #936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended bounty data lookups to include additional issue `#932` alongside existing issues.

* **Bug Fixes**
  * Fixed UTF-8 encoding handling to properly display special characters in command output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->