### PR TITLE
Publish account OpenAPI response schemas

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -14,6 +14,7 @@ from app.db import session_scope
 from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
 from app.ledger_views import account_ledger_transactions
 from app.models import Account
+from app.openapi_request_bodies import ACCOUNT_ACCEPTED_WORK_RESPONSE, ACCOUNT_RESPONSE
 from app.path_params import SQLITE_INTEGER_MAX, reject_path_whitespace_padding
 from app.query_validation import reject_repeated_query_param
 from app.serializers import (
@@ -188,7 +189,7 @@ def account_page_context(
 
 
 def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
-    @app.get("/api/v1/accounts/{account}")
+    @app.get("/api/v1/accounts/{account}", openapi_extra=ACCOUNT_RESPONSE)
     def api_account(request: Request, account: str) -> dict[str, Any]:
         reject_path_whitespace_padding(account, "account")
         if request.query_params.getlist("type") or request.query_params.getlist("tx_type"):
@@ -199,7 +200,10 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
         with session_scope(db_url) as session:
             return account_api_context(session, account)
 
-    @app.get("/api/v1/accounts/{account}/accepted-work")
+    @app.get(
+        "/api/v1/accounts/{account}/accepted-work",
+        openapi_extra=ACCOUNT_ACCEPTED_WORK_RESPONSE,
+    )
     def api_account_accepted_work(account: str) -> dict[str, Any]:
         reject_path_whitespace_padding(account, "account")
         with session_scope(db_url) as session:

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -220,6 +220,159 @@ TREASURY_PROPOSAL_RESPONSE_SCHEMA = _object_schema(
     }
 )
 
+ACCOUNT_ACCEPTED_SUMMARY_SCHEMA = _object_schema(
+    {
+        "accepted_awards": {"type": "integer", "minimum": 0},
+        "accepted_mrwk": MRWK_DECIMAL_SCHEMA,
+        "latest_ledger_sequence": {"type": "integer", "minimum": 1, "nullable": True},
+        "latest_submission_url": {"type": "string", "nullable": True},
+        "latest_proof_hash": {**LOWERCASE_HEX_64_SCHEMA, "nullable": True},
+        "latest_proof_url": {"type": "string", "nullable": True},
+        "latest_proof_public_url": {"type": "string", "nullable": True},
+    },
+    required=[
+        "accepted_awards",
+        "accepted_mrwk",
+        "latest_ledger_sequence",
+        "latest_submission_url",
+        "latest_proof_hash",
+        "latest_proof_url",
+        "latest_proof_public_url",
+    ],
+)
+
+ACCOUNT_PENDING_SUMMARY_SCHEMA = _object_schema(
+    {
+        "pending_awards": {"type": "integer", "minimum": 0},
+        "pending_mrwk": MRWK_DECIMAL_SCHEMA,
+        "next_executes_after": {"type": "string", "nullable": True},
+    },
+    required=["pending_awards", "pending_mrwk", "next_executes_after"],
+)
+
+ACCOUNT_PENDING_PAYOUT_SCHEMA = _object_schema(
+    {
+        "proposal_id": {"type": "integer", "minimum": 1},
+        "proposal_url": {"type": "string"},
+        "status": {"type": "string"},
+        "amount_mrwk": {**MRWK_DECIMAL_SCHEMA, "nullable": True},
+        "bounty_id": {"type": "integer", "minimum": 1, "nullable": True},
+        "bounty_url": {"type": "string", "nullable": True},
+        "repo": {"type": "string", "nullable": True},
+        "issue_number": {"type": "integer", "minimum": 1, "nullable": True},
+        "issue_url": {"type": "string", "nullable": True},
+        "submission_url": {"type": "string", "nullable": True},
+        "accepted_by": {"type": "string", "nullable": True},
+        "proposed_at": {"type": "string"},
+        "executes_after": {"type": "string"},
+    },
+    required=[
+        "proposal_id",
+        "proposal_url",
+        "status",
+        "amount_mrwk",
+        "bounty_id",
+        "bounty_url",
+        "repo",
+        "issue_number",
+        "issue_url",
+        "submission_url",
+        "accepted_by",
+        "proposed_at",
+        "executes_after",
+    ],
+)
+
+ACCOUNT_ACCEPTED_WORK_ROW_SCHEMA = _object_schema(
+    {
+        "ledger_sequence": {"type": "integer", "minimum": 1},
+        "ledger_url": {"type": "string"},
+        "ledger_public_url": {"type": "string", "nullable": True},
+        "proof_hash": LOWERCASE_HEX_64_SCHEMA,
+        "proof_url": {"type": "string"},
+        "proof_public_url": {"type": "string", "nullable": True},
+        "amount_mrwk": MRWK_DECIMAL_SCHEMA,
+        "submission_url": {"type": "string", "nullable": True},
+        "issue_url": {"type": "string", "nullable": True},
+        "repo": {"type": "string", "nullable": True},
+        "issue_number": {"type": "integer", "minimum": 1, "nullable": True},
+        "bounty_id": {"type": "integer", "minimum": 1, "nullable": True},
+        "bounty_url": {"type": "string", "nullable": True},
+        "bounty_public_url": {"type": "string", "nullable": True},
+        "accepted_by": {"type": "string", "nullable": True},
+        "created_at": {"type": "string"},
+    },
+    required=[
+        "ledger_sequence",
+        "ledger_url",
+        "ledger_public_url",
+        "proof_hash",
+        "proof_url",
+        "proof_public_url",
+        "amount_mrwk",
+        "submission_url",
+        "issue_url",
+        "repo",
+        "issue_number",
+        "bounty_id",
+        "bounty_url",
+        "bounty_public_url",
+        "accepted_by",
+        "created_at",
+    ],
+)
+
+ACCOUNT_RESPONSE_SCHEMA = _object_schema(
+    {
+        "account": {"type": "string"},
+        "ledger_address": {"type": "string"},
+        "github_login": {"type": "string", "nullable": True},
+        "exists": {"type": "boolean"},
+        "balance_mrwk": MRWK_DECIMAL_SCHEMA,
+        "transfer_status": {"type": "string"},
+        "accepted_work": ACCOUNT_ACCEPTED_SUMMARY_SCHEMA,
+        "pending_summary": ACCOUNT_PENDING_SUMMARY_SCHEMA,
+        "pending_payouts": {"type": "array", "items": ACCOUNT_PENDING_PAYOUT_SCHEMA},
+    },
+    required=[
+        "account",
+        "ledger_address",
+        "github_login",
+        "exists",
+        "balance_mrwk",
+        "transfer_status",
+        "accepted_work",
+        "pending_summary",
+        "pending_payouts",
+    ],
+)
+
+ACCOUNT_ACCEPTED_WORK_RESPONSE_SCHEMA = _object_schema(
+    {
+        "account": {"type": "string"},
+        "summary": ACCOUNT_ACCEPTED_SUMMARY_SCHEMA,
+        "accepted_work": {"type": "array", "items": ACCOUNT_ACCEPTED_WORK_ROW_SCHEMA},
+        "pending_summary": ACCOUNT_PENDING_SUMMARY_SCHEMA,
+        "pending_payouts": {"type": "array", "items": ACCOUNT_PENDING_PAYOUT_SCHEMA},
+    },
+    required=["account", "summary", "accepted_work", "pending_summary", "pending_payouts"],
+)
+
+ACCOUNT_RESPONSE = {
+    "responses": {
+        "200": _json_response(ACCOUNT_RESPONSE_SCHEMA, description="Account summary."),
+    },
+}
+
+ACCOUNT_ACCEPTED_WORK_RESPONSE = {
+    "responses": {
+        "200": _json_response(
+            ACCOUNT_ACCEPTED_WORK_RESPONSE_SCHEMA,
+            description="Account accepted-work and pending-payout summary.",
+        ),
+    },
+}
+
 OPTIONAL_ATTEMPT_BODY = {
     "requestBody": _request_body(
         _object_schema(

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -23,6 +23,12 @@ def _post_response_schema(openapi: dict, path: str, status: str = "200") -> dict
     ]
 
 
+def _get_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
+    return openapi["paths"][path]["get"]["responses"][status]["content"]["application/json"][
+        "schema"
+    ]
+
+
 def _assert_properties(schema: dict, expected: Iterable[str]) -> None:
     assert set(expected).issubset(schema["properties"])
 
@@ -328,6 +334,115 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
             "created_at",
         },
     )
+
+
+def test_public_get_account_openapi_response_schemas_expose_account_fields(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    account_schema = _get_response_schema(openapi, "/api/v1/accounts/{account}")
+    _assert_properties(
+        account_schema,
+        {
+            "account",
+            "ledger_address",
+            "github_login",
+            "exists",
+            "balance_mrwk",
+            "transfer_status",
+            "accepted_work",
+            "pending_summary",
+            "pending_payouts",
+        },
+    )
+    assert set(account_schema["required"]) == {
+        "account",
+        "ledger_address",
+        "github_login",
+        "exists",
+        "balance_mrwk",
+        "transfer_status",
+        "accepted_work",
+        "pending_summary",
+        "pending_payouts",
+    }
+    assert account_schema["properties"]["balance_mrwk"]["pattern"] == r"^\d+(?:\.\d{1,6})?$"
+    assert account_schema["properties"]["github_login"]["nullable"] is True
+
+    accepted_summary = account_schema["properties"]["accepted_work"]
+    _assert_properties(
+        accepted_summary,
+        {
+            "accepted_awards",
+            "accepted_mrwk",
+            "latest_ledger_sequence",
+            "latest_submission_url",
+            "latest_proof_hash",
+            "latest_proof_url",
+            "latest_proof_public_url",
+        },
+    )
+    assert accepted_summary["properties"]["latest_ledger_sequence"]["nullable"] is True
+    assert accepted_summary["properties"]["latest_proof_hash"]["nullable"] is True
+    assert accepted_summary["properties"]["latest_proof_hash"]["pattern"] == "^[0-9a-f]{64}$"
+
+    pending_summary = account_schema["properties"]["pending_summary"]
+    _assert_properties(pending_summary, {"pending_awards", "pending_mrwk", "next_executes_after"})
+    assert pending_summary["properties"]["next_executes_after"]["nullable"] is True
+
+    pending_payout = account_schema["properties"]["pending_payouts"]["items"]
+    _assert_properties(
+        pending_payout,
+        {
+            "proposal_id",
+            "proposal_url",
+            "status",
+            "amount_mrwk",
+            "bounty_id",
+            "bounty_url",
+            "repo",
+            "issue_number",
+            "issue_url",
+            "submission_url",
+            "accepted_by",
+            "proposed_at",
+            "executes_after",
+        },
+    )
+    assert pending_payout["properties"]["amount_mrwk"]["nullable"] is True
+    assert pending_payout["properties"]["bounty_id"]["nullable"] is True
+
+    accepted_work_schema = _get_response_schema(openapi, "/api/v1/accounts/{account}/accepted-work")
+    _assert_properties(
+        accepted_work_schema,
+        {"account", "summary", "accepted_work", "pending_summary", "pending_payouts"},
+    )
+    accepted_row = accepted_work_schema["properties"]["accepted_work"]["items"]
+    _assert_properties(
+        accepted_row,
+        {
+            "ledger_sequence",
+            "ledger_url",
+            "ledger_public_url",
+            "proof_hash",
+            "proof_url",
+            "proof_public_url",
+            "amount_mrwk",
+            "submission_url",
+            "issue_url",
+            "repo",
+            "issue_number",
+            "bounty_id",
+            "bounty_url",
+            "bounty_public_url",
+            "accepted_by",
+            "created_at",
+        },
+    )
+    assert accepted_row["properties"]["proof_hash"]["pattern"] == "^[0-9a-f]{64}$"
+    assert accepted_row["properties"]["ledger_public_url"]["nullable"] is True
 
 
 def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- Publishes explicit OpenAPI `200` response schemas for `GET /api/v1/accounts/{account}` and `GET /api/v1/accounts/{account}/accepted-work`.
- Documents the existing account summary, accepted-work summary, pending payout rows, and proof-backed accepted-work row fields used by clients and agents.
- Preserves existing runtime JSON behavior; this is OpenAPI/client contract metadata plus regression coverage only.

## Evidence
- The account API already returns stable account, balance, accepted-work, pending-summary, and pending-payout shapes from `account_api_context(...)` and `account_accepted_work_context(...)`.
- This PR wires those existing shapes into `/openapi.json` without changing serializers, ledger, wallet, payout, treasury, or page behavior.
- I checked open PRs for account/OpenAPI schema overlap before starting and did not find a current duplicate account response-schema PR.

## Test Evidence
- [x] `.\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py::test_public_get_account_openapi_response_schemas_expose_account_fields tests\test_account_routes.py::test_registered_account_routes_preserve_api_and_page_shapes tests\test_account_routes.py::test_account_routes_expose_pending_payouts_separately_from_paid_work -q` -> 3 passed, 1 existing Starlette/httpx warning.
- [x] `.\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py tests\test_account_routes.py tests\test_api_mcp.py::test_explorer_links_ledger_proof_and_account tests\test_api_mcp.py::test_account_api_keeps_schema_when_accepted_work_proof_is_malformed -q` -> 20 passed, 1 existing Starlette/httpx warning.
- [x] `.\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py -q` -> 9 passed, 1 existing Starlette/httpx warning.
- [x] `.\.venv\Scripts\ruff.exe check app\openapi_request_bodies.py app\accounts.py tests\test_openapi_request_bodies.py` -> All checks passed.
- [x] `.\.venv\Scripts\ruff.exe format --check app\openapi_request_bodies.py app\accounts.py tests\test_openapi_request_bodies.py` -> 3 files already formatted.
- [x] `git diff --check` -> clean.
- [x] `git merge-tree --write-tree origin/main HEAD` -> clean tree `08bc24f7de691939a2dd21399651ead0245dd605`.

## MRWK
Bounty #944
Refs #944

## Scope
OpenAPI/account response metadata only. No runtime account serialization changes, ledger mutation, wallet custody, treasury/proposal execution, payout execution, admin-token behavior, bridge/exchange/cash-out behavior, MRWK price behavior, private data, or secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced OpenAPI docs for account-related API endpoints with detailed response schemas, including account summary, accepted-work rows, pending summaries, and payout item fields.

* **Tests**
  * Added contract tests validating account API response schemas, required/nullable fields, nested collections, and schema constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->