### PR TITLE
Advertise MCP bounty output schemas

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -14,6 +14,87 @@ MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any] | MCP
 MCP_PROTOCOL_VERSION = "2025-06-18"
 MCP_SERVER_INFO = {"name": "mergework", "version": "0.1.0"}
 
+
+MCP_BOUNTY_SUMMARY_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "id": {"type": "integer", "minimum": 1},
+        "repo": {"type": "string"},
+        "issue_number": {"type": "integer", "minimum": 1},
+        "issue_url": {"type": "string"},
+        "title": {"type": "string"},
+        "reward_mrwk": {"type": "string"},
+        "status": {"type": "string"},
+        "acceptance": {"type": "string"},
+        "created_at": {"type": "string"},
+        "award_mode": {"type": "string"},
+        "max_awards": {"type": "integer", "minimum": 1},
+        "awards_paid": {"type": "integer", "minimum": 0},
+        "awards_remaining": {"type": "integer", "minimum": 0},
+        "accepted_awards_count": {"type": "integer", "minimum": 0},
+        "effective_awards_remaining": {"type": "integer", "minimum": 0},
+        "submission_requirements": {"type": "object"},
+    },
+    "required": [
+        "id",
+        "repo",
+        "issue_number",
+        "issue_url",
+        "title",
+        "reward_mrwk",
+        "status",
+        "acceptance",
+        "created_at",
+        "award_mode",
+        "max_awards",
+        "accepted_awards_count",
+        "effective_awards_remaining",
+    ],
+    "additionalProperties": True,
+}
+
+MCP_BOUNTY_ATTEMPT_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "id": {"type": "integer", "minimum": 1},
+        "bounty_id": {"type": "integer", "minimum": 1},
+        "repo": {"type": "string"},
+        "issue_number": {"type": "integer", "minimum": 1},
+        "issue_url": {"type": "string"},
+        "claimant": {"type": "string"},
+        "comment_url": {"type": "string"},
+        "expires_at": {"type": "string"},
+        "created_at": {"type": "string"},
+        "expired": {"type": "boolean"},
+    },
+    "required": [
+        "id",
+        "bounty_id",
+        "repo",
+        "issue_number",
+        "issue_url",
+        "claimant",
+        "comment_url",
+        "expires_at",
+        "created_at",
+        "expired",
+    ],
+    "additionalProperties": False,
+}
+
+MCP_BOUNTY_ATTEMPTS_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "bounty_id": {"type": "integer", "minimum": 1},
+        "issue_number": {"type": "integer", "minimum": 1},
+        "status": {"type": "string"},
+        "warnings": {"type": "array", "items": {"type": "string"}},
+        "attempts": {"type": "array", "items": MCP_BOUNTY_ATTEMPT_OUTPUT_SCHEMA},
+    },
+    "required": ["bounty_id", "issue_number", "status", "warnings", "attempts"],
+    "additionalProperties": False,
+}
+
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
@@ -55,6 +136,10 @@ MCP_TOOLS: list[dict[str, Any]] = [
                 },
             },
             "additionalProperties": False,
+        },
+        "outputSchema": {
+            "type": "array",
+            "items": MCP_BOUNTY_SUMMARY_OUTPUT_SCHEMA,
         },
     },
     {
@@ -100,6 +185,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "dependentRequired": {"repo": ["issue_number"]},
             "additionalProperties": False,
         },
+        "outputSchema": MCP_BOUNTY_SUMMARY_OUTPUT_SCHEMA,
     },
     {
         "name": "list_bounty_attempts",
@@ -151,6 +237,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "dependentRequired": {"repo": ["issue_number"]},
             "additionalProperties": False,
         },
+        "outputSchema": MCP_BOUNTY_ATTEMPTS_OUTPUT_SCHEMA,
     },
     {
         "name": "get_balance",

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -313,6 +313,23 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert list_bounties_schema["additionalProperties"] is False
     assert list_bounties_schema["properties"]["q"]["maxLength"] == 500
     assert list_bounties_schema["properties"]["limit"]["maximum"] == 100
+    list_bounties_output_schema = tools["result"]["tools"][0]["outputSchema"]
+    assert list_bounties_output_schema["type"] == "array"
+    assert list_bounties_output_schema["items"]["required"] == [
+        "id",
+        "repo",
+        "issue_number",
+        "issue_url",
+        "title",
+        "reward_mrwk",
+        "status",
+        "acceptance",
+        "created_at",
+        "award_mode",
+        "max_awards",
+        "accepted_awards_count",
+        "effective_awards_remaining",
+    ]
     submit_tool = next(
         tool for tool in tools["result"]["tools"] if tool["name"] == "submit_work_proof"
     )
@@ -350,6 +367,9 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
         {"required": ["issue_number"]},
     ]
     assert bounty_schema["dependentRequired"] == {"repo": ["issue_number"]}
+    bounty_output_schema = bounty_tool["outputSchema"]
+    assert bounty_output_schema["properties"]["effective_awards_remaining"]["minimum"] == 0
+    assert bounty_output_schema["properties"]["submission_requirements"]["type"] == "object"
     attempt_tool = next(
         tool for tool in tools["result"]["tools"] if tool["name"] == "list_bounty_attempts"
     )
@@ -370,6 +390,17 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
         {"required": ["issue_number"]},
     ]
     assert attempt_schema["dependentRequired"] == {"repo": ["issue_number"]}
+    attempt_output_schema = attempt_tool["outputSchema"]
+    assert attempt_output_schema["required"] == [
+        "bounty_id",
+        "issue_number",
+        "status",
+        "warnings",
+        "attempts",
+    ]
+    assert attempt_output_schema["properties"]["attempts"]["items"]["properties"]["expired"] == {
+        "type": "boolean"
+    }
     wallet_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_wallet")
     wallet_schema = wallet_tool["inputSchema"]
     assert wallet_schema["required"] == ["address"]


### PR DESCRIPTION
## Summary
- Advertises `outputSchema` metadata for MCP bounty discovery tools: `list_bounties`, `get_bounty`, and `list_bounty_attempts`.
- Reuses schema constants so `tools/list` exposes predictable structured result shapes for agent clients.
- Adds regression coverage for the advertised output schemas in the MCP tools/list test.

## Verification
- `python3 -m py_compile app/mcp.py tests/test_api_mcp.py`
- `uv run --extra dev ruff check app/mcp.py tests/test_api_mcp.py`
- `uv run --extra dev pytest tests/test_mcp_tools.py tests/test_mcp_work_proof.py tests/test_api_mcp.py::test_mcp_tools_list_and_call -q` (18 passed, 1 existing StarletteDeprecationWarning)
- `git diff --check`
- Added-line security scan: 0 findings
- Independent reviewer: passed; no security concerns or logic errors

Bounty #946

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated bounty-related output schema definitions for improved consistency across API tools

* **Tests**
  * Enhanced validation checks for bounty and attempt API contract specifications, including awards, submission requirements, and status fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->