### PR TITLE
fix: ignore fenced markdown links in docs smoke

### DIFF
--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -180,6 +180,26 @@ def _markdown_anchors(path: Path) -> set[str]:
     return anchors
 
 
+def _markdown_links_outside_fences(text: str) -> list[str]:
+    links: list[str] = []
+    fence_marker = ""
+
+    for line in text.splitlines():
+        fence_match = FENCE_RE.match(line)
+        if fence_match:
+            marker = fence_match.group(1)
+            if not fence_marker:
+                fence_marker = marker
+            elif marker.startswith(fence_marker[0]) and len(marker) >= len(fence_marker):
+                fence_marker = ""
+            continue
+        if fence_marker:
+            continue
+        links.extend(LINK_RE.findall(line))
+
+    return links
+
+
 def _local_target_exists(source: Path, target: str) -> bool:
     clean, separator, fragment = target.partition("#")
     if clean.startswith(("http://", "https://", "mailto:")):
@@ -267,7 +287,7 @@ def main() -> int:
             if _squash(phrase) not in squashed:
                 print(f"missing required public phrase in {relative}: {phrase}")
                 ok = False
-        for link in LINK_RE.findall(text):
+        for link in _markdown_links_outside_fences(text):
             if not _local_target_exists(path, link):
                 print(f"broken local link in {relative}: {link}")
                 ok = False

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -9,6 +9,7 @@ from scripts.docs_smoke import (
     _local_target_exists,
     _markdown_anchors,
     _markdown_heading_anchor,
+    _markdown_links_outside_fences,
     _template_field_is_required,
 )
 
@@ -239,6 +240,24 @@ def test_markdown_anchors_ignore_fenced_code_headings(tmp_path: Path) -> None:
     )
 
     assert _markdown_anchors(target) == {"real-heading"}
+
+
+def test_markdown_links_outside_fences_ignore_code_examples() -> None:
+    text = (
+        "[Real](docs/bounty-lifecycle.md)\n"
+        "```markdown\n"
+        "[Example](definitely-missing.md)\n"
+        "```\n"
+        "~~~md\n"
+        "[Other Example](also-missing.md)\n"
+        "~~~\n"
+        "[Second](docs/api-examples.md#account-response-shape)\n"
+    )
+
+    assert _markdown_links_outside_fences(text) == [
+        "docs/bounty-lifecycle.md",
+        "docs/api-examples.md#account-response-shape",
+    ]
 
 
 def test_markdown_heading_anchor_handles_inline_code() -> None:


### PR DESCRIPTION
## Summary
- Updates `scripts/docs_smoke.py` so Markdown links inside fenced code examples are ignored by the local-link checker.
- Reuses the same fence-tracking behavior already used for heading anchor extraction.
- Adds regression coverage for backtick and tilde fenced Markdown examples while still checking real links outside fences.

Bounty #936

## Verification
- `python -m pytest tests/test_docs_public_urls.py::test_markdown_links_outside_fences_ignore_code_examples tests/test_docs_public_urls.py::test_markdown_anchors_ignore_fenced_code_headings -q` -> 2 passed
- `python scripts/docs_smoke.py` -> docs smoke ok
- `python -m pytest tests/test_docs_public_urls.py -q` -> 42 passed
- `python -m ruff check scripts/docs_smoke.py tests/test_docs_public_urls.py` -> All checks passed
- `python -m ruff format --check scripts/docs_smoke.py tests/test_docs_public_urls.py` -> 2 files already formatted
- `git diff --check` -> clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation link validation now ignores links inside fenced code blocks, reducing false positives from code examples.

* **Tests**
  * Added a test to ensure markdown link extraction only returns links found outside fenced code blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->