### PR TITLE
Publish attempt source URL OpenAPI bounds

### DIFF
--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -110,6 +110,16 @@ WALLET_MEMO_SCHEMA = {
     "maxLength": 240,
 }
 
+ATTEMPT_SOURCE_URL_SCHEMA = {
+    "type": "string",
+    "format": "uri",
+    "maxLength": 500,
+    "description": (
+        "Optional public HTTP(S) work URL. The API trims whitespace, rejects "
+        "credentials, private hosts, control characters, and values over 500 characters."
+    ),
+}
+
 WALLET_RESPONSE_SCHEMA = _object_schema(
     {
         "address": MRWK_WALLET_ADDRESS_SCHEMA,
@@ -157,7 +167,7 @@ BOUNTY_ATTEMPT_RESPONSE_SCHEMA = _object_schema(
         "id": {"type": "integer", "minimum": 1},
         "bounty_id": {"type": "integer", "minimum": 1},
         "submitter_account": {"type": "string"},
-        "source_url": {"type": "string", "nullable": True},
+        "source_url": {**ATTEMPT_SOURCE_URL_SCHEMA, "nullable": True},
         "status": {"type": "string"},
         "expires_at": {"type": "string"},
         "created_at": {"type": "string"},
@@ -231,9 +241,8 @@ OPTIONAL_ATTEMPT_BODY = {
                     ),
                 },
                 "source_url": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "Optional public work branch or pull request URL.",
+                    **ATTEMPT_SOURCE_URL_SCHEMA,
+                    "nullable": True,
                 },
                 "ttl_seconds": {
                     "anyOf": [

--- a/tests/test_bounty_attempts.py
+++ b/tests/test_bounty_attempts.py
@@ -273,6 +273,39 @@ def test_bounty_attempt_source_url_rejects_raw_control_characters(
         assert session.scalars(select(BountyAttempt)).all() == []
 
 
+def test_bounty_attempt_source_url_rejects_too_long_url(sqlite_url: str, monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", COOKIE_SECRET)
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=329,
+            issue_url="https://github.com/ramimbo/mergework/issues/329",
+            title="Attempt source URL max length",
+            reward_mrwk="50",
+            max_awards=1,
+            acceptance="Attempt source URLs should match the public URL length contract.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _set_login(client, "alice")
+
+    response = client.post(
+        f"/api/v1/bounties/{bounty.id}/attempts",
+        json={
+            "source_url": f"https://example.com/{'a' * 500}",
+            "ttl_seconds": 3600,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "URL is too long"
+    with session_scope(sqlite_url) as session:
+        assert session.scalars(select(BountyAttempt)).all() == []
+
+
 def test_single_award_bounty_warns_when_active_attempt_uses_available_slot(
     sqlite_url: str, monkeypatch
 ) -> None:

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -103,6 +103,10 @@ def test_public_post_openapi_request_bodies_publish_stable_constraints(
         schema.get("type") == "string" and schema.get("pattern") == EXPECTED_TTL_STRING_PATTERN
         for schema in ttl_any_of
     )
+    assert attempt_props["source_url"]["format"] == "uri"
+    assert attempt_props["source_url"]["maxLength"] == 500
+    assert attempt_props["source_url"]["nullable"] is True
+    assert "public HTTP(S)" in attempt_props["source_url"]["description"]
 
     wallet_props = _post_schema(openapi, "/api/v1/wallets/register")["properties"]
     assert wallet_props["public_key_hex"]["minLength"] == 64
@@ -267,6 +271,7 @@ def test_public_post_openapi_response_schemas_expose_wallet_transfer_and_attempt
         openapi, "/api/v1/bounties/{bounty_id}/attempts", "201"
     )
     _assert_properties(registered_attempt_schema, {"status", "attempt", "warnings"})
+    attempt_props = registered_attempt_schema["properties"]["attempt"]["properties"]
     _assert_properties(
         registered_attempt_schema["properties"]["attempt"],
         {
@@ -280,6 +285,9 @@ def test_public_post_openapi_response_schemas_expose_wallet_transfer_and_attempt
             "updated_at",
         },
     )
+    assert attempt_props["source_url"]["format"] == "uri"
+    assert attempt_props["source_url"]["maxLength"] == 500
+    assert attempt_props["source_url"]["nullable"] is True
 
     conflict_schema = _post_response_schema(openapi, "/api/v1/bounties/{bounty_id}/attempts", "409")
     _assert_properties(conflict_schema, {"status", "attempt", "bounty_id", "warnings"})


### PR DESCRIPTION
## Summary
- Publish the existing bounty-attempt `source_url` public URL contract in OpenAPI request and response schemas.
- Add a shared `ATTEMPT_SOURCE_URL_SCHEMA` with `format: uri`, `maxLength: 500`, nullable handling, and the runtime public-host validation note.
- Add focused `/openapi.json` assertions plus a runtime regression test proving over-500-character attempt source URLs are rejected before persistence.

## Bounty scope
Refs #944.

This is a focused public API/OpenAPI client-contract improvement. It is distinct from existing wallet constraint, treasury enum, response-required, and typed attempt response work because it only tightens the existing `source_url` attempt URL contract against the runtime `validate_public_url` behavior and `BountyAttempt.source_url` 500-character storage limit.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py tests\test_bounty_attempts.py -q` -> 21 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py::test_public_post_openapi_request_bodies_publish_stable_constraints tests\test_openapi_request_bodies.py::test_public_post_openapi_response_schemas_expose_wallet_transfer_and_attempt_fields tests\test_bounty_attempts.py::test_bounty_attempt_source_url_rejects_too_long_url -q` -> 3 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\python.exe -m mypy app\openapi_request_bodies.py` -> Success: no issues found.
- `.\.venv\Scripts\ruff.exe check app\openapi_request_bodies.py tests\test_openapi_request_bodies.py tests\test_bounty_attempts.py` -> All checks passed.
- `.\.venv\Scripts\ruff.exe format --check app\openapi_request_bodies.py tests\test_openapi_request_bodies.py tests\test_bounty_attempts.py` -> 3 files already formatted.
- `git diff --check` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `51351c48b1538693f9ce4418ee70714c980f755c`.

## Out of scope
No runtime behavior changes, no bounty lifecycle changes, no ledger/wallet/treasury mutation changes, no payout execution, no bridge/exchange/off-ramp/cash-out or MRWK price behavior, and no private data or secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced source URL validation for bounty attempts with format requirements (public HTTP/HTTPS) and maximum length constraints.

* **Tests**
  * Added test to verify oversized source URLs are rejected with appropriate error messages.
  * Updated schema validation tests to confirm source URL constraints including format, maximum length, and null handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->