### PR TITLE
Link work discovery from docs page

### DIFF
--- a/app/templates/docs.html
+++ b/app/templates/docs.html
@@ -24,6 +24,8 @@
     <li><a href="/api/docs">OpenAPI docs</a></li>
     <li><a href="/api/v1/bounties">Bounty API</a></li>
     <li><a href="/api/v1/bounties/summary">Bounty summary API</a></li>
+    <li><a href="/api/v1/work-discovery">Work discovery API</a></li>
+    <li><a href="/bounties?status=open&amp;availability=effectively_open">Claimable bounties</a></li>
     <li><a href="/api/v1/treasury/proposals">Treasury proposals API</a></li>
     <li><a href="/activity">Activity dashboard</a></li>
     <li><a href="/api/v1/activity">Activity API</a></li>

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -129,6 +129,8 @@ def test_docs_page_marks_static_github_links_as_untrusted(sqlite_url: str) -> No
         assert f'href="{url}" rel="nofollow noopener"' in page.text
     for url in (
         "/api/v1/bounties/summary",
+        "/api/v1/work-discovery",
+        "/bounties?status=open&amp;availability=effectively_open",
         "/api/v1/treasury/proposals",
     ):
         assert f'href="{url}"' in page.text


### PR DESCRIPTION
## Summary
- Add direct `/docs` links to `GET /api/v1/work-discovery` and the claimable bounties filtered view.
- Help contributors move from the public docs page to the current claimable-work lane without guessing API routes.
- Preserve all bounty lifecycle semantics; this is routing/documentation surface only.

## Bounty scope
Refs #935.

This is a focused public contributor-routing improvement for the docs page. It does not change work-discovery payloads, bounty filtering behavior, claimability logic, proposal execution, payout execution, ledger mutation, wallet behavior, admin-token behavior, bridge/exchange/off-ramp/cash-out behavior, MRWK price behavior, private data, or secrets.

## Duplicate check
Searched current open PRs and #935 comments for `docs page work-discovery`, `docs.html work-discovery`, and `Work discovery API`. Existing #935 work covers bounty list/detail routing, work-discovery source URLs, pending-create visibility, claimable filter notices, activity search notices, and proposed-work discovery metadata. I did not find an open #935 submission adding the work-discovery and claimable-lane links to the public `/docs` page.

## Verification
- `.\.venv\Scripts\python.exe -m pytest tests\test_public_routes.py::test_docs_page_marks_static_github_links_as_untrusted -q` -> 1 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok.
- `.\.venv\Scripts\ruff.exe check tests\test_public_routes.py` -> All checks passed.
- `.\.venv\Scripts\ruff.exe format --check tests\test_public_routes.py` -> 1 file already formatted.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `6aa1f069ebb3fb0e1666e8389701f90be21ff84d`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new documentation links for the Work Discovery API endpoint and Claimable bounties functionality.

* **Tests**
  * Updated documentation page tests to validate the new links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->