### PR TITLE
Add structured MCP balance format

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -165,6 +165,12 @@ MCP_TOOLS: list[dict[str, Any]] = [
                         "reserve:bounty:<id>, or an mrwk1 wallet address."
                     ),
                 },
+                "format": {
+                    "type": "string",
+                    "enum": ["text", "json"],
+                    "default": "text",
+                    "description": "Use json for machine-readable structuredContent.",
+                },
             },
             "required": ["account"],
             "additionalProperties": False,

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -253,8 +253,16 @@ def call_mcp_tool(database_url: str, name: str, args: dict[str, Any]) -> str | d
                 "attempts": attempt_listing["attempts"],
             }
         if name == "get_balance":
+            require_known_fields("account", "format")
             account = normalized_account(str_arg("account"))
-            return f"{account}: {format_mrwk(get_balance(session, account))} MRWK"
+            balance_microunits = get_balance(session, account)
+            if output_format_arg() == "json":
+                return {
+                    "account": account,
+                    "balance_microunits": balance_microunits,
+                    "balance_mrwk": format_mrwk(balance_microunits),
+                }
+            return f"{account}: {format_mrwk(balance_microunits)} MRWK"
         if name == "register_wallet":
             reject_unexpected_args("register_wallet", {"public_key_hex", "label"})
             wallet = register_wallet(

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -259,6 +259,9 @@ curl -s -X POST "$MCP_HOST/mcp" \
 {"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_balance","arguments":{"account":"treasury:mrwk"}}}
 ```
 
+Pass `{"format":"json"}` when you need `account`, `balance_microunits`,
+and `balance_mrwk` in `result.structuredContent`.
+
 List open bounties through MCP:
 
 ```bash
@@ -307,7 +310,7 @@ Tools:
 - `list_bounties`
 - `get_bounty`
 - `list_bounty_attempts`
-- `get_balance`
+- `get_balance` (`format: "json"` returns structuredContent)
 - `register_wallet`
 - `get_wallet`
 - `submit_wallet_transfer`
@@ -319,8 +322,7 @@ Tools:
 Successful MCP tools that return JSON objects or lists include both the
 backward-compatible JSON string in `result.content[0].text` and parsed
 `result.structuredContent`. Prefer `structuredContent` when present, and fall
-back to text for human-readable responses such as balances or not-found
-messages.
+back to text for human-readable responses such as not-found messages.
 
 ## Contribution Rules
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -778,6 +778,15 @@ curl -s -X POST "$MCP_HOST/mcp" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_balance","arguments":{"account":"treasury:mrwk"}}}'
 ```
 
+Pass `{"format":"json"}` when an agent needs `account`,
+`balance_microunits`, and `balance_mrwk` in `result.structuredContent`.
+
+```bash
+curl -s -X POST "$MCP_HOST/mcp" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_balance","arguments":{"account":"treasury:mrwk","format":"json"}}}'
+```
+
 Call `list_bounties`:
 
 ```bash

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -377,6 +377,8 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert balance_schema["additionalProperties"] is False
     assert balance_schema["properties"]["account"]["minLength"] == 1
     assert "github:<login>" in balance_schema["properties"]["account"]["description"]
+    assert balance_schema["properties"]["format"]["enum"] == ["text", "json"]
+    assert balance_schema["properties"]["format"]["default"] == "text"
 
     balance = client.post(
         "/mcp",
@@ -390,6 +392,23 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert balance["result"]["content"][0]["type"] == "text"
     assert "100000000" in balance["result"]["content"][0]["text"]
     assert "structuredContent" not in balance["result"]
+    structured_balance = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "get_balance",
+                "arguments": {"account": "treasury:mrwk", "format": "json"},
+            },
+        },
+    ).json()
+    structured_payload = structured_balance["result"]["structuredContent"]
+    assert structured_payload["account"] == "treasury:mrwk"
+    assert structured_payload["balance_microunits"] > 0
+    assert structured_payload["balance_mrwk"] == "100000000"
+    assert json.loads(structured_balance["result"]["content"][0]["text"]) == structured_payload
 
 
 def test_mcp_initialize_returns_server_capabilities(sqlite_url: str) -> None:
@@ -1633,6 +1652,7 @@ def test_mcp_accepts_canonical_integer_string_arguments(sqlite_url: str) -> None
         ("get_balance", {"account": True}, 13),
         ("get_balance", {"account": 123}, 14),
         ("get_balance", {"account": ""}, 15),
+        ("get_balance", {"account": "treasury:mrwk", "format": "yaml"}, 19),
         ("get_wallet", {"address": 123}, 16),
         ("get_proof", {"hash": 123}, 17),
         ("get_wallet", {"address": "not-a-wallet"}, 18),

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -444,6 +444,10 @@ def test_api_examples_document_mcp_wallet_transfer_response() -> None:
 def test_api_examples_document_mcp_lookup_response_shapes() -> None:
     examples = Path("docs/api-examples.md").read_text(encoding="utf-8")
 
+    assert '"name":"get_balance"' in examples
+    assert '"format":"json"' in examples
+    assert "balance_microunits" in examples
+    assert "balance_mrwk" in examples
     assert '"name":"get_ledger_entry"' in examples
     assert '"arguments":{"sequence":42}' in examples
     assert "same ledger-entry shape as" in examples


### PR DESCRIPTION
Refs #934

## Summary
- Adds an optional `format` argument to the MCP `get_balance` tools/list schema.
- Keeps the default text balance response unchanged.
- Allows `format: json` to return machine-readable `structuredContent` with `account`, `balance_microunits`, and `balance_mrwk`.
- Documents the structured balance mode in the MCP examples and agent guide.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py::test_mcp_tools_list_and_call tests\test_api_mcp.py::test_mcp_rejects_invalid_string_arguments tests\test_docs_public_urls.py::test_api_examples_document_mcp_lookup_response_shapes` -> 9 passed, 1 existing Starlette/httpx warning
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `.\.venv\Scripts\ruff.exe check app\mcp.py app\mcp_tools.py tests\test_api_mcp.py tests\test_docs_public_urls.py` -> All checks passed
- `.\.venv\Scripts\ruff.exe format --check app\mcp.py app\mcp_tools.py tests\test_api_mcp.py tests\test_docs_public_urls.py` -> 4 files already formatted
- `git diff --check` -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `get_balance` tool now supports an optional `format` parameter, accepting either `"text"` (default) or `"json"` output mode, including structured balance data.

* **Documentation**
  * Updated agent guide and API examples with guidance on using the new `format: "json"` option and its returned fields.

* **Tests**
  * Extended test coverage to validate the new `format` parameter and verify JSON response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->