### PR TITLE
Publish attempt OpenAPI status enums

### DIFF
--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -110,6 +110,11 @@ WALLET_MEMO_SCHEMA = {
     "maxLength": 240,
 }
 
+BOUNTY_ATTEMPT_STATUS_ENUM = ["active", "expired", "released"]
+ATTEMPT_REGISTRATION_STATUS_ENUM = ["registered"]
+ATTEMPT_CONFLICT_STATUS_ENUM = ["duplicate_active_attempt", "not_available"]
+ATTEMPT_RELEASE_STATUS_ENUM = ["already_expired", "already_released", "released"]
+
 WALLET_RESPONSE_SCHEMA = _object_schema(
     {
         "address": MRWK_WALLET_ADDRESS_SCHEMA,
@@ -158,7 +163,7 @@ BOUNTY_ATTEMPT_RESPONSE_SCHEMA = _object_schema(
         "bounty_id": {"type": "integer", "minimum": 1},
         "submitter_account": {"type": "string"},
         "source_url": {"type": "string", "nullable": True},
-        "status": {"type": "string"},
+        "status": {"type": "string", "enum": BOUNTY_ATTEMPT_STATUS_ENUM},
         "expires_at": {"type": "string"},
         "created_at": {"type": "string"},
         "updated_at": {"type": "string"},
@@ -167,7 +172,7 @@ BOUNTY_ATTEMPT_RESPONSE_SCHEMA = _object_schema(
 
 ATTEMPT_REGISTRATION_RESPONSE_SCHEMA = _object_schema(
     {
-        "status": {"type": "string"},
+        "status": {"type": "string", "enum": ATTEMPT_REGISTRATION_STATUS_ENUM},
         "attempt": BOUNTY_ATTEMPT_RESPONSE_SCHEMA,
         "warnings": {"type": "array", "items": {"type": "string"}},
     }
@@ -175,7 +180,7 @@ ATTEMPT_REGISTRATION_RESPONSE_SCHEMA = _object_schema(
 
 ATTEMPT_CONFLICT_RESPONSE_SCHEMA = _object_schema(
     {
-        "status": {"type": "string"},
+        "status": {"type": "string", "enum": ATTEMPT_CONFLICT_STATUS_ENUM},
         "bounty_id": {"type": "integer", "minimum": 1},
         "attempt": BOUNTY_ATTEMPT_RESPONSE_SCHEMA,
         "warnings": {"type": "array", "items": {"type": "string"}},
@@ -184,7 +189,7 @@ ATTEMPT_CONFLICT_RESPONSE_SCHEMA = _object_schema(
 
 ATTEMPT_RELEASE_RESPONSE_SCHEMA = _object_schema(
     {
-        "status": {"type": "string"},
+        "status": {"type": "string", "enum": ATTEMPT_RELEASE_STATUS_ENUM},
         "attempt": BOUNTY_ATTEMPT_RESPONSE_SCHEMA,
     }
 )

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -288,6 +288,39 @@ def test_public_post_openapi_response_schemas_expose_wallet_transfer_and_attempt
     _assert_properties(release_schema, {"status", "attempt"})
 
 
+def test_bounty_attempt_response_schemas_publish_status_enums(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    registered_attempt_schema = _post_response_schema(
+        openapi, "/api/v1/bounties/{bounty_id}/attempts", "201"
+    )
+    assert registered_attempt_schema["properties"]["status"]["enum"] == ["registered"]
+    assert registered_attempt_schema["properties"]["attempt"]["properties"]["status"]["enum"] == [
+        "active",
+        "expired",
+        "released",
+    ]
+
+    conflict_schema = _post_response_schema(openapi, "/api/v1/bounties/{bounty_id}/attempts", "409")
+    assert conflict_schema["properties"]["status"]["enum"] == [
+        "duplicate_active_attempt",
+        "not_available",
+    ]
+
+    release_schema = _post_response_schema(openapi, "/api/v1/bounty-attempts/{attempt_id}/release")
+    assert release_schema["properties"]["status"]["enum"] == [
+        "already_expired",
+        "already_released",
+        "released",
+    ]
+    assert release_schema["properties"]["attempt"]["properties"]["status"]["enum"] == [
+        "active",
+        "expired",
+        "released",
+    ]
+
+
 def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
     openapi = client.get("/openapi.json").json()


### PR DESCRIPTION
## Summary
- publish bounded OpenAPI enum values for bounty-attempt response statuses
- document the existing runtime states for attempt registration, conflict, release, and nested attempt records
- add focused `/openapi.json` coverage so SDK/client contracts can rely on the advertised status sets

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py` -> 9 passed, 1 warning
- `.\.venv\Scripts\ruff.exe check app\openapi_request_bodies.py tests\test_openapi_request_bodies.py` -> All checks passed
- `.\.venv\Scripts\ruff.exe format --check app\openapi_request_bodies.py tests\test_openapi_request_bodies.py` -> 2 files already formatted
- `git diff --check` -> clean

## Scope
- Bounty #944 OpenAPI/client contract completion only.
- No runtime attempt behavior, auth/session behavior, ledger mutation, payout execution, treasury/proposal execution, wallet behavior, bridge/exchange/cash-out behavior, MRWK price behavior, private data, or secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Stricter API response validation for bounty attempt workflows: status fields for registration, conflict, and release responses are now constrained to explicit allowed values.
* **Tests**
  * Added automated checks validating the published response schemas expose the exact status value lists for the relevant endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->