### PR TITLE
Advertise MCP proof and ledger schemas

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -194,8 +194,40 @@ MCP_TOOLS: list[dict[str, Any]] = [
         "name": "submit_wallet_transfer",
         "description": "Submit a signed MRWK wallet transfer",
     },
-    {"name": "get_ledger_entry", "description": "Get a ledger entry"},
-    {"name": "get_proof", "description": "Get a public proof by hash"},
+    {
+        "name": "get_ledger_entry",
+        "description": "Get a public ledger entry by sequence number",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "sequence": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Public MRWK ledger sequence number.",
+                },
+            },
+            "required": ["sequence"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "get_proof",
+        "description": "Get a public proof by 64-character lowercase hex hash",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "hash": {
+                    "type": "string",
+                    "minLength": 64,
+                    "maxLength": 64,
+                    "pattern": "^[0-9a-f]{64}$",
+                    "description": "Public proof hash.",
+                },
+            },
+            "required": ["hash"],
+            "additionalProperties": False,
+        },
+    },
     {
         "name": "submit_work_proof",
         "description": (

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -377,6 +377,20 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert balance_schema["additionalProperties"] is False
     assert balance_schema["properties"]["account"]["minLength"] == 1
     assert "github:<login>" in balance_schema["properties"]["account"]["description"]
+    ledger_entry_tool = next(
+        tool for tool in tools["result"]["tools"] if tool["name"] == "get_ledger_entry"
+    )
+    ledger_entry_schema = ledger_entry_tool["inputSchema"]
+    assert ledger_entry_schema["required"] == ["sequence"]
+    assert ledger_entry_schema["additionalProperties"] is False
+    assert ledger_entry_schema["properties"]["sequence"]["minimum"] == 1
+    proof_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_proof")
+    proof_schema = proof_tool["inputSchema"]
+    assert proof_schema["required"] == ["hash"]
+    assert proof_schema["additionalProperties"] is False
+    assert proof_schema["properties"]["hash"]["minLength"] == 64
+    assert proof_schema["properties"]["hash"]["maxLength"] == 64
+    assert proof_schema["properties"]["hash"]["pattern"] == "^[0-9a-f]{64}$"
 
     balance = client.post(
         "/mcp",


### PR DESCRIPTION
## Summary
- add explicit MCP input schemas for `get_proof` and `get_ledger_entry`
- document supported proof hash and ledger sequence arguments for agent/tool clients
- add conformance coverage that verifies both schemas are advertised

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py tests\test_mcp_tools.py` -> 131 passed, 1 warning
- `.\.venv\Scripts\ruff.exe check app\mcp.py tests\test_api_mcp.py` -> All checks passed
- `.\.venv\Scripts\ruff.exe format --check app\mcp.py tests\test_api_mcp.py` -> 2 files already formatted
- `git diff --check origin/main..HEAD` -> clean

## Scope
- Bounty #946 MCP structured output/conformance surface only.
- No MCP tool runtime behavior, ledger mutation, payout execution, treasury/proposal execution, wallet behavior, bridge/exchange/cash-out behavior, MRWK price behavior, private data, or secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced input validation for ledger entry and proof lookup tools with stricter parameter constraints, preventing invalid requests and improving data reliability.

* **Tests**
  * Added comprehensive validation tests to verify tools enforce proper input constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->