### PR TITLE
Advertise MCP wallet output schema

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -13,6 +13,44 @@ MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any]]
 MCP_PROTOCOL_VERSION = "2025-06-18"
 MCP_SERVER_INFO = {"name": "mergework", "version": "0.1.0"}
 
+MCP_WALLET_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "address": {
+            "type": "string",
+            "pattern": "^mrwk1[0-9a-f]{40}$",
+            "description": "Canonical lowercase MRWK wallet address.",
+        },
+        "public_key_hex": {
+            "type": "string",
+            "minLength": 64,
+            "maxLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+        },
+        "label": {"type": ["string", "null"], "maxLength": 160},
+        "github_login": {"type": ["string", "null"]},
+        "balance_mrwk": {
+            "type": "string",
+            "pattern": r"^\d+(?:\.\d{1,6})?$",
+            "description": "Decimal MRWK balance with at most six decimal places.",
+        },
+        "nonce": {"type": "integer", "minimum": 0},
+        "next_nonce": {"type": "integer", "minimum": 1},
+        "created_at": {"type": "string", "format": "date-time"},
+    },
+    "required": [
+        "address",
+        "public_key_hex",
+        "label",
+        "github_login",
+        "balance_mrwk",
+        "nonce",
+        "next_nonce",
+        "created_at",
+    ],
+    "additionalProperties": False,
+}
+
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
@@ -189,6 +227,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "required": ["address"],
             "additionalProperties": False,
         },
+        "outputSchema": MCP_WALLET_OUTPUT_SCHEMA,
     },
     {
         "name": "submit_wallet_transfer",

--- a/app/mcp.py
+++ b/app/mcp.py
@@ -36,7 +36,11 @@ MCP_WALLET_OUTPUT_SCHEMA: dict[str, Any] = {
         },
         "nonce": {"type": "integer", "minimum": 0},
         "next_nonce": {"type": "integer", "minimum": 1},
-        "created_at": {"type": "string", "format": "date-time"},
+        "created_at": {
+            "type": "string",
+            "pattern": r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$",
+            "description": "UTC-normalized timestamp without timezone suffix.",
+        },
     },
     "required": [
         "address",

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -309,7 +309,7 @@ Tools:
 - `list_bounty_attempts`
 - `get_balance`
 - `register_wallet`
-- `get_wallet`
+- `get_wallet` (`tools/list` advertises its structured wallet output schema)
 - `submit_wallet_transfer`
 - `get_ledger_entry`
 - `get_proof`

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -387,6 +387,10 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert wallet_output_schema["properties"]["public_key_hex"]["pattern"] == "^[0-9a-f]{64}$"
     assert wallet_output_schema["properties"]["label"]["maxLength"] == 160
     assert wallet_output_schema["properties"]["balance_mrwk"]["pattern"] == r"^\d+(?:\.\d{1,6})?$"
+    assert wallet_output_schema["properties"]["created_at"]["pattern"] == (
+        r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$"
+    )
+    assert "format" not in wallet_output_schema["properties"]["created_at"]
     balance_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_balance")
     balance_schema = balance_tool["inputSchema"]
     assert balance_schema["required"] == ["account"]

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -371,6 +371,22 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert wallet_schema["properties"]["address"]["pattern"] == (
         "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$"
     )
+    wallet_output_schema = wallet_tool["outputSchema"]
+    assert wallet_output_schema["additionalProperties"] is False
+    assert wallet_output_schema["required"] == [
+        "address",
+        "public_key_hex",
+        "label",
+        "github_login",
+        "balance_mrwk",
+        "nonce",
+        "next_nonce",
+        "created_at",
+    ]
+    assert wallet_output_schema["properties"]["address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
+    assert wallet_output_schema["properties"]["public_key_hex"]["pattern"] == "^[0-9a-f]{64}$"
+    assert wallet_output_schema["properties"]["label"]["maxLength"] == 160
+    assert wallet_output_schema["properties"]["balance_mrwk"]["pattern"] == r"^\d+(?:\.\d{1,6})?$"
     balance_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_balance")
     balance_schema = balance_tool["inputSchema"]
     assert balance_schema["required"] == ["account"]
@@ -2858,6 +2874,16 @@ def test_mcp_can_register_and_fetch_wallet(sqlite_url: str) -> None:
     fetched_wallet = json.loads(fetched["result"]["content"][0]["text"])
     assert fetched["result"]["structuredContent"] == fetched_wallet
 
+    assert set(fetched_wallet) == {
+        "address",
+        "public_key_hex",
+        "label",
+        "github_login",
+        "balance_mrwk",
+        "nonce",
+        "next_nonce",
+        "created_at",
+    }
     assert fetched_wallet["address"] == registered_wallet["address"]
     assert fetched_wallet["label"] == "MCP wallet"
     assert fetched_wallet["created_at"] == registered_wallet["created_at"]


### PR DESCRIPTION
Bounty #946

## Summary
- Adds an MCP `outputSchema` for the read-only `get_wallet` tool, matching the wallet object already returned in `result.structuredContent`.
- Captures the stable wallet fields agents need: canonical address, public key, optional label/GitHub login, balance, nonce, next nonce, and creation timestamp.
- Keeps runtime text and JSON behavior unchanged; this only improves `tools/list` metadata and tests.
- Distinct from #989, which advertises input schemas for wallet write tools. This PR is focused on the `get_wallet` structured output contract.

## Validation
- `.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py::test_mcp_tools_list_and_call tests\test_api_mcp.py::test_mcp_can_register_and_fetch_wallet` -> 2 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py tests\test_mcp_tools.py` -> 131 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `.venv\Scripts\ruff.exe check app\mcp.py tests\test_api_mcp.py` -> All checks passed
- `.venv\Scripts\ruff.exe format --check app\mcp.py tests\test_api_mcp.py` -> 2 files already formatted
- `git diff --check` -> clean, Windows CRLF warning only for docs

Touched MCP surface: `tools/list` metadata for `get_wallet` plus focused tests/docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the agent guide to describe the tool's structured wallet output schema.

* **Tests**
  * Strengthened wallet API tests to assert exact required fields, disable extra properties, and validate field formats and constraints for wallet responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->