### PR TITLE
Advertise MCP attempt output schema

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -13,6 +13,45 @@ MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
 MCP_PROTOCOL_VERSION = "2025-06-18"
 MCP_SERVER_INFO = {"name": "mergework", "version": "0.1.0"}
 
+MCP_BOUNTY_ATTEMPT_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "bounty_id": {"type": "integer", "minimum": 1},
+        "issue_number": {"type": "integer", "minimum": 1},
+        "status": {"type": "string"},
+        "warnings": {"type": "array", "items": {"type": "string"}},
+        "attempts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer", "minimum": 1},
+                    "bounty_id": {"type": "integer", "minimum": 1},
+                    "submitter_account": {"type": "string"},
+                    "source_url": {"type": ["string", "null"]},
+                    "status": {"type": "string", "enum": ["active", "expired", "released"]},
+                    "expires_at": {"type": "string", "format": "date-time"},
+                    "created_at": {"type": "string", "format": "date-time"},
+                    "updated_at": {"type": "string", "format": "date-time"},
+                },
+                "required": [
+                    "id",
+                    "bounty_id",
+                    "submitter_account",
+                    "source_url",
+                    "status",
+                    "expires_at",
+                    "created_at",
+                    "updated_at",
+                ],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["bounty_id", "issue_number", "status", "warnings", "attempts"],
+    "additionalProperties": False,
+}
+
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
@@ -150,6 +189,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "dependentRequired": {"repo": ["issue_number"]},
             "additionalProperties": False,
         },
+        "outputSchema": MCP_BOUNTY_ATTEMPT_OUTPUT_SCHEMA,
     },
     {
         "name": "get_balance",

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -306,7 +306,7 @@ Tools:
 
 - `list_bounties`
 - `get_bounty`
-- `list_bounty_attempts`
+- `list_bounty_attempts` (`tools/list` advertises its structured output schema)
 - `get_balance`
 - `register_wallet`
 - `get_wallet`

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -811,7 +811,8 @@ curl -s -X POST "$MCP_HOST/mcp" \
 Call `list_bounty_attempts` with the same internal `bounty_id` (or the `id`
 field returned by `list_bounties`/`get_bounty`), or the GitHub `issue_number`
 plus `repo`, before opening a PR. Omit `include_expired` to see only active
-attempts:
+attempts. The MCP `tools/list` metadata advertises the structured output schema
+for this tool so agents can validate the `structuredContent` attempt wrapper:
 
 ```bash
 curl -s -X POST "$MCP_HOST/mcp" \

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -364,6 +364,25 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
         {"required": ["issue_number"]},
     ]
     assert attempt_schema["dependentRequired"] == {"repo": ["issue_number"]}
+    attempt_output_schema = attempt_tool["outputSchema"]
+    assert attempt_output_schema["required"] == [
+        "bounty_id",
+        "issue_number",
+        "status",
+        "warnings",
+        "attempts",
+    ]
+    assert attempt_output_schema["properties"]["attempts"]["items"]["required"] == [
+        "id",
+        "bounty_id",
+        "submitter_account",
+        "source_url",
+        "status",
+        "expires_at",
+        "created_at",
+        "updated_at",
+    ]
+    assert attempt_output_schema["properties"]["attempts"]["items"]["additionalProperties"] is False
     wallet_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_wallet")
     wallet_schema = wallet_tool["inputSchema"]
     assert wallet_schema["required"] == ["address"]
@@ -521,7 +540,19 @@ def test_mcp_list_bounty_attempts_reports_active_and_expired(sqlite_url: str) ->
     active_payload = active_result["structuredContent"]
     assert active_payload["bounty_id"] == bounty.id
     assert active_payload["issue_number"] == 321
+    assert set(active_payload) == {"bounty_id", "issue_number", "status", "warnings", "attempts"}
+    assert active_payload["status"] == "open"
     assert active_payload["warnings"] == ["bounty has 2 active attempts"]
+    assert set(active_payload["attempts"][0]) == {
+        "id",
+        "bounty_id",
+        "submitter_account",
+        "source_url",
+        "status",
+        "expires_at",
+        "created_at",
+        "updated_at",
+    }
     assert [attempt["submitter_account"] for attempt in active_payload["attempts"]] == [
         "github:bob",
         "github:alice",


### PR DESCRIPTION
Bounty #946

## Summary
- Adds an MCP `outputSchema` for `list_bounty_attempts`, matching the structured attempt wrapper returned in `result.structuredContent`.
- Captures the wrapper fields agents need before opening duplicate bounty work: `bounty_id`, `issue_number`, `status`, `warnings`, and `attempts`.
- Documents that `tools/list` now advertises this structured output contract for attempt checks.

## Validation
- `.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py::test_mcp_tools_list_and_call tests\test_api_mcp.py::test_mcp_list_bounty_attempts_reports_active_and_expired` -> 2 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py tests\test_mcp_tools.py` -> 131 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\python.exe -m pytest tests\test_docs_public_urls.py::test_api_examples_document_mcp_lookup_response_shapes` -> 1 passed
- `.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `.venv\Scripts\ruff.exe check app\mcp.py app\mcp_tools.py tests\test_api_mcp.py tests\test_mcp_tools.py` -> All checks passed
- `.venv\Scripts\ruff.exe format --check app\mcp.py app\mcp_tools.py tests\test_api_mcp.py tests\test_mcp_tools.py` -> 4 files already formatted
- `git diff --check` -> clean, Windows CRLF warnings only for docs

Touched MCP surface: `tools/list` metadata for `list_bounty_attempts` plus tests/docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Documented the structured output schema for bounty attempt listings with explicit field definitions and validation rules.
  * Clarified endpoint behavior regarding active vs. expired attempt filtering.

* **Tests**
  * Added comprehensive validation tests to ensure bounty attempt responses comply with the documented output schema structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->