### PR TITLE
Publish health and status OpenAPI response schemas

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.me import me_page_context
 from app.models import (
     Proof,
 )
+from app.openapi_request_bodies import HEALTH_RESPONSE, SYSTEM_STATUS_RESPONSE
 from app.path_params import (
     SQLITE_INTEGER_MAX,
     positive_bounty_id,
@@ -180,12 +181,12 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
 
     auth = auth_module.register_auth_routes(app, settings=settings)
 
-    @app.get("/health")
+    @app.get("/health", responses=HEALTH_RESPONSE)
     def health() -> dict[str, Any]:
         with session_scope(db_url) as session:
             return health_status(session)
 
-    @app.get("/api/v1/status")
+    @app.get("/api/v1/status", responses=SYSTEM_STATUS_RESPONSE)
     def api_status() -> dict[str, Any]:
         with session_scope(db_url) as session:
             return system_status(session)

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -67,6 +67,53 @@ MRWK_DECIMAL_SCHEMA = {
     "pattern": r"^\d+(?:\.\d{1,6})?$",
 }
 
+HEALTH_RESPONSE_SCHEMA = _object_schema(
+    {
+        "ok": {"type": "boolean"},
+        "service": {"type": "string"},
+        "ticker": {"type": "string"},
+        "ledger_height": {"type": "integer", "minimum": 0},
+    },
+    required=["ok", "service", "ticker", "ledger_height"],
+    description="Public health check response.",
+)
+
+SYSTEM_STATUS_RESPONSE_SCHEMA = _object_schema(
+    {
+        "name": {"type": "string"},
+        "ticker": {"type": "string"},
+        "genesis_supply_mrwk": MRWK_DECIMAL_SCHEMA,
+        "ledger_height": {"type": "integer", "minimum": 0},
+        "active_bounties": {"type": "integer", "minimum": 0},
+        "treasury_balance_mrwk": MRWK_DECIMAL_SCHEMA,
+        "current_transfer_paths": {"type": "array", "items": {"type": "string"}},
+        "unsupported_public_paths": {"type": "array", "items": {"type": "string"}},
+        "unsupported_public_paths_summary": {"type": "string"},
+        "future_path": {"type": "string"},
+        "future_path_boundary": {"type": "string"},
+    },
+    required=[
+        "name",
+        "ticker",
+        "genesis_supply_mrwk",
+        "ledger_height",
+        "active_bounties",
+        "treasury_balance_mrwk",
+        "current_transfer_paths",
+        "unsupported_public_paths",
+        "unsupported_public_paths_summary",
+        "future_path",
+        "future_path_boundary",
+    ],
+    description="Public system status response.",
+)
+
+HEALTH_RESPONSE: dict[int | str, dict[str, Any]] = {200: _json_response(HEALTH_RESPONSE_SCHEMA)}
+
+SYSTEM_STATUS_RESPONSE: dict[int | str, dict[str, Any]] = {
+    200: _json_response(SYSTEM_STATUS_RESPONSE_SCHEMA)
+}
+
 BOUNDED_TTL_STRING_SCHEMA = {
     "type": "string",
     "description": "Integer value encoded as a string (60..604800).",

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -23,6 +23,12 @@ def _post_response_schema(openapi: dict, path: str, status: str = "200") -> dict
     ]
 
 
+def _get_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
+    return openapi["paths"][path]["get"]["responses"][status]["content"]["application/json"][
+        "schema"
+    ]
+
+
 def _assert_properties(schema: dict, expected: Iterable[str]) -> None:
     assert set(expected).issubset(schema["properties"])
 
@@ -341,3 +347,46 @@ def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None
 
     assert attempt_body.get("required") is not True
     assert release_body.get("required") is not True
+
+
+def test_public_status_openapi_response_schemas_expose_runtime_fields(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    health_schema = _get_response_schema(openapi, "/health")
+    assert health_schema["description"] == "Public health check response."
+    assert health_schema["required"] == ["ok", "service", "ticker", "ledger_height"]
+    assert health_schema["properties"]["ok"] == {"type": "boolean"}
+    assert health_schema["properties"]["ledger_height"] == {"type": "integer", "minimum": 0}
+
+    status_schema = _get_response_schema(openapi, "/api/v1/status")
+    assert status_schema["description"] == "Public system status response."
+    assert status_schema["required"] == [
+        "name",
+        "ticker",
+        "genesis_supply_mrwk",
+        "ledger_height",
+        "active_bounties",
+        "treasury_balance_mrwk",
+        "current_transfer_paths",
+        "unsupported_public_paths",
+        "unsupported_public_paths_summary",
+        "future_path",
+        "future_path_boundary",
+    ]
+    assert status_schema["properties"]["ledger_height"] == {"type": "integer", "minimum": 0}
+    assert status_schema["properties"]["active_bounties"] == {"type": "integer", "minimum": 0}
+    assert status_schema["properties"]["genesis_supply_mrwk"]["pattern"] == (r"^\d+(?:\.\d{1,6})?$")
+    assert status_schema["properties"]["treasury_balance_mrwk"]["pattern"] == (
+        r"^\d+(?:\.\d{1,6})?$"
+    )
+    assert status_schema["properties"]["current_transfer_paths"]["items"] == {"type": "string"}
+    assert status_schema["properties"]["unsupported_public_paths"]["items"] == {"type": "string"}
+
+    health = client.get("/health").json()
+    status = client.get("/api/v1/status").json()
+
+    assert set(health_schema["required"]) == set(health)
+    assert set(status_schema["required"]) == set(status)


### PR DESCRIPTION
﻿## Summary
- Publishes explicit OpenAPI `200` response schemas for public health/status routes: `GET /health` and `GET /api/v1/status`.
- Documents the existing runtime health fields (`ok`, `service`, `ticker`, `ledger_height`) and system status fields used by clients for ledger height, active bounty count, treasury balance, and public transfer-path boundaries.
- Preserves existing runtime JSON behavior; this is OpenAPI/client contract metadata plus focused regression coverage only.

## Bounty scope
Refs #944.

This is a focused public API/OpenAPI client-contract improvement for two existing public read routes. It does not change health/status serialization or application behavior.

## Duplicate check
- Searched current #944 submissions and open PRs for `health OpenAPI`, `api/v1/status OpenAPI`, and `system status schema`.
- Existing #944 submissions cover treasury status/proposals, bounty list/detail/summary, work-discovery, accounts, ledger/proof, activity, auth session, wallet lookup, attempts, and POST response metadata.
- I found old broad PR #699 from prior bounty 647 includes `/api/v1/status`, but it is dirty, labeled `mrwk:needs-info`, and covers many public read routes at once. This PR is a current #944-focused health/status contract patch and also covers `/health`, which #699 does not list.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py tests\test_api_mcp.py::test_health_status_and_bounty_api tests\test_status.py -q` -> 13 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\ruff.exe check app\openapi_request_bodies.py app\main.py tests\test_openapi_request_bodies.py` -> All checks passed.
- `.\.venv\Scripts\ruff.exe format --check app\openapi_request_bodies.py app\main.py tests\test_openapi_request_bodies.py` -> 3 files already formatted.
- `.\.venv\Scripts\python.exe -m mypy app\openapi_request_bodies.py app\main.py` -> Success: no issues found.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `faf438d6435f4c611e94df7e6ee7b020bdbcff64`.

## Out of scope
No runtime JSON changes, no bounty filtering/sorting changes, no payment or payout execution, no ledger mutation, no wallet custody, no treasury execution, no admin-token behavior, no bridge/exchange/off-ramp/cash-out or MRWK price behavior, and no private data or secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Health check and system status endpoints now publish detailed OpenAPI response schemas to improve API documentation and developer discoverability.

* **Tests**
  * Added tests that validate the OpenAPI response schemas for the public status endpoints against live runtime responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
