### PR TITLE
Fix activity search notice rendering

### DIFF
--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -18,7 +18,7 @@
 {% elif account %}
 <p class="notice">Showing accepted work for <code>{{ account }}</code></p>
 {% elif query %}
-<p class="notice">Showing accepted work matching “{{ query }}”.</p>
+<p class="notice">Showing accepted work matching "{{ query }}"</p>
 {% endif %}
 <nav class="actions detail-actions" aria-label="Activity inspection links">
   <a href="{{ api_activity_url }}">View JSON activity</a>

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -201,6 +201,18 @@ def test_activity_api_filters_accepted_work_by_query(sqlite_url: str) -> None:
         assert invalid_hash_query["recent"] == []
 
 
+def test_activity_page_renders_search_notice(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/activity?q=Proof")
+
+    assert response.status_code == 200
+    assert 'Showing accepted work matching "proof"' in response.text
+    assert "{{ query }}" not in response.text
+
+
 def test_activity_api_filters_by_exact_account(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -525,14 +537,14 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
 
     assert filtered.status_code == 200
     assert 'value="bob"' in filtered.text
-    assert "Showing accepted work matching “bob”." in filtered.text
+    assert 'Showing accepted work matching "bob"' in filtered.text
     assert 'href="/api/v1/activity?q=bob">View JSON activity</a>' in filtered.text
     assert 'href="/activity">Clear</a>' in filtered.text
     assert "No contributors match this search." not in filtered.text
     assert "No accepted work matches this search." not in filtered.text
     assert issue_ref.status_code == 200
     assert 'value="#12"' in issue_ref.text
-    assert "Showing accepted work matching “#12”." in issue_ref.text
+    assert 'Showing accepted work matching "#12"' in issue_ref.text
     assert 'href="/api/v1/activity?q=%2312">View JSON activity</a>' in issue_ref.text
     assert "github:bob" in issue_ref.text
 
@@ -540,7 +552,7 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
 
     assert no_match.status_code == 200
     assert 'value="alice"' in no_match.text
-    assert "Showing accepted work matching “alice”." in no_match.text
+    assert 'Showing accepted work matching "alice"' in no_match.text
     assert "No contributors match this search." in no_match.text
     assert "No accepted work matches this search." in no_match.text
     assert "No pending accepted work matches this search." in no_match.text


### PR DESCRIPTION
## Summary
- Fix the public `/activity?q=...` notice so the accepted-work search term renders plainly instead of relying on typographic quote text.
- Add regression coverage for the activity page search notice, including a guard that the raw `{{ query }}` placeholder never leaks into rendered HTML.
- Update existing activity page assertions to match the normalized ASCII notice text.

## Bounty scope
Refs #935.

This is a focused public activity-page clarity fix for contributor discovery. It preserves activity filtering, account scoping, API URLs, pending-work rows, paid-work rows, ledger/proof/account links, and all bounty lifecycle semantics.

## Duplicate check
I checked open PRs and #935 comments for activity query/search notice work (`activity query notice`, `activity search notice`, `accepted work`) and did not find an open submission covering this page notice rendering gap.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_activity.py tests\test_activity_routes.py -q` -> 9 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\ruff.exe check tests\test_activity.py tests\test_activity_routes.py` -> All checks passed.
- `.\.venv\Scripts\ruff.exe format --check tests\test_activity.py tests\test_activity_routes.py` -> 2 files already formatted.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `1d699935dedfe714911a3a19251826b5e8a930ca`.

## Out of scope
No payout execution, ledger mutation, wallet behavior, treasury/proposal execution, admin-token behavior, bridge/exchange/off-ramp/cash-out behavior, MRWK price behavior, private data, or secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected search notice text formatting to use straight quotes instead of curly quotes for better consistency and readability.

* **Tests**
  * Added new test coverage for search notice rendering on the activity page.
  * Updated existing tests to match the revised search notice formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->