### PR TITLE
Surface safe field-level MCP argument errors via additive error.data

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -395,6 +395,138 @@ def _jsonrpc_error(response_id: Any, code: int, message: str) -> dict[str, Any]:
     return {"jsonrpc": "2.0", "id": response_id, "error": {"code": code, "message": message}}
 
 
+# Field-level error metadata for the additive `error.data` payload. The
+# dispatcher surfaces this only when a `ValueError` raised by
+# :func:`call_mcp_tool` matches a whitelisted safe phrase. Untrusted caller
+# input is never echoed: `field` must be one of `_KNOWN_TOOL_FIELDS` and
+# `message` must be one of `_KNOWN_FIELD_MESSAGES` or `None` (field-less).
+_KNOWN_TOOL_FIELDS: frozenset[str] = frozenset(
+    {
+        "id",
+        "bounty_id",
+        "issue_number",
+        "repo",
+        "include_awards",
+        "include_expired",
+        "limit",
+        "q",
+        "sort",
+        "availability",
+        "status",
+        "account",
+        "address",
+        "public_key_hex",
+        "label",
+        "from_address",
+        "to_address",
+        "amount_mrwk",
+        "nonce",
+        "memo",
+        "signature_hex",
+        "sequence",
+        "hash",
+        "format",
+    }
+)
+
+# Safe, no-user-input phrases recognized as the trailing half of a
+# field-prefixed `ValueError` message. Values are the strings that callers
+# will see in `error.data.message`; they are never derived from caller input.
+_KNOWN_FIELD_MESSAGES: dict[str, str] = {
+    "must be an integer": "must be an integer",
+    "must be a string": "must be a string",
+    "must be a boolean": "must be a boolean",
+    "must be positive": "must be positive",
+    "must not be empty": "must not be empty",
+    "must not contain control characters": "must not contain control characters",
+    "is too large": "is too large",
+    "is too long": "is too long",
+    "must be at most 100": "must be at most 100",
+    "must be at most 500 characters": "must be at most 500 characters",
+    "must be one of: open, paid, closed": "must be one of: open, paid, closed",
+    "must be text or json": "must be text or json",
+}
+
+# Field-less safe phrases emitted when the underlying message is not
+# field-prefixed (e.g. `unknown tool`).
+_KNOWN_FIELDLESS_MESSAGES: dict[str, str] = {
+    "unknown tool": "unknown tool",
+    "matches multiple bounties": "matches multiple bounties",
+    "repo can only be used with issue_number": ("repo can only be used with issue_number"),
+}
+
+
+def _classify_value_error(exc: ValueError) -> dict[str, Any] | None:
+    """Map a ``ValueError`` raised by :func:`call_mcp_tool` to a safe
+    field-level error data payload.
+
+    Returns a ``{"code", "tool", "field", "message"}`` dict built only from
+    the static ``_KNOWN_TOOL_FIELDS`` / ``_KNOWN_FIELD_MESSAGES`` /
+    ``_KNOWN_FIELDLESS_MESSAGES`` whitelists when the original message
+    matches, or ``None`` if it does not — in which case the dispatcher
+    returns the legacy envelope without ``error.data`` so untrusted caller
+    input never reaches the response.
+
+    The recognised patterns are:
+
+    - ``"<field> <safe phrase>"`` where ``<field>`` is a known tool field
+      and ``<safe phrase>`` is a known field-level message.
+    - A field-less known message (e.g. ``"unknown tool"``).
+    """
+    if not exc.args:
+        return None
+    message = str(exc.args[0])
+    if not message:
+        return None
+
+    # Field-prefixed: "<field> <safe phrase>". Split on the first whitespace
+    # only; the field token is the first identifier-shaped run and the rest
+    # of the message must match a whitelisted safe phrase verbatim. This
+    # keeps the surface area to a small finite set of literal strings.
+    head, sep, tail = message.partition(" ")
+    if sep and head in _KNOWN_TOOL_FIELDS and tail in _KNOWN_FIELD_MESSAGES:
+        return {
+            "code": "invalid_argument",
+            "field": head,
+            "message": _KNOWN_FIELD_MESSAGES[tail],
+        }
+
+    # Field-less safe phrases.
+    if message in _KNOWN_FIELDLESS_MESSAGES:
+        return {
+            "code": "invalid_argument",
+            "field": None,
+            "message": _KNOWN_FIELDLESS_MESSAGES[message],
+        }
+
+    return None
+
+
+def _invalid_tool_arguments_response(
+    response_id: Any, tool_name: str, exc: ValueError
+) -> dict[str, Any]:
+    """Return the legacy ``-32602 invalid tool arguments`` envelope with an
+    optional, additive ``error.data`` payload for safe argument-validation
+    failures.
+
+    The JSON-RPC ``error.message`` always stays exactly
+    ``"invalid tool arguments"`` for backward compatibility. The new
+    ``error.data`` is attached only when the underlying ``ValueError``
+    message matches a whitelisted safe phrase, so untrusted caller input
+    never reaches the response.
+    """
+    error_payload: dict[str, Any] = {"code": -32602, "message": "invalid tool arguments"}
+    classified = _classify_value_error(exc)
+    if classified is not None:
+        error_payload["data"] = {
+            "code": classified["code"],
+            "tool": tool_name,
+            "field": classified["field"],
+            "message": classified["message"],
+        }
+    return {"jsonrpc": "2.0", "id": response_id, "error": error_payload}
+
+
 def _initialize_response(response_id: Any, params: Any) -> dict[str, Any]:
     protocol_version = MCP_PROTOCOL_VERSION
     if (
@@ -497,7 +629,9 @@ async def handle_mcp_request(
 
     try:
         tool_result = call_tool(database_url, name, args)
-    except (KeyError, TypeError, ValueError, LedgerError, HTTPException):
+    except ValueError as exc:
+        return _invalid_tool_arguments_response(response_id, name, exc)
+    except (KeyError, TypeError, LedgerError, HTTPException):
         return _jsonrpc_error(response_id, -32602, "invalid tool arguments")
 
     return _tool_result_response(response_id, tool_result)

--- a/app/mcp.py
+++ b/app/mcp.py
@@ -391,6 +391,15 @@ MCP_TOOLS: list[dict[str, Any]] = [
 ]
 
 
+# Static whitelist of registered MCP tool names, derived once at import time
+# from :data:`MCP_TOOLS`. The dispatcher uses this set to bound the
+# ``data["tool"]`` slot of the additive field-level error envelope: only
+# names that actually belong to a registered tool are surfaced, so an
+# unknown-tool ``ValueError`` (whose ``tool_name`` is, by definition, not in
+# the set) cannot echo arbitrary caller input into the response body.
+_KNOWN_TOOL_NAMES: frozenset[str] = frozenset(tool["name"] for tool in MCP_TOOLS)
+
+
 def _jsonrpc_error(response_id: Any, code: int, message: str) -> dict[str, Any]:
     return {"jsonrpc": "2.0", "id": response_id, "error": {"code": code, "message": message}}
 
@@ -491,6 +500,21 @@ def _classify_value_error(exc: ValueError) -> dict[str, Any] | None:
             "message": _KNOWN_FIELD_MESSAGES[tail],
         }
 
+    # Some upstream ``ValueError`` messages are emitted as
+    # ``"<field> <field-less safe phrase>"`` even when the phrase itself is
+    # semantically field-less (e.g. ``"issue_number matches multiple
+    # bounties"``). Treat that case as a field-less known phrase so the
+    # whitelist remains reachable for those callsites; the leading field
+    # token is dropped from the response because the message is the
+    # user-facing signal and the field is the static name the dispatcher
+    # would have surfaced anyway.
+    if sep and head in _KNOWN_TOOL_FIELDS and tail in _KNOWN_FIELDLESS_MESSAGES:
+        return {
+            "code": "invalid_argument",
+            "field": None,
+            "message": _KNOWN_FIELDLESS_MESSAGES[tail],
+        }
+
     # Field-less safe phrases.
     if message in _KNOWN_FIELDLESS_MESSAGES:
         return {
@@ -518,9 +542,18 @@ def _invalid_tool_arguments_response(
     error_payload: dict[str, Any] = {"code": -32602, "message": "invalid tool arguments"}
     classified = _classify_value_error(exc)
     if classified is not None:
+        # Bound the ``data["tool"]`` slot to the static
+        # :data:`_KNOWN_TOOL_NAMES` whitelist. Field-level argument
+        # validation always runs *after* the dispatcher has already
+        # resolved ``tool_name`` to a registered tool, so the bound
+        # value is identical to ``tool_name`` on the success path. For
+        # the ``unknown tool`` path the rejected caller name is, by
+        # definition, not in the whitelist; reflecting it would surface
+        # untrusted caller input, so the slot is left as ``None``.
+        safe_tool = tool_name if tool_name in _KNOWN_TOOL_NAMES else None
         error_payload["data"] = {
             "code": classified["code"],
-            "tool": tool_name,
+            "tool": safe_tool,
             "field": classified["field"],
             "message": classified["message"],
         }

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -329,6 +329,47 @@ back to text for human-readable not-found messages.
 `result.structuredContent.account`, `balance_mrwk`, and `balance_microunits` so
 callers do not need to parse the text response.
 
+### Argument-validation errors
+
+`tools/call` returns the standard JSON-RPC `code: -32602` with a literal
+`message: "invalid tool arguments"` for every argument-validation failure, so
+existing clients that only read the message keep working. When the underlying
+`ValueError` matches a whitelisted safe phrase, the dispatcher also attaches
+an additive `error.data` payload so clients can act on the failure without
+parsing natural language:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "error": {
+    "code": -32602,
+    "message": "invalid tool arguments",
+    "data": {
+      "code": "invalid_argument",
+      "tool": "list_bounties",
+      "field": "limit",
+      "message": "must be at most 100"
+    }
+  }
+}
+```
+
+The shape is:
+
+- `code` — always `"invalid_argument"` for argument-validation failures.
+- `tool` — the requested tool name as the dispatcher saw it.
+- `field` — the offending field name, or `null` for field-less phrases such
+  as `unknown tool` or `repo can only be used with issue_number`.
+- `message` — a static, whitelisted safe phrase. Caller input is never
+  echoed, so the payload is safe to surface to LLM prompts or logs.
+
+When the underlying `ValueError` does not match the whitelist, the
+`error.data` key is omitted and the response is byte-for-byte identical to
+the previous envelope. `KeyError`, `TypeError`, `LedgerError`, and
+`HTTPException` paths still go through the legacy envelope with no
+`error.data`.
+
 ## Contribution Rules
 
 - Read `AGENTS.md` before starting.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -358,9 +358,16 @@ parsing natural language:
 The shape is:
 
 - `code` — always `"invalid_argument"` for argument-validation failures.
-- `tool` — the requested tool name as the dispatcher saw it.
+- `tool` — the registered MCP tool name when it is a known tool, or
+  `null` for the `unknown tool` path. The dispatcher never reflects an
+  arbitrary caller-supplied string into this slot, so the value is safe
+  to surface to LLM prompts or logs.
 - `field` — the offending field name, or `null` for field-less phrases such
-  as `unknown tool` or `repo can only be used with issue_number`.
+  as `unknown tool`, `matches multiple bounties`, or
+  `repo can only be used with issue_number`. Some upstream messages are
+  emitted as `"<field> <field-less phrase>"` (for example
+  `issue_number matches multiple bounties`); the classifier treats those
+  as field-less and drops the leading field token from the response.
 - `message` — a static, whitelisted safe phrase. Caller input is never
   echoed, so the payload is safe to surface to LLM prompts or logs.
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -3109,16 +3109,95 @@ def test_mcp_field_error_data_attaches_known_fieldless_unknown_tool(sqlite_url: 
         },
     )
 
+    # The rejected tool name is not in the static ``MCP_TOOLS`` whitelist,
+    # so the dispatcher leaves ``data.tool`` as ``None`` instead of
+    # echoing arbitrary caller input.
     _assert_invalid_tool_arguments_envelope(
         response.json(),
         request_id=5,
         expected_data={
             "code": "invalid_argument",
-            "tool": "definitely_unknown",
+            "tool": None,
             "field": None,
             "message": "unknown tool",
         },
     )
+
+
+def test_mcp_field_error_data_binds_known_tool_name(sqlite_url: str) -> None:
+    """For field-prefixed argument validation the dispatcher must echo the
+    registered tool name (not the raw caller string) into ``data.tool``.
+
+    This is the positive half of the ``data.tool`` bounding guarantee:
+    known tools get their registered name, unknown tools get ``None``.
+    """
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounties",
+                "arguments": {"limit": 0},
+            },
+        },
+    )
+
+    _assert_invalid_tool_arguments_envelope(
+        response.json(),
+        request_id=9,
+        expected_data={
+            "code": "invalid_argument",
+            "tool": "list_bounties",
+            "field": "limit",
+            "message": "must be positive",
+        },
+    )
+
+
+def test_mcp_field_error_data_reaches_fieldless_matches_multiple_bounties(
+    sqlite_url: str,
+) -> None:
+    """``issue_number matches multiple bounties`` is the field-less
+    phrase ``matches multiple bounties`` prefixed with a known tool
+    field. The classifier must reach the field-less whitelist even when
+    the message carries the field token, and surface
+    ``field: None, message: "matches multiple bounties"``.
+
+    The integration path is unreachable because the ``Bounty`` model
+    has a ``UniqueConstraint("repo", "issue_number")`` that prevents
+    duplicate ``issue_number`` rows. We exercise the classifier
+    directly to lock in the new branch.
+    """
+    from app.mcp import _classify_value_error
+
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        for issue_number in (902, 903):
+            create_bounty(
+                session,
+                repo="ramimbo/mergework",
+                issue_number=issue_number,
+                issue_url=f"https://github.com/ramimbo/mergework/issues/{issue_number}",
+                title=f"Single-issue coverage {issue_number}",
+                reward_mrwk="100",
+                acceptance="Accepted label",
+            )
+
+    classified = _classify_value_error(ValueError("issue_number matches multiple bounties"))
+    assert classified == {
+        "code": "invalid_argument",
+        "field": None,
+        "message": "matches multiple bounties",
+    }
 
 
 def test_mcp_field_error_data_attaches_repo_requires_issue_number(sqlite_url: str) -> None:

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -19,6 +19,42 @@ from app.models import BountyAttempt, Proof
 from app.serializers import public_utc_timestamp
 from app.treasury import propose_treasury_action
 
+# Sentinel used by ``_assert_invalid_tool_arguments_envelope`` to mean
+# "do not assert on the presence of ``error.data``". The literal
+# ``"__unset__"`` string is used as a stable, human-readable token.
+_UNSET: object = "__unset__"
+
+
+def _assert_invalid_tool_arguments_envelope(
+    response_json: dict[str, object],
+    *,
+    request_id: object,
+    expected_data: object = _UNSET,
+) -> None:
+    """Assert that a JSON-RPC error envelope matches the legacy
+    ``-32602 invalid tool arguments`` contract.
+
+    The dispatcher may optionally attach an additive ``error.data`` payload
+    built from the whitelisted safe phrase list in :mod:`app.mcp`. Pass
+    ``expected_data`` as a dict to require an exact match, pass
+    ``expected_data=None`` to require that no ``data`` key is present, and
+    leave it at the default sentinel to make no assertion about the
+    presence of ``data`` at all — useful for tests that do not care about
+    the new shape.
+    """
+    assert response_json["jsonrpc"] == "2.0"
+    assert response_json["id"] == request_id
+    error = response_json["error"]
+    assert isinstance(error, dict)
+    assert error["code"] == -32602
+    assert error["message"] == "invalid tool arguments"
+    if expected_data is _UNSET:
+        return
+    if expected_data is None:
+        assert "data" not in error
+        return
+    assert error["data"] == expected_data
+
 
 def test_health_status_and_bounty_api(sqlite_url: str) -> None:
     create_schema(sqlite_url)
@@ -744,11 +780,7 @@ def test_mcp_list_bounty_attempts_rejects_invalid_arguments(sqlite_url: str) -> 
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 23,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=23)
 
 
 def test_mcp_list_bounty_attempts_rejects_mixed_id_aliases(sqlite_url: str) -> None:
@@ -782,11 +814,7 @@ def test_mcp_list_bounty_attempts_rejects_mixed_id_aliases(sqlite_url: str) -> N
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 26,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=26)
 
 
 def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> None:
@@ -1048,11 +1076,7 @@ def test_mcp_list_bounties_rejects_invalid_filters(
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": request_id,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=request_id)
 
 
 def test_mcp_rejects_malformed_requests_without_500(sqlite_url: str) -> None:
@@ -1136,11 +1160,7 @@ def test_mcp_rejects_unknown_tool_name(sqlite_url: str) -> None:
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 12,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=12)
 
 
 def test_mcp_get_bounty_can_include_accepted_awards(sqlite_url: str) -> None:
@@ -1321,11 +1341,7 @@ def test_mcp_get_bounty_rejects_ambiguous_issue_number_selector(sqlite_url: str)
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 4,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=4)
 
 
 def test_mcp_get_bounty_rejects_mixed_selectors(sqlite_url: str) -> None:
@@ -1363,11 +1379,7 @@ def test_mcp_get_bounty_rejects_mixed_selectors(sqlite_url: str) -> None:
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 5,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=5)
 
 
 def test_mcp_get_bounty_rejects_mixed_internal_id_aliases(sqlite_url: str) -> None:
@@ -1401,11 +1413,7 @@ def test_mcp_get_bounty_rejects_mixed_internal_id_aliases(sqlite_url: str) -> No
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 6,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=6)
 
 
 def test_mcp_get_bounty_skips_malformed_award_proof_payloads(sqlite_url: str) -> None:
@@ -1483,11 +1491,7 @@ def test_mcp_get_bounty_rejects_fractional_id(sqlite_url: str) -> None:
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 12,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=12)
 
 
 @pytest.mark.parametrize("include_awards", ["true", 1, []])
@@ -1524,11 +1528,7 @@ def test_mcp_get_bounty_rejects_non_boolean_include_awards(
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 12,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=12)
 
 
 @pytest.mark.parametrize("bounty_id", [0, -1])
@@ -1550,11 +1550,7 @@ def test_mcp_get_bounty_rejects_non_positive_id(sqlite_url: str, bounty_id: int)
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 12,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=12)
 
 
 def test_mcp_get_wallet_returns_not_found_for_unregistered_wallet(sqlite_url: str) -> None:
@@ -1616,11 +1612,7 @@ def test_mcp_rejects_oversized_integer_arguments_without_500(
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": request_id,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=request_id)
 
 
 @pytest.mark.parametrize(
@@ -1658,11 +1650,7 @@ def test_mcp_rejects_noncanonical_integer_string_arguments(
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": request_id,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=request_id)
 
 
 def test_mcp_accepts_canonical_integer_string_arguments(sqlite_url: str) -> None:
@@ -1727,11 +1715,7 @@ def test_mcp_rejects_invalid_string_arguments(
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": request_id,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=request_id)
 
 
 def test_mcp_get_ledger_entry_includes_payment_proof_hash(sqlite_url: str) -> None:
@@ -1797,11 +1781,7 @@ def test_mcp_get_ledger_entry_rejects_non_positive_sequence(sqlite_url: str) -> 
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 2,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=2)
 
 
 def test_mcp_get_proof_returns_public_proof_details(sqlite_url: str) -> None:
@@ -1965,11 +1945,7 @@ def test_mcp_get_proof_rejects_malformed_hash(sqlite_url: str) -> None:
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 3,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=3)
 
 
 def test_mcp_submit_work_proof_returns_bounty_specific_guidance(sqlite_url: str) -> None:
@@ -2420,11 +2396,7 @@ def test_mcp_submit_work_proof_rejects_invalid_bounty_selectors(
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": request_id,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=request_id)
 
 
 @pytest.mark.parametrize(
@@ -2456,11 +2428,7 @@ def test_mcp_submit_work_proof_rejects_undeclared_arguments(
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": request_id,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=request_id)
 
 
 def test_mcp_submit_work_proof_rejects_ambiguous_issue_number(sqlite_url: str) -> None:
@@ -2499,11 +2467,7 @@ def test_mcp_submit_work_proof_rejects_ambiguous_issue_number(sqlite_url: str) -
     )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "jsonrpc": "2.0",
-        "id": 26,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=26)
 
 
 def test_host_specific_homepages(sqlite_url: str) -> None:
@@ -2953,11 +2917,7 @@ def test_mcp_wallet_write_tools_reject_unexpected_arguments(sqlite_url: str) -> 
     )
 
     assert register_response.status_code == 200
-    assert register_response.json() == {
-        "jsonrpc": "2.0",
-        "id": 1,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
-    }
+    _assert_invalid_tool_arguments_envelope(register_response.json(), request_id=1)
 
     transfer_response = client.post(
         "/mcp",
@@ -2981,7 +2941,343 @@ def test_mcp_wallet_write_tools_reject_unexpected_arguments(sqlite_url: str) -> 
     )
 
     assert transfer_response.status_code == 200
-    assert transfer_response.json()["error"] == {
-        "code": -32602,
-        "message": "invalid tool arguments",
+    assert transfer_response.json()["error"]["code"] == -32602
+    assert transfer_response.json()["error"]["message"] == "invalid tool arguments"
+
+
+# ---------------------------------------------------------------------------
+# Field-level error.data contract
+#
+# The dispatcher attaches an additive ``error.data`` payload when the
+# underlying ``ValueError`` matches a whitelisted safe phrase. The tests
+# below pin the exact shape and verify that untrusted caller input is never
+# echoed into the response.
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_field_error_data_attaches_known_limit_violation(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "list_bounties", "arguments": {"limit": 250}},
+        },
+    )
+
+    _assert_invalid_tool_arguments_envelope(
+        response.json(),
+        request_id=1,
+        expected_data={
+            "code": "invalid_argument",
+            "tool": "list_bounties",
+            "field": "limit",
+            "message": "must be at most 100",
+        },
+    )
+
+
+def test_mcp_field_error_data_attaches_known_string_violation(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "get_balance",
+                "arguments": {"account": 12345},
+            },
+        },
+    )
+
+    _assert_invalid_tool_arguments_envelope(
+        response.json(),
+        request_id=2,
+        expected_data={
+            "code": "invalid_argument",
+            "tool": "get_balance",
+            "field": "account",
+            "message": "must be a string",
+        },
+    )
+
+
+def test_mcp_field_error_data_attaches_known_boolean_violation(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=901,
+            issue_url="https://github.com/ramimbo/mergework/issues/901",
+            title="Boolean field error coverage",
+            reward_mrwk="100",
+            acceptance="Agents should see a safe field-level boolean error.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounty_attempts",
+                "arguments": {"bounty_id": bounty.id, "include_expired": "yes"},
+            },
+        },
+    )
+
+    _assert_invalid_tool_arguments_envelope(
+        response.json(),
+        request_id=3,
+        expected_data={
+            "code": "invalid_argument",
+            "tool": "list_bounty_attempts",
+            "field": "include_expired",
+            "message": "must be a boolean",
+        },
+    )
+
+
+def test_mcp_field_error_data_attaches_known_status_violation(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounties",
+                "arguments": {"status": "frozen"},
+            },
+        },
+    )
+
+    _assert_invalid_tool_arguments_envelope(
+        response.json(),
+        request_id=4,
+        expected_data={
+            "code": "invalid_argument",
+            "tool": "list_bounties",
+            "field": "status",
+            "message": "must be one of: open, paid, closed",
+        },
+    )
+
+
+def test_mcp_field_error_data_attaches_known_fieldless_unknown_tool(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {
+                "name": "definitely_unknown",
+                "arguments": {},
+            },
+        },
+    )
+
+    _assert_invalid_tool_arguments_envelope(
+        response.json(),
+        request_id=5,
+        expected_data={
+            "code": "invalid_argument",
+            "tool": "definitely_unknown",
+            "field": None,
+            "message": "unknown tool",
+        },
+    )
+
+
+def test_mcp_field_error_data_attaches_repo_requires_issue_number(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": {
+                "name": "get_bounty",
+                "arguments": {"id": 1, "repo": "ramimbo/mergework"},
+            },
+        },
+    )
+
+    _assert_invalid_tool_arguments_envelope(
+        response.json(),
+        request_id=6,
+        expected_data={
+            "code": "invalid_argument",
+            "tool": "get_bounty",
+            "field": None,
+            "message": "repo can only be used with issue_number",
+        },
+    )
+
+
+def test_mcp_field_error_data_omitted_for_unmatched_value_error(sqlite_url: str) -> None:
+    """A ``ValueError`` whose message is not on the whitelist must fall
+    back to the legacy envelope *without* an ``error.data`` key, so the
+    additive contract is opt-in and bounded.
+    """
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=902,
+            issue_url="https://github.com/ramimbo/mergework/issues/902",
+            title="Multiple internal id fields coverage",
+            reward_mrwk="100",
+            acceptance="Agents should see no data field for unrecognised phrases.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    # Supplying both ``id`` and ``bounty_id`` (the two internal id aliases for
+    # ``get_bounty``) raises ``ValueError("use id or bounty_id, not multiple
+    # internal id fields")``. The first word ("use") is not in the tool-field
+    # whitelist, so the classifier must return ``None`` and the response must
+    # keep the legacy envelope with no ``error.data``.
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "tools/call",
+            "params": {
+                "name": "get_bounty",
+                "arguments": {"id": bounty.id, "bounty_id": bounty.id},
+            },
+        },
+    )
+
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=7, expected_data=None)
+
+
+def test_mcp_field_error_data_does_not_echo_caller_input(sqlite_url: str) -> None:
+    """A caller-supplied value must never appear in ``error.data`` or
+    ``error.message``. Only the static whitelisted phrases are returned.
+
+    Uses ``account=12345`` (an int) on ``get_balance`` so the dispatcher
+    surfaces the static ``"must be a string"`` phrase from the whitelist
+    and rejects the call. The string ``"12345"`` must not appear in the
+    response; only the literal phrase ``must be a string`` may appear.
+    """
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    sentinel_int = 1234567890
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 8,
+            "method": "tools/call",
+            "params": {
+                "name": "get_balance",
+                "arguments": {"account": sentinel_int},
+            },
+        },
+    )
+
+    body = response.text
+    assert str(sentinel_int) not in body
+    assert "1234567890" not in body
+
+    error = response.json()["error"]
+    assert error["code"] == -32602
+    assert error["message"] == "invalid tool arguments"
+    assert error["data"] == {
+        "code": "invalid_argument",
+        "tool": "get_balance",
+        "field": "account",
+        "message": "must be a string",
     }
+
+
+def test_mcp_field_error_data_does_not_echo_oversized_limit_value(sqlite_url: str) -> None:
+    """An oversized ``limit`` value must not appear in the response. Only
+    the static whitelisted phrase survives. ``limit=2**63`` is rejected by
+    ``int_arg`` with the static phrase ``"is too large"``; the integer
+    value itself must not be present in the response body.
+    """
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    huge_limit = 2**63
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 9,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounties",
+                "arguments": {"limit": huge_limit},
+            },
+        },
+    )
+
+    body = response.text
+    # The integer literal ``9223372036854775808`` must not appear in the
+    # response. We check both common Python renderings.
+    assert str(huge_limit) not in body
+    assert f"{huge_limit}" not in body
+
+    error = response.json()["error"]
+    assert error["code"] == -32602
+    assert error["message"] == "invalid tool arguments"
+    data = error["data"]
+    assert data["code"] == "invalid_argument"
+    assert data["tool"] == "list_bounties"
+    assert data["field"] == "limit"
+    # The ``int_arg`` size check is what fires for a value > SQLITE_INTEGER_MAX;
+    # if the value parses to an int but exceeds the SQLite range the message
+    # is the static ``"is too large"`` phrase.
+    assert data["message"] == "is too large"

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1451,7 +1451,8 @@ def test_mcp_malformed_tool_call_returns_jsonrpc_error(sqlite_url: str) -> None:
     )
 
     assert response.status_code == 200
-    assert response.json()["error"] == {"code": -32602, "message": "invalid tool arguments"}
+    assert response.json()["error"]["code"] == -32602
+    assert response.json()["error"]["message"] == "invalid tool arguments"
 
 
 def test_pay_bounty_rejects_reentrant_duplicate_before_ledger_write(


### PR DESCRIPTION
Bounty #946

## Summary
- Adds a whitelist-only field-level `error.data` payload to the MCP `tools/call` error envelope so clients can act on argument-validation failures without parsing natural language.
- The legacy `error.message` stays exactly `"invalid tool arguments"` for every argument-validation failure, so existing clients that only read the message keep working.
- Caller input is never echoed into the response: `field` and `message` are built from static whitelists in `app/mcp.py`.
- Updated the 20 exact-dict error-envelope assertions in `tests/test_api_mcp.py` and the one in `tests/test_security.py` to use a small helper that asserts `code` + `message` + (optional) `data` shape, instead of brittle full-dict equality.
- Added 9 focused new tests covering: known field-level phrases (limit, account, include_expired, status), known field-less phrases (unknown tool, repo requires issue_number), the classifier fallthrough path (unmatched phrases get no `data`), and PII safety (caller-supplied values never appear in the response).
- Updated `docs/agent-guide.md` with a short paragraph and example for the additive `error.data` shape, including the legacy-fallback note for unmatched phrases.

## Why
The bounty body explicitly calls out "improving safe field-level MCP argument errors for invalid selectors or fields" as good scope. Eight other open PRs against this bounty add `outputSchema` blocks for specific tools; zero of them touch the dispatcher error path. This PR targets that open lane with a minimal, additive, backward-compatible change.

## What changed
- `app/mcp.py`
  - New constants: `_KNOWN_TOOL_FIELDS`, `_KNOWN_FIELD_MESSAGES`, `_KNOWN_FIELDLESS_MESSAGES` — static whitelists of closed-set strings.
  - New helper `_classify_value_error(exc)` — returns a `{"code", "field", "message"}` dict only when the `ValueError` message matches the whitelist, else `None`.
  - New helper `_invalid_tool_arguments_response(response_id, tool_name, exc)` — builds the legacy envelope, attaches `error.data` only when the classifier matches.
  - Dispatcher split: `ValueError` flows through the new helper; `(KeyError, TypeError, LedgerError, HTTPException)` still goes through the unchanged `_jsonrpc_error` (no `data`).
- `tests/test_api_mcp.py`
  - New helper `_assert_invalid_tool_arguments_envelope(response_json, request_id, expected_data=_UNSET)` — replaces 18 exact-dict assertions in this file with calls to the helper.
  - 9 new focused tests for the `error.data` contract.
- `tests/test_security.py`
  - One exact-dict assertion updated to a code+message pair (no behavior change, just non-brittle).
- `docs/agent-guide.md`
  - New "Argument-validation errors" sub-section under "MCP Endpoint" with the shape, an example, and the legacy-fallback note.

## Backward compatibility
- `error.code` is unchanged: `-32602` for every argument-validation failure.
- `error.message` is unchanged: literal `"invalid tool arguments"` for every argument-validation failure.
- `error.data` is additive. When the underlying `ValueError` does not match the whitelist, `error.data` is omitted and the response is byte-for-byte identical to the previous envelope.
- `KeyError`, `TypeError`, `LedgerError`, and `HTTPException` paths still go through the legacy `_jsonrpc_error` with no `error.data`.

## Security
- No caller input is echoed into `error.message` or `error.data`. The two new tests `test_mcp_field_error_data_does_not_echo_caller_input` and `test_mcp_field_error_data_does_not_echo_oversized_limit_value` pin this invariant.

## Touched surfaces
- `app/mcp.py`
- `tests/test_api_mcp.py`
- `tests/test_security.py`
- `docs/agent-guide.md`

4 files changed, 572 insertions, 100 deletions.

## Validation
- `python3 -m pytest tests/ -q` -> 869 passed, 1 existing Starlette/httpx warning.
- `python3 -m pytest tests/test_api_mcp.py -k field_error -v` -> 9 passed.
- `python3 -m ruff check app/mcp.py tests/test_api_mcp.py tests/test_security.py docs/agent-guide.md` -> All checks passed.
- `python3 -m ruff format --check app/mcp.py tests/test_api_mcp.py tests/test_security.py` -> 3 files already formatted.
- `python3 -m mypy app/mcp.py` -> Success: no issues found.
- `python3 scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.

## Out of scope
- No new write-capable MCP tools, no admin-token APIs, no payouts, no treasury mutation, no ledger mutation, no wallet custody, no bridge, exchange, off-ramp, cash-out, or price behavior. No MRWK investment or price claims.
- No private security details, secrets, or fabricated payout claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invalid-tool-argument responses may now include a structured, non-echoing error.data object (code, tool, field, message) for approved safe phrases while retaining the legacy envelope otherwise.

* **Documentation**
  * Added guidance describing when the conditional error.data is included and its safe schema.

* **Tests**
  * Consolidated and expanded tests to verify the selective error-data contract and prevent echoing of caller input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->