### PR TITLE
Publish treasury status OpenAPI schema

### DIFF
--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -232,7 +232,19 @@ TREASURY_PENDING_CREATE_BOUNTY_SCHEMA = _object_schema(
         "proposed_at": {"type": "string"},
         "executes_after": {"type": "string"},
         "capacity_releases_at": {"type": "string"},
-    }
+    },
+    required=[
+        "proposal_id",
+        "issue_number",
+        "issue_url",
+        "title",
+        "reward_mrwk",
+        "max_awards",
+        "reserve_mrwk",
+        "proposed_at",
+        "executes_after",
+        "capacity_releases_at",
+    ],
 )
 
 TREASURY_PROJECTED_CAPACITY_EVENT_SCHEMA = _object_schema(
@@ -249,7 +261,14 @@ TREASURY_PROJECTED_CAPACITY_EVENT_SCHEMA = _object_schema(
         "amount_mrwk": MRWK_DECIMAL_SCHEMA,
         "available_create_reserve_mrwk": MRWK_DECIMAL_SCHEMA,
         "note": {"type": "string"},
-    }
+    },
+    required=[
+        "at",
+        "event_type",
+        "amount_mrwk",
+        "available_create_reserve_mrwk",
+        "note",
+    ],
 )
 
 TREASURY_RECENT_RESERVE_SCHEMA = _object_schema(
@@ -259,7 +278,8 @@ TREASURY_RECENT_RESERVE_SCHEMA = _object_schema(
         "reference": {"type": "string", "nullable": True},
         "created_at": {"type": "string"},
         "expires_at": {"type": "string"},
-    }
+    },
+    required=["ledger_sequence", "amount_mrwk", "reference", "created_at", "expires_at"],
 )
 
 TREASURY_STATUS_RESPONSE_SCHEMA = _object_schema(

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -220,6 +220,89 @@ TREASURY_PROPOSAL_RESPONSE_SCHEMA = _object_schema(
     }
 )
 
