### PR TITLE
feat(openapi): publish activity response schema

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -15,6 +15,130 @@ from app.query_validation import reject_control_char_query_param, reject_repeate
 from app.serializers import activity_to_dict
 
 
+def _nullable(schema: dict[str, Any]) -> dict[str, Any]:
+    return {"anyOf": [schema, {"type": "null"}]}
+
+
+ACTIVITY_RESPONSE_SCHEMA = {
+    "description": "Public activity feed with accepted and pending MRWK bounty work.",
+    "content": {
+        "application/json": {
+            "schema": {
+                "type": "object",
+                "required": [
+                    "totals",
+                    "pending_totals",
+                    "query",
+                    "contributors",
+                    "pending_payouts",
+                    "recent",
+                ],
+                "properties": {
+                    "totals": {
+                        "type": "object",
+                        "required": ["accepted_awards", "accepted_mrwk", "contributors"],
+                        "properties": {
+                            "accepted_awards": {"type": "integer", "minimum": 0},
+                            "accepted_mrwk": {"type": "string"},
+                            "contributors": {"type": "integer", "minimum": 0},
+                        },
+                    },
+                    "pending_totals": {
+                        "type": "object",
+                        "required": ["pending_awards", "pending_mrwk"],
+                        "properties": {
+                            "pending_awards": {"type": "integer", "minimum": 0},
+                            "pending_mrwk": {"type": "string"},
+                        },
+                    },
+                    "query": {"type": "string"},
+                    "account": _nullable({"type": "string"}),
+                    "contributors": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["account", "accepted_awards", "accepted_mrwk"],
+                            "properties": {
+                                "account": _nullable({"type": "string"}),
+                                "accepted_awards": {"type": "integer", "minimum": 0},
+                                "accepted_mrwk": {"type": "string"},
+                                "latest_submission_url": _nullable({"type": "string"}),
+                                "latest_bounty_repo": _nullable({"type": "string"}),
+                                "latest_bounty_issue_number": _nullable({"type": "integer"}),
+                                "latest_bounty_issue_url": _nullable({"type": "string"}),
+                                "latest_proof_hash": _nullable({"type": "string"}),
+                                "latest_proof_url": _nullable({"type": "string"}),
+                            },
+                        },
+                    },
+                    "pending_payouts": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "proposal_id",
+                                "proposal_url",
+                                "status",
+                                "account",
+                                "bounty_id",
+                                "bounty_url",
+                            ],
+                            "properties": {
+                                "proposal_id": {"type": "integer"},
+                                "proposal_url": {"type": "string"},
+                                "status": {"type": "string"},
+                                "account": _nullable({"type": "string"}),
+                                "amount_mrwk": _nullable({"type": "string"}),
+                                "submission_url": _nullable({"type": "string"}),
+                                "bounty_repo": _nullable({"type": "string"}),
+                                "bounty_issue_number": _nullable({"type": "integer"}),
+                                "bounty_issue_url": _nullable({"type": "string"}),
+                                "bounty_id": _nullable({"type": "integer"}),
+                                "bounty_url": _nullable({"type": "string"}),
+                                "accepted_by": _nullable({"type": "string"}),
+                                "proposed_at": {"type": "string"},
+                                "executes_after": {"type": "string"},
+                            },
+                        },
+                    },
+                    "recent": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "ledger_sequence",
+                                "account",
+                                "amount_mrwk",
+                                "submission_url",
+                                "proof_hash",
+                                "proof_url",
+                                "created_at",
+                            ],
+                            "properties": {
+                                "ledger_sequence": {"type": "integer"},
+                                "account": _nullable({"type": "string"}),
+                                "amount_mrwk": _nullable({"type": "string"}),
+                                "submission_url": _nullable({"type": "string"}),
+                                "bounty_repo": _nullable({"type": "string"}),
+                                "bounty_issue_number": _nullable({"type": "integer"}),
+                                "bounty_issue_url": _nullable({"type": "string"}),
+                                "proof_hash": {"type": "string"},
+                                "proof_url": {"type": "string"},
+                                "bounty_id": _nullable({"type": "integer"}),
+                                "bounty_url": _nullable({"type": "string"}),
+                                "created_at": {"type": "string"},
+                            },
+                        },
+                    },
+                    "api_activity_url": {"type": "string"},
+                    "clear_activity_url": {"type": "string"},
+                },
+            }
+        }
+    },
+}
+
+
 def activity_context(
     session: Session, query: str | None = None, account: str | None = None
 ) -> dict[str, Any]:
