### PR TITLE
Report invalid treasury executor config cleanly

### DIFF
--- a/scripts/treasury_executor.py
+++ b/scripts/treasury_executor.py
@@ -78,7 +78,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--once", action="store_true", help="Run one enabled pass and exit.")
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
-    config = executor_config_from_env()
+    try:
+        config = executor_config_from_env()
+    except ValueError as exc:
+        logging.error("treasury executor configuration invalid: %s", exc)
+        return 1
     if not config.enabled:
         logging.info("treasury executor disabled by MERGEWORK_TREASURY_EXECUTOR_ENABLED")
         if args.once:

--- a/tests/test_treasury_executor_script.py
+++ b/tests/test_treasury_executor_script.py
@@ -174,3 +174,20 @@ def test_executor_once_returns_failure_when_pass_fails(monkeypatch: pytest.Monke
     monkeypatch.setattr(executor_script, "run_once", fake_run_once)
 
     assert executor_script.main(["--once"]) == 1
+
+
+def test_executor_main_reports_invalid_config_without_traceback(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(
+        executor_script,
+        "executor_config_from_env",
+        lambda: (_ for _ in ()).throw(
+            ValueError("MERGEWORK_TREASURY_EXECUTOR_INTERVAL_SECONDS must be at least 15")
+        ),
+    )
+
+    assert executor_script.main(["--once"]) == 1
+    assert "treasury executor configuration invalid" in caplog.text
+    assert "MERGEWORK_TREASURY_EXECUTOR_INTERVAL_SECONDS must be at least 15" in caplog.text

--- a/tests/test_treasury_executor_script.py
+++ b/tests/test_treasury_executor_script.py
@@ -191,3 +191,4 @@ def test_executor_main_reports_invalid_config_without_traceback(
     assert executor_script.main(["--once"]) == 1
     assert "treasury executor configuration invalid" in caplog.text
     assert "MERGEWORK_TREASURY_EXECUTOR_INTERVAL_SECONDS must be at least 15" in caplog.text
+    assert "Traceback (most recent call last)" not in caplog.text


### PR DESCRIPTION
Bounty #936

## Summary
- Handles invalid treasury-executor environment configuration in `scripts/treasury_executor.py` as a normal operational failure.
- Logs the specific configuration error and returns exit code `1` instead of letting a raw `ValueError` traceback escape from `main()`.
- Adds regression coverage for the invalid-config path.

## Verification
- `.venv\Scripts\python.exe -m pytest tests\test_treasury_executor_script.py` -> 9 passed
- `.venv\Scripts\ruff.exe check scripts\treasury_executor.py tests\test_treasury_executor_script.py` -> All checks passed
- `.venv\Scripts\ruff.exe format --check scripts\treasury_executor.py tests\test_treasury_executor_script.py` -> 2 files already formatted
- `git diff --check` -> clean

Scope: treasury executor CLI error handling only. No ledger mutation, treasury execution behavior, payout behavior, wallet custody, admin token handling, bridge/exchange/cash-out behavior, price behavior, secrets, or private data changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid treasury executor configuration so the application exits cleanly instead of crashing.
  * Logs now report a clear, user-friendly error message when configuration is invalid.
  * Reduced noisy stack traces in logs for this failure case, making error output easier to read and act on.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->