### PR TITLE
Advertise wallet transfer MCP output schema

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -119,6 +119,37 @@ MCP_BOUNTY_ATTEMPTS_OUTPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
+MCP_WALLET_TRANSFER_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Serialized signed wallet transfer returned in structuredContent.",
+    "properties": {
+        "hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "type": {"type": "string", "enum": ["wallet_transfer"]},
+        "ledger_sequence": {"type": "integer", "minimum": 1},
+        "from_address": {"type": "string", "pattern": "^mrwk1[0-9a-f]{40}$"},
+        "to_address": {"type": "string", "pattern": "^mrwk1[0-9a-f]{40}$"},
+        "amount_mrwk": {
+            "type": "string",
+            "pattern": r"^(?=.*[1-9])\d+(?:\.\d{1,6})?$",
+        },
+        "nonce": {"type": "integer", "minimum": 1},
+        "memo": {"type": ["string", "null"]},
+        "created_at": {"type": "string"},
+    },
+    "required": [
+        "hash",
+        "type",
+        "ledger_sequence",
+        "from_address",
+        "to_address",
+        "amount_mrwk",
+        "nonce",
+        "memo",
+        "created_at",
+    ],
+    "additionalProperties": False,
+}
+
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
@@ -305,6 +336,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "submit_wallet_transfer",
         "description": "Submit a signed MRWK wallet transfer",
