### PR TITLE
Publish wallet lookup OpenAPI response schema

### DIFF
--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -297,6 +297,12 @@ WALLET_REGISTER_BODY = {
     },
 }
 
+WALLET_LOOKUP_RESPONSE = {
+    "responses": {
+        "200": _json_response(WALLET_RESPONSE_SCHEMA),
+    },
+}
+
 SIGNED_WALLET_ACTION_PROPERTIES = {
     "address": MRWK_WALLET_ADDRESS_SCHEMA,
     "nonce": INTEGER_OR_STRING_SCHEMA,

--- a/app/wallet_api.py
+++ b/app/wallet_api.py
@@ -17,6 +17,7 @@ from app.models import Wallet
 from app.openapi_request_bodies import (
     GITHUB_CLAIM_BODY,
     SIGNED_WALLET_ACTION_BODY,
+    WALLET_LOOKUP_RESPONSE,
     WALLET_REGISTER_BODY,
     WALLET_TRANSFER_BODY,
 )
@@ -66,7 +67,7 @@ def register_wallet_api_routes(
     def api_link_wallet_github_get() -> None:
         post_only_route()
 
-    @app.get("/api/v1/wallets/{address}")
+    @app.get("/api/v1/wallets/{address}", openapi_extra=WALLET_LOOKUP_RESPONSE)
     def api_wallet(request: Request, address: str) -> dict[str, Any]:
         reject_path_whitespace_padding(address, "MRWK wallet address")
         if request.query_params.getlist("type") or request.query_params.getlist("tx_type"):

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -23,6 +23,12 @@ def _post_response_schema(openapi: dict, path: str, status: str = "200") -> dict
     ]
 
 
+def _get_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
+    return openapi["paths"][path]["get"]["responses"][status]["content"]["application/json"][
+        "schema"
+    ]
+
+
 def _assert_properties(schema: dict, expected: Iterable[str]) -> None:
     assert set(expected).issubset(schema["properties"])
 
@@ -328,6 +334,40 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
             "created_at",
         },
     )
+
+
+def test_public_get_wallet_openapi_response_schema_exposes_wallet_fields(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    wallet_schema = _get_response_schema(openapi, "/api/v1/wallets/{address}")
+    _assert_properties(
+        wallet_schema,
+        {
+            "address",
+            "public_key_hex",
+            "label",
+            "github_login",
+            "balance_mrwk",
+            "nonce",
+            "next_nonce",
+            "created_at",
+        },
+    )
+    wallet_props = wallet_schema["properties"]
+    assert wallet_props["address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
+    assert wallet_props["address"]["minLength"] == 45
+    assert wallet_props["address"]["maxLength"] == 45
+    assert wallet_props["public_key_hex"]["pattern"] == "^[0-9a-f]{64}$"
+    assert wallet_props["public_key_hex"]["minLength"] == 64
+    assert wallet_props["public_key_hex"]["maxLength"] == 64
+    assert wallet_props["balance_mrwk"]["pattern"] == r"^\d+(?:\.\d{1,6})?$"
+    assert wallet_props["nonce"]["minimum"] == 0
+    assert wallet_props["next_nonce"]["minimum"] == 1
+    assert wallet_props["label"]["nullable"] is True
+    assert wallet_props["github_login"]["nullable"] is True
 
 
 def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- Publish an explicit OpenAPI `200` response schema for `GET /api/v1/wallets/{address}`.
- Reuse the existing wallet response schema so wallet lookup exposes the same stable address, public key, balance, nonce, next nonce, label, GitHub login, and created-at fields as wallet registration/link responses.
- Preserve runtime wallet lookup behavior; this is OpenAPI/client-contract metadata plus focused regression coverage only.

## Bounty scope
Refs #944.

This is a focused public API/OpenAPI client-contract improvement for an existing public read route. It does not change wallet lookup serialization, balance calculation, registration, linking, signed transfers, or wallet custody behavior.

## Duplicate check
Searched open PRs and #944 submissions for wallet lookup/OpenAPI response schema overlap, including `wallets address OpenAPI response schema`, `/api/v1/wallets`, and wallet response schema work. Existing open work covers wallet POST request/response schemas, MCP wallet output schemas, and unrelated wallet path validation. I did not find an open #944 submission covering the public `GET /api/v1/wallets/{address}` response schema.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py tests\test_wallet_api.py -q` -> 54 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\ruff.exe check app\openapi_request_bodies.py app\wallet_api.py tests\test_openapi_request_bodies.py` -> All checks passed.
- `.\.venv\Scripts\ruff.exe format --check app\openapi_request_bodies.py app\wallet_api.py tests\test_openapi_request_bodies.py` -> 3 files already formatted.
- `.\.venv\Scripts\python.exe -m mypy app\openapi_request_bodies.py app\wallet_api.py` -> Success: no issues found.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `1d699935dedfe714911a3a19251826b5e8a930ca`.

## Out of scope
No runtime JSON changes, no wallet custody, no signing behavior, no wallet registration/linking/transfer behavior, no ledger mutation, no payout execution, no treasury/proposal execution, no admin-token behavior, no bridge/exchange/off-ramp/cash-out or MRWK price behavior, and no private data or secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved OpenAPI specifications for the wallet lookup endpoint, including detailed response schema definitions and field constraints.

* **Tests**
  * Added validation tests to verify wallet lookup API responses include all required fields and conform to documented specifications, including property constraints and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->