### PR TITLE
Clarify effective availability filter

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -193,6 +193,15 @@ def public_bounties_context(
             None,
             selected_availability,
         ),
+        "clear_availability_filter_url": _bounties_page_url(
+            selected_status,
+            query_text,
+            selected_sort,
+            limit,
+            selected_repo,
+            issue_number,
+            "all",
+        ),
         "status_filter_urls": {
             "all": _bounties_page_url(
                 None,

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -39,6 +39,9 @@
 {% if selected_repo or selected_issue_number %}
 <p>Source filter:{% if selected_repo %} {{ selected_repo }}{% endif %}{% if selected_issue_number %} #{{ selected_issue_number }}{% endif %}. <a href="{{ clear_source_filter_url | safe }}">Clear source filter</a></p>
 {% endif %}
+{% if selected_availability == "effectively_open" %}
+<p>Showing only effectively open bounties. <a href="{{ clear_availability_filter_url | safe }}">Show all visible rows</a></p>
+{% endif %}
 <section class="bounty-list-summary" aria-label="Bounty list summary">
   <article>
     <span>Bounties shown</span>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -701,6 +701,8 @@ def test_bounties_page_api_and_summary_filter_effectively_open_rows(sqlite_url: 
     assert partially_open.title in page.text
     assert effectively_full.title not in page.text
     assert 'href="/api/v1/bounties?status=open&amp;availability=effectively_open">' in page.text
+    assert "Showing only effectively open bounties." in page.text
+    assert 'href="/bounties?status=open">Show all visible rows</a>' in page.text
 
     filtered_search_page = client.get("/bounties?status=open&q=Fresh&availability=effectively_open")
     assert filtered_search_page.status_code == 200
@@ -713,10 +715,15 @@ def test_bounties_page_api_and_summary_filter_effectively_open_rows(sqlite_url: 
         'href="/bounties?status=paid&q=Fresh&availability=effectively_open"'
         in filtered_search_page.text
     )
+    assert (
+        'href="/bounties?status=open&q=Fresh">Show all visible rows</a>'
+        in filtered_search_page.text
+    )
 
     empty_effective_page = client.get("/bounties?availability=effectively_open&q=missing")
     assert empty_effective_page.status_code == 200
     assert "No bounties match these filters." in empty_effective_page.text
+    assert 'href="/bounties?q=missing">Show all visible rows</a>' in empty_effective_page.text
 
 
 def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -60,6 +60,9 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
             "/bounties?status=open&repo=ramimbo%2Fmergework&issue_number=649&sort=reward"
         ),
         "clear_source_filter_url": "/bounties?status=open&q=proof&sort=reward",
+        "clear_availability_filter_url": (
+            "/bounties?status=open&q=proof&repo=ramimbo%2Fmergework&issue_number=649&sort=reward"
+        ),
         "status_filter_urls": {
             "all": ("/bounties?q=proof&repo=ramimbo%2Fmergework&issue_number=649&sort=reward"),
             "open": (
@@ -101,6 +104,24 @@ def test_public_bounties_context_clear_source_filter_preserves_other_filters() -
 
     assert context["clear_source_filter_url"] == (
         "/bounties?status=open&q=proof&sort=reward&limit=25&availability=effectively_open"
+    )
+
+
+def test_public_bounties_context_clear_availability_filter_preserves_other_filters() -> None:
+    context = public_bounties_context(
+        [],
+        status="open",
+        q="proof",
+        sort="reward",
+        limit=25,
+        repo="ramimbo/mergework",
+        issue_number=649,
+        availability="effectively_open",
+    )
+
+    assert context["clear_availability_filter_url"] == (
+        "/bounties?status=open&q=proof&repo=ramimbo%2Fmergework"
+        "&issue_number=649&sort=reward&limit=25"
     )
 
 


### PR DESCRIPTION
Refs #935

## Summary
- Adds a dedicated public-page notice when `/bounties` is filtered to `availability=effectively_open`.
- Adds a `Show all visible rows` link that clears only the availability filter while preserving status, search, source, sort, and limit filters.
- Keeps lifecycle semantics unchanged: the filter still only hides rows with no effective award capacity; no pending/live/paid state behavior changes.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_public_routes.py::test_public_bounties_context_normalizes_filter_state tests\test_public_routes.py::test_public_bounties_context_clear_availability_filter_preserves_other_filters tests\test_bounty_pages.py::test_bounties_page_api_and_summary_filter_effectively_open_rows` -> 3 passed, 1 existing Starlette/httpx warning
- `.\.venv\Scripts\ruff.exe check app\public_routes.py tests\test_public_routes.py tests\test_bounty_pages.py` -> All checks passed
- `.\.venv\Scripts\ruff.exe format --check app\public_routes.py tests\test_public_routes.py tests\test_bounty_pages.py` -> 3 files already formatted
- `git diff --check` -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When filtering bounties by "effectively open" status, users now see an informational message with a link to quickly clear the filter and view all available bounties while preserving other search parameters.

* **Tests**
  * Updated and added tests to verify the new filter clearing functionality works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->