### PR TITLE
Decode check-agents git output as UTF-8

### DIFF
--- a/scripts/check_agents.py
+++ b/scripts/check_agents.py
@@ -21,6 +21,7 @@ def tracked_paths() -> list[str]:
         cwd=ROOT,
         check=True,
         capture_output=True,
+        encoding="utf-8",
         text=True,
     )
     return [line for line in result.stdout.splitlines() if line]

--- a/tests/test_check_agents.py
+++ b/tests/test_check_agents.py
@@ -45,7 +45,7 @@ def test_tracked_paths_decodes_git_output_as_utf8(monkeypatch: pytest.MonkeyPatc
         return subprocess.CompletedProcess(
             args,
             0,
-            stdout="AGENTS.md\ndocs/AGENTS.md\nnotes/unicode-name.md\n",
+            stdout="AGENTS.md\ndocs/AGENTS.md\nnotes/naïve-名.md\n",
             stderr="",
         )
 
@@ -54,7 +54,7 @@ def test_tracked_paths_decodes_git_output_as_utf8(monkeypatch: pytest.MonkeyPatc
     assert check_agents.tracked_paths() == [
         "AGENTS.md",
         "docs/AGENTS.md",
-        "notes/unicode-name.md",
+        "notes/naïve-名.md",
     ]
 
 

--- a/tests/test_check_agents.py
+++ b/tests/test_check_agents.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -35,6 +36,26 @@ def test_agent_instruction_paths_include_nested_agents_files() -> None:
     )
 
     assert paths == ["AGENTS.md", "docs/AGENTS.md"]
+
+
+def test_tracked_paths_decodes_git_output_as_utf8(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(args, **kwargs):  # noqa: ANN001, ANN202
+        assert args == ["git", "ls-files"]
+        assert kwargs["encoding"] == "utf-8"
+        return subprocess.CompletedProcess(
+            args,
+            0,
+            stdout="AGENTS.md\ndocs/AGENTS.md\nnotes/unicode-name.md\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(check_agents.subprocess, "run", fake_run)
+
+    assert check_agents.tracked_paths() == [
+        "AGENTS.md",
+        "docs/AGENTS.md",
+        "notes/unicode-name.md",
+    ]
 
 
 def test_main_rejects_oversized_nested_agents_file(


### PR DESCRIPTION
## Summary
- make scripts/check_agents.py decode git ls-files output explicitly as UTF-8
- add regression coverage so the AGENTS.md check keeps the same Windows-safe subprocess behavior

## Validation
- .\\.venv\\Scripts\\python.exe -m pytest tests\\test_check_agents.py
- .\\.venv\\Scripts\\ruff.exe check scripts\\check_agents.py tests\\test_check_agents.py
- .\\.venv\\Scripts\\python.exe scripts\\check_agents.py

Refs #936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure git-tracked filenames are decoded as UTF-8 to fix issues with non-ASCII characters.

* **Tests**
  * Added a test validating UTF-8 decoding of git output and correct handling of filenames containing both ASCII and non-ASCII characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->