### PR TITLE
Advertise ledger proof MCP output schemas

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -119,6 +119,75 @@ MCP_BOUNTY_ATTEMPTS_OUTPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
+MCP_LEDGER_ENTRY_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Serialized public ledger entry returned in structuredContent.",
+    "properties": {
+        "sequence": {"type": "integer", "minimum": 1},
+        "type": {"type": "string"},
+        "from": {"type": ["string", "null"]},
+        "to": {"type": "string"},
+        "amount_mrwk": {"type": "string", "pattern": r"^\d+(?:\.\d{1,6})?$"},
+        "reference": {"type": ["string", "null"]},
+        "previous_hash": {"type": ["string", "null"]},
+        "entry_hash": {
+            "type": "string",
+            "minLength": 64,
+            "maxLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+        },
+        "proof_hash": {
+            "type": ["string", "null"],
+            "minLength": 64,
+            "maxLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+        },
+        "created_at": {"type": "string"},
+    },
+    "required": [
+        "sequence",
+        "type",
+        "from",
+        "to",
+        "amount_mrwk",
+        "reference",
+        "previous_hash",
+        "entry_hash",
+        "proof_hash",
+        "created_at",
+    ],
+    "additionalProperties": False,
+}
+
+MCP_PROOF_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Public proof wrapper returned in structuredContent.",
+    "properties": {
+        "hash": {
+            "type": "string",
+            "minLength": 64,
+            "maxLength": 64,
+            "pattern": "^[0-9a-f]{64}$",
+        },
+        "kind": {"type": "string"},
+        "ledger_sequence": {"type": "integer", "minimum": 1},
+        "bounty_id": {"type": ["integer", "null"], "minimum": 1},
+        "submission_id": {"type": ["integer", "null"], "minimum": 1},
+        "created_at": {"type": "string"},
+        "proof": {"type": "object", "additionalProperties": True},
+    },
+    "required": [
+        "hash",
+        "kind",
+        "ledger_sequence",
+        "bounty_id",
+        "submission_id",
+        "created_at",
+        "proof",
+    ],
+    "additionalProperties": False,
+}
+
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
@@ -321,6 +390,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "required": ["sequence"],
             "additionalProperties": False,
         },
+        "outputSchema": MCP_LEDGER_ENTRY_OUTPUT_SCHEMA,
     },
     {
         "name": "get_proof",
@@ -339,6 +409,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "required": ["hash"],
             "additionalProperties": False,
         },
