### PR TITLE
Fix docs smoke percent-encoded local links

### DIFF
--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from urllib.parse import unquote
 
 ROOT = Path(__file__).resolve().parents[1]
 REQUIRED = [
@@ -184,11 +185,11 @@ def _local_target_exists(source: Path, target: str) -> bool:
     clean, separator, fragment = target.partition("#")
     if clean.startswith(("http://", "https://", "mailto:")):
         return True
-    target_path = (source.parent / clean).resolve() if clean else source.resolve()
+    target_path = (source.parent / unquote(clean)).resolve() if clean else source.resolve()
     if not target_path.exists():
         return False
     if separator and fragment and target_path.suffix.lower() in {".md", ".markdown"}:
-        return fragment in _markdown_anchors(target_path)
+        return unquote(fragment) in _markdown_anchors(target_path)
     return True
 
 

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -225,6 +225,19 @@ def test_docs_smoke_validates_duplicate_markdown_heading_anchors(tmp_path: Path)
     assert _local_target_exists(source, "docs.md#current-transfer-paths-2") is False
 
 
+def test_docs_smoke_decodes_percent_encoded_local_links(tmp_path: Path) -> None:
+    source = tmp_path / "README.md"
+    target = tmp_path / "docs path.md"
+    source.write_text(
+        "[Docs](docs%20path.md#caf%C3%A9-examples)\n",
+        encoding="utf-8",
+    )
+    target.write_text("## Café Examples\n\nDetails.\n", encoding="utf-8")
+
+    assert _local_target_exists(source, "docs%20path.md#caf%C3%A9-examples") is True
+    assert _local_target_exists(source, "docs%20path.md#caf%C3%A9-missing") is False
+
+
 def test_markdown_anchors_ignore_fenced_code_headings(tmp_path: Path) -> None:
     target = tmp_path / "docs.md"
     target.write_text(


### PR DESCRIPTION
## Summary
- Decode percent-encoded local Markdown link paths before checking target files
- Decode percent-encoded Markdown fragments before matching generated anchors
- Add regression coverage for encoded spaces in paths and Unicode anchors

Bounty #936

## Verification
- `uv run --extra dev pytest tests/test_docs_public_urls.py -q` — 42 passed
- `uv run --extra dev python scripts/docs_smoke.py` — docs smoke ok
- `uv run --extra dev ruff check scripts/docs_smoke.py tests/test_docs_public_urls.py` — All checks passed
- `git diff --check` — passed
- Added-line security scan — security_findings_count 0
- Independent reviewer — passed; no security or logic blockers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed documentation validation to correctly resolve URL-encoded characters in local markdown links and anchor references.

* **Tests**
  * Added test coverage for handling percent-encoded characters in local markdown links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->