### PR TITLE
Publish wallet OpenAPI field constraints

### DIFF
--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -90,11 +90,31 @@ LOWERCASE_HEX_128_SCHEMA = {
     "pattern": "^[0-9a-f]{128}$",
 }
 
+MRWK_WALLET_ADDRESS_SCHEMA = {
+    "type": "string",
+    "description": "Registered MRWK wallet address in mrwk1 + 40 lowercase hex format.",
+    "minLength": 45,
+    "maxLength": 45,
+    "pattern": "^mrwk1[0-9a-f]{40}$",
+}
+
+WALLET_LABEL_SCHEMA = {
+    "type": "string",
+    "description": "Optional wallet display label, trimmed and limited to 160 characters.",
+    "maxLength": 160,
+}
+
+WALLET_MEMO_SCHEMA = {
+    "type": "string",
+    "description": "Transfer memo string, trimmed by the API and limited to 240 characters.",
+    "maxLength": 240,
+}
+
 WALLET_RESPONSE_SCHEMA = _object_schema(
     {
-        "address": {"type": "string"},
+        "address": MRWK_WALLET_ADDRESS_SCHEMA,
         "public_key_hex": LOWERCASE_HEX_64_SCHEMA,
-        "label": {"type": "string", "nullable": True},
+        "label": {**WALLET_LABEL_SCHEMA, "nullable": True},
         "github_login": {"type": "string", "nullable": True},
         "balance_mrwk": MRWK_DECIMAL_SCHEMA,
         "nonce": {"type": "integer", "minimum": 0},
@@ -123,8 +143,8 @@ WALLET_TRANSFER_RESPONSE_SCHEMA = _object_schema(
         "hash": LOWERCASE_HEX_64_SCHEMA,
         "type": {"type": "string"},
         "ledger_sequence": {"type": "integer", "minimum": 1},
-        "from_address": {"type": "string"},
-        "to_address": {"type": "string"},
+        "from_address": MRWK_WALLET_ADDRESS_SCHEMA,
+        "to_address": MRWK_WALLET_ADDRESS_SCHEMA,
         "amount_mrwk": MRWK_AMOUNT_SCHEMA,
         "nonce": {"type": "integer", "minimum": 1},
         "memo": {"type": "string", "nullable": True},
@@ -267,7 +287,7 @@ WALLET_REGISTER_BODY = {
                     **LOWERCASE_HEX_64_SCHEMA,
                     "description": "64-character lowercase hex Ed25519 public key.",
                 },
-                "label": {"type": "string", "description": "Optional wallet display label."},
+                "label": WALLET_LABEL_SCHEMA,
             },
             required=["public_key_hex"],
         ),
@@ -278,7 +298,7 @@ WALLET_REGISTER_BODY = {
 }
 
 SIGNED_WALLET_ACTION_PROPERTIES = {
-    "address": {"type": "string", "description": "Registered mrwk1 wallet address."},
+    "address": MRWK_WALLET_ADDRESS_SCHEMA,
     "nonce": INTEGER_OR_STRING_SCHEMA,
     "signature_hex": {
         **LOWERCASE_HEX_128_SCHEMA,
@@ -309,11 +329,17 @@ WALLET_TRANSFER_BODY = {
     "requestBody": _request_body(
         _object_schema(
             {
-                "from_address": {"type": "string", "description": "Sender mrwk1 wallet address."},
-                "to_address": {"type": "string", "description": "Receiver mrwk1 wallet address."},
+                "from_address": {
+                    **MRWK_WALLET_ADDRESS_SCHEMA,
+                    "description": "Sender registered mrwk1 wallet address.",
+                },
+                "to_address": {
+                    **MRWK_WALLET_ADDRESS_SCHEMA,
+                    "description": "Receiver registered mrwk1 wallet address.",
+                },
                 "amount_mrwk": MRWK_AMOUNT_SCHEMA,
                 "nonce": INTEGER_OR_STRING_SCHEMA,
-                "memo": {"type": "string", "description": "Optional transfer memo."},
+                "memo": WALLET_MEMO_SCHEMA,
                 "signature_hex": {
                     **LOWERCASE_HEX_128_SCHEMA,
                     "description": "128-character lowercase hex Ed25519 signature.",

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -108,15 +108,22 @@ def test_public_post_openapi_request_bodies_publish_stable_constraints(
     assert wallet_props["public_key_hex"]["minLength"] == 64
     assert wallet_props["public_key_hex"]["maxLength"] == 64
     assert wallet_props["public_key_hex"]["pattern"] == "^[0-9a-f]{64}$"
+    assert wallet_props["label"]["maxLength"] == 160
 
     link_props = _post_schema(openapi, "/api/v1/wallets/link-github")["properties"]
     assert link_props["signature_hex"]["minLength"] == 128
     assert link_props["signature_hex"]["maxLength"] == 128
     assert link_props["signature_hex"]["pattern"] == "^[0-9a-f]{128}$"
+    assert link_props["address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
+    assert link_props["address"]["minLength"] == 45
+    assert link_props["address"]["maxLength"] == 45
     assert {"type": "integer", "minimum": 1} in link_props["nonce"]["anyOf"]
 
     transfer_props = _post_schema(openapi, "/api/v1/transfers")["properties"]
     assert transfer_props["signature_hex"]["pattern"] == "^[0-9a-f]{128}$"
+    assert transfer_props["from_address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
+    assert transfer_props["to_address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
+    assert transfer_props["memo"]["maxLength"] == 240
 
 
 def test_public_post_openapi_request_bodies_match_runtime_amount_and_ttl_bounds(


### PR DESCRIPTION
## Summary
- Publish reusable MRWK wallet address, label, and memo constraints in the OpenAPI schema
- Apply wallet address patterns/min/max lengths to wallet action and transfer schemas
- Add regression assertions for these published schema constraints

Bounty #944

## Verification
- `pytest tests/test_openapi_request_bodies.py tests/test_wallet_api.py -q` (53 passed, 1 warning)
- `pytest -q` (859 passed, 1 warning)
- `ruff check .`
- `git diff --check`
- Added-line security scan: 0 findings
- Independent review: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized wallet address, label, and memo validation across wallet registration, linking, and transfer operations.

* **Tests**
  * Extended validation test coverage for wallet and transfer constraint enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->