### PR TITLE
Expose work discovery next actions

### DIFF
--- a/app/work_discovery.py
+++ b/app/work_discovery.py
@@ -52,7 +52,26 @@ def _bounty_source_urls(row: dict[str, Any]) -> dict[str, str]:
     }
 
 
+def _next_action(requirements: dict[str, Any]) -> dict[str, Any]:
+    actions = requirements.get("next_actions")
+    if not isinstance(actions, list) or not actions:
+        return {
+            "id": "review_submission_requirements",
+            "required": True,
+            "text": "Review submission requirements before opening or claiming work.",
+        }
+    action = actions[0]
+    if not isinstance(action, dict):
+        return {
+            "id": "review_submission_requirements",
+            "required": True,
+            "text": "Review submission requirements before opening or claiming work.",
+        }
+    return action
+
+
 def _bounty_work_item(row: dict[str, Any], availability_state: str) -> dict[str, Any]:
+    submission_requirements = row["submission_requirements"]
     return {
         "availability_state": availability_state,
         "bounty_id": int(row["id"]),
@@ -65,7 +84,8 @@ def _bounty_work_item(row: dict[str, Any], availability_state: str) -> dict[str,
         "bounty_availability_state": str(row["availability_state"]),
         "pending_payout_awards": int(row["pending_payout_awards"]),
         "source_urls": _bounty_source_urls(row),
-        "submission_requirements": row["submission_requirements"],
+        "next_action": _next_action(submission_requirements),
+        "submission_requirements": submission_requirements,
     }
 
 
@@ -77,6 +97,13 @@ def _not_claimable_state(row: dict[str, Any]) -> str:
 
 def _pending_create_item(proposal: TreasuryProposal) -> dict[str, Any]:
     payload = proposal_payload(proposal)
+    submission_requirements = work_proof_submission_requirements(
+        bounty_id=None,
+        issue_number=int(payload["issue_number"]),
+        availability="unknown",
+        title=str(payload["title"]),
+        acceptance=str(payload.get("acceptance", "")),
+    )
     return {
         "availability_state": "pending_create",
         "proposal_id": int(proposal.id),
@@ -91,13 +118,8 @@ def _pending_create_item(proposal: TreasuryProposal) -> dict[str, Any]:
             "proposal": f"/api/v1/treasury/proposals/{proposal.id}",
             "github_issue": str(payload["issue_url"]),
         },
-        "submission_requirements": work_proof_submission_requirements(
-            bounty_id=None,
-            issue_number=int(payload["issue_number"]),
-            availability="unknown",
-            title=str(payload["title"]),
-            acceptance=str(payload.get("acceptance", "")),
-        ),
+        "next_action": _next_action(submission_requirements),
+        "submission_requirements": submission_requirements,
     }
 
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -184,6 +184,11 @@ non-claimable states out of the claimable list, and accepts optional
         "bounty": "/api/v1/bounties/108",
         "attempts": "/api/v1/bounties/108/attempts",
         "github_issue": "https://github.com/ramimbo/mergework/issues/800"
+      },
+      "next_action": {
+        "id": "confirm_award_slot",
+        "required": true,
+        "text": "Confirm this bounty is open and has at least one award slot remaining."
       }
     }
   ],
@@ -201,6 +206,11 @@ non-claimable states out of the claimable list, and accepts optional
       "source_urls": {
         "proposal": "/api/v1/treasury/proposals/125",
         "github_issue": "https://github.com/ramimbo/mergework/issues/798"
+      },
+      "next_action": {
+        "id": "select_bounty",
+        "required": true,
+        "text": "Select a concrete open bounty before submitting work proof."
       }
     }
   ],
@@ -220,6 +230,11 @@ non-claimable states out of the claimable list, and accepts optional
         "bounty": "/api/v1/bounties/102",
         "attempts": "/api/v1/bounties/102/attempts",
         "github_issue": "https://github.com/ramimbo/mergework/issues/761"
+      },
+      "next_action": {
+        "id": "choose_open_bounty",
+        "required": true,
+        "text": "Do not open or claim new work for this bounty unless a maintainer reopens it."
       }
     }
   ],

