### PR TITLE
Publish bounty read OpenAPI response schemas

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -26,6 +26,7 @@ from app.ledger.service import (
     validate_public_url,
 )
 from app.models import Bounty, Proof, Submission
+from app.openapi_request_bodies import BOUNTY_DETAIL_RESPONSE, BOUNTY_LIST_RESPONSE
 from app.path_params import SQLITE_INTEGER_MAX, issue_number_search_value, positive_bounty_id
 from app.query_validation import (
     reject_control_char_query_param,
@@ -218,7 +219,7 @@ def register_bounty_api_routes(
             context="bounty detail",
         )
 
-    @app.get("/api/v1/bounties")
+    @app.get("/api/v1/bounties", openapi_extra=BOUNTY_LIST_RESPONSE)
     def api_bounties(
         request: Request,
         status: str | None = Query(None),
@@ -331,7 +332,7 @@ def register_bounty_api_routes(
             result["accepted_awards"] = bounty_awards_to_dict(session, bounty.id)
             return result
 
-    @app.get("/api/v1/bounties/{bounty_id}")
+    @app.get("/api/v1/bounties/{bounty_id}", openapi_extra=BOUNTY_DETAIL_RESPONSE)
     def api_bounty(request: Request, bounty_id: str) -> dict[str, Any]:
         _reject_bounty_detail_list_filters(request)
         return get_bounty_detail(bounty_id)

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -220,6 +220,202 @@ TREASURY_PROPOSAL_RESPONSE_SCHEMA = _object_schema(
     }
 )
 
+SUBMISSION_REQUIREMENTS_SCHEMA = _object_schema(
+    {
+        "submission_mode": {"type": "string"},
+        "submission_url_kind": {"type": "string"},
+        "expected_artifact": {"type": "string"},
+        "attempt_endpoint_applicability": {"type": "string"},
+        "reference_formats": {"type": "array", "items": {"type": "string"}},
+        "claim_command": {"type": "string"},
+        "attempt_endpoint": {"type": "string"},
+        "evidence_required": {"type": "array", "items": {"type": "string"}},
+        "acceptance_trigger": {"type": "string"},
+        "public_metadata_must_avoid": {"type": "array", "items": {"type": "string"}},
+        "next_actions": {
+            "type": "array",
+            "items": {"type": "object", "additionalProperties": True},
+        },
+    },
+    required=[
+        "submission_mode",
+        "submission_url_kind",
+        "expected_artifact",
+        "attempt_endpoint_applicability",
+        "reference_formats",
+        "claim_command",
+        "attempt_endpoint",
+        "evidence_required",
+        "acceptance_trigger",
+        "public_metadata_must_avoid",
+        "next_actions",
+    ],
+)
+
+PENDING_PAYOUT_PROPOSAL_SCHEMA = _object_schema(
+    {
+        "proposal_id": {"type": "integer", "minimum": 1},
+        "proposed_by": {"type": "string"},
+        "proposed_at": {"type": "string"},
+        "executes_after": {"type": "string"},
+        "to_account": {"type": "string", "nullable": True},
+        "submission_url": {"type": "string", "nullable": True},
+        "accepted_by": {"type": "string", "nullable": True},
+    },
+    required=[
+        "proposal_id",
+        "proposed_by",
+        "proposed_at",
+        "executes_after",
+        "to_account",
+        "submission_url",
+        "accepted_by",
+    ],
+)
+
+PENDING_CLOSE_PROPOSAL_SCHEMA = _object_schema(
+    {
+        "proposal_id": {"type": "integer", "minimum": 1},
+        "proposed_by": {"type": "string"},
+        "proposed_at": {"type": "string"},
+        "executes_after": {"type": "string"},
+        "closed_by": {"type": "string", "nullable": True},
+        "reference": {"type": "string", "nullable": True},
+    },
+    required=[
+        "proposal_id",
+        "proposed_by",
+        "proposed_at",
+        "executes_after",
+        "closed_by",
+        "reference",
+    ],
+)
+
+BOUNTY_RESPONSE_REQUIRED_FIELDS = [
+    "id",
+    "repo",
+    "issue_number",
+    "issue_url",
+    "title",
+    "reward_mrwk",
+    "available_mrwk",
+    "reserved_mrwk",
+    "max_awards",
+    "awards_paid",
+    "awards_remaining",
+    "effective_available_mrwk",
+    "effective_awards_remaining",
+    "pending_payout_awards",
+    "pending_payout_proposals",
+    "pending_close_proposal",
+    "availability_state",
+    "availability_note",
+    "submission_requirements",
+    "status",
+    "acceptance",
+    "created_at",
+    "active_attempt_count",
+    "active_attempt_warnings",
+    "attempt_endpoint",
+]
+
+BOUNTY_RESPONSE_SCHEMA = _object_schema(
+    {
+        "id": {"type": "integer", "minimum": 1},
+        "repo": {"type": "string"},
+        "issue_number": {"type": "integer", "minimum": 1},
+        "issue_url": {"type": "string", "format": "uri"},
+        "title": {"type": "string"},
+        "reward_mrwk": MRWK_DECIMAL_SCHEMA,
+        "available_mrwk": MRWK_DECIMAL_SCHEMA,
+        "reserved_mrwk": MRWK_DECIMAL_SCHEMA,
+        "max_awards": {"type": "integer", "minimum": 1},
+        "awards_paid": {"type": "integer", "minimum": 0},
+        "awards_remaining": {"type": "integer", "minimum": 0},
+        "effective_available_mrwk": MRWK_DECIMAL_SCHEMA,
+        "effective_awards_remaining": {"type": "integer", "minimum": 0},
+        "pending_payout_awards": {"type": "integer", "minimum": 0},
+        "pending_payout_proposals": {
+            "type": "array",
+            "items": PENDING_PAYOUT_PROPOSAL_SCHEMA,
+        },
+        "pending_close_proposal": {**PENDING_CLOSE_PROPOSAL_SCHEMA, "nullable": True},
+        "availability_state": {
+            "type": "string",
+            "enum": [
+                "open",
+                "full",
+                "pending_payouts_partial",
+                "pending_payouts_full",
+                "pending_close",
+                "paid",
+                "closed",
+            ],
+        },
+        "availability_note": {"type": "string"},
+        "submission_requirements": SUBMISSION_REQUIREMENTS_SCHEMA,
+        "status": {"type": "string", "enum": ["open", "paid", "closed"]},
+        "acceptance": {"type": "string"},
+        "created_at": {"type": "string"},
+        "active_attempt_count": {"type": "integer", "minimum": 0},
+        "active_attempt_warnings": {"type": "array", "items": {"type": "string"}},
+        "attempt_endpoint": {"type": "string"},
+    },
+    required=BOUNTY_RESPONSE_REQUIRED_FIELDS,
+    description="Public bounty row returned by the bounty list and detail APIs.",
+)
+
+BOUNTY_ACCEPTED_AWARD_SCHEMA = _object_schema(
+    {
+        "proof_hash": LOWERCASE_HEX_64_SCHEMA,
+        "proof_url": {"type": "string"},
+        "ledger_sequence": {"type": "integer", "minimum": 1},
+        "ledger_url": {"type": "string"},
+        "account": {"type": "string", "nullable": True},
+        "amount_mrwk": {**MRWK_DECIMAL_SCHEMA, "nullable": True},
+        "submission_url": {"type": "string", "nullable": True},
+        "accepted_by": {"type": "string", "nullable": True},
+        "created_at": {"type": "string"},
+    },
+    required=[
+        "proof_hash",
+        "proof_url",
+        "ledger_sequence",
+        "ledger_url",
+        "account",
+        "amount_mrwk",
+        "submission_url",
+        "accepted_by",
+        "created_at",
+    ],
+)
+
+BOUNTY_DETAIL_RESPONSE_SCHEMA = {
+    **BOUNTY_RESPONSE_SCHEMA,
+    "properties": {
+        **BOUNTY_RESPONSE_SCHEMA["properties"],
+        "accepted_awards": {"type": "array", "items": BOUNTY_ACCEPTED_AWARD_SCHEMA},
+    },
+    "required": [*BOUNTY_RESPONSE_REQUIRED_FIELDS, "accepted_awards"],
+    "description": "Public bounty detail row including proof-backed accepted awards.",
+}
+
+BOUNTY_LIST_RESPONSE = {
+    "responses": {
+        "200": _json_response(
+            {"type": "array", "items": BOUNTY_RESPONSE_SCHEMA},
+            description="Public bounty rows.",
+        ),
+    },
+}
+
+BOUNTY_DETAIL_RESPONSE = {
+    "responses": {
+        "200": _json_response(BOUNTY_DETAIL_RESPONSE_SCHEMA, description="Public bounty detail."),
+    },
+}
+
 OPTIONAL_ATTEMPT_BODY = {
     "requestBody": _request_body(
         _object_schema(

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -23,6 +23,12 @@ def _post_response_schema(openapi: dict, path: str, status: str = "200") -> dict
     ]
 
 
+def _get_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
+    return openapi["paths"][path]["get"]["responses"][status]["content"]["application/json"][
+        "schema"
+    ]
+
+
 def _assert_properties(schema: dict, expected: Iterable[str]) -> None:
     assert set(expected).issubset(schema["properties"])
 
@@ -328,6 +334,81 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
             "created_at",
         },
     )
+
+
+def test_public_get_bounty_openapi_response_schemas_expose_bounty_fields(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    list_schema = _get_response_schema(openapi, "/api/v1/bounties")
+    assert list_schema["type"] == "array"
+    bounty_schema = list_schema["items"]
+    detail_schema = _get_response_schema(openapi, "/api/v1/bounties/{bounty_id}")
+
+    expected_fields = {
+        "id",
+        "repo",
+        "issue_number",
+        "issue_url",
+        "title",
+        "reward_mrwk",
+        "available_mrwk",
+        "reserved_mrwk",
+        "max_awards",
+        "awards_paid",
+        "awards_remaining",
+        "effective_available_mrwk",
+        "effective_awards_remaining",
+        "pending_payout_awards",
+        "pending_payout_proposals",
+        "pending_close_proposal",
+        "availability_state",
+        "availability_note",
+        "submission_requirements",
+        "status",
+        "acceptance",
+        "created_at",
+        "active_attempt_count",
+        "active_attempt_warnings",
+        "attempt_endpoint",
+    }
+    for schema in (bounty_schema, detail_schema):
+        _assert_properties(schema, expected_fields)
+        assert expected_fields.issubset(schema["required"])
+
+    props = bounty_schema["properties"]
+    assert props["issue_url"]["format"] == "uri"
+    assert props["reward_mrwk"]["pattern"] == r"^\d+(?:\.\d{1,6})?$"
+    assert props["effective_available_mrwk"]["pattern"] == r"^\d+(?:\.\d{1,6})?$"
+    assert props["max_awards"]["minimum"] == 1
+    assert props["awards_paid"]["minimum"] == 0
+    assert props["effective_awards_remaining"]["minimum"] == 0
+    assert props["pending_close_proposal"]["nullable"] is True
+    assert set(props["status"]["enum"]) == {"open", "paid", "closed"}
+    assert "pending_payouts_partial" in props["availability_state"]["enum"]
+    assert props["submission_requirements"]["properties"]["next_actions"]["type"] == "array"
+
+    accepted_awards = detail_schema["properties"]["accepted_awards"]
+    assert "accepted_awards" in detail_schema["required"]
+    award_props = accepted_awards["items"]["properties"]
+    _assert_properties(
+        accepted_awards["items"],
+        {
+            "proof_hash",
+            "proof_url",
+            "ledger_sequence",
+            "ledger_url",
+            "account",
+            "amount_mrwk",
+            "submission_url",
+            "accepted_by",
+            "created_at",
+        },
+    )
+    assert award_props["proof_hash"]["pattern"] == "^[0-9a-f]{64}$"
+    assert award_props["amount_mrwk"]["nullable"] is True
 
 
 def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- Publish explicit OpenAPI `200` response schemas for public bounty read routes: `GET /api/v1/bounties` and `GET /api/v1/bounties/{bounty_id}`.
- Document the current runtime bounty row fields used by clients and agents, including capacity fields, pending payout/close proposal summaries, availability state, submission requirements, and active-attempt summary.
- Document the bounty detail-only `accepted_awards` proof-backed award history shape.
- Preserve existing runtime JSON behavior; this is OpenAPI/client contract metadata plus regression coverage only.

## Bounty scope
Refs #944.

This is a focused public API/OpenAPI client-contract improvement for existing public read routes. It does not change bounty list/detail serialization or filtering behavior.

## Duplicate check
I searched open #944 submissions and PRs for bounty read/list/detail OpenAPI response schema overlap, including `GET /api/v1/bounties`, `bounty list response schema`, `bounty detail response schema`, and `OpenAPI bounty read`. Existing open work covers bounty attempts, activity, summary, accounts, ledger/proof, treasury status/proposals, wallet constraints, and POST response metadata. I did not find an open submission covering the public bounty list/detail response schemas.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py tests\test_bounty_api.py tests\test_bounty_api_routes.py -q` -> 56 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\ruff.exe check app\openapi_request_bodies.py app\bounty_api.py tests\test_openapi_request_bodies.py` -> All checks passed.
- `.\.venv\Scripts\ruff.exe format --check app\openapi_request_bodies.py app\bounty_api.py tests\test_openapi_request_bodies.py` -> 3 files already formatted.
- `.\.venv\Scripts\python.exe -m mypy app\openapi_request_bodies.py app\bounty_api.py` -> Success: no issues found.
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `1d699935dedfe714911a3a19251826b5e8a930ca`.

## Out of scope
No runtime JSON changes, no bounty filtering/sorting changes, no payment or payout execution, no ledger mutation, no wallet custody, no treasury execution, no admin-token behavior, no bridge/exchange/off-ramp/cash-out or MRWK price behavior, and no private data or secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed OpenAPI response documentation for bounty list and detail endpoints, specifying required fields, types, enums, nullable fields, and nested structures (submission requirements, pending proposals, accepted awards).

* **Tests**
  * Added tests that validate the public bounty API response schemas to ensure fields, formats, constraints, and required properties are correctly documented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->