### PR TITLE
Share accepted submission reconciliation query

### DIFF
--- a/app/ledger/reconciliation.py
+++ b/app/ledger/reconciliation.py
@@ -65,14 +65,8 @@ class DuplicateAcceptedSourceUrl:
 
 
 def reconcile_accepted_payouts(session: Session) -> list[AcceptedPayoutCheck]:
-    rows = session.execute(
-        select(Submission, Bounty)
-        .join(Bounty, Bounty.id == Submission.bounty_id)
-        .where(Submission.status == "accepted")
-        .order_by(Submission.id)
-    ).all()
     checks: list[AcceptedPayoutCheck] = []
-    for submission, bounty in rows:
+    for submission, bounty in _accepted_submission_rows(session):
         evidence = _payout_evidence(session, submission, bounty)
         checks.append(
             AcceptedPayoutCheck(
@@ -89,14 +83,8 @@ def reconcile_accepted_payouts(session: Session) -> list[AcceptedPayoutCheck]:
 
 
 def duplicate_accepted_source_urls(session: Session) -> list[DuplicateAcceptedSourceUrl]:
-    rows = session.execute(
-        select(Submission, Bounty)
-        .join(Bounty, Bounty.id == Submission.bounty_id)
-        .where(Submission.status == "accepted")
-        .order_by(Submission.id)
-    ).all()
     groups: dict[str, list[AcceptedSourceReference]] = {}
-    for submission, bounty in rows:
+    for submission, bounty in _accepted_submission_rows(session):
         source_url = _canonical_source_url(submission.url)
         groups.setdefault(source_url, []).append(
             AcceptedSourceReference(
@@ -112,6 +100,15 @@ def duplicate_accepted_source_urls(session: Session) -> list[DuplicateAcceptedSo
         for source_url, submissions in groups.items()
         if len(submissions) > 1
     ]
+
+
+def _accepted_submission_rows(session: Session) -> Sequence[tuple[Submission, Bounty]]:
+    return session.execute(
+        select(Submission, Bounty)
+        .join(Bounty, Bounty.id == Submission.bounty_id)
+        .where(Submission.status == "accepted")
+        .order_by(Submission.id)
+    ).all()
 
 
 def payout_reconciliation_summary(checks: Sequence[AcceptedPayoutCheck]) -> dict[str, int]:

--- a/app/ledger/reconciliation.py
+++ b/app/ledger/reconciliation.py
@@ -103,12 +103,13 @@ def duplicate_accepted_source_urls(session: Session) -> list[DuplicateAcceptedSo
 
 
 def _accepted_submission_rows(session: Session) -> Sequence[tuple[Submission, Bounty]]:
-    return session.execute(
+    rows = session.execute(
         select(Submission, Bounty)
         .join(Bounty, Bounty.id == Submission.bounty_id)
         .where(Submission.status == "accepted")
         .order_by(Submission.id)
     ).all()
+    return [(submission, bounty) for submission, bounty in rows]
 
 
 def payout_reconciliation_summary(checks: Sequence[AcceptedPayoutCheck]) -> dict[str, int]:


### PR DESCRIPTION
Bounty #936

## Summary
- Extracts the accepted-submission/bounty query used by payout reconciliation into `_accepted_submission_rows()`.
- Reuses that helper from both `reconcile_accepted_payouts()` and `duplicate_accepted_source_urls()`.
- Preserves accepted-only filtering and `Submission.id` ordering for both report paths.

## Why
Both reconciliation paths need the same accepted submission rows joined with their bounty metadata. Sharing the query removes duplicated SQL construction while keeping the payout and duplicate-source behavior easier to audit together.

## Validation
- `.venv\Scripts\python.exe -m pytest tests\test_ledger_reconciliation.py -q` -> 8 passed
- `.venv\Scripts\ruff.exe check app\ledger\reconciliation.py tests\test_ledger_reconciliation.py` -> All checks passed
- `.venv\Scripts\ruff.exe format --check app\ledger\reconciliation.py tests\test_ledger_reconciliation.py` -> 2 files already formatted
- `git diff --check` -> clean

## Scope
No ledger mutation, payout execution, proof generation, wallet behavior, treasury behavior, API response changes, or public artifact claims. This is a narrow maintainability cleanup for the reconciliation query path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized internal ledger reconciliation logic by consolidating duplicated reconciliation steps into a single shared implementation. This reduces code duplication, improves maintainability, and lowers the chance of reconciliation bugs. No public interfaces or behaviors were changed; end-user functionality remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->