### PR TITLE
Publish attempt and treasury response requirements

### DIFF
--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -182,10 +182,18 @@ ATTEMPT_DUPLICATE_ACTIVE_RESPONSE_SCHEMA = _object_schema(
     required=["status", "attempt", "warnings"],
 )
 
+ATTEMPT_CONFLICT_FALLBACK_RESPONSE_SCHEMA = _object_schema(
+    {
+        "detail": {"type": "string"},
+    },
+    required=["detail"],
+)
+
 ATTEMPT_CONFLICT_RESPONSE_SCHEMA = {
     "oneOf": [
         ATTEMPT_NOT_AVAILABLE_RESPONSE_SCHEMA,
         ATTEMPT_DUPLICATE_ACTIVE_RESPONSE_SCHEMA,
+        ATTEMPT_CONFLICT_FALLBACK_RESPONSE_SCHEMA,
     ],
 }
 

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -164,15 +164,30 @@ ATTEMPT_REGISTRATION_RESPONSE_SCHEMA = _object_schema(
     required=["status", "attempt", "warnings"],
 )
 
-ATTEMPT_CONFLICT_RESPONSE_SCHEMA = _object_schema(
+ATTEMPT_NOT_AVAILABLE_RESPONSE_SCHEMA = _object_schema(
     {
         "status": {"type": "string"},
         "bounty_id": {"type": "integer", "minimum": 1},
+        "warnings": {"type": "array", "items": {"type": "string"}},
+    },
+    required=["status", "bounty_id", "warnings"],
+)
+
+ATTEMPT_DUPLICATE_ACTIVE_RESPONSE_SCHEMA = _object_schema(
+    {
+        "status": {"type": "string"},
         "attempt": BOUNTY_ATTEMPT_RESPONSE_SCHEMA,
         "warnings": {"type": "array", "items": {"type": "string"}},
     },
-    required=["status", "bounty_id", "attempt", "warnings"],
+    required=["status", "attempt", "warnings"],
 )
+
+ATTEMPT_CONFLICT_RESPONSE_SCHEMA = {
+    "oneOf": [
+        ATTEMPT_NOT_AVAILABLE_RESPONSE_SCHEMA,
+        ATTEMPT_DUPLICATE_ACTIVE_RESPONSE_SCHEMA,
+    ],
+}
 
 ATTEMPT_RELEASE_RESPONSE_SCHEMA = _object_schema(
     {

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -142,7 +142,17 @@ BOUNTY_ATTEMPT_RESPONSE_SCHEMA = _object_schema(
         "expires_at": {"type": "string"},
         "created_at": {"type": "string"},
         "updated_at": {"type": "string"},
-    }
+    },
+    required=[
+        "id",
+        "bounty_id",
+        "submitter_account",
+        "source_url",
+        "status",
+        "expires_at",
+        "created_at",
+        "updated_at",
+    ],
 )
 
 ATTEMPT_REGISTRATION_RESPONSE_SCHEMA = _object_schema(
@@ -150,7 +160,8 @@ ATTEMPT_REGISTRATION_RESPONSE_SCHEMA = _object_schema(
         "status": {"type": "string"},
         "attempt": BOUNTY_ATTEMPT_RESPONSE_SCHEMA,
         "warnings": {"type": "array", "items": {"type": "string"}},
-    }
+    },
+    required=["status", "attempt", "warnings"],
 )
 
 ATTEMPT_CONFLICT_RESPONSE_SCHEMA = _object_schema(
@@ -159,14 +170,16 @@ ATTEMPT_CONFLICT_RESPONSE_SCHEMA = _object_schema(
         "bounty_id": {"type": "integer", "minimum": 1},
         "attempt": BOUNTY_ATTEMPT_RESPONSE_SCHEMA,
         "warnings": {"type": "array", "items": {"type": "string"}},
-    }
+    },
+    required=["status", "bounty_id", "attempt", "warnings"],
 )
 
 ATTEMPT_RELEASE_RESPONSE_SCHEMA = _object_schema(
     {
         "status": {"type": "string"},
         "attempt": BOUNTY_ATTEMPT_RESPONSE_SCHEMA,
-    }
+    },
+    required=["status", "attempt"],
 )
 
 TREASURY_CHALLENGE_RESPONSE_SCHEMA = _object_schema(
@@ -178,7 +191,16 @@ TREASURY_CHALLENGE_RESPONSE_SCHEMA = _object_schema(
         "status": {"type": "string"},
         "reason": {"type": "string"},
         "created_at": {"type": "string"},
-    }
+    },
+    required=[
+        "id",
+        "proposal_id",
+        "challenger_account",
+        "challenge_type",
+        "status",
+        "reason",
+        "created_at",
+    ],
 )
 
 TREASURY_PROPOSAL_RESPONSE_SCHEMA = _object_schema(
@@ -197,7 +219,23 @@ TREASURY_PROPOSAL_RESPONSE_SCHEMA = _object_schema(
         "executed_ledger_sequence": {"type": "integer", "nullable": True},
         "result": {"type": "object", "additionalProperties": True},
         "challenges": {"type": "array", "items": TREASURY_CHALLENGE_RESPONSE_SCHEMA},
-    }
+    },
+    required=[
+        "id",
+        "type",
+        "action",
+        "status",
+        "payload_hash",
+        "payload",
+        "proposed_by",
+        "executed_by",
+        "proposed_at",
+        "executes_after",
+        "executed_at",
+        "executed_ledger_sequence",
+        "result",
+        "challenges",
+    ],
 )
 
 OPTIONAL_ATTEMPT_BODY = {

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -257,7 +257,9 @@ def test_public_post_openapi_response_schemas_expose_wallet_transfer_and_attempt
     )
 
     conflict_schema = _post_response_schema(openapi, "/api/v1/bounties/{bounty_id}/attempts", "409")