+        "outputSchema": MCP_PROOF_OUTPUT_SCHEMA,
     },
     {
         "name": "submit_work_proof",

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -316,9 +316,9 @@ Tools:
 - `submit_work_proof` (`format: "json"` returns structuredContent; `tools/list`
   advertises the selector and format schema)
 
-`tools/list` advertises required selector schemas for proof and ledger lookups:
-`get_proof` requires a 64-character proof `hash`, and `get_ledger_entry`
-requires a positive integer `sequence`.
+`tools/list` advertises required selector schemas and structured output schemas
+for proof and ledger lookups: `get_proof` requires a 64-character proof `hash`,
+and `get_ledger_entry` requires a positive integer `sequence`.
 
 Successful MCP tools that return JSON objects or lists include both the
 backward-compatible JSON string in `result.content[0].text` and parsed

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -437,11 +437,52 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert ledger_schema["required"] == ["sequence"]
     assert ledger_schema["additionalProperties"] is False
     assert ledger_schema["properties"]["sequence"]["minimum"] == 1
+    ledger_output_schema = ledger_tool["outputSchema"]
+    assert ledger_output_schema["description"] == (
+        "Serialized public ledger entry returned in structuredContent."
+    )
+    assert ledger_output_schema["required"] == [
+        "sequence",
+        "type",
+        "from",
+        "to",
+        "amount_mrwk",
+        "reference",
+        "previous_hash",
+        "entry_hash",
+        "proof_hash",
+        "created_at",
+    ]
+    assert ledger_output_schema["additionalProperties"] is False
+    assert ledger_output_schema["properties"]["sequence"]["minimum"] == 1
+    assert ledger_output_schema["properties"]["amount_mrwk"]["pattern"] == (r"^\d+(?:\.\d{1,6})?$")
+    assert ledger_output_schema["properties"]["entry_hash"]["pattern"] == "^[0-9a-f]{64}$"
+    assert ledger_output_schema["properties"]["proof_hash"]["type"] == ["string", "null"]
+    assert ledger_output_schema["properties"]["proof_hash"]["pattern"] == "^[0-9a-f]{64}$"
     proof_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_proof")
     proof_schema = proof_tool["inputSchema"]
     assert proof_schema["required"] == ["hash"]
     assert proof_schema["additionalProperties"] is False
     assert proof_schema["properties"]["hash"]["pattern"] == "^[0-9a-fA-F]{64}$"
+    proof_output_schema = proof_tool["outputSchema"]
+    assert (
+        proof_output_schema["description"] == "Public proof wrapper returned in structuredContent."
+    )
+    assert proof_output_schema["required"] == [
+        "hash",
+        "kind",
+        "ledger_sequence",
+        "bounty_id",
+        "submission_id",
+        "created_at",
+        "proof",
+    ]
+    assert proof_output_schema["additionalProperties"] is False
+    assert proof_output_schema["properties"]["hash"]["pattern"] == "^[0-9a-f]{64}$"
+    assert proof_output_schema["properties"]["ledger_sequence"]["minimum"] == 1
+    assert proof_output_schema["properties"]["bounty_id"]["type"] == ["integer", "null"]
+    assert proof_output_schema["properties"]["submission_id"]["type"] == ["integer", "null"]
+    assert proof_output_schema["properties"]["proof"]["additionalProperties"] is True
 
     balance = client.post(
         "/mcp",


### PR DESCRIPTION
Bounty #946 delivery summary:
- Adds MCP `outputSchema` metadata for `get_ledger_entry`, matching the ledger entry JSON already returned in `result.structuredContent`.
- Adds MCP `outputSchema` metadata for `get_proof`, matching the public proof wrapper already returned in `result.structuredContent`.
- Captures stable fields and constraints for ledger sequences, MRWK decimal strings, lowercase 64-char hashes, nullable proof/submission ids, and extensible nested public proof payloads.
- Preserves existing runtime text/structuredContent behavior; this is `tools/list` metadata, focused conformance coverage, and a concise agent guide note.

Validation:
- `.\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py::test_mcp_tools_list_and_call tests\test_api_mcp.py::test_mcp_get_ledger_entry_includes_payment_proof_hash tests\test_api_mcp.py::test_mcp_get_proof_returns_public_proof_details -q` -> 3 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py tests\test_mcp_tools.py -q` -> 131 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok.
- `.\.venv\Scripts\python.exe -m mypy app\mcp.py` -> Success: no issues found.
- `.\.venv\Scripts\ruff.exe check app\mcp.py tests\test_api_mcp.py` -> All checks passed.
- `.\.venv\Scripts\ruff.exe format --check app\mcp.py tests\test_api_mcp.py` -> 2 files already formatted.
- `git diff --check` -> clean, Windows CRLF warning only for docs.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `e6b0725bcf4c3c1d0817802fbd89a1e1b1c039b9`.

Touched surfaces: `app/mcp.py`, `tests/test_api_mcp.py`, `docs/agent-guide.md`. Scope is MCP `tools/list` output metadata for read-only ledger/proof lookups only; no runtime ledger mutation, proof storage behavior, wallet custody, payouts, treasury mutation, bridge/exchange/off-ramp, MRWK price behavior, private data, or secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured output schemas for proof and ledger entry lookup tools with validated field formats including hash validation, timestamps, and amounts.

* **Documentation**
  * Clarified MCP tool capabilities and schema requirements in the agent guide for proof and ledger lookups.

* **Tests**
  * Expanded validation tests to verify structured output schemas and field constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->