### PR TITLE
refactor: share script HTTP URL validation

### DIFF
--- a/scripts/api_host_args.py
+++ b/scripts/api_host_args.py
@@ -4,11 +4,20 @@ import argparse
 import urllib.parse
 
 
-def public_api_host(value: str) -> str:
+def public_http_url(value: str, *, label: str = "URL", forbid_credentials: bool = False) -> str:
     clean = value.strip()
     if not clean:
-        raise argparse.ArgumentTypeError("api host must be a non-empty HTTP(S) URL")
+        raise ValueError(f"{label} must be a non-empty HTTP(S) URL")
     parsed = urllib.parse.urlparse(clean)
+    if forbid_credentials and (parsed.username or parsed.password):
+        raise ValueError(f"{label} must not include username or password")
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        raise argparse.ArgumentTypeError("api host must be an absolute HTTP(S) URL")
+        raise ValueError(f"{label} must be an absolute HTTP(S) URL")
     return clean
+
+
+def public_api_host(value: str) -> str:
+    try:
+        return public_http_url(value, label="api host")
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from None

--- a/scripts/staging_webhook_dry_run.py
+++ b/scripts/staging_webhook_dry_run.py
@@ -12,6 +12,8 @@ from urllib.parse import urlparse
 
 import httpx
 
+from scripts.api_host_args import public_http_url
+
 _REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
 
 
@@ -58,11 +60,10 @@ def _parse_object_response(url: str, response: httpx.Response) -> dict[str, obje
 
 
 def _validate_http_url(url: str) -> None:
-    parsed = urlparse(url)
-    if parsed.username or parsed.password:
-        raise RuntimeError("staging dry-run URL must not include username or password")
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        raise RuntimeError(f"{url} must use http or https")
+    try:
+        public_http_url(url, label="staging dry-run URL", forbid_credentials=True)
+    except ValueError as exc:
+        raise RuntimeError(str(exc)) from None
 
 
 def _dry_run_repo() -> str:
@@ -82,6 +83,7 @@ def _dry_run_contributor() -> str:
 
 
 def _enforce_staging_target(base_url: str) -> None:
+    _validate_http_url(base_url)
     parsed = urlparse(base_url)
     host = parsed.hostname or ""
     try:

--- a/tests/test_api_host_args.py
+++ b/tests/test_api_host_args.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from scripts.api_host_args import public_api_host, public_http_url
+
+
+def test_public_http_url_rejects_blank_and_relative_values() -> None:
+    with pytest.raises(ValueError, match=r"service URL must be a non-empty HTTP\(S\) URL"):
+        public_http_url("   ", label="service URL")
+    with pytest.raises(ValueError, match=r"service URL must be an absolute HTTP\(S\) URL"):
+        public_http_url("/api/v1/bounties", label="service URL")
+
+
+def test_public_http_url_can_reject_embedded_credentials() -> None:
+    with pytest.raises(ValueError, match="service URL must not include username or password"):
+        public_http_url(
+            "https://operator:secret@staging.mrwk.example.test",
+            label="service URL",
+            forbid_credentials=True,
+        )
+
+    assert public_http_url("https://staging.mrwk.example.test", label="service URL") == (
+        "https://staging.mrwk.example.test"
+    )
+
+
+def test_public_api_host_preserves_argparse_error_type() -> None:
+    with pytest.raises(argparse.ArgumentTypeError, match="api host must be an absolute"):
+        public_api_host("localhost:8000")


### PR DESCRIPTION
## Summary
- Adds a shared `public_http_url` helper for scripts that need HTTP(S) URL validation.
- Keeps `public_api_host` argparse behavior while reusing the shared validation path.
- Reuses the helper in `staging_webhook_dry_run` so staging URLs and request URLs reject malformed values consistently.

Bounty #936

## Verification
- `uv run --extra dev python -m pytest tests/test_api_host_args.py tests/test_staging_webhook_dry_run.py -q` — 17 passed
- `uv run --extra dev python -m ruff format --check scripts/api_host_args.py scripts/staging_webhook_dry_run.py tests/test_api_host_args.py tests/test_staging_webhook_dry_run.py`
- `uv run --extra dev python -m ruff check scripts/api_host_args.py scripts/staging_webhook_dry_run.py tests/test_api_host_args.py tests/test_staging_webhook_dry_run.py`
- `git diff --check`

Bounty #936


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced URL and host validation with improved reusable validation logic.

* **Tests**
  * Added comprehensive test coverage for URL and host argument parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->