### PR TITLE
Publish ledger proof OpenAPI response schemas

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,11 @@ from app.me import me_page_context
 from app.models import (
     Proof,
 )
+from app.openapi_request_bodies import (
+    LEDGER_ENTRY_RESPONSE,
+    LEDGER_LIST_RESPONSE,
+    PROOF_RESPONSE,
+)
 from app.path_params import (
     SQLITE_INTEGER_MAX,
     positive_bounty_id,
@@ -249,7 +254,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         with session_scope(db_url) as session:
             return recent_ledger_entries(session, limit, offset)
 
-    @app.get("/api/v1/ledger")
+    @app.get("/api/v1/ledger", openapi_extra=LEDGER_LIST_RESPONSE)
     def api_ledger(
         request: Request,
         limit: Annotated[int, Query(ge=1, le=200)] = 50,
@@ -260,7 +265,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
             reject_noncanonical_int_query_param(request, name)
         return ledger_rows(limit, offset)
 
-    @app.get("/api/v1/ledger/{sequence}")
+    @app.get("/api/v1/ledger/{sequence}", openapi_extra=LEDGER_ENTRY_RESPONSE)
     def api_ledger_entry(sequence: int | str) -> dict[str, Any]:
         sequence_id = positive_ledger_sequence(sequence)
         with session_scope(db_url) as session:
@@ -269,7 +274,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
                 raise HTTPException(status_code=404, detail="ledger entry not found")
             return entry
 
-    @app.get("/api/v1/proofs/{proof_hash}")
+    @app.get("/api/v1/proofs/{proof_hash}", openapi_extra=PROOF_RESPONSE)
     def api_proof(proof_hash: str) -> dict[str, Any]:
         proof_hash = proof_hash_from_path(proof_hash)
         with session_scope(db_url) as session:

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -138,6 +138,59 @@ LEDGER_ENTRY_RESPONSE_SCHEMA = _object_schema(
     }
 )
 
+LEDGER_LIST_RESPONSE = {
+    "responses": {
+        "200": _json_response(
+            {"type": "array", "items": LEDGER_ENTRY_RESPONSE_SCHEMA},
+            description="Recent ledger entries.",
+        ),
+    },
+}
+
+LEDGER_ENTRY_RESPONSE = {
+    "responses": {
+        "200": _json_response(LEDGER_ENTRY_RESPONSE_SCHEMA, description="Ledger entry."),
+    },
+}
+
+BOUNTY_PAYMENT_PROOF_RESPONSE_SCHEMA = _object_schema(
+    {
+        "kind": {"type": "string", "enum": ["bounty_payment"]},
+        "bounty_id": {"type": "integer", "minimum": 1},
+        "repo": {"type": "string"},
+        "issue_number": {"type": "integer", "minimum": 1},
+        "submission_url": {"type": "string"},
+        "accepted_by": {"type": "string"},
+        "to_account": {"type": "string"},
+        "amount_mrwk": MRWK_DECIMAL_SCHEMA,
+        "ledger_sequence": {"type": "integer", "minimum": 1},
+        "ledger_hash": LOWERCASE_HEX_64_SCHEMA,
+        "verifier_result": {"type": "object", "additionalProperties": True},
+    },
+    required=[
+        "kind",
+        "bounty_id",
+        "repo",
+        "issue_number",
+        "submission_url",
+        "accepted_by",
+        "to_account",
+        "amount_mrwk",
+        "ledger_sequence",
+        "ledger_hash",
+        "verifier_result",
+    ],
+)
+
+PROOF_RESPONSE = {
+    "responses": {
+        "200": _json_response(
+            BOUNTY_PAYMENT_PROOF_RESPONSE_SCHEMA,
+            description="Public bounty payment proof payload.",
+        ),
+    },
+}
+
 WALLET_TRANSFER_RESPONSE_SCHEMA = _object_schema(
     {
         "hash": LOWERCASE_HEX_64_SCHEMA,

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -23,6 +23,12 @@ def _post_response_schema(openapi: dict, path: str, status: str = "200") -> dict
     ]
 
 
+def _get_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
+    return openapi["paths"][path]["get"]["responses"][status]["content"]["application/json"][
+        "schema"
+    ]
+
+
 def _assert_properties(schema: dict, expected: Iterable[str]) -> None:
     assert set(expected).issubset(schema["properties"])
 
@@ -328,6 +334,72 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
             "created_at",
         },
     )
