### PR TITLE
Advertise MCP schemas for wallet write tools

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -174,6 +174,23 @@ MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "register_wallet",
         "description": "Register an MRWK wallet public key",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "public_key_hex": {
+                    "type": "string",
+                    "pattern": "^[0-9a-fA-F]{64}$",
+                    "description": "Ed25519 public key as 64 hex characters.",
+                },
+                "label": {
+                    "type": "string",
+                    "maxLength": 160,
+                    "description": "Optional wallet label.",
+                },
+            },
+            "required": ["public_key_hex"],
+            "additionalProperties": False,
+        },
     },
     {
         "name": "get_wallet",
@@ -194,6 +211,49 @@ MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "submit_wallet_transfer",
         "description": "Submit a signed MRWK wallet transfer",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "from_address": {
+                    "type": "string",
+                    "pattern": "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$",
+                    "description": "Sender MRWK wallet address.",
+                },
+                "to_address": {
+                    "type": "string",
+                    "pattern": "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$",
+                    "description": "Receiver MRWK wallet address.",
+                },
+                "amount_mrwk": {
+                    "type": "string",
+                    "description": "MRWK amount, with up to 6 decimal places.",
+                },
+                "nonce": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Next wallet nonce signed in the transfer payload.",
+                },
+                "memo": {
+                    "type": "string",
+                    "maxLength": 240,
+                    "default": "",
+                    "description": "Optional transfer memo.",
+                },
+                "signature_hex": {
+                    "type": "string",
+                    "pattern": "^[0-9a-fA-F]{128}$",
+                    "description": "Ed25519 signature as 128 hex characters.",
+                },
+            },
+            "required": [
+                "from_address",
+                "to_address",
+                "amount_mrwk",
+                "nonce",
+                "signature_hex",
+            ],
+            "additionalProperties": False,
+        },
     },
     {
         "name": "get_ledger_entry",

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -395,6 +395,35 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert proof_schema["required"] == ["hash"]
     assert proof_schema["additionalProperties"] is False
     assert proof_schema["properties"]["hash"]["pattern"] == "^[0-9a-fA-F]{64}$"
+    register_tool = next(
+        tool for tool in tools["result"]["tools"] if tool["name"] == "register_wallet"
+    )
+    register_schema = register_tool["inputSchema"]
+    assert register_schema["required"] == ["public_key_hex"]
+    assert register_schema["additionalProperties"] is False
+    assert register_schema["properties"]["public_key_hex"]["pattern"] == "^[0-9a-fA-F]{64}$"
+    assert register_schema["properties"]["label"]["maxLength"] == 160
+    transfer_tool = next(
+        tool for tool in tools["result"]["tools"] if tool["name"] == "submit_wallet_transfer"
+    )
+    transfer_schema = transfer_tool["inputSchema"]
+    assert transfer_schema["required"] == [
+        "from_address",
+        "to_address",
+        "amount_mrwk",
+        "nonce",
+        "signature_hex",
+    ]
+    assert transfer_schema["additionalProperties"] is False
+    assert transfer_schema["properties"]["from_address"]["pattern"] == (
+        "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$"
+    )
+    assert transfer_schema["properties"]["to_address"]["pattern"] == (
+        "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$"
+    )
+    assert transfer_schema["properties"]["nonce"]["minimum"] == 1
+    assert transfer_schema["properties"]["memo"]["maxLength"] == 240
+    assert transfer_schema["properties"]["signature_hex"]["pattern"] == "^[0-9a-fA-F]{128}$"
 
     balance = client.post(
         "/mcp",


### PR DESCRIPTION
## Summary
- add 	ools/list input schemas for egister_wallet and submit_wallet_transfer
- document required wallet write arguments, address/signature/public-key patterns, nonce minimums, and label/memo limits in the advertised schemas
- extend MCP tools/list coverage so these schemas stay aligned with runtime validation

## Validation
- .\\.venv\\Scripts\\python.exe -m pytest tests\\test_api_mcp.py::test_mcp_tools_list_and_call tests\\test_api_mcp.py::test_mcp_can_register_and_fetch_wallet tests\\test_api_mcp.py::test_mcp_wallet_write_tools_reject_unexpected_arguments
- .\\.venv\\Scripts\\ruff.exe check app\\mcp.py tests\\test_api_mcp.py

Refs #934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet registration and transfer inputs now enforce explicit validation: public keys must be 64-hex, addresses must be mrwk1-prefixed 40-hex, signatures must be 128-hex, required fields (e.g., public key, from/to, amount, nonce, signature) are enforced, memo and label length limits apply, and extraneous fields are rejected.

* **Tests**
  * Added tests covering the new wallet input validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->