-    _assert_properties(conflict_schema, {"status", "attempt", "bounty_id", "warnings"})
+    not_available_schema, duplicate_schema = conflict_schema["oneOf"]
+    _assert_properties(not_available_schema, {"status", "bounty_id", "warnings"})
+    _assert_properties(duplicate_schema, {"status", "attempt", "warnings"})
 
     release_schema = _post_response_schema(openapi, "/api/v1/bounty-attempts/{attempt_id}/release")
     _assert_properties(release_schema, {"status", "attempt"})
@@ -328,8 +330,10 @@ def test_public_post_openapi_attempt_and_treasury_responses_publish_required_fie
     assert registered_attempt_schema["properties"]["attempt"]["required"] == attempt_required
 
     conflict_schema = _post_response_schema(openapi, "/api/v1/bounties/{bounty_id}/attempts", "409")
-    assert conflict_schema["required"] == ["status", "bounty_id", "attempt", "warnings"]
-    assert conflict_schema["properties"]["attempt"]["required"] == attempt_required
+    not_available_schema, duplicate_schema = conflict_schema["oneOf"]
+    assert not_available_schema["required"] == ["status", "bounty_id", "warnings"]
+    assert duplicate_schema["required"] == ["status", "attempt", "warnings"]
+    assert duplicate_schema["properties"]["attempt"]["required"] == attempt_required
 
     release_schema = _post_response_schema(openapi, "/api/v1/bounty-attempts/{attempt_id}/release")
     assert release_schema["required"] == ["status", "attempt"]

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -257,9 +257,10 @@ def test_public_post_openapi_response_schemas_expose_wallet_transfer_and_attempt
     )
 
     conflict_schema = _post_response_schema(openapi, "/api/v1/bounties/{bounty_id}/attempts", "409")
-    not_available_schema, duplicate_schema = conflict_schema["oneOf"]
+    not_available_schema, duplicate_schema, fallback_schema = conflict_schema["oneOf"]
     _assert_properties(not_available_schema, {"status", "bounty_id", "warnings"})
     _assert_properties(duplicate_schema, {"status", "attempt", "warnings"})
+    _assert_properties(fallback_schema, {"detail"})
 
     release_schema = _post_response_schema(openapi, "/api/v1/bounty-attempts/{attempt_id}/release")
     _assert_properties(release_schema, {"status", "attempt"})
@@ -330,10 +331,11 @@ def test_public_post_openapi_attempt_and_treasury_responses_publish_required_fie
     assert registered_attempt_schema["properties"]["attempt"]["required"] == attempt_required
 
     conflict_schema = _post_response_schema(openapi, "/api/v1/bounties/{bounty_id}/attempts", "409")
