### PR TITLE
Publish wallet OpenAPI string constraints

### DIFF
--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -61,6 +61,26 @@ MRWK_AMOUNT_SCHEMA = {
     "pattern": r"^(?=.*[1-9])\d+(?:\.\d{1,6})?$",
 }
 
+MRWK_WALLET_ADDRESS_SCHEMA = {
+    "type": "string",
+    "description": "Registered mrwk1 wallet address.",
+    "minLength": 45,
+    "maxLength": 45,
+    "pattern": "^mrwk1[0-9a-f]{40}$",
+}
+
+WALLET_LABEL_SCHEMA = {
+    "type": "string",
+    "description": "Optional wallet display label.",
+    "maxLength": 160,
+}
+
+WALLET_TRANSFER_MEMO_SCHEMA = {
+    "type": "string",
+    "description": "Optional transfer memo.",
+    "maxLength": 240,
+}
+
 MRWK_DECIMAL_SCHEMA = {
     "type": "string",
     "description": "Decimal MRWK amount with at most six decimal places.",
@@ -267,7 +287,7 @@ WALLET_REGISTER_BODY = {
                     **LOWERCASE_HEX_64_SCHEMA,
                     "description": "64-character lowercase hex Ed25519 public key.",
                 },
-                "label": {"type": "string", "description": "Optional wallet display label."},
+                "label": WALLET_LABEL_SCHEMA,
             },
             required=["public_key_hex"],
         ),
@@ -278,7 +298,7 @@ WALLET_REGISTER_BODY = {
 }
 
 SIGNED_WALLET_ACTION_PROPERTIES = {
-    "address": {"type": "string", "description": "Registered mrwk1 wallet address."},
+    "address": MRWK_WALLET_ADDRESS_SCHEMA,
     "nonce": INTEGER_OR_STRING_SCHEMA,
     "signature_hex": {
         **LOWERCASE_HEX_128_SCHEMA,
@@ -309,11 +329,17 @@ WALLET_TRANSFER_BODY = {
     "requestBody": _request_body(
         _object_schema(
             {
-                "from_address": {"type": "string", "description": "Sender mrwk1 wallet address."},
-                "to_address": {"type": "string", "description": "Receiver mrwk1 wallet address."},
+                "from_address": {
+                    **MRWK_WALLET_ADDRESS_SCHEMA,
+                    "description": "Sender mrwk1 wallet address.",
+                },
+                "to_address": {
+                    **MRWK_WALLET_ADDRESS_SCHEMA,
+                    "description": "Receiver mrwk1 wallet address.",
+                },
                 "amount_mrwk": MRWK_AMOUNT_SCHEMA,
                 "nonce": INTEGER_OR_STRING_SCHEMA,
-                "memo": {"type": "string", "description": "Optional transfer memo."},
+                "memo": WALLET_TRANSFER_MEMO_SCHEMA,
                 "signature_hex": {
                     **LOWERCASE_HEX_128_SCHEMA,
                     "description": "128-character lowercase hex Ed25519 signature.",

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -108,14 +108,25 @@ def test_public_post_openapi_request_bodies_publish_stable_constraints(
     assert wallet_props["public_key_hex"]["minLength"] == 64
     assert wallet_props["public_key_hex"]["maxLength"] == 64
     assert wallet_props["public_key_hex"]["pattern"] == "^[0-9a-f]{64}$"
+    assert wallet_props["label"]["maxLength"] == 160
 
     link_props = _post_schema(openapi, "/api/v1/wallets/link-github")["properties"]
+    assert link_props["address"]["minLength"] == 45
+    assert link_props["address"]["maxLength"] == 45
+    assert link_props["address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
     assert link_props["signature_hex"]["minLength"] == 128
     assert link_props["signature_hex"]["maxLength"] == 128
     assert link_props["signature_hex"]["pattern"] == "^[0-9a-f]{128}$"
     assert {"type": "integer", "minimum": 1} in link_props["nonce"]["anyOf"]
 
     transfer_props = _post_schema(openapi, "/api/v1/transfers")["properties"]
+    assert transfer_props["from_address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
+    assert transfer_props["from_address"]["minLength"] == 45
+    assert transfer_props["from_address"]["maxLength"] == 45
+    assert transfer_props["to_address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
+    assert transfer_props["to_address"]["minLength"] == 45
+    assert transfer_props["to_address"]["maxLength"] == 45
+    assert transfer_props["memo"]["maxLength"] == 240
     assert transfer_props["signature_hex"]["pattern"] == "^[0-9a-f]{128}$"
 
 


### PR DESCRIPTION
Bounty #944

## Summary
- Publishes stricter OpenAPI request schemas for wallet-facing public POST routes without changing runtime JSON behavior.
- Adds the existing `mrwk1` address shape (`^mrwk1[0-9a-f]{40}$`, length 45) to signed wallet actions and transfers.
- Publishes existing runtime string limits for wallet registration labels (`maxLength: 160`) and transfer memos (`maxLength: 240`).
- Adds focused `/openapi.json` assertions so client generators keep these constraints.

## Validation
- `.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py` -> 8 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py tests\test_wallet_api.py::test_wallet_transfer_api_rejects_invalid_requests tests\test_wallet_api.py::test_wallet_register_api_rejects_label_control_characters tests\test_wallet_api.py::test_wallet_method_boundary_routes_are_hidden_from_openapi` -> 14 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\ruff.exe check app\openapi_request_bodies.py tests\test_openapi_request_bodies.py` -> All checks passed
- `.venv\Scripts\ruff.exe format --check app\openapi_request_bodies.py tests\test_openapi_request_bodies.py` -> 2 files already formatted
- `git diff --check` -> clean

Touched routes/schemas: `/api/v1/wallets/register`, `/api/v1/wallets/link-github`, `/api/v1/github/claim`, `/api/v1/transfers` request metadata only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored wallet-related API schema definitions to centralize and improve validation consistency across wallet registration, transfers, and authentication operations.

* **Tests**
  * Extended validation tests for wallet API schemas to ensure stricter enforcement of field length and format constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->