### PR TITLE
Publish required OpenAPI response fields

### DIFF
--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -100,7 +100,17 @@ WALLET_RESPONSE_SCHEMA = _object_schema(
         "nonce": {"type": "integer", "minimum": 0},
         "next_nonce": {"type": "integer", "minimum": 1},
         "created_at": {"type": "string"},
-    }
+    },
+    required=[
+        "address",
+        "public_key_hex",
+        "label",
+        "github_login",
+        "balance_mrwk",
+        "nonce",
+        "next_nonce",
+        "created_at",
+    ],
 )
 
 LEDGER_ENTRY_RESPONSE_SCHEMA = _object_schema(
@@ -115,7 +125,19 @@ LEDGER_ENTRY_RESPONSE_SCHEMA = _object_schema(
         "entry_hash": LOWERCASE_HEX_64_SCHEMA,
         "proof_hash": {**LOWERCASE_HEX_64_SCHEMA, "nullable": True},
         "created_at": {"type": "string"},
-    }
+    },
+    required=[
+        "sequence",
+        "type",
+        "from",
+        "to",
+        "amount_mrwk",
+        "reference",
+        "previous_hash",
+        "entry_hash",
+        "proof_hash",
+        "created_at",
+    ],
 )
 
 WALLET_TRANSFER_RESPONSE_SCHEMA = _object_schema(
@@ -129,7 +151,18 @@ WALLET_TRANSFER_RESPONSE_SCHEMA = _object_schema(
         "nonce": {"type": "integer", "minimum": 1},
         "memo": {"type": "string", "nullable": True},
         "created_at": {"type": "string"},
-    }
+    },
+    required=[
+        "hash",
+        "type",
+        "ledger_sequence",
+        "from_address",
+        "to_address",
+        "amount_mrwk",
+        "nonce",
+        "memo",
+        "created_at",
+    ],
 )
 
 BOUNTY_ATTEMPT_RESPONSE_SCHEMA = _object_schema(

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -263,6 +263,53 @@ def test_public_post_openapi_response_schemas_expose_wallet_transfer_and_attempt
     _assert_properties(release_schema, {"status", "attempt"})
 
 
+def test_public_post_openapi_wallet_response_schemas_publish_required_fields(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    wallet_required = [
+        "address",
+        "public_key_hex",
+        "label",
+        "github_login",
+        "balance_mrwk",
+        "nonce",
+        "next_nonce",
+        "created_at",
+    ]
+    assert _post_response_schema(openapi, "/api/v1/wallets/register")["required"] == wallet_required
+    assert (
+        _post_response_schema(openapi, "/api/v1/wallets/link-github")["required"] == wallet_required
+    )
+
+    assert _post_response_schema(openapi, "/api/v1/github/claim")["required"] == [
+        "sequence",
+        "type",
+        "from",
+        "to",
+        "amount_mrwk",
+        "reference",
+        "previous_hash",
+        "entry_hash",
+        "proof_hash",
+        "created_at",
+    ]
+
+    assert _post_response_schema(openapi, "/api/v1/transfers")["required"] == [
+        "hash",
+        "type",
+        "ledger_sequence",
+        "from_address",
+        "to_address",
+        "amount_mrwk",
+        "nonce",
+        "memo",
+        "created_at",
+    ]
+
+
 def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
     openapi = client.get("/openapi.json").json()


### PR DESCRIPTION
Bounty #944

## Summary
- Publishes required field lists for existing public POST response schemas without changing runtime JSON behavior.
- Covers wallet registration/link responses, GitHub claim ledger-entry responses, and signed wallet transfer responses.
- Keeps nullable fields such as `label`, `github_login`, `from`, `reference`, `previous_hash`, `proof_hash`, and `memo` in the required list because the runtime emits those keys with null when absent.
- Adds focused `/openapi.json` assertions so SDK/client contracts can rely on the response object shape.

## Validation
- `.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py tests\test_wallet_api.py::test_wallet_api_register_lookup_and_transfer tests\test_wallet_api.py::test_github_session_can_link_and_claim_wallet` -> 11 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\ruff.exe check app\openapi_request_bodies.py tests\test_openapi_request_bodies.py` -> All checks passed
- `.venv\Scripts\ruff.exe format --check app\openapi_request_bodies.py tests\test_openapi_request_bodies.py` -> 2 files already formatted
- `git diff --check` -> clean

Touched routes/schemas: `/api/v1/wallets/register`, `/api/v1/wallets/link-github`, `/api/v1/github/claim`, `/api/v1/transfers` response metadata only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Formalized OpenAPI response schemas by explicitly declaring all required fields for wallet, ledger entry, and transfer responses, enhancing API contract transparency and reliability.

* **Tests**
  * Added OpenAPI contract test to validate required field declarations for wallet registration, GitHub linking, claim operations, and transfer endpoint responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->