### PR TITLE
Handle missing gh in proposed-work triage live mode

### DIFF
--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -390,6 +390,11 @@ def _run_gh(args: list[str]) -> Any:
         )
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s") from exc
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "GitHub CLI executable 'gh' was not found; install gh and ensure it is on PATH "
+            "before using live mode."
+        ) from exc
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or result.stdout.strip())
     try:

--- a/tests/test_proposed_work_triage.py
+++ b/tests/test_proposed_work_triage.py
@@ -729,6 +729,21 @@ def test_run_gh_reports_timeout_and_invalid_json(monkeypatch) -> None:
         raise AssertionError("expected invalid JSON RuntimeError")
 
 
+def test_run_gh_reports_missing_executable(monkeypatch) -> None:
+    def missing_gh(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr("scripts.proposed_work_triage.subprocess.run", missing_gh)
+
+    try:
+        _run_gh(["issue", "list"])
+    except RuntimeError as exc:
+        assert "GitHub CLI executable 'gh' was not found" in str(exc)
+        assert "live mode" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("expected missing gh RuntimeError")
+
+
 def test_run_gh_rejects_mutating_commands_before_subprocess(monkeypatch) -> None:
     def fail_if_called(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
         raise AssertionError("mutating gh command should be rejected before subprocess.run")


### PR DESCRIPTION
Refs #936

## Summary
- Wrap FileNotFoundError from proposed-work triage live-mode gh calls in a clear RuntimeError.
- Keep the existing read-only command guard, timeout handling, gh failure handling, and invalid JSON handling unchanged.
- Add regression coverage for the missing-gh path.

## Validation
- .\.venv\Scripts\python.exe -m pytest tests\test_proposed_work_triage.py -> 21 passed
- .\.venv\Scripts\ruff.exe check scripts\proposed_work_triage.py tests\test_proposed_work_triage.py -> All checks passed
- .\.venv\Scripts\ruff.exe format --check scripts\proposed_work_triage.py tests\test_proposed_work_triage.py -> 2 files already formatted
- git diff --check -> clean

Scope: scripts/proposed_work_triage.py live-mode error handling only. No ledger, wallet, treasury, payout, admin, security-sensitive, price, bridge, exchange, or cash-out behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling to display clear, actionable messages when a required external tool is not found on the system. Users now receive specific guidance for installation and PATH configuration instead of cryptic failures.

* **Tests**
  * Added test coverage for missing external tool detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->