### PR TITLE
fix: handle invalid bounty page filters

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -15,8 +15,11 @@ from app.accounts import (
     ACCOUNT_TRANSACTION_TYPES,
     normalized_wallet_address,
 )
-from app.bounty_availability import normalize_bounty_availability_filter
-from app.bounty_sorting import BOUNTY_SORT_LABELS, normalize_bounty_sort
+from app.bounty_availability import (
+    BOUNTY_AVAILABILITY_ERROR,
+    normalize_bounty_availability_filter,
+)
+from app.bounty_sorting import BOUNTY_SORT_ERROR, BOUNTY_SORT_LABELS, normalize_bounty_sort
 from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger_views import account_ledger_transaction_types, account_ledger_transactions
@@ -136,6 +139,26 @@ def _bounties_page_url(
     )
 
 
+def _normalize_bounty_view_filter(name: str, value: str | None) -> str:
+    try:
+        if name == "sort":
+            return normalize_bounty_sort(value)
+        if name == "availability":
+            return normalize_bounty_availability_filter(value)
+    except ValueError as exc:
+        detail = str(exc)
+        allowed_details = {
+            BOUNTY_SORT_ERROR,
+            BOUNTY_AVAILABILITY_ERROR,
+            "sort must not contain control characters",
+            "availability must not contain control characters",
+        }
+        if detail not in allowed_details:
+            detail = BOUNTY_SORT_ERROR if name == "sort" else BOUNTY_AVAILABILITY_ERROR
+        raise HTTPException(status_code=400, detail=detail) from exc
+    raise ValueError(f"unsupported bounty filter: {name}")
+
+
 def public_bounties_context(
     bounties: list[dict[str, Any]],
     status: str | None,
@@ -149,8 +172,8 @@ def public_bounties_context(
     selected_status = status.strip().lower() if status is not None else None
     query_text = q.strip() if q is not None else ""
     selected_repo = repo.strip().lower() if repo is not None else ""
-    selected_sort = normalize_bounty_sort(sort)
-    selected_availability = normalize_bounty_availability_filter(availability)
+    selected_sort = _normalize_bounty_view_filter("sort", sort)
+    selected_availability = _normalize_bounty_view_filter("availability", availability)
     limit_options: tuple[int, ...] = (10, 25, 50, 100, 200)
     if limit is not None and limit not in limit_options:
         limit_options = tuple(sorted((*limit_options, limit)))

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
@@ -543,6 +544,28 @@ def test_bounties_page_and_api_search_by_text_and_issue_number(sqlite_url: str) 
     assert plus_limit_page.json()["detail"] == "limit must be a canonical positive integer"
     assert leading_zero_limit_page.status_code == 400
     assert leading_zero_limit_page.json()["detail"] == "limit must be a canonical positive integer"
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_detail"),
+    [
+        ("/bounties?sort=oldest", "sort must be one of: newest, reward, available, awards"),
+        ("/bounties?availability=stale", "availability must be one of: all, effectively_open"),
+    ],
+)
+def test_bounties_page_rejects_invalid_sort_and_availability_filters(
+    sqlite_url: str, path: str, expected_detail: str
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(path)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == expected_detail
 
 
 def test_bounties_page_and_api_sort_public_rows(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- Make the `/bounties` HTML page return the same 400 JSON validation errors as `/api/v1/bounties` for invalid `sort` and `availability` filters.
- Add regression coverage for invalid bounty page filter values.

## Why
Invalid public bounty page filters currently reach `public_bounties_context()` and raise uncaught `ValueError`s from the shared normalizers. This keeps the page route's validation behavior explicit and consistent with the API route.

## Verification
- `pytest -q tests/test_bounty_pages.py`
- `pytest -q tests/test_bounty_pages.py tests/test_bounty_api.py tests/test_public_routes.py tests/test_bounty_sorting.py`
- `ruff check app/public_routes.py tests/test_bounty_pages.py`
- `git diff --check`
- Added-line security scan: only flagged the existing test-only `webhook_secret="secret"` TestClient convention; independent review passed it as non-production test code.

Bounty #936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for bounty page filter parameters (`sort` and `availability`). Invalid filter values now return HTTP 400 with specific, descriptive error messages instead of potential ambiguous responses.

* **Tests**
  * Added test coverage for invalid bounty filter rejection to ensure proper error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->