### PR TITLE
Refactor submission quality API JSON loading

### DIFF
--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -565,13 +565,17 @@ def _load_issue_maintainer_activity(repo: str, issue_number: int) -> dict[str, A
     }
 
 
-def _load_api_bounties(repo: str, api_host: str) -> dict[int, dict[str, Any]]:
-    url = f"{api_host.rstrip('/')}/api/v1/bounties?status=open"
+def _load_json_url(url: str, *, description: str) -> Any:
     try:
         with urlopen(url, timeout=GH_TIMEOUT_SECONDS) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-    except (OSError, URLError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f"MergeWork API bounty data unavailable: {exc}") from exc
+            return json.loads(response.read().decode("utf-8"))
+    except (HTTPError, OSError, URLError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"{description} unavailable: {exc}") from exc
+
+
+def _load_api_bounties(repo: str, api_host: str) -> dict[int, dict[str, Any]]:
+    url = f"{api_host.rstrip('/')}/api/v1/bounties?status=open"
+    payload = _load_json_url(url, description="MergeWork API bounty data")
     if not isinstance(payload, list):
         raise RuntimeError("MergeWork API bounty data must be a list")
     bounties: dict[int, dict[str, Any]] = {}
@@ -606,11 +610,7 @@ def _load_api_attempts(api_host: str, bounty_id: Any) -> list[dict[str, Any]]:
     if not isinstance(bounty_id, int):
         raise RuntimeError("MergeWork API bounty id unavailable for attempts lookup")
     url = f"{api_host.rstrip('/')}/api/v1/bounties/{bounty_id}/attempts"
-    try:
-        with urlopen(url, timeout=GH_TIMEOUT_SECONDS) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-    except (HTTPError, OSError, URLError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f"MergeWork API attempts data unavailable: {exc}") from exc
+    payload = _load_json_url(url, description="MergeWork API attempts data")
     attempts = payload.get("attempts") if isinstance(payload, dict) else payload
     if not isinstance(attempts, list):
         raise RuntimeError("MergeWork API attempts data must be a list")

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -784,6 +784,43 @@ def test_submission_quality_gate_live_mode_warns_when_github_unavailable(
     assert "load_warning" in output
 
 
+class _JsonResponse:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> _JsonResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_submission_quality_gate_load_json_url_decodes_response(monkeypatch) -> None:
+    def fake_urlopen(url: str, *, timeout: int) -> _JsonResponse:
+        assert url == "https://api.example.test/data"
+        assert timeout == submission_quality_gate.GH_TIMEOUT_SECONDS
+        return _JsonResponse({"ok": True})
+
+    monkeypatch.setattr(submission_quality_gate, "urlopen", fake_urlopen)
+
+    assert submission_quality_gate._load_json_url(
+        "https://api.example.test/data", description="test data"
+    ) == {"ok": True}
+
+
+def test_submission_quality_gate_attempts_loader_keeps_contextual_error(monkeypatch) -> None:
+    def fake_urlopen(url: str, *, timeout: int) -> _JsonResponse:
+        return _JsonResponse({"attempts": "not-a-list"})
+
+    monkeypatch.setattr(submission_quality_gate, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError, match="MergeWork API attempts data must be a list"):
+        submission_quality_gate._load_api_attempts("https://api.example.test", 42)
+
+
 def test_submission_quality_gate_warns_when_live_collections_hit_safety_caps(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Refactors `scripts/submission_quality_gate.py` to share HTTP JSON response loading between live bounty and attempts API calls.
- Keeps the existing contextual RuntimeError messages and payload-shape validation at each caller.
- Adds focused tests for the shared loader and attempts payload validation path.

Refs #936

## Verification
- `./.venv/bin/python -m pytest tests/test_submission_quality_gate.py -q` -> `49 passed in 0.28s`
- `./.venv/bin/python -m ruff format --check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` -> `2 files already formatted`
- `./.venv/bin/python -m ruff check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` -> `All checks passed!`
- `git diff --check` -> passed

## Bounty #936
This is a small maintainability cleanup for the submission quality gate. Behavior is preserved while duplicated URL-open/read/decode/JSON error handling is centralized in one helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate API data loading logic with unified timeout and error handling.

* **Tests**
  * Added tests for JSON loading functionality and API error scenarios with enhanced messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->