### PR TITLE
Validate staging dry-run labeler

### DIFF
--- a/scripts/staging_webhook_dry_run.py
+++ b/scripts/staging_webhook_dry_run.py
@@ -81,6 +81,15 @@ def _dry_run_contributor() -> str:
     return contributor
 
 
+def _dry_run_labeler() -> str:
+    labeler = _required_env("MERGEWORK_GITHUB_ACCEPTED_LABELERS").split(",", 1)[0].strip()
+    if not labeler:
+        raise RuntimeError(
+            "MERGEWORK_GITHUB_ACCEPTED_LABELERS must include a non-empty first labeler"
+        )
+    return labeler
+
+
 def _enforce_staging_target(base_url: str) -> None:
     parsed = urlparse(base_url)
     host = parsed.hostname or ""
@@ -106,7 +115,7 @@ def main() -> int:
         webhook_secret = _required_env("MERGEWORK_GITHUB_WEBHOOK_SECRET")
         repo = _dry_run_repo()
         contributor = _dry_run_contributor()
-        labeler = _required_env("MERGEWORK_GITHUB_ACCEPTED_LABELERS").split(",", 1)[0].strip()
+        labeler = _dry_run_labeler()
         issue_number = int(time.time() * 1000)
         issue_url = f"https://github.com/{repo}/issues/{issue_number}"
         bounty = _post_json(

--- a/tests/test_staging_webhook_dry_run.py
+++ b/tests/test_staging_webhook_dry_run.py
@@ -5,6 +5,7 @@ import pytest
 
 from scripts.staging_webhook_dry_run import (
     _dry_run_contributor,
+    _dry_run_labeler,
     _dry_run_repo,
     _enforce_staging_target,
     _parse_object_response,
@@ -69,6 +70,14 @@ def test_staging_webhook_dry_run_uses_valid_default_identity_envs(
     assert _dry_run_contributor() == "mergework-dry-run"
 
 
+def test_staging_webhook_dry_run_uses_first_non_empty_labeler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MERGEWORK_GITHUB_ACCEPTED_LABELERS", " maintainer , other ")
+
+    assert _dry_run_labeler() == "maintainer"
+
+
 @pytest.mark.parametrize(
     "repo",
     [
@@ -113,3 +122,20 @@ def test_staging_webhook_dry_run_rejects_blank_contributor_before_http(
 
     assert main() == 1
     assert "MERGEWORK_DRY_RUN_CONTRIBUTOR" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("labelers", ["", "   ", ",maintainer"])
+def test_staging_webhook_dry_run_rejects_blank_labeler_before_http(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    labelers: str,
+) -> None:
+    _set_required_dry_run_env(monkeypatch)
+    monkeypatch.setenv("MERGEWORK_GITHUB_ACCEPTED_LABELERS", labelers)
+    monkeypatch.setattr(
+        "scripts.staging_webhook_dry_run.httpx.post",
+        lambda *_args, **_kwargs: pytest.fail("dry run posted before labeler validation"),
+    )
+
+    assert main() == 1
+    assert "MERGEWORK_GITHUB_ACCEPTED_LABELERS" in capsys.readouterr().err


### PR DESCRIPTION
Refs #936

## Summary
- Extract staging webhook dry-run accepted-labeler parsing into a validated helper.
- Fail before any HTTP calls when `MERGEWORK_GITHUB_ACCEPTED_LABELERS` is blank or starts with an empty first labeler.
- Add focused regression coverage for the happy path and early-failure path.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_staging_webhook_dry_run.py` -> 18 passed
- `.\.venv\Scripts\ruff.exe check scripts\staging_webhook_dry_run.py tests\test_staging_webhook_dry_run.py` -> All checks passed
- `.\.venv\Scripts\ruff.exe format --check scripts\staging_webhook_dry_run.py tests\test_staging_webhook_dry_run.py` -> 2 files already formatted
- `git diff --check` -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to validate label parsing and configuration handling, ensuring proper selection of labeler values and rejection of invalid configurations.

* **Refactor**
  * Improved code organization by extracting label parsing logic into a dedicated helper function for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->