### PR TITLE
Publish treasury proposals GET OpenAPI schemas

### DIFF
--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -220,6 +220,24 @@ TREASURY_PROPOSAL_RESPONSE_SCHEMA = _object_schema(
     }
 )
 
+TREASURY_PROPOSAL_LIST_RESPONSE = {
+    "responses": {
+        "200": _json_response(
+            {"type": "array", "items": TREASURY_PROPOSAL_RESPONSE_SCHEMA},
+            description="Treasury proposals.",
+        ),
+    },
+}
+
+TREASURY_PROPOSAL_DETAIL_RESPONSE = {
+    "responses": {
+        "200": _json_response(
+            TREASURY_PROPOSAL_RESPONSE_SCHEMA,
+            description="Treasury proposal.",
+        ),
+    },
+}
+
 OPTIONAL_ATTEMPT_BODY = {
     "requestBody": _request_body(
         _object_schema(

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -11,7 +11,12 @@ from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import LedgerError
 from app.models import TreasuryProposal
-from app.openapi_request_bodies import TREASURY_CHALLENGE_BODY, TREASURY_PROPOSAL_BODY
+from app.openapi_request_bodies import (
+    TREASURY_CHALLENGE_BODY,
+    TREASURY_PROPOSAL_BODY,
+    TREASURY_PROPOSAL_DETAIL_RESPONSE,
+    TREASURY_PROPOSAL_LIST_RESPONSE,
+)
 from app.path_params import SQLITE_INTEGER_MAX, positive_proposal_id
 from app.query_validation import (
     reject_control_char_query_param,
@@ -129,7 +134,7 @@ def register_treasury_routes(
     require_github_login: Any,
     json_object: Any,
 ) -> None:
-    @app.get("/api/v1/treasury/proposals")
+    @app.get("/api/v1/treasury/proposals", openapi_extra=TREASURY_PROPOSAL_LIST_RESPONSE)
     def api_treasury_proposals(
         request: Request,
         limit: Annotated[int, Query(ge=1, le=200)] = 100,
@@ -200,7 +205,10 @@ def register_treasury_routes(
         with session_scope(db_url) as session:
             return treasury_status(session)
 
-    @app.get("/api/v1/treasury/proposals/{proposal_id}")
+    @app.get(
+        "/api/v1/treasury/proposals/{proposal_id}",
+        openapi_extra=TREASURY_PROPOSAL_DETAIL_RESPONSE,
+    )
     def api_treasury_proposal(request: Request, proposal_id: str) -> dict[str, Any]:
         _reject_treasury_proposal_detail_filters(request)
         proposal_id_int = positive_proposal_id(proposal_id)

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -23,6 +23,12 @@ def _post_response_schema(openapi: dict, path: str, status: str = "200") -> dict
     ]
 
 
+def _get_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
+    return openapi["paths"][path]["get"]["responses"][status]["content"]["application/json"][
+        "schema"
+    ]
+
+
 def _assert_properties(schema: dict, expected: Iterable[str]) -> None:
     assert set(expected).issubset(schema["properties"])
 
@@ -316,6 +322,51 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
     challenge_schema = _post_response_schema(
         openapi, "/api/v1/treasury/proposals/{proposal_id}/challenges"
     )
+    _assert_properties(
+        challenge_schema,
+        {
+            "id",
+            "proposal_id",
+            "challenger_account",
+            "challenge_type",
+            "status",
+            "reason",
+            "created_at",
+        },
+    )
+
+
+def test_public_get_openapi_response_schemas_expose_treasury_proposal_fields(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    proposal_fields = {
+        "id",
+        "type",
+        "action",
+        "status",
+        "payload_hash",
+        "payload",
+        "proposed_by",
+        "executed_by",
+        "proposed_at",
+        "executes_after",
+        "executed_at",
+        "executed_ledger_sequence",
+        "result",
+        "challenges",
+    }
+
+    list_schema = _get_response_schema(openapi, "/api/v1/treasury/proposals")
+    assert list_schema["type"] == "array"
+    _assert_properties(list_schema["items"], proposal_fields)
+
+    detail_schema = _get_response_schema(openapi, "/api/v1/treasury/proposals/{proposal_id}")
+    _assert_properties(detail_schema, proposal_fields)
+
+    challenge_schema = detail_schema["properties"]["challenges"]["items"]
     _assert_properties(
         challenge_schema,
         {


### PR DESCRIPTION
## Summary
- Publish explicit OpenAPI `200` response schemas for public treasury proposal GET routes.
- `GET /api/v1/treasury/proposals` now advertises an array of treasury proposal payloads.
- `GET /api/v1/treasury/proposals/{proposal_id}` now advertises the single treasury proposal payload.
- Reuses the existing `TREASURY_PROPOSAL_RESPONSE_SCHEMA` and nested challenge schema, preserving runtime JSON behavior.

## Bounty scope
Refs #944.

This is a focused public API/OpenAPI client-contract improvement for existing public read routes. It does not change treasury behavior or response shape.

## Duplicate check
I searched open PRs and #944 comments for treasury proposal GET/OpenAPI response schema work, including `treasury proposals OpenAPI response schema`, `treasury proposal list response schema`, and `GET /api/v1/treasury/proposals OpenAPI`. I found existing treasury enum and POST response-required work, but no open submission covering the GET treasury proposal list/detail response schemas.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py tests\test_treasury_proposals.py::test_treasury_proposals_list_filters_by_action_status_and_bounty_id tests\test_treasury_proposals.py::test_treasury_proposals_list_rejects_invalid_filters tests\test_treasury_proposals.py::test_treasury_proposals_list_rejects_repeated_scalar_filters -q` -> 26 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py -q` -> 9 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\python.exe -m mypy app\openapi_request_bodies.py app\treasury_routes.py` -> Success: no issues found.
- `.\.venv\Scripts\ruff.exe check app\openapi_request_bodies.py app\treasury_routes.py tests\test_openapi_request_bodies.py` -> All checks passed.
- `.\.venv\Scripts\ruff.exe format --check app\openapi_request_bodies.py app\treasury_routes.py tests\test_openapi_request_bodies.py` -> 3 files already formatted.
- `git diff --check` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `10c4a7018132aab0b2edd9a69fa5c12219c6c7b6`.

## Out of scope
No runtime JSON changes, no treasury proposal execution changes, no payout execution, no ledger mutation, no wallet custody, no bridge/exchange/off-ramp/cash-out or MRWK price behavior, and no private data or secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced OpenAPI documentation and API metadata for treasury proposal list and detail endpoints, adding complete response schemas.

* **Tests**
  * Added tests validating the public OpenAPI response schemas expose expected treasury proposal fields, including nested challenge item fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->