### PR TITLE
Advertise MCP balance output schema

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -170,6 +170,27 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "required": ["account"],
             "additionalProperties": False,
         },
+        "outputSchema": {
+            "type": "object",
+            "properties": {
+                "account": {
+                    "type": "string",
+                    "description": "Normalized ledger account selector.",
+                },
+                "balance_mrwk": {
+                    "type": "string",
+                    "pattern": r"^\d+(?:\.\d{1,6})?$",
+                    "description": "Decimal MRWK balance with at most six decimal places.",
+                },
+                "balance_microunits": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Raw MRWK microunit balance.",
+                },
+            },
+            "required": ["account", "balance_mrwk", "balance_microunits"],
+            "additionalProperties": False,
+        },
     },
     {
         "name": "register_wallet",

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -307,7 +307,8 @@ Tools:
 - `list_bounties`
 - `get_bounty`
 - `list_bounty_attempts`
-- `get_balance`
+- `get_balance` (returns structured `account`, `balance_mrwk`, and `balance_microunits`;
+  `tools/list` advertises the matching `outputSchema`)
 - `register_wallet`
 - `get_wallet`
 - `submit_wallet_transfer`

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -383,6 +383,17 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert balance_schema["additionalProperties"] is False
     assert balance_schema["properties"]["account"]["minLength"] == 1
     assert "github:<login>" in balance_schema["properties"]["account"]["description"]
+    balance_output_schema = balance_tool["outputSchema"]
+    assert balance_output_schema["additionalProperties"] is False
+    assert balance_output_schema["required"] == [
+        "account",
+        "balance_mrwk",
+        "balance_microunits",
+    ]
+    assert balance_output_schema["properties"]["balance_mrwk"]["pattern"] == (
+        r"^\d+(?:\.\d{1,6})?$"
+    )
+    assert balance_output_schema["properties"]["balance_microunits"]["minimum"] == 0
     ledger_tool = next(
         tool for tool in tools["result"]["tools"] if tool["name"] == "get_ledger_entry"
     )
@@ -412,6 +423,7 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
         "balance_mrwk": "100000000",
         "balance_microunits": GENESIS_SUPPLY_MICRO,
     }
+    assert set(balance["result"]["structuredContent"]) == set(balance_output_schema["required"])
 
 
 def test_mcp_initialize_returns_server_capabilities(sqlite_url: str) -> None:


### PR DESCRIPTION
﻿Bounty #946

## Summary
- Adds an MCP `outputSchema` for `get_balance`, matching the structured balance payload already returned at runtime.
- Captures the normalized `account`, formatted `balance_mrwk`, and raw `balance_microunits` fields for schema-aware agents.
- Updates the agent guide so clients know to rely on the advertised output schema instead of parsing the legacy text line.

## Before / after
- Before: `get_balance` returned `structuredContent`, but `tools/list` only advertised the input shape.
- After: `tools/list` advertises the exact structured output contract while preserving the existing text and structured runtime response.

## Validation
- `.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py::test_mcp_tools_list_and_call -q` -> 1 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py tests\test_mcp_tools.py -q` -> 131 passed, 1 existing Starlette/httpx warning
- `.venv\Scripts\ruff.exe check app\mcp.py tests\test_api_mcp.py docs\agent-guide.md` -> All checks passed
- `.venv\Scripts\ruff.exe format --check app\mcp.py tests\test_api_mcp.py` -> 2 files already formatted
- `.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean, Windows CRLF warning only for docs

Scope: MCP `get_balance` tool metadata, focused tests, and agent docs only. No ledger mutation, wallet custody, payout execution, treasury behavior, admin-token behavior, bridge/exchange/cash-out behavior, MRWK price behavior, private data, or secrets changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the agent guide with detailed specifications for the `get_balance` tool, explicitly documenting all response fields, including account identifiers and balance values, along with their validation constraints.

* **Tests**
  * Enhanced the test suite for the `get_balance` tool to comprehensively validate the output schema structure, required field definitions, and response data format constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->