### PR TITLE
Report invalid payout reconciliation settings cleanly

### DIFF
--- a/scripts/reconcile_payouts.py
+++ b/scripts/reconcile_payouts.py
@@ -14,7 +14,21 @@ from app.ledger.reconciliation import (
 
 
 def main() -> int:
-    settings = get_settings()
+    try:
+        settings = get_settings()
+    except ValueError as exc:
+        print(
+            json.dumps(
+                {
+                    "summary": {"status": "configuration_invalid"},
+                    "issues": [{"status": "configuration_invalid", "message": str(exc)}],
+                    "duplicate_source_urls": [],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 1
     with session_scope(settings.database_url) as session:
         checks = reconcile_accepted_payouts(session)
         duplicate_sources = duplicate_accepted_source_urls(session)

--- a/tests/test_reconcile_payouts_script.py
+++ b/tests/test_reconcile_payouts_script.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts import reconcile_payouts
+
+
+def test_reconcile_payouts_reports_malformed_settings_without_session(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fail_settings() -> object:
+        raise ValueError("MERGEWORK_DATABASE_URL is invalid")
+
+    def fail_session_scope(_database_url: str) -> object:
+        raise AssertionError("session_scope should not be called for invalid settings")
+
+    monkeypatch.setattr(reconcile_payouts, "get_settings", fail_settings)
+    monkeypatch.setattr(reconcile_payouts, "session_scope", fail_session_scope)
+
+    assert reconcile_payouts.main() == 1
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "duplicate_source_urls": [],
+        "issues": [
+            {
+                "message": "MERGEWORK_DATABASE_URL is invalid",
+                "status": "configuration_invalid",
+            }
+        ],
+        "summary": {"status": "configuration_invalid"},
+    }


### PR DESCRIPTION
## Summary
- catch malformed app settings in `scripts/reconcile_payouts.py` before opening a database session
- emit a stable JSON failure payload with `configuration_invalid` status and exit code 1
- add focused regression coverage proving invalid settings do not reach `session_scope`

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_reconcile_payouts_script.py` -> 1 passed
- `.\.venv\Scripts\ruff.exe check scripts\reconcile_payouts.py tests\test_reconcile_payouts_script.py` -> All checks passed
- `.\.venv\Scripts\ruff.exe format --check scripts\reconcile_payouts.py tests\test_reconcile_payouts_script.py` -> 2 files already formatted
- `git diff --check` -> clean

## Scope
- Bounty #936 focused cleanup for a script error path.
- No ledger reconciliation logic, payout execution, treasury/proposal execution, wallet behavior, bridge/exchange/cash-out behavior, MRWK price behavior, private data, or secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling in payout reconciliation. When configuration is invalid, the system now returns a clear error status with diagnostic details in a structured format and an appropriate exit code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->