### PR TITLE
Publish bounty summary OpenAPI response schema

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -26,6 +26,7 @@ from app.ledger.service import (
     validate_public_url,
 )
 from app.models import Bounty, Proof, Submission
+from app.openapi_request_bodies import BOUNTY_SUMMARY_RESPONSE
 from app.path_params import SQLITE_INTEGER_MAX, issue_number_search_value, positive_bounty_id
 from app.query_validation import (
     reject_control_char_query_param,
@@ -240,7 +241,7 @@ def register_bounty_api_routes(
             availability=availability,
         )
 
-    @app.get("/api/v1/bounties/summary")
+    @app.get("/api/v1/bounties/summary", openapi_extra=BOUNTY_SUMMARY_RESPONSE)
     def api_bounties_summary(
         request: Request,
         status: str | None = Query(None),

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -189,6 +189,36 @@ ATTEMPT_RELEASE_RESPONSE_SCHEMA = _object_schema(
     }
 )
 
+BOUNTY_SUMMARY_RESPONSE_SCHEMA = _object_schema(
+    {
+        "bounties_shown": {"type": "integer", "minimum": 0},
+        "open_awards": {"type": "integer", "minimum": 0},
+        "open_pool_mrwk": MRWK_DECIMAL_SCHEMA,
+        "effective_open_awards": {"type": "integer", "minimum": 0},
+        "effective_open_pool_mrwk": MRWK_DECIMAL_SCHEMA,
+        "availability_state_counts": {
+            "type": "object",
+            "additionalProperties": {"type": "integer", "minimum": 0},
+            "description": "Counts keyed by public bounty availability state.",
+        },
+        "pending_payout_awards": {"type": "integer", "minimum": 0},
+        "reduced_capacity_bounties": {"type": "integer", "minimum": 0},
+        "effectively_unavailable_bounties": {"type": "integer", "minimum": 0},
+    },
+    required=[
+        "bounties_shown",
+        "open_awards",
+        "open_pool_mrwk",
+        "effective_open_awards",
+        "effective_open_pool_mrwk",
+        "availability_state_counts",
+        "pending_payout_awards",
+        "reduced_capacity_bounties",
+        "effectively_unavailable_bounties",
+    ],
+    description="Aggregated public bounty capacity and availability counters.",
+)
+
 TREASURY_CHALLENGE_RESPONSE_SCHEMA = _object_schema(
     {
         "id": {"type": "integer", "minimum": 1},
@@ -276,6 +306,12 @@ OPTIONAL_ATTEMPT_RELEASE_BODY = {
     ),
     "responses": {
         "200": _json_response(ATTEMPT_RELEASE_RESPONSE_SCHEMA),
+    },
+}
+
+BOUNTY_SUMMARY_RESPONSE = {
+    "responses": {
+        "200": _json_response(BOUNTY_SUMMARY_RESPONSE_SCHEMA),
     },
 }
 

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -23,6 +23,12 @@ def _post_response_schema(openapi: dict, path: str, status: str = "200") -> dict
     ]
 
 
+def _get_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
+    return openapi["paths"][path]["get"]["responses"][status]["content"]["application/json"][
+        "schema"
+    ]
+
+
 def _assert_properties(schema: dict, expected: Iterable[str]) -> None:
     assert set(expected).issubset(schema["properties"])
 
@@ -328,6 +334,50 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
             "created_at",
         },
     )
+
+
+def test_bounty_summary_openapi_response_schema_matches_runtime_fields(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    schema = _get_response_schema(openapi, "/api/v1/bounties/summary")
+    expected_fields = {
+        "bounties_shown",
+        "open_awards",
+        "open_pool_mrwk",
+        "effective_open_awards",
+        "effective_open_pool_mrwk",
+        "availability_state_counts",
+        "pending_payout_awards",
+        "reduced_capacity_bounties",
+        "effectively_unavailable_bounties",
+    }
+
+    assert schema["type"] == "object"
+    assert set(schema["required"]) == expected_fields
+    _assert_properties(schema, expected_fields)
+
+    props = schema["properties"]
+    for field in (
+        "bounties_shown",
+        "open_awards",
+        "effective_open_awards",
+        "pending_payout_awards",
+        "reduced_capacity_bounties",
+        "effectively_unavailable_bounties",
+    ):
+        assert props[field] == {"type": "integer", "minimum": 0}
+    assert props["open_pool_mrwk"]["pattern"] == r"^\d+(?:\.\d{1,6})?$"
+    assert props["effective_open_pool_mrwk"]["pattern"] == r"^\d+(?:\.\d{1,6})?$"
+    assert props["availability_state_counts"]["additionalProperties"] == {
+        "type": "integer",
+        "minimum": 0,
+    }
+
+    runtime_summary = client.get("/api/v1/bounties/summary").json()
+    assert set(runtime_summary) == expected_fields
 
 
 def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #944
Refs #944

## Summary
- Publishes an explicit OpenAPI `200` response schema for `GET /api/v1/bounties/summary`.
- Documents the existing public summary fields clients use for bounty capacity and availability counts.
- Keeps runtime JSON behavior unchanged; this is OpenAPI/client contract metadata only.

## Contract surface
Affected route: `GET /api/v1/bounties/summary`

Published response fields:
- `bounties_shown`
- `open_awards`
- `open_pool_mrwk`
- `effective_open_awards`
- `effective_open_pool_mrwk`
- `availability_state_counts`
- `pending_payout_awards`
- `reduced_capacity_bounties`
- `effectively_unavailable_bounties`

The schema marks all current runtime keys as required, uses non-negative integers for counters, and reuses the existing MRWK decimal pattern for MRWK capacity totals.

## Verification
- `.\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py tests\test_bounty_api.py::TestBountyListRoutes::test_bounties_summary -q` -> 10 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\ruff.exe check app\openapi_request_bodies.py app\bounty_api.py tests\test_openapi_request_bodies.py` -> All checks passed.
- `.\.venv\Scripts\ruff.exe format --check app\openapi_request_bodies.py app\bounty_api.py tests\test_openapi_request_bodies.py` -> 3 files already formatted.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `7b9ebc2555a5fcba92fe90823f427e7b0047f4d4`.

## Scope boundaries
No runtime bounty listing, treasury, payout, ledger mutation, wallet custody, admin-token, bridge, exchange, off-ramp, cash-out, MRWK price, private data, or secret behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced OpenAPI documentation for the bounty summary API endpoint with complete schema definitions for response structure, including bounty capacity and availability counters.

* **Tests**
  * Added validation tests to ensure API documentation schema matches runtime responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->