### PR TITLE
Advertise MCP proof and ledger output schemas

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -14,6 +14,66 @@ MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any] | MCP
 MCP_PROTOCOL_VERSION = "2025-06-18"
 MCP_SERVER_INFO = {"name": "mergework", "version": "0.1.0"}
 
+MCP_LEDGER_ENTRY_OUTPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "sequence": {"type": "integer", "minimum": 1},
+        "type": {"type": "string"},
+        "from": {"type": ["string", "null"]},
+        "to": {"type": "string"},
+        "amount_mrwk": {
+            "type": "string",
+            "description": "Decimal MRWK amount with at most six decimal places.",
+            "pattern": r"^\d+(?:\.\d{1,6})?$",
+        },
+        "reference": {"type": ["string", "null"]},
+        "previous_hash": {"type": ["string", "null"]},
+        "entry_hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "proof_hash": {"type": ["string", "null"], "pattern": "^[0-9a-f]{64}$"},
+        "created_at": {"type": "string"},
+    },
+    "required": [
+        "sequence",
+        "type",
+        "from",
+        "to",
+        "amount_mrwk",
+        "reference",
+        "previous_hash",
+        "entry_hash",
+        "proof_hash",
+        "created_at",
+    ],
+    "additionalProperties": False,
+}
+
+MCP_PROOF_OUTPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "kind": {"type": "string"},
+        "ledger_sequence": {"type": "integer", "minimum": 1},
+        "bounty_id": {"type": ["integer", "null"], "minimum": 1},
+        "submission_id": {"type": ["integer", "null"], "minimum": 1},
+        "created_at": {"type": "string"},
+        "proof": {
+            "type": "object",
+            "description": "Stored public proof payload.",
+            "additionalProperties": True,
+        },
+    },
+    "required": [
+        "hash",
+        "kind",
+        "ledger_sequence",
+        "bounty_id",
+        "submission_id",
+        "created_at",
+        "proof",
+    ],
+    "additionalProperties": False,
+}
+
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
@@ -210,6 +270,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "required": ["sequence"],
             "additionalProperties": False,
         },
+        "outputSchema": MCP_LEDGER_ENTRY_OUTPUT_SCHEMA,
     },
     {
         "name": "get_proof",
@@ -228,6 +289,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "required": ["hash"],
             "additionalProperties": False,
         },
