### PR TITLE
Add structured MCP balance responses

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -8,8 +8,9 @@ from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from app.ledger.service import LedgerError
+from app.mcp_results import MCPTextResult
 
-MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
+MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any] | MCPTextResult]
 MCP_PROTOCOL_VERSION = "2025-06-18"
 MCP_SERVER_INFO = {"name": "mergework", "version": "0.1.0"}
 
@@ -280,7 +281,14 @@ def _structured_json_payload(text: str) -> dict[str, Any] | list[Any] | None:
     return None
 
 
-def _tool_result_response(response_id: Any, tool_result: str | dict[str, Any]) -> dict[str, Any]:
+def _tool_result_response(
+    response_id: Any, tool_result: str | dict[str, Any] | MCPTextResult
+) -> dict[str, Any]:
+    if isinstance(tool_result, MCPTextResult):
+        result: dict[str, Any] = {"content": [{"type": "text", "text": tool_result.text}]}
+        if tool_result.structured_content is not None:
+            result["structuredContent"] = tool_result.structured_content
+        return {"jsonrpc": "2.0", "id": response_id, "result": result}
     if isinstance(tool_result, dict):
         return {
             "jsonrpc": "2.0",

--- a/app/mcp_results.py
+++ b/app/mcp_results.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class MCPTextResult:
+    text: str
+    structured_content: dict[str, Any] | list[Any] | None = None

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -17,6 +17,7 @@ from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import format_mrwk, get_balance, register_wallet, submit_wallet_transfer
 from app.ledger_views import ledger_entry_to_dict
+from app.mcp_results import MCPTextResult
 from app.mcp_work_proof import (
     generic_work_proof_guidance_json,
     work_proof_guidance,
@@ -37,7 +38,9 @@ MCP_INTEGER_RE = re.compile(r"^(?:0|-?[1-9][0-9]*)$")
 MCP_BOUNTY_SEARCH_QUERY_MAX_LENGTH = 500
 
 
-def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | dict[str, Any]:
+def call_mcp_tool(
+    database_url: str, name: str, args: dict[str, Any]
+) -> str | dict[str, Any] | MCPTextResult:
     def int_arg(field: str) -> int:
         value = args[field]
         if isinstance(value, bool):
@@ -254,7 +257,16 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
             }
         if name == "get_balance":
             account = normalized_account(str_arg("account"))
-            return f"{account}: {format_mrwk(get_balance(session, account))} MRWK"
+            balance_microunits = get_balance(session, account)
+            balance_mrwk = format_mrwk(balance_microunits)
+            return MCPTextResult(
+                text=f"{account}: {balance_mrwk} MRWK",
+                structured_content={
+                    "account": account,
+                    "balance_mrwk": balance_mrwk,
+                    "balance_microunits": balance_microunits,
+                },
+            )
         if name == "register_wallet":
             reject_unexpected_args("register_wallet", {"public_key_hex", "label"})
             wallet = register_wallet(

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -319,8 +319,11 @@ Tools:
 Successful MCP tools that return JSON objects or lists include both the
 backward-compatible JSON string in `result.content[0].text` and parsed
 `result.structuredContent`. Prefer `structuredContent` when present, and fall
-back to text for human-readable responses such as balances or not-found
-messages.
+back to text for human-readable not-found messages.
+
+`get_balance` keeps the legacy balance text and also includes
+`result.structuredContent.account`, `balance_mrwk`, and `balance_microunits` so
+callers do not need to parse the text response.
 
 ## Contribution Rules
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -778,6 +778,28 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_balance","arguments":{"account":"treasury:mrwk"}}}'
 ```
 
+`get_balance` keeps the legacy text response and adds parsed balance fields:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "treasury:mrwk: 100000000 MRWK"
+      }
+    ],
+    "structuredContent": {
+      "account": "treasury:mrwk",
+      "balance_mrwk": "100000000",
+      "balance_microunits": 100000000000000
+    }
+  }
+}
+```
+
 Call `list_bounties`:
 
 ```bash
@@ -849,8 +871,7 @@ curl -s -X POST "$MCP_HOST/mcp" \
 Successful MCP tools that return JSON objects or lists include the
 backward-compatible JSON string in `result.content[0].text` and the parsed
 payload in `result.structuredContent`. Prefer `structuredContent` when present;
-fall back to text for human-readable responses such as balances and not-found
-messages.
+fall back to text for human-readable not-found messages.
 
 Successful MCP transfer responses expose the transfer hash, ledger sequence,
 addresses, amount, nonce, memo, and timestamp in that JSON payload:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -7,7 +7,13 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
-from app.ledger.service import close_bounty, create_bounty, ensure_genesis, pay_bounty
+from app.ledger.service import (
+    GENESIS_SUPPLY_MICRO,
+    close_bounty,
+    create_bounty,
+    ensure_genesis,
+    pay_bounty,
+)
 from app.main import create_app
 from app.models import BountyAttempt, Proof
 from app.serializers import public_utc_timestamp
@@ -389,7 +395,11 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     ).json()
     assert balance["result"]["content"][0]["type"] == "text"
     assert "100000000" in balance["result"]["content"][0]["text"]
-    assert "structuredContent" not in balance["result"]
+    assert balance["result"]["structuredContent"] == {
+        "account": "treasury:mrwk",
+        "balance_mrwk": "100000000",
+        "balance_microunits": GENESIS_SUPPLY_MICRO,
+    }
 
 
 def test_mcp_initialize_returns_server_capabilities(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- Keeps `get_balance` text output while adding `structuredContent` with normalized account, `balance_mrwk`, and `balance_microunits`.
- Adds a small MCP text-result wrapper so text-first responses can expose parsed payloads without changing legacy content.
- Updates MCP docs and regression coverage for the balance response shape.

## Bounty
Bounty #934

## Evidence
- Confusion addressed: `get_balance` previously returned only human-readable text, forcing tool callers to parse strings for account and balance values.
- Bounty capacity check: #934 is a live MergeWork bounty with multiple awards available at submission time.
- Intended files: MCP response serialization, balance tool handling, MCP docs, and focused MCP tests.
- Expected PR size: small, backward-compatible MCP response clarity change with focused tests and docs.
- Out of scope: ledger mutation, wallet custody, treasury execution, payouts, admin-token behavior, price claims, bridge, exchange, cash-out behavior, private data, and secrets.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py tests\test_mcp_tools.py`
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py`
- `.\.venv\Scripts\python.exe -m ruff check app\mcp.py app\mcp_tools.py app\mcp_results.py tests\test_api_mcp.py`
- `.\.venv\Scripts\python.exe -m ruff format --check app\mcp.py app\mcp_tools.py app\mcp_results.py tests\test_api_mcp.py`
- `.\.venv\Scripts\python.exe -m mypy app\mcp.py app\mcp_tools.py app\mcp_results.py`
- `.\.venv\Scripts\python.exe -m py_compile app\mcp.py app\mcp_tools.py app\mcp_results.py`
- `git diff --cached --check`
- PR title/body and staged added-line public identity hygiene scans