### PR TITLE
Handle missing gh in submission quality gate

### DIFF
--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -522,6 +522,11 @@ def _run_gh_json(args: list[str]) -> Any:
         )
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s: {command}") from exc
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "GitHub CLI executable 'gh' was not found; install gh and ensure it is on PATH "
+            "before using live mode."
+        ) from exc
     except subprocess.CalledProcessError as exc:
         raise RuntimeError(
             "gh command failed "

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -784,6 +784,16 @@ def test_submission_quality_gate_live_mode_warns_when_github_unavailable(
     assert "load_warning" in output
 
 
+def test_run_gh_json_reports_missing_executable(monkeypatch) -> None:
+    def missing_gh(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202, ARG001
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr(submission_quality_gate.subprocess, "run", missing_gh)
+
+    with pytest.raises(RuntimeError, match="GitHub CLI executable 'gh' was not found"):
+        submission_quality_gate._run_gh_json(["gh", "pr", "list"])
+
+
 def test_submission_quality_gate_warns_when_live_collections_hit_safety_caps(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
Refs #936

## Summary
- Wrap FileNotFoundError from the submission quality gate gh JSON helper in a clear RuntimeError.
- Keep timeout, nonzero gh failure, JSON parsing, and live-context warning behavior unchanged.
- Add direct regression coverage for the missing gh executable path.

## Validation
- .\.venv\Scripts\python.exe -m pytest tests\test_submission_quality_gate.py -> 48 passed
- .\.venv\Scripts\ruff.exe check scripts\submission_quality_gate.py tests\test_submission_quality_gate.py -> All checks passed
- .\.venv\Scripts\ruff.exe format --check scripts\submission_quality_gate.py tests\test_submission_quality_gate.py -> 2 files already formatted
- git diff --check -> clean

Scope: scripts/submission_quality_gate.py live-mode helper error handling only. No ledger, wallet, treasury, payout, admin, security-sensitive, price, bridge, exchange, or cash-out behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messages when the GitHub CLI tool is not installed, providing clearer guidance on what needs to be configured.

* **Tests**
  * Added test coverage for error handling when required dependencies are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->