### PR TITLE
Publish auth session OpenAPI response schema

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.me import me_page_context
 from app.models import (
     Proof,
 )
+from app.openapi_request_bodies import AUTH_ME_RESPONSE
 from app.path_params import (
     SQLITE_INTEGER_MAX,
     positive_bounty_id,
@@ -228,7 +229,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     register_account_routes(app, db_url=db_url, templates=templates)
 
-    @app.get("/api/v1/auth/me")
+    @app.get("/api/v1/auth/me", openapi_extra=AUTH_ME_RESPONSE)
     def api_auth_me(request: Request) -> dict[str, Any]:
         login = auth.github_login_from_request(request)
         return {"authenticated": login is not None, "github_login": login}

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -123,6 +123,22 @@ WALLET_RESPONSE_SCHEMA = _object_schema(
     }
 )
 
+AUTH_ME_RESPONSE_SCHEMA = _object_schema(
+    {
+        "authenticated": {
+            "type": "boolean",
+            "description": "Whether the request has a valid GitHub session.",
+        },
+        "github_login": {
+            "type": "string",
+            "nullable": True,
+            "description": "Authenticated GitHub login, or null when signed out.",
+        },
+    },
+    required=["authenticated", "github_login"],
+    description="Current GitHub session state for the caller.",
+)
+
 LEDGER_ENTRY_RESPONSE_SCHEMA = _object_schema(
     {
         "sequence": {"type": "integer", "minimum": 1},
@@ -315,6 +331,12 @@ SIGNED_WALLET_ACTION_BODY = {
     ),
     "responses": {
         "200": _json_response(WALLET_RESPONSE_SCHEMA),
+    },
+}
+
+AUTH_ME_RESPONSE = {
+    "responses": {
+        "200": _json_response(AUTH_ME_RESPONSE_SCHEMA),
     },
 }
 

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -23,6 +23,12 @@ def _post_response_schema(openapi: dict, path: str, status: str = "200") -> dict
     ]
 
 
+def _get_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
+    return openapi["paths"][path]["get"]["responses"][status]["content"]["application/json"][
+        "schema"
+    ]
+
+
 def _assert_properties(schema: dict, expected: Iterable[str]) -> None:
     assert set(expected).issubset(schema["properties"])
 
@@ -328,6 +334,25 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
             "created_at",
         },
     )
+
+
+def test_auth_me_openapi_response_schema_exposes_session_fields(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    schema = _get_response_schema(openapi, "/api/v1/auth/me")
+    assert schema["type"] == "object"
+    assert set(schema["required"]) == {"authenticated", "github_login"}
+    _assert_properties(schema, {"authenticated", "github_login"})
+
+    props = schema["properties"]
+    assert props["authenticated"]["type"] == "boolean"
+    assert props["github_login"]["type"] == "string"
+    assert props["github_login"]["nullable"] is True
+
+    response = client.get("/api/v1/auth/me")
+    assert response.status_code == 200
+    assert response.json() == {"authenticated": False, "github_login": None}
 
 
 def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #944
Refs #944

## Summary

- Publishes an explicit OpenAPI `200` response schema for `GET /api/v1/auth/me`.
- Documents the existing runtime session fields: `authenticated` and nullable `github_login`.
- Adds regression coverage proving `/openapi.json` exposes the schema and the unauthenticated runtime JSON shape remains unchanged.

## Duplicate Check

- Searched current PRs and bounty comments for `/api/v1/auth/me` OpenAPI response schema work.
- Existing #944 submissions cover wallet, account, bounty, ledger/proof, work-discovery, activity, treasury, and attempt schema surfaces.
- I did not find an open #944 submission covering the auth session status response contract.

## Validation

- `.\\.venv\\Scripts\\python.exe -m pytest tests\\test_openapi_request_bodies.py tests\\test_wallet_api.py::test_auth_routes_exist_when_oauth_is_unconfigured -q` -> 10 passed, 1 existing Starlette/httpx warning.
- `.\\.venv\\Scripts\\ruff.exe check app\\openapi_request_bodies.py app\\main.py tests\\test_openapi_request_bodies.py` -> All checks passed.
- `.\\.venv\\Scripts\\ruff.exe format --check app\\openapi_request_bodies.py app\\main.py tests\\test_openapi_request_bodies.py` -> 3 files already formatted.
- `.\\.venv\\Scripts\\python.exe -m mypy app\\openapi_request_bodies.py app\\main.py` -> Success: no issues found.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `1d699935dedfe714911a3a19251826b5e8a930ca`.

## Scope

Touched surfaces: `app/openapi_request_bodies.py`, `app/main.py`, `tests/test_openapi_request_bodies.py`.

This is OpenAPI/client response metadata plus focused regression coverage only. It does not change runtime auth/session behavior, OAuth configuration, wallet custody, signing, transfers, ledger mutation, payout execution, treasury/proposal execution, admin-token behavior, bridge/exchange/off-ramp/cash-out behavior, MRWK price behavior, private data, or secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced API docs for the /api/v1/auth/me endpoint to include a detailed 200 response schema showing an authentication boolean and a nullable username field.

* **Tests**
  * Added tests that validate the API documentation exposes the expected response structure and that the endpoint returns the documented runtime shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->