### PR TITLE
Advertise submit work proof output schema

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -296,6 +296,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
                 "repository": {"type": ["string", "null"]},
                 "issue_url": {"type": ["string", "null"]},
                 "title": {"type": ["string", "null"]},
+                "acceptance": {"type": ["string", "null"]},
                 "submission_format": {"type": "string"},
                 "submission_requirements": {
                     "type": "object",
@@ -328,6 +329,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "required": [
                 "bounty_id",
                 "issue_number",
+                "status",
                 "availability",
                 "can_submit",
                 "availability_warnings",

--- a/app/mcp.py
+++ b/app/mcp.py
@@ -276,6 +276,67 @@ MCP_TOOLS: list[dict[str, Any]] = [
                 {"if": {"required": ["bounty_id"]}, "then": {"not": {"required": ["repo"]}}},
             ],
         },
+        "outputSchema": {
+            "type": "object",
+            "properties": {
+                "bounty_id": {"type": ["integer", "null"]},
+                "issue_number": {"type": ["integer", "null"]},
+                "status": {"type": "string"},
+                "availability": {"type": "string"},
+                "can_submit": {"type": ["boolean", "null"]},
+                "availability_warnings": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+                "awards_remaining": {"type": ["integer", "null"]},
+                "max_awards": {"type": ["integer", "null"]},
+                "awards_paid": {"type": ["integer", "null"]},
+                "reward_mrwk": {"type": ["string", "null"]},
+                "available_mrwk": {"type": ["string", "null"]},
+                "repository": {"type": ["string", "null"]},
+                "issue_url": {"type": ["string", "null"]},
+                "title": {"type": ["string", "null"]},
+                "submission_format": {"type": "string"},
+                "submission_requirements": {
+                    "type": "object",
+                    "properties": {
+                        "reference_formats": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "claim_command": {"type": "string"},
+                        "attempt_endpoint": {"type": ["string", "null"]},
+                        "next_actions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {"type": "string"},
+                                    "required": {"type": "boolean"},
+                                    "text": {"type": "string"},
+                                },
+                                "required": ["id", "required", "text"],
+                                "additionalProperties": True,
+                            },
+                        },
+                    },
+                    "required": ["reference_formats", "claim_command", "next_actions"],
+                    "additionalProperties": True,
+                },
+                "safety_rules": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": [
+                "bounty_id",
+                "issue_number",
+                "availability",
+                "can_submit",
+                "availability_warnings",
+                "submission_format",
+                "submission_requirements",
+                "safety_rules",
+            ],
+            "additionalProperties": True,
+        },
     },
 ]
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -314,7 +314,7 @@ Tools:
 - `get_ledger_entry`
 - `get_proof`
 - `submit_work_proof` (`format: "json"` returns structuredContent; `tools/list`
-  advertises the selector and format schema)
+  advertises the selector, format, and structured guidance output schemas)
 
 `tools/list` advertises required selector schemas for proof and ledger lookups:
 `get_proof` requires a 64-character proof `hash`, and `get_ledger_entry`

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -339,11 +339,13 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert submit_output_schema["type"] == "object"
     assert submit_output_schema["additionalProperties"] is True
     assert submit_output_schema["properties"]["can_submit"]["type"] == ["boolean", "null"]
+    assert submit_output_schema["properties"]["acceptance"]["type"] == ["string", "null"]
     assert submit_output_schema["properties"]["submission_requirements"]["required"] == [
         "reference_formats",
         "claim_command",
         "next_actions",
     ]
+    assert "status" in submit_output_schema["required"]
     assert "submission_requirements" in submit_output_schema["required"]
     bounty_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_bounty")
     assert "accepted awards" in bounty_tool["description"]

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -335,6 +335,16 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
         },
         {"if": {"required": ["bounty_id"]}, "then": {"not": {"required": ["repo"]}}},
     ]
+    submit_output_schema = submit_tool["outputSchema"]
+    assert submit_output_schema["type"] == "object"
+    assert submit_output_schema["additionalProperties"] is True
+    assert submit_output_schema["properties"]["can_submit"]["type"] == ["boolean", "null"]
+    assert submit_output_schema["properties"]["submission_requirements"]["required"] == [
+        "reference_formats",
+        "claim_command",
+        "next_actions",
+    ]
+    assert "submission_requirements" in submit_output_schema["required"]
     bounty_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_bounty")
     assert "accepted awards" in bounty_tool["description"]
     bounty_schema = bounty_tool["inputSchema"]


### PR DESCRIPTION
Bounty #946

## Summary
- Advertise a conservative `outputSchema` for the MCP `submit_work_proof` structured guidance payload.
- Cover the stable fields agents already consume from `format: json`, including availability, submission requirements, next actions, and safety rules.
- Keep `additionalProperties: true` so the guidance contract remains additive while still making the core structured shape discoverable from `tools/list`.
- Update the agent guide to mention the structured guidance output schema.

## Validation
- `.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py::test_mcp_tools_list_and_call tests\test_api_mcp.py::test_mcp_submit_work_proof_returns_structured_bounty_guidance tests\test_api_mcp.py::test_mcp_submit_work_proof_returns_structured_generic_guidance -q` -> 3 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py -q` -> 122 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\ruff.exe check app\mcp.py tests\test_api_mcp.py docs\agent-guide.md` -> All checks passed
- `.venv\Scripts\ruff.exe format --check app\mcp.py tests\test_api_mcp.py` -> 2 files already formatted
- `.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean, Windows CRLF warning for docs only

## Scope
MCP `tools/list` metadata, focused MCP tests, and concise agent docs only. No runtime submission behavior, ledger mutation, wallet behavior, treasury/proposal execution, payout execution, private data, credentials, bridge/exchange/cash-out behavior, or MRWK price behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced work-proof submission to return richer, structured response details for end-user flows

* **Documentation**
  * Clarified guidance on advertised tool output schemas and structured guidance formats

* **Tests**
  * Added stronger validation tests to verify the work-proof response structure and required fields
<!-- end of auto-generated comment: release notes by coderabbit.ai -->