### PR TITLE
Report malformed deploy settings cleanly

### DIFF
--- a/scripts/check_deploy_ready.py
+++ b/scripts/check_deploy_ready.py
@@ -10,7 +10,12 @@ from app.treasury_executor_config import executor_config_from_env
 
 
 def main() -> int:
-    errors = validate_deploy_settings(get_settings())
+    try:
+        settings = get_settings()
+    except ValueError as exc:
+        errors = [str(exc)]
+    else:
+        errors = validate_deploy_settings(settings)
     try:
         executor_config_from_env()
     except ValueError as exc:

--- a/tests/test_deploy_readiness.py
+++ b/tests/test_deploy_readiness.py
@@ -512,6 +512,15 @@ def test_deploy_readiness_accepts_treasury_executor_minimum_bounds() -> None:
     assert result.stdout.strip() == "Deploy readiness check passed."
 
 
+def test_deploy_readiness_reports_malformed_settings_without_traceback() -> None:
+    result = _run_deploy_ready(_deploy_ready_env(MERGEWORK_BOUNTY_BOARD_ISSUE_NUMBER="notanumber"))
+
+    assert result.returncode == 1, result.stdout
+    assert "Deploy readiness check failed:" in result.stdout
+    assert "- MERGEWORK_BOUNTY_BOARD_ISSUE_NUMBER must be an integer" in result.stdout
+    assert "Traceback" not in result.stderr
+
+
 @pytest.mark.parametrize(
     ("name", "value", "expected_error"),
     [


### PR DESCRIPTION
Refs #936

## Summary
- Makes `scripts/check_deploy_ready.py` report malformed settings from `get_settings()` as normal deploy-readiness failures instead of crashing with a traceback.
- Preserves the existing executor-config validation and success/failure output shape.
- Adds subprocess regression coverage for a malformed `MERGEWORK_BOUNTY_BOARD_ISSUE_NUMBER` env value.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_deploy_readiness.py::test_get_settings_rejects_malformed_bounty_board_issue_number tests\test_deploy_readiness.py::test_deploy_readiness_script_runs_directly_from_source tests\test_deploy_readiness.py::test_deploy_readiness_reports_malformed_settings_without_traceback` -> 3 passed
- `.\.venv\Scripts\ruff.exe check scripts\check_deploy_ready.py tests\test_deploy_readiness.py` -> All checks passed
- `.\.venv\Scripts\ruff.exe format --check scripts\check_deploy_ready.py tests\test_deploy_readiness.py` -> 2 files already formatted
- `git diff --check` -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for malformed deployment configuration settings with refined error reporting behavior.

* **Tests**
  * Added test coverage for deployment readiness validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->