-    not_available_schema, duplicate_schema = conflict_schema["oneOf"]
+    not_available_schema, duplicate_schema, fallback_schema = conflict_schema["oneOf"]
     assert not_available_schema["required"] == ["status", "bounty_id", "warnings"]
     assert duplicate_schema["required"] == ["status", "attempt", "warnings"]
     assert duplicate_schema["properties"]["attempt"]["required"] == attempt_required
+    assert fallback_schema["required"] == ["detail"]
 
     release_schema = _post_response_schema(openapi, "/api/v1/bounty-attempts/{attempt_id}/release")
     assert release_schema["required"] == ["status", "attempt"]

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -305,6 +305,72 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
     )
 
 
+def test_public_post_openapi_attempt_and_treasury_responses_publish_required_fields(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    attempt_required = [
+        "id",
+        "bounty_id",
+        "submitter_account",
+        "source_url",
+        "status",
+        "expires_at",
+        "created_at",
+        "updated_at",
+    ]
+    registered_attempt_schema = _post_response_schema(
+        openapi, "/api/v1/bounties/{bounty_id}/attempts", "201"
+    )
+    assert registered_attempt_schema["required"] == ["status", "attempt", "warnings"]
+    assert registered_attempt_schema["properties"]["attempt"]["required"] == attempt_required
+
+    conflict_schema = _post_response_schema(openapi, "/api/v1/bounties/{bounty_id}/attempts", "409")
+    assert conflict_schema["required"] == ["status", "bounty_id", "attempt", "warnings"]
+    assert conflict_schema["properties"]["attempt"]["required"] == attempt_required
+
+    release_schema = _post_response_schema(openapi, "/api/v1/bounty-attempts/{attempt_id}/release")
+    assert release_schema["required"] == ["status", "attempt"]
+    assert release_schema["properties"]["attempt"]["required"] == attempt_required
+
+    proposal_required = [
+        "id",
+        "type",
+        "action",
+        "status",
+        "payload_hash",
+        "payload",
+        "proposed_by",
+        "executed_by",
+        "proposed_at",
+        "executes_after",
+        "executed_at",
+        "executed_ledger_sequence",
+        "result",
+        "challenges",
+    ]
+    proposal_schema = _post_response_schema(openapi, "/api/v1/treasury/proposals")
+    assert proposal_schema["required"] == proposal_required
+
+    challenge_required = [
+        "id",
+        "proposal_id",
+        "challenger_account",
+        "challenge_type",
+        "status",
+        "reason",
+        "created_at",
+    ]
+    assert proposal_schema["properties"]["challenges"]["items"]["required"] == challenge_required
+
+    challenge_schema = _post_response_schema(
+        openapi, "/api/v1/treasury/proposals/{proposal_id}/challenges"
+    )
+    assert challenge_schema["required"] == challenge_required
+
+
 def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
     openapi = client.get("/openapi.json").json()


### PR DESCRIPTION
## Summary
- Publish explicit `required` field lists for bounty-attempt response schemas.
- Publish explicit `required` field lists for treasury proposal and challenge response schemas.
- Add OpenAPI regression coverage for the POST attempt and treasury response contracts.

## Why this helps
Public POST response schemas already expose these properties, but attempts and treasury responses did not declare which fields are always present. This tightens generated OpenAPI clients without changing runtime behavior.

## Validation
- `.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py tests\test_bounty_attempts.py tests\test_treasury_proposals.py` -> 82 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\ruff.exe check app\openapi_request_bodies.py tests\test_openapi_request_bodies.py` -> All checks passed
- `.venv\Scripts\ruff.exe format --check app\openapi_request_bodies.py tests\test_openapi_request_bodies.py` -> 2 files already formatted
- `git diff --check` -> clean

Bounty #944

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * API response schemas now declare explicit required fields for attempt and treasury responses, making payload keys mandatory and improving contract clarity.
  * Conflict responses now present distinct variants so each conflict type exposes its own required fields.

* **Tests**
  * Added tests verifying response schemas publish exact required-field lists (including nested fields) for attempt and treasury endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->