### PR TITLE
Handle missing gh in claim inventory

### DIFF
--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -534,6 +534,11 @@ def _run_gh_json(args: list[str]) -> Any:
         )
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s") from exc
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "GitHub CLI executable 'gh' was not found; install gh and ensure it is on PATH "
+            "before using live --repo mode"
+        ) from exc
     except subprocess.CalledProcessError as exc:
         raise RuntimeError(
             f"gh command failed with exit {exc.returncode}: {' '.join(args)}\n{exc.stderr}"

--- a/tests/test_claim_inventory.py
+++ b/tests/test_claim_inventory.py
@@ -415,6 +415,21 @@ def test_claim_inventory_live_mode_uses_read_only_calls(monkeypatch) -> None:
     ), calls
 
 
+def test_run_gh_json_reports_missing_gh(monkeypatch) -> None:
+    def missing_gh(*args, **kwargs):
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr(claim_inventory.subprocess, "run", missing_gh)
+
+    try:
+        claim_inventory._run_gh_json(["gh", "issue", "list"])
+    except RuntimeError as exc:
+        assert "GitHub CLI executable 'gh' was not found" in str(exc)
+        assert "live --repo mode" in str(exc)
+    else:
+        raise AssertionError("expected missing gh RuntimeError")
+
+
 def test_claim_inventory_script_entrypoint_loads_shared_parser() -> None:
     result = subprocess.run(
         [sys.executable, "scripts/claim_inventory.py", "--help"],


### PR DESCRIPTION
Bounty #936

## Summary
- Wrap missing GitHub CLI errors in `scripts/claim_inventory.py` with a clear RuntimeError instead of letting live `--repo` mode leak a raw `FileNotFoundError` traceback.
- Keep the existing read-only command guard, timeout handling, gh nonzero failure handling, and JSON decoding behavior unchanged.
- Add regression coverage for the missing-`gh` path.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/test_claim_inventory.py -q` -> 8 passed
- `uv run --python 3.12 --extra dev ruff check scripts/claim_inventory.py tests/test_claim_inventory.py` -> passed
- `uv run --python 3.12 --extra dev ruff format --check scripts/claim_inventory.py tests/test_claim_inventory.py` -> 2 files already formatted
- `uv run --python 3.12 --extra dev mypy scripts/claim_inventory.py` -> success
- `git diff --check` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `f082123778c6143ab6d584dccc7f96e4ae792bff`

Scope: claim-inventory script error handling only. No public API, ledger, wallet, treasury, payout, bridge, exchange, cash-out, private data, secrets, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when GitHub CLI is unavailable. Users now receive clear guidance to install `gh` and ensure it's on `PATH` before using live repo mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->