### PR TITLE
Add bounty closeout guard checks

### DIFF
--- a/scripts/bounty_refs.py
+++ b/scripts/bounty_refs.py
@@ -2,14 +2,20 @@ from __future__ import annotations
 
 import re
 
-LINKED_BOUNTY_VERBS = r"bounty|claims?|close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?"
-GITHUB_LINKED_ISSUE_VERBS = r"close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?|references?"
+GITHUB_CLOSING_ISSUE_VERBS = r"close[sd]?|fix(?:e[sd])?|resolve[sd]?"
+LINKED_BOUNTY_VERBS = rf"bounty|claims?|{GITHUB_CLOSING_ISSUE_VERBS}|refs?|references?"
+GITHUB_LINKED_ISSUE_VERBS = rf"{GITHUB_CLOSING_ISSUE_VERBS}|refs?|references?"
 BOUNTY_REF_RE = re.compile(
     rf"\b(?:{LINKED_BOUNTY_VERBS})\s*:?\s+`?#(\d+)`?(?![A-Za-z0-9_-])",
     re.IGNORECASE,
 )
 GITHUB_LINKED_ISSUE_RE = re.compile(
     rf"\b(?:{GITHUB_LINKED_ISSUE_VERBS})\s*:?\s+`?#(\d+)`?(?![A-Za-z0-9_-])",
+    re.IGNORECASE,
+)
+GITHUB_CLOSING_ISSUE_RE = re.compile(
+    rf"\b(?P<verb>{GITHUB_CLOSING_ISSUE_VERBS})\s*:?\s+`?#(?P<issue>\d+)`?"
+    r"(?![A-Za-z0-9_-])",
     re.IGNORECASE,
 )
 LEADING_BOUNTY_REF_RE = re.compile(

--- a/scripts/check_bounty_issue_states.py
+++ b/scripts/check_bounty_issue_states.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.api_host_args import public_api_host
+
+DEFAULT_API_HOST = "https://api.mrwk.online"
+GH_TIMEOUT_SECONDS = 30
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _status_value(raw: dict[str, Any]) -> str:
+    return str(raw.get("status") or raw.get("state") or "").lower()
+
+
+def _issue_number(raw: dict[str, Any]) -> int | None:
+    return _int_or_none(raw.get("issue_number", raw.get("number")))
+
+
+def _open_public_bounties(data: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for item in data.get("bounties", []):
+        if not isinstance(item, dict) or _status_value(item) != "open":
+            continue
+        issue_number = _issue_number(item)
+        if issue_number is None:
+            continue
+        rows.append({**item, "issue_number": issue_number})
+    return rows
+
+
+def _issue_index(data: dict[str, Any]) -> dict[int, dict[str, Any]]:
+    index: dict[int, dict[str, Any]] = {}
+    for issue in data.get("issues", []):
+        if not isinstance(issue, dict):
+            continue
+        number = _issue_number(issue)
+        if number is not None:
+            index[number] = issue
+    return index
+
+
+def _issue_is_open(issue: dict[str, Any] | None) -> bool:
+    if issue is None:
+        return False
+    return _status_value(issue) == "open"
+
+
+def analyze_issue_states(data: dict[str, Any]) -> dict[str, Any]:
+    open_bounties = _open_public_bounties(data)
+    issues = _issue_index(data)
+    violations: list[dict[str, Any]] = []
+    for bounty in open_bounties:
+        issue_number = int(bounty["issue_number"])
+        issue = issues.get(issue_number)
+        if _issue_is_open(issue):
+            continue
+        issue_state = _status_value(issue or {}) or "missing"
+        violations.append(
+            {
+                "issue_number": issue_number,
+                "bounty_id": _int_or_none(bounty.get("id", bounty.get("bounty_id"))),
+                "availability_state": bounty.get("availability_state"),
+                "effective_awards_remaining": bounty.get("effective_awards_remaining"),
+                "awards_paid": bounty.get("awards_paid"),
+                "max_awards": bounty.get("max_awards"),
+                "issue_state": issue_state,
+                "issue_url": bounty.get("issue_url") or (issue or {}).get("url"),
+                "detail": (
+                    f"Open public bounty #{issue_number} has GitHub issue state "
+                    f"{issue_state.upper()}"
+                ),
+            }
+        )
+    return {
+        "summary": {
+            "open_public_bounties": len(open_bounties),
+            "closed_or_missing_github_issues": len(violations),
+        },
+        "violations": violations,
+    }
+
+
+def has_violations(report: dict[str, Any]) -> bool:
+    return bool(report["violations"])
+
+
+def format_text_report(report: dict[str, Any]) -> str:
+    lines = ["Public bounty GitHub issue-state check"]
+    for key, value in report["summary"].items():
+        lines.append(f"- {key.replace('_', ' ')}: {value}")
+    if not has_violations(report):
+        lines.append("")
+        lines.append("All open public bounty rows have open GitHub issues.")
+        return "\n".join(lines)
+    lines.append("")
+    lines.append("Open public bounty rows with non-open GitHub issues")
+    for item in report["violations"]:
+        detail = item["detail"]
+        if item.get("effective_awards_remaining") is not None:
+            detail += f"; effective awards remaining: {item['effective_awards_remaining']}"
+        lines.append(f"- #{item['issue_number']}: {detail}")
+    return "\n".join(lines)
+
+
+def _run_gh_json(args: list[str]) -> Any:
+    command = " ".join(args)
+    try:
+        completed = subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s: {command}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            "gh command failed "
+            f"(exit {exc.returncode}): {command}\n"
+            f"stdout:\n{exc.stdout or exc.output or ''}\n"
+            f"stderr:\n{exc.stderr or ''}"
+        ) from exc
+    return json.loads(completed.stdout)
+
+
+def _run_gh(args: list[str]) -> None:
+    command = " ".join(args)
+    try:
+        subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s: {command}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            "gh command failed "
+            f"(exit {exc.returncode}): {command}\n"
+            f"stdout:\n{exc.stdout or exc.output or ''}\n"
+            f"stderr:\n{exc.stderr or ''}"
+        ) from exc
+
+
+def _fetch_json(url: str) -> Any:
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=GH_TIMEOUT_SECONDS) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (TimeoutError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"failed to fetch JSON from {url}: {exc}") from exc
+
+
+def _load_public_bounties(api_host: str) -> list[dict[str, Any]]:
+    url = f"{api_host.rstrip('/')}/api/v1/bounties?status=open&limit=200"
+    data = _fetch_json(url)
+    if not isinstance(data, list):
+        raise RuntimeError(f"expected a JSON list from {url}")
+    return [item for item in data if isinstance(item, dict)]
+
+
+def _load_issue(repo: str, issue_number: int) -> dict[str, Any]:
+    return _run_gh_json(
+        [
+            "gh",
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--json",
+            "number,state,url,closed,closedAt",
+        ]
+    )
+
+
+def load_live_data(repo: str, api_host: str) -> dict[str, Any]:
+    bounties = _load_public_bounties(api_host)
+    issue_numbers = sorted(
+        number for number in (_issue_number(bounty) for bounty in bounties) if number is not None
+    )
+    return {
+        "bounties": bounties,
+        "issues": [_load_issue(repo, issue_number) for issue_number in issue_numbers],
+    }
+
+
+def reopen_violations(repo: str, violations: list[dict[str, Any]]) -> None:
+    for item in violations:
+        if item.get("issue_state") == "closed":
+            _run_gh(["gh", "issue", "reopen", str(item["issue_number"]), "--repo", repo])
+
+
+def _load_input(path: str) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("input must be a JSON object")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify open public MergeWork bounty rows still have open GitHub issues."
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--input", help="Read bounties and issues from a JSON fixture.")
+    source.add_argument("--repo", help="GitHub repository, for example ramimbo/mergework.")
+    parser.add_argument("--api-host", type=public_api_host, default=DEFAULT_API_HOST)
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--fail-on-issues", action="store_true")
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Reopen closed GitHub issues for open public bounties. Does not post comments.",
+    )
+    args = parser.parse_args(argv)
+
+    data = _load_input(args.input) if args.input else load_live_data(args.repo, args.api_host)
+    report = analyze_issue_states(data)
+    if args.fix:
+        if args.input:
+            raise SystemExit("--fix requires --repo, not --input")
+        reopen_violations(args.repo, report["violations"])
+        data = load_live_data(args.repo, args.api_host)
+        report = analyze_issue_states(data)
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(format_text_report(report))
+    return 1 if args.fail_on_issues and has_violations(report) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_live_bounty_closing_refs.py
+++ b/scripts/check_live_bounty_closing_refs.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.api_host_args import public_api_host
+from scripts.bounty_refs import GITHUB_CLOSING_ISSUE_RE
+
+DEFAULT_API_HOST = "https://api.mrwk.online"
+GH_TIMEOUT_SECONDS = 30
+GH_PR_SAFETY_CAP = 200
+MAX_BOUNTY_REF = 2**63 - 1
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _status_value(raw: dict[str, Any]) -> str:
+    return str(raw.get("status") or raw.get("state") or "").lower()
+
+
+def _issue_number(raw: dict[str, Any]) -> int | None:
+    return _int_or_none(raw.get("issue_number", raw.get("number")))
+
+
+def _open_public_bounty_numbers(data: dict[str, Any]) -> set[int]:
+    numbers: set[int] = set()
+    for item in data.get("bounties", []):
+        if not isinstance(item, dict) or _status_value(item) != "open":
+            continue
+        issue_number = _issue_number(item)
+        if issue_number is not None:
+            numbers.add(issue_number)
+    return numbers
+
+
+def _closing_refs(text: str) -> list[tuple[int, str]]:
+    refs: list[tuple[int, str]] = []
+    for match in GITHUB_CLOSING_ISSUE_RE.finditer(text or ""):
+        issue_number = _int_or_none(match.group("issue"))
+        if issue_number is None or issue_number > MAX_BOUNTY_REF:
+            continue
+        refs.append((issue_number, f"{match.group('verb')} #{issue_number}"))
+    return refs
+
+
+def analyze_closing_refs(data: dict[str, Any]) -> dict[str, Any]:
+    open_bounties = _open_public_bounty_numbers(data)
+    violations: list[dict[str, Any]] = []
+    pull_requests = [item for item in data.get("pull_requests", []) if isinstance(item, dict)]
+    for pr in pull_requests:
+        number = _int_or_none(pr.get("number"))
+        if number is None:
+            continue
+        text = "\n".join(str(pr.get(key) or "") for key in ("title", "body"))
+        for issue_number, matched_reference in _closing_refs(text):
+            if issue_number not in open_bounties:
+                continue
+            violations.append(
+                {
+                    "pull_request": number,
+                    "title": str(pr.get("title") or ""),
+                    "url": pr.get("url"),
+                    "issue_number": issue_number,
+                    "matched_reference": matched_reference,
+                    "detail": (
+                        f"PR #{number} uses closing reference {matched_reference!r} "
+                        f"against open public bounty #{issue_number}"
+                    ),
+                }
+            )
+    return {
+        "summary": {
+            "pull_requests": len(pull_requests),
+            "open_public_bounties": len(open_bounties),
+            "closing_references_to_open_bounties": len(violations),
+        },
+        "violations": violations,
+    }
+
+
+def has_violations(report: dict[str, Any]) -> bool:
+    return bool(report["violations"])
+
+
+def _single_line(value: Any) -> str:
+    return " ".join(str(value or "").split())
+
+
+def format_text_report(report: dict[str, Any]) -> str:
+    lines = ["Live bounty closing-reference check"]
+    for key, value in report["summary"].items():
+        lines.append(f"- {key.replace('_', ' ')}: {value}")
+    if not has_violations(report):
+        lines.append("")
+        lines.append("No closing references to open public bounties found.")
+        return "\n".join(lines)
+    lines.append("")
+    lines.append("Closing references to open public bounties")
+    for item in report["violations"]:
+        lines.append(
+            "- PR #{pull_request}: {title} ({matched_reference} -> bounty #{issue_number})".format(
+                pull_request=item["pull_request"],
+                title=_single_line(item["title"]),
+                matched_reference=item["matched_reference"],
+                issue_number=item["issue_number"],
+            )
+        )
+    return "\n".join(lines)
+
+
+def _run_gh_json(args: list[str]) -> Any:
+    command = " ".join(args)
+    try:
+        completed = subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=GH_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s: {command}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            "gh command failed "
+            f"(exit {exc.returncode}): {command}\n"
+            f"stdout:\n{exc.stdout or exc.output or ''}\n"
+            f"stderr:\n{exc.stderr or ''}"
+        ) from exc
+    return json.loads(completed.stdout)
+
+
+def _fetch_json(url: str) -> Any:
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=GH_TIMEOUT_SECONDS) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (TimeoutError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"failed to fetch JSON from {url}: {exc}") from exc
+
+
+def _load_public_bounties(api_host: str) -> list[dict[str, Any]]:
+    url = f"{api_host.rstrip('/')}/api/v1/bounties?status=open&limit=200"
+    data = _fetch_json(url)
+    if not isinstance(data, list):
+        raise RuntimeError(f"expected a JSON list from {url}")
+    return [item for item in data if isinstance(item, dict)]
+
+
+def _load_pull_requests(repo: str, state: str, pr_numbers: list[int]) -> list[dict[str, Any]]:
+    if pr_numbers:
+        return [
+            _run_gh_json(
+                [
+                    "gh",
+                    "pr",
+                    "view",
+                    str(number),
+                    "--repo",
+                    repo,
+                    "--json",
+                    "number,title,url,body,state",
+                ]
+            )
+            for number in pr_numbers
+        ]
+    prs = _run_gh_json(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            state,
+            "--limit",
+            str(GH_PR_SAFETY_CAP),
+            "--json",
+            "number,title,url,body,state",
+        ]
+    )
+    if len(prs) >= GH_PR_SAFETY_CAP:
+        raise RuntimeError(
+            f"gh pr list reached the {GH_PR_SAFETY_CAP} item safety cap; "
+            "use --pr for a bounded check or an API-paginated collector"
+        )
+    return [item for item in prs if isinstance(item, dict)]
+
+
+def load_live_data(repo: str, api_host: str, state: str, pr_numbers: list[int]) -> dict[str, Any]:
+    return {
+        "bounties": _load_public_bounties(api_host),
+        "pull_requests": _load_pull_requests(repo, state, pr_numbers),
+    }
+
+
+def _load_input(path: str) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("input must be a JSON object")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail when GitHub closing keywords target currently open public MergeWork "
+            "bounty issues."
+        )
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--input", help="Read bounties and pull_requests from a JSON fixture.")
+    source.add_argument("--repo", help="GitHub repository, for example ramimbo/mergework.")
+    parser.add_argument("--api-host", type=public_api_host, default=DEFAULT_API_HOST)
+    parser.add_argument("--state", choices=["open", "closed", "merged", "all"], default="open")
+    parser.add_argument("--pr", type=int, action="append", default=[], help="Specific PR to check.")
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--fail-on-issues", action="store_true")
+    args = parser.parse_args(argv)
+
+    data = (
+        _load_input(args.input)
+        if args.input
+        else load_live_data(args.repo, args.api_host, args.state, args.pr)
+    )
+    report = analyze_closing_refs(data)
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(format_text_report(report))
+    return 1 if args.fail_on_issues and has_violations(report) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_check_bounty_issue_states.py
+++ b/tests/test_check_bounty_issue_states.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts import check_bounty_issue_states
+from scripts.check_bounty_issue_states import analyze_issue_states, main
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_issue_state_check_flags_closed_github_issue_for_open_public_bounty(
+    tmp_path, capsys
+) -> None:
+    fixture = {
+        "bounties": [
+            {
+                "id": 117,
+                "issue_number": 936,
+                "status": "open",
+                "availability_state": "open",
+                "awards_paid": 2,
+                "max_awards": 8,
+                "effective_awards_remaining": 6,
+            },
+            {
+                "id": 118,
+                "issue_number": 944,
+                "status": "open",
+                "availability_state": "open",
+                "effective_awards_remaining": 4,
+            },
+        ],
+        "issues": [
+            {"number": 936, "state": "CLOSED", "url": "https://github.com/x/y/issues/936"},
+            {"number": 944, "state": "OPEN", "url": "https://github.com/x/y/issues/944"},
+        ],
+    }
+
+    report = analyze_issue_states(fixture)
+
+    assert report["summary"] == {
+        "open_public_bounties": 2,
+        "closed_or_missing_github_issues": 1,
+    }
+    assert report["violations"][0] == {
+        "issue_number": 936,
+        "bounty_id": 117,
+        "availability_state": "open",
+        "effective_awards_remaining": 6,
+        "awards_paid": 2,
+        "max_awards": 8,
+        "issue_state": "closed",
+        "issue_url": "https://github.com/x/y/issues/936",
+        "detail": "Open public bounty #936 has GitHub issue state CLOSED",
+    }
+
+    input_path = tmp_path / "issue_states.json"
+    input_path.write_text(json.dumps(fixture), encoding="utf-8")
+    exit_code = main(["--input", str(input_path), "--format", "text", "--fail-on-issues"])
+    assert exit_code == 1
+    assert "#936" in capsys.readouterr().out
+
+
+def test_issue_state_check_accepts_open_github_issue() -> None:
+    report = analyze_issue_states(
+        {
+            "bounties": [{"id": 118, "issue_number": 944, "status": "open"}],
+            "issues": [{"number": 944, "state": "OPEN"}],
+        }
+    )
+
+    assert report["summary"]["closed_or_missing_github_issues"] == 0
+    assert report["violations"] == []
+
+
+def test_issue_state_check_script_entrypoint_loads_shared_parser() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/check_bounty_issue_states.py", "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout
+
+
+def test_issue_state_check_fix_reopens_closed_issues(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        if args[:3] == ["gh", "issue", "reopen"]:
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(check_bounty_issue_states.subprocess, "run", fake_run)
+
+    check_bounty_issue_states.reopen_violations(
+        "ramimbo/mergework",
+        [
+            {"issue_number": 936, "issue_state": "closed"},
+            {"issue_number": 944, "issue_state": "missing"},
+        ],
+    )
+
+    assert calls == [["gh", "issue", "reopen", "936", "--repo", "ramimbo/mergework"]]

--- a/tests/test_check_live_bounty_closing_refs.py
+++ b/tests/test_check_live_bounty_closing_refs.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts import check_live_bounty_closing_refs
+from scripts.check_live_bounty_closing_refs import analyze_closing_refs, main
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_closing_ref_check_flags_open_public_bounty_reference(tmp_path, capsys) -> None:
+    fixture = {
+        "bounties": [
+            {"id": 117, "issue_number": 936, "status": "open"},
+            {"id": 118, "issue_number": 944, "status": "open"},
+            {"id": 120, "issue_number": 950, "status": "paid"},
+        ],
+        "pull_requests": [
+            {
+                "number": 991,
+                "title": "Refactor activity helpers",
+                "body": "Closes #936",
+                "url": "https://github.com/ramimbo/mergework/pull/991",
+            },
+            {
+                "number": 1015,
+                "title": "Publish OpenAPI constraints",
+                "body": "Bounty #944\nRefs #944",
+                "url": "https://github.com/ramimbo/mergework/pull/1015",
+            },
+            {
+                "number": 1200,
+                "title": "Final closeout",
+                "body": "Resolves #950",
+                "url": "https://github.com/ramimbo/mergework/pull/1200",
+            },
+        ],
+    }
+
+    report = analyze_closing_refs(fixture)
+
+    assert report["summary"] == {
+        "pull_requests": 3,
+        "open_public_bounties": 2,
+        "closing_references_to_open_bounties": 1,
+    }
+    assert report["violations"][0]["pull_request"] == 991
+    assert report["violations"][0]["issue_number"] == 936
+    assert report["violations"][0]["matched_reference"] == "Closes #936"
+
+    input_path = tmp_path / "closing_refs.json"
+    input_path.write_text(json.dumps(fixture), encoding="utf-8")
+    exit_code = main(["--input", str(input_path), "--format", "text", "--fail-on-issues"])
+    assert exit_code == 1
+    assert "PR #991" in capsys.readouterr().out
+
+
+def test_closing_ref_check_accepts_non_closing_bounty_refs() -> None:
+    report = analyze_closing_refs(
+        {
+            "bounties": [{"id": 118, "issue_number": 944, "status": "open"}],
+            "pull_requests": [
+                {
+                    "number": 1015,
+                    "title": "Bounty #944: publish OpenAPI constraints",
+                    "body": "Bounty #944\nRefs #944\n/claim #944",
+                }
+            ],
+        }
+    )
+
+    assert report["summary"]["closing_references_to_open_bounties"] == 0
+    assert report["violations"] == []
+
+
+def test_closing_ref_check_script_entrypoint_loads_shared_parser() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/check_live_bounty_closing_refs.py", "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout
+
+
+def test_closing_ref_check_loads_specific_prs(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(args)
+        if args[:3] == ["gh", "pr", "view"]:
+            stdout = json.dumps(
+                {
+                    "number": int(args[3]),
+                    "title": "Guard bounty closeout",
+                    "body": "Closes #944",
+                    "url": "https://github.com/ramimbo/mergework/pull/1015",
+                    "state": "OPEN",
+                }
+            )
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+        raise AssertionError(args)
+
+    monkeypatch.setattr(check_live_bounty_closing_refs.subprocess, "run", fake_run)
+
+    prs = check_live_bounty_closing_refs._load_pull_requests("ramimbo/mergework", "open", [1015])
+
+    assert prs[0]["number"] == 1015
+    assert calls[0][:4] == ["gh", "pr", "view", "1015"]


### PR DESCRIPTION
Maintainer PR; no bounty requested.

## Summary

- Add a live closing-reference guard that fails when PR title/body text uses GitHub closing keywords against currently open public bounty rows.
- Add a public bounty issue-state guard that verifies every open public bounty row still has an open GitHub issue, with an explicit reopen-only `--fix` mode.
- Share a dedicated GitHub closing-reference parser and cover the #936/#944 failure shape with regression tests.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: GitHub auto-closed live bounty issues when merged PR bodies used closing references even though the public bounty rows still had effective capacity.
- Bounty capacity and active attempts/open PRs checked: maintainer infrastructure PR; no bounty requested. Live guard checks covered 84 open PRs and 10 open public bounty rows with zero current violations.
- Intended files or surfaces: `scripts/bounty_refs.py`, `scripts/check_live_bounty_closing_refs.py`, `scripts/check_bounty_issue_states.py`, and focused tests.
- Expected PR size: small.
- Out of scope: bounty creation, bounty payment, ledger mutation, proof generation, treasury execution, wallet behavior, deployment, and public GitHub issue/comment mutations.

## Test Evidence

- [x] `./.venv/bin/python scripts/check_agents.py` -> `AGENTS.md files ok (4 checked)`
- [x] `./.venv/bin/python -m pytest tests/test_check_live_bounty_closing_refs.py tests/test_check_bounty_issue_states.py -q` -> `8 passed`
- [x] `./.venv/bin/python scripts/check_live_bounty_closing_refs.py --repo ramimbo/mergework --state open --fail-on-issues` -> 84 open PRs, 10 open public bounties, 0 violations
- [x] `./.venv/bin/python scripts/check_bounty_issue_states.py --repo ramimbo/mergework --fail-on-issues` -> 10 open public bounties, 0 violations
- [x] `./.venv/bin/python -m pytest` -> `868 passed`
- [x] `./.venv/bin/python -m ruff format --check .` -> `124 files already formatted`
- [x] `./.venv/bin/python -m ruff check .` -> `All checks passed!`
- [x] `./.venv/bin/python -m mypy app` -> `Success: no issues found in 45 source files`
- [x] `./.venv/bin/python scripts/docs_smoke.py` -> `docs smoke ok`
- [x] `git diff --check` -> clean

## MRWK

Maintainer PR; no bounty requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI utility to verify bounty GitHub issue states and optionally reopen closed issues.
  * Added CLI utility to validate that GitHub closing keywords reference open public bounties.

* **Refactor**
  * Updated regex patterns with named capture groups for improved issue reference extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->