+        "outputSchema": MCP_PROOF_OUTPUT_SCHEMA,
     },
     {
         "name": "submit_work_proof",

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -320,6 +320,10 @@ Tools:
 `get_proof` requires a 64-character proof `hash`, and `get_ledger_entry`
 requires a positive integer `sequence`.
 
+`tools/list` also advertises output schemas for `get_proof` and
+`get_ledger_entry`, including the proof metadata fields and ledger-entry
+fields agents receive in `result.structuredContent`.
+
 Successful MCP tools that return JSON objects or lists include both the
 backward-compatible JSON string in `result.content[0].text` and parsed
 `result.structuredContent`. Prefer `structuredContent` when present, and fall

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -390,11 +390,43 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert ledger_schema["required"] == ["sequence"]
     assert ledger_schema["additionalProperties"] is False
     assert ledger_schema["properties"]["sequence"]["minimum"] == 1
+    ledger_output_schema = ledger_tool["outputSchema"]
+    assert ledger_output_schema["additionalProperties"] is False
+    assert set(ledger_output_schema["required"]) == {
+        "sequence",
+        "type",
+        "from",
+        "to",
+        "amount_mrwk",
+        "reference",
+        "previous_hash",
+        "entry_hash",
+        "proof_hash",
+        "created_at",
+    }
+    assert ledger_output_schema["properties"]["sequence"]["minimum"] == 1
+    assert ledger_output_schema["properties"]["amount_mrwk"]["pattern"] == (r"^\d+(?:\.\d{1,6})?$")
+    assert ledger_output_schema["properties"]["entry_hash"]["pattern"] == "^[0-9a-f]{64}$"
+    assert ledger_output_schema["properties"]["proof_hash"]["type"] == ["string", "null"]
     proof_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_proof")
     proof_schema = proof_tool["inputSchema"]
     assert proof_schema["required"] == ["hash"]
     assert proof_schema["additionalProperties"] is False
     assert proof_schema["properties"]["hash"]["pattern"] == "^[0-9a-fA-F]{64}$"
+    proof_output_schema = proof_tool["outputSchema"]
+    assert proof_output_schema["additionalProperties"] is False
+    assert set(proof_output_schema["required"]) == {
+        "hash",
+        "kind",
+        "ledger_sequence",
+        "bounty_id",
+        "submission_id",
+        "created_at",
+        "proof",
+    }
+    assert proof_output_schema["properties"]["hash"]["pattern"] == "^[0-9a-f]{64}$"
+    assert proof_output_schema["properties"]["ledger_sequence"]["minimum"] == 1
+    assert proof_output_schema["properties"]["proof"]["additionalProperties"] is True
 
     balance = client.post(
         "/mcp",
@@ -1730,6 +1762,11 @@ def test_mcp_get_ledger_entry_includes_payment_proof_hash(sqlite_url: str) -> No
 
     assert payload["sequence"] == ledger_sequence
     assert payload["proof_hash"] == proof_hash
+    tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"}).json()
+    ledger_tool = next(
+        tool for tool in tools["result"]["tools"] if tool["name"] == "get_ledger_entry"
+    )
+    assert set(payload) == set(ledger_tool["outputSchema"]["required"])
 
 
 def test_mcp_get_ledger_entry_rejects_non_positive_sequence(sqlite_url: str) -> None:
@@ -1805,6 +1842,8 @@ def test_mcp_get_proof_returns_public_proof_details(sqlite_url: str) -> None:
     assert payload["proof"]["repo"] == "ramimbo/mergework"
     assert payload["proof"]["submission_url"] == "https://github.com/ramimbo/mergework/pull/37"
     assert payload["proof"]["accepted_by"] == "maintainer"
+    proof_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_proof")
+    assert set(payload) == set(proof_tool["outputSchema"]["required"])
 
 
 def test_mcp_get_proof_reports_unknown_hash(sqlite_url: str) -> None:


### PR DESCRIPTION
Refs Bounty #946

## Summary
- advertises `outputSchema` for the MCP `get_ledger_entry` tool so agents know the ledger structuredContent fields before calling it
- advertises `outputSchema` for the MCP `get_proof` tool, including proof metadata and the stored public proof payload object
- adds focused MCP conformance assertions that the advertised required output fields match actual `structuredContent` keys for ledger and proof calls
- updates the agent guide to tell clients that these proof/ledger output schemas are available from `tools/list`

## MCP tools touched
- `get_ledger_entry`
- `get_proof`

## Before / after
- Before: both tools returned JSON text plus parsed `structuredContent`, but `tools/list` only advertised their input schemas.
- After: `tools/list` also advertises output schemas for the structured responses, preserving existing text and runtime JSON behavior.

## Verification
- `.venv\\Scripts\\python.exe -m pytest tests\\test_api_mcp.py::test_mcp_tools_list_and_call tests\\test_api_mcp.py::test_mcp_get_ledger_entry_includes_payment_proof_hash tests\\test_api_mcp.py::test_mcp_get_proof_returns_public_proof_details`
- `.venv\\Scripts\\ruff.exe check app\\mcp.py tests\\test_api_mcp.py`
- `.venv\\Scripts\\ruff.exe format --check app\\mcp.py tests\\test_api_mcp.py`
- `.venv\\Scripts\\python.exe scripts\\docs_smoke.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP tools (`get_ledger_entry` and `get_proof`) now include formal output schema definitions specifying field types, constraints, and expected response structures.

* **Documentation**
  * Updated agent guide to detail output schemas and response field information for MCP tools.

* **Tests**
  * Enhanced test suite to validate output schema definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->