### PR TITLE
Report invalid ledger snapshot settings cleanly

### DIFF
--- a/scripts/export_ledger_snapshot.py
+++ b/scripts/export_ledger_snapshot.py
@@ -52,7 +52,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         sys.stdout.write(ledger_snapshot_schema_json())
         return 0
 
-    settings = get_settings()
+    try:
+        settings = get_settings()
+    except ValueError as exc:
+        print(f"ledger snapshot export configuration invalid: {exc}", file=sys.stderr)
+        return 1
     database_url = args.database_url or settings.database_url
     source_host = args.source_host if args.source_host is not None else settings.public_base_url
     with read_only_session_scope(database_url) as session:

--- a/tests/test_ledger_snapshot.py
+++ b/tests/test_ledger_snapshot.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 
+import scripts.export_ledger_snapshot as export_ledger_snapshot_script
 from app.db import create_schema, session_scope
 from app.ledger.service import (
     GENESIS_SUPPLY_MICRO,
@@ -168,6 +169,33 @@ def test_exporter_main_accepts_schema_argv(capsys) -> None:
     schema = json.loads(capsys.readouterr().out)
 
     assert schema["$id"] == LEDGER_SNAPSHOT_SCHEMA
+
+
+def test_exporter_schema_mode_does_not_load_settings(monkeypatch) -> None:
+    monkeypatch.setattr(
+        export_ledger_snapshot_script,
+        "get_settings",
+        lambda: (_ for _ in ()).throw(AssertionError("settings should not load")),
+    )
+
+    assert export_ledger_snapshot_main(["--schema"]) == 0
+
+
+def test_exporter_reports_malformed_settings_without_traceback(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        export_ledger_snapshot_script,
+        "get_settings",
+        lambda: (_ for _ in ()).throw(
+            ValueError("MERGEWORK_BOUNTY_BOARD_ISSUE_NUMBER must be an integer")
+        ),
+    )
+
+    assert export_ledger_snapshot_main([]) == 1
+    output = capsys.readouterr()
+    assert output.out == ""
+    assert "ledger snapshot export configuration invalid" in output.err
+    assert "MERGEWORK_BOUNTY_BOARD_ISSUE_NUMBER must be an integer" in output.err
+    assert "Traceback (most recent call last)" not in output.err
 
 
 def test_exporter_main_accepts_snapshot_argv(sqlite_url: str, capsys) -> None:


### PR DESCRIPTION
Bounty #936

## Summary
- Handles malformed application settings in `scripts/export_ledger_snapshot.py` as a normal CLI failure for snapshot exports.
- Prints a concise stderr error and returns exit code `1` instead of letting a raw `ValueError` traceback escape.
- Preserves `--schema` behavior so schema export remains deterministic and does not load application settings.

## Verification
- `.venv\Scripts\python.exe -m pytest tests\test_ledger_snapshot.py` -> 10 passed
- `.venv\Scripts\python.exe -m pytest tests\test_ledger_snapshot.py::test_exporter_main_accepts_schema_argv tests\test_ledger_snapshot.py::test_exporter_schema_mode_does_not_load_settings tests\test_ledger_snapshot.py::test_exporter_reports_malformed_settings_without_traceback tests\test_ledger_snapshot.py::test_exporter_main_accepts_snapshot_argv` -> 4 passed
- `.venv\Scripts\ruff.exe check scripts\export_ledger_snapshot.py tests\test_ledger_snapshot.py` -> All checks passed
- `.venv\Scripts\ruff.exe format --check scripts\export_ledger_snapshot.py tests\test_ledger_snapshot.py` -> 2 files already formatted
- `git diff --check` -> clean

Scope: read-only ledger snapshot exporter CLI error handling only. No ledger mutation, payout behavior, treasury execution, wallet custody, admin-token handling, bridge/exchange/cash-out behavior, price behavior, secrets, or private data changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for configuration loading failures, now displays clear error messages instead of proceeding with invalid settings.

* **Tests**
  * Added test coverage for schema mode to ensure settings are not unnecessarily loaded.
  * Added tests verifying graceful error handling for malformed configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->