+TREASURY_PENDING_CREATE_BOUNTY_SCHEMA = _object_schema(
+    {
+        "proposal_id": {"type": "integer", "minimum": 1},
+        "issue_number": {"type": "integer", "minimum": 1},
+        "issue_url": {"type": "string", "format": "uri"},
+        "title": {"type": "string"},
+        "reward_mrwk": MRWK_AMOUNT_SCHEMA,
+        "max_awards": {"type": "integer", "minimum": 1},
+        "reserve_mrwk": MRWK_DECIMAL_SCHEMA,
+        "proposed_at": {"type": "string"},
+        "executes_after": {"type": "string"},
+        "capacity_releases_at": {"type": "string"},
+    }
+)
+
+TREASURY_PROJECTED_CAPACITY_EVENT_SCHEMA = _object_schema(
+    {
+        "at": {"type": "string"},
+        "event_type": {
+            "type": "string",
+            "enum": [
+                "recent_reserve_releases",
+                "pending_create_executes",
+                "pending_create_releases",
+            ],
+        },
+        "amount_mrwk": MRWK_DECIMAL_SCHEMA,
+        "available_create_reserve_mrwk": MRWK_DECIMAL_SCHEMA,
+        "note": {"type": "string"},
+    }
+)
+
+TREASURY_RECENT_RESERVE_SCHEMA = _object_schema(
+    {
+        "ledger_sequence": {"type": "integer", "minimum": 1},
+        "amount_mrwk": MRWK_DECIMAL_SCHEMA,
+        "reference": {"type": "string", "nullable": True},
+        "created_at": {"type": "string"},
+        "expires_at": {"type": "string"},
+    }
+)
+
+TREASURY_STATUS_RESPONSE_SCHEMA = _object_schema(
+    {
+        "type": {"type": "string", "enum": ["treasury_status"]},
+        "epoch_window_hours": {"type": "integer", "minimum": 1},
+        "reserve_cap_mrwk": MRWK_DECIMAL_SCHEMA,
+        "executed_reserve_24h_mrwk": MRWK_DECIMAL_SCHEMA,
+        "pending_create_reserve_mrwk": MRWK_DECIMAL_SCHEMA,
+        "available_create_reserve_mrwk": MRWK_DECIMAL_SCHEMA,
+        "next_capacity_release_at": {"type": "string", "nullable": True},
+        "next_projected_capacity_release_at": {"type": "string", "nullable": True},
+        "pending_create_bounties": {
+            "type": "array",
+            "items": TREASURY_PENDING_CREATE_BOUNTY_SCHEMA,
+        },
+        "projected_capacity_events": {
+            "type": "array",
+            "items": TREASURY_PROJECTED_CAPACITY_EVENT_SCHEMA,
+        },
+        "recent_reserves": {"type": "array", "items": TREASURY_RECENT_RESERVE_SCHEMA},
+    },
+    required=[
+        "type",
+        "epoch_window_hours",
+        "reserve_cap_mrwk",
+        "executed_reserve_24h_mrwk",
+        "pending_create_reserve_mrwk",
+        "available_create_reserve_mrwk",
+        "next_capacity_release_at",
+        "next_projected_capacity_release_at",
+        "pending_create_bounties",
+        "projected_capacity_events",
+        "recent_reserves",
+    ],
+)
+
+TREASURY_STATUS_RESPONSE = {
+    "responses": {
+        "200": _json_response(TREASURY_STATUS_RESPONSE_SCHEMA),
+    },
+}
+
 OPTIONAL_ATTEMPT_BODY = {
     "requestBody": _request_body(
         _object_schema(

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -11,7 +11,11 @@ from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import LedgerError
 from app.models import TreasuryProposal
-from app.openapi_request_bodies import TREASURY_CHALLENGE_BODY, TREASURY_PROPOSAL_BODY
+from app.openapi_request_bodies import (
+    TREASURY_CHALLENGE_BODY,
+    TREASURY_PROPOSAL_BODY,
+    TREASURY_STATUS_RESPONSE,
+)
 from app.path_params import SQLITE_INTEGER_MAX, positive_proposal_id
 from app.query_validation import (
     reject_control_char_query_param,
@@ -194,7 +198,7 @@ def register_treasury_routes(
                     break
             return proposals
 
-    @app.get("/api/v1/treasury/status")
+    @app.get("/api/v1/treasury/status", openapi_extra=TREASURY_STATUS_RESPONSE)
     def api_treasury_status(request: Request) -> dict[str, Any]:
         _reject_treasury_status_filters(request)
         with session_scope(db_url) as session:

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -23,6 +23,12 @@ def _post_response_schema(openapi: dict, path: str, status: str = "200") -> dict
     ]
 
 
+def _get_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
+    return openapi["paths"][path]["get"]["responses"][status]["content"]["application/json"][
+        "schema"
+    ]
+
+
 def _assert_properties(schema: dict, expected: Iterable[str]) -> None:
     assert set(expected).issubset(schema["properties"])
 
@@ -327,6 +333,63 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
             "reason",
             "created_at",
         },
+    )
+
+
+def test_treasury_status_openapi_response_schema_matches_runtime_fields(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    schema = _get_response_schema(openapi, "/api/v1/treasury/status")
+    body = client.get("/api/v1/treasury/status").json()
+
+    expected_fields = {
+        "type",
+        "epoch_window_hours",
+        "reserve_cap_mrwk",
+        "executed_reserve_24h_mrwk",
+        "pending_create_reserve_mrwk",
+        "available_create_reserve_mrwk",
+        "next_capacity_release_at",
+        "next_projected_capacity_release_at",
+        "pending_create_bounties",
+        "projected_capacity_events",
+        "recent_reserves",
+    }
+    _assert_properties(schema, expected_fields)
+    assert set(schema["required"]) == expected_fields
+    assert schema["properties"]["type"]["enum"] == ["treasury_status"]
+    assert schema["properties"]["epoch_window_hours"]["minimum"] == 1
+    assert schema["properties"]["reserve_cap_mrwk"]["pattern"] == r"^\d+(?:\.\d{1,6})?$"
+    assert set(body) == expected_fields
+
+    pending_schema = schema["properties"]["pending_create_bounties"]["items"]
+    _assert_properties(
+        pending_schema,
+        {
+            "proposal_id",
+            "issue_number",
+            "issue_url",
+            "title",
+            "reward_mrwk",
+            "max_awards",
+            "reserve_mrwk",
+            "proposed_at",
+            "executes_after",
+            "capacity_releases_at",
+        },
+    )
+    event_schema = schema["properties"]["projected_capacity_events"]["items"]
+    assert event_schema["properties"]["event_type"]["enum"] == [
+        "recent_reserve_releases",
+        "pending_create_executes",
+        "pending_create_releases",
+    ]
+    _assert_properties(
+        schema["properties"]["recent_reserves"]["items"],
+        {"ledger_sequence", "amount_mrwk", "reference", "created_at", "expires_at"},
     )
 
 

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -366,30 +366,42 @@ def test_treasury_status_openapi_response_schema_matches_runtime_fields(
     assert set(body) == expected_fields
 
     pending_schema = schema["properties"]["pending_create_bounties"]["items"]
+    pending_fields = {
+        "proposal_id",
+        "issue_number",
+        "issue_url",
+        "title",
+        "reward_mrwk",
+        "max_awards",
+        "reserve_mrwk",
+        "proposed_at",
+        "executes_after",
+        "capacity_releases_at",
+    }
+    assert set(pending_schema["required"]) == pending_fields
     _assert_properties(
         pending_schema,
-        {
-            "proposal_id",
-            "issue_number",
-            "issue_url",
-            "title",
-            "reward_mrwk",
-            "max_awards",
-            "reserve_mrwk",
-            "proposed_at",
-            "executes_after",
-            "capacity_releases_at",
-        },
+        pending_fields,
     )
     event_schema = schema["properties"]["projected_capacity_events"]["items"]
+    assert set(event_schema["required"]) == {
+        "at",
+        "event_type",
+        "amount_mrwk",
+        "available_create_reserve_mrwk",
+        "note",
+    }
     assert event_schema["properties"]["event_type"]["enum"] == [
         "recent_reserve_releases",
         "pending_create_executes",
         "pending_create_releases",
     ]
+    reserve_schema = schema["properties"]["recent_reserves"]["items"]
+    reserve_fields = {"ledger_sequence", "amount_mrwk", "reference", "created_at", "expires_at"}
+    assert set(reserve_schema["required"]) == reserve_fields
     _assert_properties(
-        schema["properties"]["recent_reserves"]["items"],
-        {"ledger_sequence", "amount_mrwk", "reference", "created_at", "expires_at"},
+        reserve_schema,
+        reserve_fields,
     )
 
 


### PR DESCRIPTION
Refs Bounty #944

## Summary
- publishes a concrete OpenAPI 200-response schema for `GET /api/v1/treasury/status`
- describes nested `pending_create_bounties`, `projected_capacity_events`, and `recent_reserves` rows for client and SDK generation
- adds a focused OpenAPI/runtime contract test so the advertised schema keeps matching the status payload fields

## Affected route
- `GET /api/v1/treasury/status`

## Before / after
- Before: the route returned a stable JSON object, but `/openapi.json` only exposed FastAPI's generic response schema for clients.
- After: `/openapi.json` advertises the status object, required top-level fields, decimal MRWK patterns, event-type enum values, and nested array item fields while preserving the runtime JSON shape.

## Verification
- `.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py tests\test_treasury_proposals.py::test_treasury_status_reports_reserve_capacity_and_pending_create_proposals tests\test_treasury_proposals.py::test_treasury_status_projects_pending_create_capacity_events`
- `.venv\Scripts\ruff.exe check app\openapi_request_bodies.py app\treasury_routes.py tests\test_openapi_request_bodies.py`
- `.venv\Scripts\ruff.exe format --check app\openapi_request_bodies.py app\treasury_routes.py tests\test_openapi_request_bodies.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OpenAPI documentation for the treasury status API: added comprehensive response schema detailing top-level fields and nested arrays for pending bounties, projected capacity events (including event-type enum), and recent reserve entries.

* **Tests**
  * Added tests that validate the treasury status OpenAPI response matches runtime fields: required properties, data-type constraints, nested-item requirements, and enum values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->