### PR TITLE
Advertise register wallet MCP schema

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -174,6 +174,49 @@ MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "register_wallet",
         "description": "Register an MRWK wallet public key",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "public_key_hex": {
+                    "type": "string",
+                    "pattern": "^[0-9a-fA-F]{64}$",
+                    "description": "Ed25519 public key as 32 bytes of hex.",
+                },
+                "label": {
+                    "type": "string",
+                    "description": "Optional human-readable wallet label.",
+                },
+            },
+            "required": ["public_key_hex"],
+            "additionalProperties": False,
+        },
+        "outputSchema": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string",
+                    "pattern": "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$",
+                },
+                "public_key_hex": {"type": "string", "pattern": "^[0-9a-fA-F]{64}$"},
+                "label": {"type": ["string", "null"]},
+                "github_login": {"type": ["string", "null"]},
+                "balance_mrwk": {"type": "string"},
+                "nonce": {"type": "integer", "minimum": 0},
+                "next_nonce": {"type": "integer", "minimum": 1},
+                "created_at": {"type": "string"},
+            },
+            "required": [
+                "address",
+                "public_key_hex",
+                "label",
+                "github_login",
+                "balance_mrwk",
+                "nonce",
+                "next_nonce",
+                "created_at",
+            ],
+            "additionalProperties": True,
+        },
     },
     {
         "name": "get_wallet",

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -308,7 +308,8 @@ Tools:
 - `get_bounty`
 - `list_bounty_attempts`
 - `get_balance`
-- `register_wallet`
+- `register_wallet` (`tools/list` advertises the public-key input schema and the
+  registered wallet output schema)
 - `get_wallet`
 - `submit_wallet_transfer`
 - `get_ledger_entry`

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -2865,6 +2865,14 @@ def test_mcp_can_register_and_fetch_wallet(sqlite_url: str) -> None:
     assert registered["result"]["structuredContent"] == registered_wallet
     assert registered_wallet["address"].startswith("mrwk1")
 
+    register_tool = next(
+        tool for tool in tools["result"]["tools"] if tool["name"] == "register_wallet"
+    )
+    assert register_tool["inputSchema"]["required"] == ["public_key_hex"]
+    assert register_tool["inputSchema"]["additionalProperties"] is False
+    assert set(register_tool["outputSchema"]["required"]) == set(registered_wallet)
+    assert set(register_tool["outputSchema"]["properties"]) == set(registered_wallet)
+
     fetched = client.post(
         "/mcp",
         json={


### PR DESCRIPTION
Bounty #946

## Summary
- Adds MCP `inputSchema` metadata for `register_wallet`, including the required Ed25519 `public_key_hex` argument and optional `label`.
- Adds an MCP `outputSchema` for the registered wallet payload already returned in `result.structuredContent`.
- Adds focused regression coverage that the advertised output schema fields match the actual registered wallet structured payload.
- Updates the agent guide so MCP clients know `register_wallet` can be driven from `tools/list` metadata instead of natural-language parsing.

## Scope / duplicate check
This is focused on the `register_wallet` schema contract. I reviewed open #946 PRs and comments; recent open work covers `list_bounty_attempts`, `get_bounty`, `list_bounties`, `get_wallet`, `get_balance`, `submit_work_proof`, proof, and ledger output schemas, but I did not find an open PR covering the `register_wallet` input/output schema.

## MCP tools touched
- `register_wallet`

## Compatibility
Runtime wallet registration behavior is unchanged. The PR only advertises schema metadata, adds tests, and updates concise agent docs.

## Verification
- `uv run --extra dev pytest tests/test_api_mcp.py::test_mcp_can_register_and_fetch_wallet -q` -> 1 passed, 1 existing Starlette/httpx warning
- `uv run --extra dev pytest tests/test_api_mcp.py::test_mcp_tools_list_and_call tests/test_api_mcp.py::test_mcp_can_register_and_fetch_wallet -q` -> 2 passed, 1 existing Starlette/httpx warning
- `uv run --extra dev ruff check app/mcp.py tests/test_api_mcp.py docs/agent-guide.md` -> All checks passed
- `uv run --extra dev ruff format --check app/mcp.py tests/test_api_mcp.py` -> 2 files already formatted
- `uv run --extra dev python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean
- Added-line security scan -> `security_findings_count 0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancement**
  * Wallet registration tool now features enhanced input validation and explicit output schema definitions, ensuring consistent response structure and data validation
  * Input validation now requires properly formatted identification with optional metadata
  * Output explicitly specifies all wallet details including account information and ledger metadata

* **Documentation**
  * Updated tool documentation to clarify wallet registration specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->