### PR TITLE
Refactor shared GitHub JSON script helpers

### DIFF
--- a/scripts/check_bounty_issue_states.py
+++ b/scripts/check_bounty_issue_states.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
-import urllib.error
-import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -13,9 +10,10 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.api_host_args import public_api_host
+from scripts.github_json import DEFAULT_TIMEOUT_SECONDS, fetch_json, run_gh, run_gh_json
 
 DEFAULT_API_HOST = "https://api.mrwk.online"
-GH_TIMEOUT_SECONDS = 30
+GH_TIMEOUT_SECONDS = DEFAULT_TIMEOUT_SECONDS
 
 
 def _int_or_none(value: Any) -> int | None:
@@ -119,72 +117,16 @@ def format_text_report(report: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def _run_gh_json(args: list[str]) -> Any:
-    command = " ".join(args)
-    try:
-        completed = subprocess.run(
-            args,
-            check=True,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=GH_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s: {command}") from exc
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            "gh command failed "
-            f"(exit {exc.returncode}): {command}\n"
-            f"stdout:\n{exc.stdout or exc.output or ''}\n"
-            f"stderr:\n{exc.stderr or ''}"
-        ) from exc
-    return json.loads(completed.stdout)
-
-
-def _run_gh(args: list[str]) -> None:
-    command = " ".join(args)
-    try:
-        subprocess.run(
-            args,
-            check=True,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=GH_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s: {command}") from exc
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            "gh command failed "
-            f"(exit {exc.returncode}): {command}\n"
-            f"stdout:\n{exc.stdout or exc.output or ''}\n"
-            f"stderr:\n{exc.stderr or ''}"
-        ) from exc
-
-
-def _fetch_json(url: str) -> Any:
-    request = urllib.request.Request(url, headers={"Accept": "application/json"})
-    try:
-        with urllib.request.urlopen(request, timeout=GH_TIMEOUT_SECONDS) as response:
-            return json.loads(response.read().decode("utf-8"))
-    except (TimeoutError, urllib.error.URLError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f"failed to fetch JSON from {url}: {exc}") from exc
-
-
 def _load_public_bounties(api_host: str) -> list[dict[str, Any]]:
     url = f"{api_host.rstrip('/')}/api/v1/bounties?status=open&limit=200"
-    data = _fetch_json(url)
+    data = fetch_json(url)
     if not isinstance(data, list):
         raise RuntimeError(f"expected a JSON list from {url}")
     return [item for item in data if isinstance(item, dict)]
 
 
 def _load_issue(repo: str, issue_number: int) -> dict[str, Any]:
-    return _run_gh_json(
+    return run_gh_json(
         [
             "gh",
             "issue",
@@ -212,7 +154,7 @@ def load_live_data(repo: str, api_host: str) -> dict[str, Any]:
 def reopen_violations(repo: str, violations: list[dict[str, Any]]) -> None:
     for item in violations:
         if item.get("issue_state") == "closed":
-            _run_gh(["gh", "issue", "reopen", str(item["issue_number"]), "--repo", repo])
+            run_gh(["gh", "issue", "reopen", str(item["issue_number"]), "--repo", repo])
 
 
 def _load_input(path: str) -> dict[str, Any]:

--- a/scripts/check_live_bounty_closing_refs.py
+++ b/scripts/check_live_bounty_closing_refs.py
@@ -2,10 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
-import urllib.error
-import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -14,9 +11,10 @@ if __package__ in {None, ""}:
 
 from scripts.api_host_args import public_api_host
 from scripts.bounty_refs import GITHUB_CLOSING_ISSUE_RE
+from scripts.github_json import DEFAULT_TIMEOUT_SECONDS, fetch_json, run_gh_json
 
 DEFAULT_API_HOST = "https://api.mrwk.online"
-GH_TIMEOUT_SECONDS = 30
+GH_TIMEOUT_SECONDS = DEFAULT_TIMEOUT_SECONDS
 GH_PR_SAFETY_CAP = 200
 MAX_BOUNTY_REF = 2**63 - 1
 
@@ -122,42 +120,9 @@ def format_text_report(report: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def _run_gh_json(args: list[str]) -> Any:
-    command = " ".join(args)
-    try:
-        completed = subprocess.run(
-            args,
-            check=True,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=GH_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(f"gh command timed out after {GH_TIMEOUT_SECONDS}s: {command}") from exc
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            "gh command failed "
-            f"(exit {exc.returncode}): {command}\n"
-            f"stdout:\n{exc.stdout or exc.output or ''}\n"
-            f"stderr:\n{exc.stderr or ''}"
-        ) from exc
-    return json.loads(completed.stdout)
-
-
-def _fetch_json(url: str) -> Any:
-    request = urllib.request.Request(url, headers={"Accept": "application/json"})
-    try:
-        with urllib.request.urlopen(request, timeout=GH_TIMEOUT_SECONDS) as response:
-            return json.loads(response.read().decode("utf-8"))
-    except (TimeoutError, urllib.error.URLError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f"failed to fetch JSON from {url}: {exc}") from exc
-
-
 def _load_public_bounties(api_host: str) -> list[dict[str, Any]]:
     url = f"{api_host.rstrip('/')}/api/v1/bounties?status=open&limit=200"
-    data = _fetch_json(url)
+    data = fetch_json(url)
     if not isinstance(data, list):
         raise RuntimeError(f"expected a JSON list from {url}")
     return [item for item in data if isinstance(item, dict)]
@@ -166,7 +131,7 @@ def _load_public_bounties(api_host: str) -> list[dict[str, Any]]:
 def _load_pull_requests(repo: str, state: str, pr_numbers: list[int]) -> list[dict[str, Any]]:
     if pr_numbers:
         return [
-            _run_gh_json(
+            run_gh_json(
                 [
                     "gh",
                     "pr",
@@ -180,7 +145,7 @@ def _load_pull_requests(repo: str, state: str, pr_numbers: list[int]) -> list[di
             )
             for number in pr_numbers
         ]
-    prs = _run_gh_json(
+    prs = run_gh_json(
         [
             "gh",
             "pr",

--- a/scripts/github_json.py
+++ b/scripts/github_json.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import urllib.error
+import urllib.request
+from typing import Any
+
+DEFAULT_TIMEOUT_SECONDS = 30
+
+
+def run_gh_json(args: list[str], *, timeout: int = DEFAULT_TIMEOUT_SECONDS) -> Any:
+    command = " ".join(args)
+    try:
+        completed = subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"gh command timed out after {timeout}s: {command}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            "gh command failed "
+            f"(exit {exc.returncode}): {command}\n"
+            f"stdout:\n{exc.stdout or exc.output or ''}\n"
+            f"stderr:\n{exc.stderr or ''}"
+        ) from exc
+    return json.loads(completed.stdout)
+
+
+def run_gh(args: list[str], *, timeout: int = DEFAULT_TIMEOUT_SECONDS) -> None:
+    command = " ".join(args)
+    try:
+        subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"gh command timed out after {timeout}s: {command}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            "gh command failed "
+            f"(exit {exc.returncode}): {command}\n"
+            f"stdout:\n{exc.stdout or exc.output or ''}\n"
+            f"stderr:\n{exc.stderr or ''}"
+        ) from exc
+
+
+def fetch_json(url: str, *, timeout: int = DEFAULT_TIMEOUT_SECONDS) -> Any:
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (TimeoutError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"failed to fetch JSON from {url}: {exc}") from exc

--- a/tests/test_check_bounty_issue_states.py
+++ b/tests/test_check_bounty_issue_states.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from scripts import check_bounty_issue_states
+from scripts import check_bounty_issue_states, github_json
 from scripts.check_bounty_issue_states import analyze_issue_states, main
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -98,7 +98,7 @@ def test_issue_state_check_fix_reopens_closed_issues(monkeypatch) -> None:
             return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
         raise AssertionError(args)
 
-    monkeypatch.setattr(check_bounty_issue_states.subprocess, "run", fake_run)
+    monkeypatch.setattr(github_json.subprocess, "run", fake_run)
 
     check_bounty_issue_states.reopen_violations(
         "ramimbo/mergework",

--- a/tests/test_check_live_bounty_closing_refs.py
+++ b/tests/test_check_live_bounty_closing_refs.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from scripts import check_live_bounty_closing_refs
+from scripts import check_live_bounty_closing_refs, github_json
 from scripts.check_live_bounty_closing_refs import analyze_closing_refs, main
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -107,7 +107,7 @@ def test_closing_ref_check_loads_specific_prs(monkeypatch) -> None:
             return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
         raise AssertionError(args)
 
-    monkeypatch.setattr(check_live_bounty_closing_refs.subprocess, "run", fake_run)
+    monkeypatch.setattr(github_json.subprocess, "run", fake_run)
 
     prs = check_live_bounty_closing_refs._load_pull_requests("ramimbo/mergework", "open", [1015])
 

--- a/tests/test_github_json.py
+++ b/tests/test_github_json.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import urllib.error
+
+import pytest
+
+from scripts import github_json
+
+
+def test_run_gh_json_decodes_success(monkeypatch) -> None:
+    def fake_run(args, **kwargs):
+        assert kwargs["capture_output"] is True
+        assert kwargs["encoding"] == "utf-8"
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout=json.dumps({"ok": True}))
+
+    monkeypatch.setattr(github_json.subprocess, "run", fake_run)
+
+    assert github_json.run_gh_json(["gh", "issue", "view", "1"]) == {"ok": True}
+
+
+def test_run_gh_reports_stderr_on_failure(monkeypatch) -> None:
+    def fake_run(args, **kwargs):
+        raise subprocess.CalledProcessError(2, args, output="out", stderr="err")
+
+    monkeypatch.setattr(github_json.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="gh command failed") as exc_info:
+        github_json.run_gh(["gh", "pr", "list"])
+
+    assert "stderr:\nerr" in str(exc_info.value)
+
+
+def test_fetch_json_wraps_url_errors(monkeypatch) -> None:
+    def fake_urlopen(request, timeout):
+        raise urllib.error.URLError("offline")
+
+    monkeypatch.setattr(github_json.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError, match="failed to fetch JSON"):
+        github_json.fetch_json("https://api.example.test/items")


### PR DESCRIPTION
## Summary
- Adds a shared `scripts.github_json` helper for `gh` JSON, `gh` command, and JSON fetch behavior.
- Reuses it in live bounty issue-state and closing-reference scripts.
- Adds focused helper tests while preserving existing script behavior.

## Verification
- `uv run pytest -q tests/test_github_json.py tests/test_check_bounty_issue_states.py tests/test_check_live_bounty_closing_refs.py` (11 passed)
- `uv run ruff check scripts/github_json.py scripts/check_bounty_issue_states.py scripts/check_live_bounty_closing_refs.py tests/test_github_json.py tests/test_check_bounty_issue_states.py tests/test_check_live_bounty_closing_refs.py`
- `git diff --check`
- Added-line security scan: 0 findings
- Independent review: passed

Closes #936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refactored GitHub and HTTP utilities into a shared library module to reduce code duplication and improve maintainability across internal scripts.
  * Added comprehensive unit tests for the new utility module to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->