### PR TITLE
Cover unsupported query guard context

### DIFF
--- a/tests/test_query_validation.py
+++ b/tests/test_query_validation.py
@@ -78,3 +78,13 @@ def test_unsupported_query_guard_reports_route_context() -> None:
 
     assert unsupported_error.value.status_code == 400
     assert unsupported_error.value.detail == "availability is not supported on bounty detail pages"
+
+
+def test_unsupported_query_guard_allows_supported_params() -> None:
+    request = _request("status=open&limit=10")
+
+    reject_unsupported_query_params(
+        request,
+        ("availability", "sort"),
+        context="bounty detail pages",
+    )

--- a/tests/test_query_validation.py
+++ b/tests/test_query_validation.py
@@ -8,6 +8,7 @@ from app.query_validation import (
     reject_noncanonical_bool_query_param,
     reject_noncanonical_int_query_param,
     reject_repeated_query_param,
+    reject_unsupported_query_params,
 )
 
 
@@ -63,3 +64,17 @@ def test_query_guards_keep_canonical_and_repeated_boundaries() -> None:
         reject_repeated_query_param(request, "status")
     assert repeated_error.value.status_code == 400
     assert repeated_error.value.detail == "status must be provided at most once"
+
+
+def test_unsupported_query_guard_reports_route_context() -> None:
+    request = _request("status=open&availability=effectively_open")
+
+    with pytest.raises(HTTPException) as unsupported_error:
+        reject_unsupported_query_params(
+            request,
+            ("availability", "sort"),
+            context="bounty detail pages",
+        )
+
+    assert unsupported_error.value.status_code == 400
+    assert unsupported_error.value.detail == "availability is not supported on bounty detail pages"


### PR DESCRIPTION
## Summary
- Adds focused unit coverage for `reject_unsupported_query_params`.
- Verifies the guard reports the unsupported parameter and the route context in its HTTP 400 detail.
- Keeps behavior unchanged; this only tightens regression coverage for the shared query validation helper.

Bounty #936

## Validation
- `.venv\Scripts\python.exe -m pytest tests\test_query_validation.py -q` -> 5 passed
- `.venv\Scripts\ruff.exe check tests\test_query_validation.py` -> All checks passed
- `.venv\Scripts\ruff.exe format --check tests\test_query_validation.py` -> 1 file already formatted
- `git diff --check` -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for query parameter validation: unsupported query parameters are rejected with an HTTP 400 and an error message that includes route-specific context.
  * Added tests confirming requests containing only supported query parameters are allowed and proceed normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->