--- a/tests/test_work_discovery.py
+++ b/tests/test_work_discovery.py
@@ -106,6 +106,11 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
                 "attempts": f"/api/v1/bounties/{live_bounty.id}/attempts",
                 "github_issue": "https://github.com/ramimbo/mergework/issues/800",
             },
+            "next_action": {
+                "id": "confirm_award_slot",
+                "required": True,
+                "text": "Confirm this bounty is open and has at least one award slot remaining.",
+            },
             "submission_requirements": live_requirements,
         }
     ]
@@ -134,6 +139,11 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
                 "proposal": f"/api/v1/treasury/proposals/{pending_create.id}",
                 "github_issue": "https://github.com/ramimbo/mergework/issues/900",
             },
+            "next_action": {
+                "id": "select_bounty",
+                "required": True,
+                "text": "Select a concrete open bounty before submitting work proof.",
+            },
             "submission_requirements": pending_create_requirements,
         }
     ]
@@ -141,6 +151,7 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
     assert datetime.fromisoformat(pending_create_executes_after.replace("Z", "+00:00"))
     assert body["not_claimable"][0]["availability_state"] == "closed_or_exhausted"
     assert body["not_claimable"][0]["issue_number"] == 761
+    assert body["not_claimable"][0]["next_action"]["id"] == "choose_open_bounty"
 
 
 def test_work_discovery_limit_caps_public_buckets(sqlite_url: str) -> None:
@@ -230,6 +241,7 @@ def test_work_discovery_limit_keeps_older_claimable_bounty_visible(sqlite_url: s
     assert body["not_claimable"][0]["bounty_id"] == newer_pending_full.id
     assert body["not_claimable"][0]["issue_number"] == 911
     assert body["not_claimable"][0]["availability_state"] == "pending_payout"
+    assert body["not_claimable"][0]["next_action"]["id"] == "watch_for_award_slot"
 
 
 def test_work_discovery_scans_open_bounties_in_bounded_pages(


### PR DESCRIPTION
Bounty #935

## Summary
- Adds a top-level `next_action` to each `/api/v1/work-discovery` item so clients can route live, opening-soon, and unavailable work without parsing the nested `submission_requirements.next_actions` array first.
- Reuses the existing shared submission-requirements action text, preserving lifecycle semantics and keeping `submission_requirements` unchanged.
- Updates the public API example and focused work-discovery tests for live bounty, pending-create, closed/exhausted, and pending-payout rows.

## Why
`/api/v1/work-discovery` already groups claimable and non-claimable work, but agent clients still need to inspect nested submission requirements to decide the immediate next step. This exposes the first required action directly beside each work item while preserving the richer nested requirements for detailed submission guidance.

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests\test_work_discovery.py tests\test_docs_public_urls.py::test_docs_document_public_work_discovery_endpoint -q` -> 5 passed, 1 existing Starlette/httpx warning
- `uv run --python 3.12 --extra dev python scripts\docs_smoke.py` -> docs smoke ok
- `uv run --python 3.12 --extra dev python -m ruff check .` -> All checks passed
- `uv run --python 3.12 --extra dev python -m ruff format --check .` -> 120 files already formatted
- `uv run --python 3.12 --extra dev python -m mypy app` -> Success: no issues found in 45 source files
- `git diff --check origin/main...HEAD` -> clean

## Scope
Read-only work-discovery response shape and docs/tests only. No bounty creation, proposal execution, payout execution, ledger mutation, wallet behavior, admin-token APIs, exchange, bridge, off-ramp, cash-out behavior, private data, secrets, price claims, or MRWK value claims changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Work discovery responses now include a `next_action` object (id, required flag, and human-readable guidance) for claimable, opening-soon, and not-claimable items.
  * Pending-create items now also surface `submission_requirements` alongside their `next_action`.

* **Documentation**
  * API examples updated to show `next_action` across availability buckets and `submission_requirements` for pending items.

* **Tests**
  * Tests updated to assert new `next_action` fields and values for multiple work states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->