@@ -47,7 +171,7 @@ def _validate_activity_filter_params(request: Request) -> None:
 
 
 def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
-    @app.get("/api/v1/activity")
+    @app.get("/api/v1/activity", responses={200: ACTIVITY_RESPONSE_SCHEMA})
     def api_activity(
         request: Request,
         q: str | None = Query(None),

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -23,8 +23,19 @@ def _post_response_schema(openapi: dict, path: str, status: str = "200") -> dict
     ]
 
 
+def _get_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
+    return openapi["paths"][path]["get"]["responses"][status]["content"]["application/json"][
+        "schema"
+    ]
+
+
 def _assert_properties(schema: dict, expected: Iterable[str]) -> None:
     assert set(expected).issubset(schema["properties"])
+
+
+def _assert_nullable(schema: dict, expected_type: str) -> None:
+    assert {"type": expected_type} in schema["anyOf"]
+    assert {"type": "null"} in schema["anyOf"]
 
 
 def test_public_post_openapi_request_bodies_expose_expected_fields(sqlite_url: str) -> None:
@@ -328,6 +339,66 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
             "created_at",
         },
     )
+
+
+def test_public_get_openapi_activity_response_schema_exposes_feed_fields(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    activity_schema = _get_response_schema(openapi, "/api/v1/activity")
+    _assert_properties(
+        activity_schema,
+        {
+            "totals",
+            "pending_totals",
+            "query",
+            "contributors",
+            "pending_payouts",
+            "recent",
+            "account",
+            "api_activity_url",
+            "clear_activity_url",
+        },
+    )
+    assert set(activity_schema["required"]) == {
+        "totals",
+        "pending_totals",
+        "query",
+        "contributors",
+        "pending_payouts",
+        "recent",
+    }
+    _assert_properties(
+        activity_schema["properties"]["totals"],
+        {"accepted_awards", "accepted_mrwk", "contributors"},
+    )
+    _assert_properties(
+        activity_schema["properties"]["pending_totals"],
+        {"pending_awards", "pending_mrwk"},
+    )
+    _assert_properties(
+        activity_schema["properties"]["contributors"]["items"],
+        {"account", "accepted_awards", "accepted_mrwk", "latest_proof_url"},
+    )
+    contributor_props = activity_schema["properties"]["contributors"]["items"]["properties"]
+    _assert_nullable(contributor_props["latest_bounty_issue_number"], "integer")
+    _assert_nullable(contributor_props["latest_proof_url"], "string")
+    _assert_properties(
+        activity_schema["properties"]["pending_payouts"]["items"],
+        {"proposal_id", "proposal_url", "status", "account", "bounty_url"},
+    )
+    pending_props = activity_schema["properties"]["pending_payouts"]["items"]["properties"]
+    _assert_nullable(pending_props["account"], "string")
+    _assert_nullable(pending_props["bounty_id"], "integer")
+    _assert_properties(
+        activity_schema["properties"]["recent"]["items"],
+        {"ledger_sequence", "account", "amount_mrwk", "proof_hash", "created_at"},
+    )
+    recent_props = activity_schema["properties"]["recent"]["items"]["properties"]
+    _assert_nullable(recent_props["bounty_id"], "integer")
+    _assert_nullable(recent_props["bounty_url"], "string")
 
 
 def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- Publishes an explicit OpenAPI `200` response schema for `GET /api/v1/activity`.
- Documents accepted totals, pending payout rows, contributor summaries, and recent proof-backed activity fields.
- Keeps runtime activity serialization unchanged and adds regression coverage for the advertised schema, including nullable fields.

## Verification
- `uv run --extra dev pytest tests/test_openapi_request_bodies.py::test_public_get_openapi_activity_response_schema_exposes_feed_fields tests/test_activity_routes.py -q` (2 passed, 1 existing Starlette/httpx deprecation warning)
- `uv run --extra dev ruff check app/activity.py tests/test_openapi_request_bodies.py`
- `git diff --check`
- Added-line security scan: no real findings; only the existing test-style dummy `webhook_secret="secret"` string was flagged.
- Independent reviewer verdict: passed; no blocking security concerns or logic errors.

Bounty #944
Refs #944


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added formal OpenAPI schema documentation for the `/api/v1/activity` API endpoint, including complete response structure, field definitions, and nullable field specifications.

* **Tests**
  * Added validation tests for the activity API response schema to ensure accurate documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->