### PR TITLE
Advertise MCP bounty list output schema

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -14,6 +14,77 @@ MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any] | MCP
 MCP_PROTOCOL_VERSION = "2025-06-18"
 MCP_SERVER_INFO = {"name": "mergework", "version": "0.1.0"}
 
+MCP_BOUNTY_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "additionalProperties": True,
+        "properties": {
+            "id": {"type": "integer", "minimum": 1},
+            "repo": {"type": "string"},
+            "issue_number": {"type": "integer", "minimum": 1},
+            "issue_url": {"type": "string", "format": "uri"},
+            "title": {"type": "string"},
+            "reward_mrwk": {"type": "string"},
+            "available_mrwk": {"type": "string"},
+            "reserved_mrwk": {"type": "string"},
+            "max_awards": {"type": "integer", "minimum": 1},
+            "awards_paid": {"type": "integer", "minimum": 0},
+            "awards_remaining": {"type": "integer", "minimum": 0},
+            "effective_available_mrwk": {"type": "string"},
+            "effective_awards_remaining": {"type": "integer", "minimum": 0},
+            "pending_payout_awards": {"type": "integer", "minimum": 0},
+            "pending_payout_proposals": {
+                "type": "array",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "pending_close_proposal": {
+                "type": ["object", "null"],
+                "additionalProperties": True,
+            },
+            "availability_state": {"type": "string"},
+            "availability_note": {"type": "string"},
+            "submission_requirements": {
+                "type": "object",
+                "additionalProperties": True,
+            },
+            "status": {"type": "string"},
+            "acceptance": {"type": "string"},
+            "created_at": {"type": "string"},
+            "active_attempt_count": {"type": "integer", "minimum": 0},
+            "active_attempt_warnings": {"type": "array", "items": {"type": "string"}},
+            "attempt_endpoint": {"type": "string"},
+        },
+        "required": [
+            "id",
+            "repo",
+            "issue_number",
+            "issue_url",
+            "title",
+            "reward_mrwk",
+            "available_mrwk",
+            "reserved_mrwk",
+            "max_awards",
+            "awards_paid",
+            "awards_remaining",
+            "effective_available_mrwk",
+            "effective_awards_remaining",
+            "pending_payout_awards",
+            "pending_payout_proposals",
+            "pending_close_proposal",
+            "availability_state",
+            "availability_note",
+            "submission_requirements",
+            "status",
+            "acceptance",
+            "created_at",
+            "active_attempt_count",
+            "active_attempt_warnings",
+            "attempt_endpoint",
+        ],
+    },
+}
+
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
@@ -56,6 +127,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
             },
             "additionalProperties": False,
         },
+        "outputSchema": MCP_BOUNTY_OUTPUT_SCHEMA,
     },
     {
         "name": "get_bounty",

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -322,8 +322,10 @@ requires a positive integer `sequence`.
 
 Successful MCP tools that return JSON objects or lists include both the
 backward-compatible JSON string in `result.content[0].text` and parsed
-`result.structuredContent`. Prefer `structuredContent` when present, and fall
-back to text for human-readable not-found messages.
+`result.structuredContent`. `tools/list` advertises the `list_bounties` array
+output schema for agents that validate bounty rows before acting. Prefer
+`structuredContent` when present, and fall back to text for human-readable
+not-found messages.
 
 `get_balance` keeps the legacy balance text and also includes
 `result.structuredContent.account`, `balance_mrwk`, and `balance_microunits` so

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -313,6 +313,46 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert list_bounties_schema["additionalProperties"] is False
     assert list_bounties_schema["properties"]["q"]["maxLength"] == 500
     assert list_bounties_schema["properties"]["limit"]["maximum"] == 100
+    list_bounties_output_schema = tools["result"]["tools"][0]["outputSchema"]
+    assert list_bounties_output_schema["type"] == "array"
+    bounty_output_schema = list_bounties_output_schema["items"]
+    assert bounty_output_schema["additionalProperties"] is True
+    assert bounty_output_schema["properties"]["id"]["minimum"] == 1
+    assert bounty_output_schema["properties"]["issue_number"]["minimum"] == 1
+    assert bounty_output_schema["properties"]["pending_close_proposal"]["type"] == [
+        "object",
+        "null",
+    ]
+    assert bounty_output_schema["properties"]["active_attempt_warnings"]["items"] == {
+        "type": "string"
+    }
+    assert bounty_output_schema["required"] == [
+        "id",
+        "repo",
+        "issue_number",
+        "issue_url",
+        "title",
+        "reward_mrwk",
+        "available_mrwk",
+        "reserved_mrwk",
+        "max_awards",
+        "awards_paid",
+        "awards_remaining",
+        "effective_available_mrwk",
+        "effective_awards_remaining",
+        "pending_payout_awards",
+        "pending_payout_proposals",
+        "pending_close_proposal",
+        "availability_state",
+        "availability_note",
+        "submission_requirements",
+        "status",
+        "acceptance",
+        "created_at",
+        "active_attempt_count",
+        "active_attempt_warnings",
+        "attempt_endpoint",
+    ]
     submit_tool = next(
         tool for tool in tools["result"]["tools"] if tool["name"] == "submit_work_proof"
     )
@@ -802,6 +842,15 @@ def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> No
     default_payload = json.loads(default_result["result"]["content"][0]["text"])
     assert default_result["result"]["structuredContent"] == default_payload
     assert [item["id"] for item in default_payload] == [open_bounty.id]
+    assert set(default_payload[0]) >= set(
+        next(
+            tool
+            for tool in client.post(
+                "/mcp", json={"jsonrpc": "2.0", "id": 0, "method": "tools/list"}
+            ).json()["result"]["tools"]
+            if tool["name"] == "list_bounties"
+        )["outputSchema"]["items"]["required"]
+    )
 
     paid_result = client.post(
         "/mcp",


### PR DESCRIPTION
Bounty #946

## Summary
- Adds an MCP `outputSchema` for `list_bounties`, matching the array of bounty rows already returned in `result.structuredContent`.
- Captures the stable fields agents use before selecting work: ids, issue metadata, reward/availability fields, pending payout metadata, submission requirements, and active-attempt summary.
- Keeps runtime text/JSON behavior unchanged; this only improves `tools/list` metadata, tests, and concise agent docs.

## Validation
- `.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py::test_mcp_tools_list_and_call tests\test_api_mcp.py::test_mcp_list_bounties_filters_status_query_and_limit` -> 2 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py tests\test_mcp_tools.py` -> 131 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `.venv\Scripts\ruff.exe check app\mcp.py tests\test_api_mcp.py` -> All checks passed
- `.venv\Scripts\ruff.exe format --check app\mcp.py tests\test_api_mcp.py` -> 2 files already formatted
- `git diff --check` -> no errors; Windows CRLF warning for docs only

Touched MCP surface: `tools/list` metadata for `list_bounties` plus focused tests/docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable bounty output schema and made the bounty-listing tool advertise that schema so responses can be validated.

* **Documentation**
  * Clarified MCP response handling: prefer parsed/structured content when present, fallback to legacy text, and documented schema-aware validation for bounty rows.

* **Tests**
  * Strengthened tests to validate the advertised bounty output schema and required fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->