+        "outputSchema": MCP_WALLET_TRANSFER_OUTPUT_SCHEMA,
     },
     {
         "name": "get_ledger_entry",

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -310,7 +310,8 @@ Tools:
 - `get_balance`
 - `register_wallet`
 - `get_wallet`
-- `submit_wallet_transfer`
+- `submit_wallet_transfer` (`tools/list` advertises the signed-transfer output
+  schema returned in structuredContent)
 - `get_ledger_entry`
 - `get_proof`
 - `submit_work_proof` (`format: "json"` returns structuredContent; `tools/list`

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -4,20 +4,43 @@ import json
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from fastapi.testclient import TestClient
 
 from app.db import create_schema, session_scope
 from app.ledger.service import (
     GENESIS_SUPPLY_MICRO,
+    TREASURY_ACCOUNT,
+    add_ledger_entry,
     close_bounty,
     create_bounty,
     ensure_genesis,
     pay_bounty,
+    wallet_transfer_payload,
 )
 from app.main import create_app
 from app.models import BountyAttempt, Proof
 from app.serializers import public_utc_timestamp
 from app.treasury import propose_treasury_action
+from app.wallets import canonical_wallet_json
+
+
+def _mcp_wallet_keypair() -> tuple[Ed25519PrivateKey, str]:
+    private_key = Ed25519PrivateKey.generate()
+    public_hex = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        .hex()
+    )
+    return private_key, public_hex
+
+
+def _sign_wallet_payload(private_key: Ed25519PrivateKey, payload: dict[str, object]) -> str:
+    return private_key.sign(canonical_wallet_json(payload).encode()).hex()
 
 
 def test_health_status_and_bounty_api(sqlite_url: str) -> None:
@@ -424,6 +447,28 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert wallet_schema["properties"]["address"]["pattern"] == (
         "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$"
     )
+    transfer_tool = next(
+        tool for tool in tools["result"]["tools"] if tool["name"] == "submit_wallet_transfer"
+    )
+    transfer_output_schema = transfer_tool["outputSchema"]
+    assert transfer_output_schema["additionalProperties"] is False
+    assert transfer_output_schema["required"] == [
+        "hash",
+        "type",
+        "ledger_sequence",
+        "from_address",
+        "to_address",
+        "amount_mrwk",
+        "nonce",
+        "memo",
+        "created_at",
+    ]
+    assert transfer_output_schema["properties"]["hash"]["pattern"] == "^[0-9a-f]{64}$"
+    assert transfer_output_schema["properties"]["type"]["enum"] == ["wallet_transfer"]
+    assert transfer_output_schema["properties"]["from_address"]["pattern"] == (
+        "^mrwk1[0-9a-f]{40}$"
+    )
+    assert transfer_output_schema["properties"]["memo"]["type"] == ["string", "null"]
     balance_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_balance")
     balance_schema = balance_tool["inputSchema"]
     assert balance_schema["required"] == ["account"]
@@ -2930,6 +2975,91 @@ def test_mcp_can_register_and_fetch_wallet(sqlite_url: str) -> None:
     assert fetched_wallet["address"] == registered_wallet["address"]
     assert fetched_wallet["label"] == "MCP wallet"
     assert fetched_wallet["created_at"] == registered_wallet["created_at"]
+
+
+def test_mcp_submit_wallet_transfer_returns_advertised_structured_payload(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    sender_key, sender_public_hex = _mcp_wallet_keypair()
+    _, receiver_public_hex = _mcp_wallet_keypair()
+
+    sender = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "register_wallet",
+                "arguments": {"public_key_hex": sender_public_hex, "label": "Sender"},
+            },
+        },
+    ).json()["result"]["structuredContent"]
+    receiver = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "register_wallet",
+                "arguments": {"public_key_hex": receiver_public_hex, "label": "Receiver"},
+            },
+        },
+    ).json()["result"]["structuredContent"]
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        add_ledger_entry(
+            session,
+            entry_type="test_funding",
+            from_account=TREASURY_ACCOUNT,
+            to_account=sender["address"],
+            amount_microunits=2_000_000,
+            reference=f"mcp-test-funding:{sender['address']}",
+        )
+
+    transfer_payload = wallet_transfer_payload(
+        from_address=sender["address"],
+        to_address=receiver["address"],
+        amount_microunits=1_000_000,
+        nonce=1,
+        memo="MCP transfer",
+    )
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_wallet_transfer",
+                "arguments": {
+                    "from_address": sender["address"],
+                    "to_address": receiver["address"],
+                    "amount_mrwk": "1",
+                    "nonce": 1,
+                    "memo": "MCP transfer",
+                    "signature_hex": _sign_wallet_payload(sender_key, transfer_payload),
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    result = response.json()["result"]
+    transfer = result["structuredContent"]
+    assert json.loads(result["content"][0]["text"]) == transfer
+    assert transfer["type"] == "wallet_transfer"
+    assert transfer["from_address"] == sender["address"]
+    assert transfer["to_address"] == receiver["address"]
+    assert transfer["amount_mrwk"] == "1"
+    assert transfer["nonce"] == 1
+    assert transfer["memo"] == "MCP transfer"
+    assert len(transfer["hash"]) == 64
+    assert isinstance(transfer["ledger_sequence"], int)
+    assert transfer["created_at"]
 
 
 def test_mcp_wallet_write_tools_reject_unexpected_arguments(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- Add an MCP `outputSchema` for `submit_wallet_transfer`, matching the signed transfer JSON already returned in `result.structuredContent`.
- Capture stable transfer fields for schema-aware clients: hash, fixed `wallet_transfer` type, ledger sequence, from/to wallet addresses, MRWK amount, nonce, nullable memo, and creation timestamp.
- Add focused tests for both `tools/list` metadata and an actual successful signed MCP transfer whose text JSON matches `structuredContent`.
- Update the agent guide to note that the signed-transfer output contract is advertised by `tools/list`.

## Bounty scope
Refs #946.

This is focused MCP structured-output metadata and conformance coverage. Runtime wallet transfer behavior is unchanged.

## Duplicate check
I checked open PR search results and #946 issue comments for `submit_wallet_transfer`, `wallet transfer MCP output schema`, and `outputSchema`. Existing #946 work covers `list_bounty_attempts`, `get_wallet`, `get_bounty`, `submit_work_proof`, `get_balance`, `get_ledger_entry`, and `get_proof` output schemas, plus register-wallet schema work. I did not find an open submission covering `submit_wallet_transfer` outputSchema.

## Verification
- `.\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py::test_mcp_tools_list_and_call tests\test_api_mcp.py::test_mcp_can_register_and_fetch_wallet tests\test_api_mcp.py::test_mcp_submit_wallet_transfer_returns_advertised_structured_payload tests\test_api_mcp.py::test_mcp_wallet_write_tools_reject_unexpected_arguments -q` -> 4 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py tests\test_mcp_tools.py -q` -> 132 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\python.exe -m mypy app\mcp.py` -> Success: no issues found.
- `.\.venv\Scripts\ruff.exe check app\mcp.py tests\test_api_mcp.py docs\agent-guide.md` -> All checks passed.
- `.\.venv\Scripts\ruff.exe format --check app\mcp.py tests\test_api_mcp.py` -> 2 files already formatted.
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean, Windows CRLF warning only for docs.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `a363320939f4bd90e6485c36b56a02d70772d96b`.

## Out of scope
No new MCP tools, no runtime transfer behavior changes, no ledger mutation changes beyond the existing transfer path, no wallet custody changes, no payouts, no treasury mutation, no admin-token behavior, no bridge/exchange/off-ramp/cash-out or MRWK price behavior, and no private data or secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet transfer tool now advertises its complete output schema structure.

* **Documentation**
  * Updated tool reference to clarify output schema disclosure via tools listing.

* **Tests**
  * Added comprehensive test coverage for wallet transfer payload signing and validation, including end-to-end verification of output structure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->