+
+
+def test_public_get_openapi_response_schemas_expose_ledger_and_proof_fields(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    ledger_list_schema = _get_response_schema(openapi, "/api/v1/ledger")
+    assert ledger_list_schema["type"] == "array"
+
+    ledger_item_schema = ledger_list_schema["items"]
+    _assert_properties(
+        ledger_item_schema,
+        {
+            "sequence",
+            "type",
+            "from",
+            "to",
+            "amount_mrwk",
+            "reference",
+            "previous_hash",
+            "entry_hash",
+            "proof_hash",
+            "created_at",
+        },
+    )
+
+    ledger_item_props = ledger_item_schema["properties"]
+    assert ledger_item_props["sequence"]["minimum"] == 1
+    assert ledger_item_props["entry_hash"]["pattern"] == "^[0-9a-f]{64}$"
+    assert ledger_item_props["proof_hash"]["nullable"] is True
+    assert ledger_item_props["proof_hash"]["pattern"] == "^[0-9a-f]{64}$"
+    assert ledger_item_props["amount_mrwk"]["pattern"] == r"^\d+(?:\.\d{1,6})?$"
+
+    ledger_entry_schema = _get_response_schema(openapi, "/api/v1/ledger/{sequence}")
+    _assert_properties(ledger_entry_schema, ledger_item_props)
+    assert ledger_entry_schema["properties"]["proof_hash"]["nullable"] is True
+    assert ledger_entry_schema["properties"]["entry_hash"]["pattern"] == "^[0-9a-f]{64}$"
+
+    proof_schema = _get_response_schema(openapi, "/api/v1/proofs/{proof_hash}")
+    expected_proof_fields = {
+        "kind",
+        "bounty_id",
+        "repo",
+        "issue_number",
+        "submission_url",
+        "accepted_by",
+        "to_account",
+        "amount_mrwk",
+        "ledger_sequence",
+        "ledger_hash",
+        "verifier_result",
+    }
+    _assert_properties(proof_schema, expected_proof_fields)
+    assert set(proof_schema["required"]) == expected_proof_fields
+
+    proof_props = proof_schema["properties"]
+    assert proof_props["kind"]["enum"] == ["bounty_payment"]
+    assert proof_props["bounty_id"]["minimum"] == 1
+    assert proof_props["issue_number"]["minimum"] == 1
+    assert proof_props["ledger_sequence"]["minimum"] == 1
+    assert proof_props["ledger_hash"]["pattern"] == "^[0-9a-f]{64}$"
+    assert proof_props["amount_mrwk"]["pattern"] == r"^\d+(?:\.\d{1,6})?$"
+    assert proof_props["verifier_result"]["type"] == "object"
+    assert proof_props["verifier_result"]["additionalProperties"] is True
 
 
 def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #944
Refs #944

delivery summary:
- Publishes explicit OpenAPI `200` response schemas for public ledger routes: `GET /api/v1/ledger` and `GET /api/v1/ledger/{sequence}`.
- Publishes an explicit OpenAPI `200` response schema for public proof lookup: `GET /api/v1/proofs/{proof_hash}`.
- Documents the existing runtime ledger entry and bounty payment proof payload fields, including hex hash constraints, MRWK decimal formatting, nullable proof hashes, and required proof fields.
- Preserves existing runtime JSON behavior; this is OpenAPI/client contract metadata only.

Validation:
- `.\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py::test_public_get_openapi_response_schemas_expose_ledger_and_proof_fields tests\test_api_mcp.py::test_ledger_api_honors_offset tests\test_api_mcp.py::test_mcp_get_ledger_entry_includes_payment_proof_hash tests\test_api_mcp.py::test_public_proof_api_reports_malformed_payload -q` -> 4 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py -q` -> 9 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\ruff.exe check app\openapi_request_bodies.py app\main.py tests\test_openapi_request_bodies.py` -> All checks passed.
- `.\.venv\Scripts\ruff.exe format --check app\openapi_request_bodies.py app\main.py tests\test_openapi_request_bodies.py` -> 3 files already formatted.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `c414925cebefab7b01a4a5b3f629cfce1a554677`.

Touched surfaces: `app/openapi_request_bodies.py`, `app/main.py`, `tests/test_openapi_request_bodies.py`. Scope is public ledger/proof OpenAPI response metadata only; no ledger mutation behavior, proof storage behavior, wallet custody, payout execution, treasury/proposal execution, admin-token behavior, bridge/exchange/cash-out behavior, MRWK price behavior, private data, or secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced API documentation for ledger listing, ledger entry retrieval, and bounty proof endpoints with explicit response schemas, field definitions, required constraints, enum/value rules, format/regex and numeric validation.

* **Tests**
  * Added tests that validate the public GET response schemas for ledger list, ledger entry, and proof endpoints to ensure documentation accuracy and enforced schema constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->