### PR TITLE
Share unsupported account query handling

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -210,11 +210,12 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
         request: Request, account: str, tx_type: str | None = Query(None)
     ) -> HTMLResponse:
         reject_path_whitespace_padding(account, "account")
-        if request.query_params.getlist("type"):
-            raise HTTPException(
-                status_code=400,
-                detail="type is not supported on account pages; use tx_type",
-            )
+        reject_unsupported_query_params(
+            request,
+            ("type",),
+            context="account pages",
+            detail="type is not supported on account pages; use tx_type",
+        )
         for value in request.query_params.getlist("tx_type"):
             if contains_control_character(value):
                 raise HTTPException(

--- a/app/query_validation.py
+++ b/app/query_validation.py
@@ -62,12 +62,16 @@ def reject_repeated_query_param(request: Request, name: str) -> None:
 
 
 def reject_unsupported_query_params(
-    request: Request, names: tuple[str, ...], *, context: str
+    request: Request,
+    names: tuple[str, ...],
+    *,
+    context: str,
+    detail: str | None = None,
 ) -> None:
     """Reject query parameters that are valid elsewhere but unsupported here."""
     for name in names:
         if _query_param_values(request, name):
             raise HTTPException(
                 status_code=400,
-                detail=f"{name} is not supported on {context}",
+                detail=detail or f"{name} is not supported on {context}",
             )

--- a/tests/test_query_validation.py
+++ b/tests/test_query_validation.py
@@ -80,6 +80,21 @@ def test_unsupported_query_params_reports_first_present_name() -> None:
     assert exc_info.value.detail == "type is not supported on account JSON detail"
 
 
+def test_unsupported_query_params_allows_custom_detail() -> None:
+    request = _request("type=github_claim")
+
+    with pytest.raises(HTTPException) as exc_info:
+        reject_unsupported_query_params(
+            request,
+            ("type",),
+            context="account pages",
+            detail="type is not supported on account pages; use tx_type",
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "type is not supported on account pages; use tx_type"
+
+
 def test_unsupported_query_params_allows_absent_names() -> None:
     reject_unsupported_query_params(
         _request("page=1"),


### PR DESCRIPTION
## Summary
- Lets `reject_unsupported_query_params` preserve a route-specific error detail when needed
- Reuses the shared unsupported-query guard on account pages for wallet-style `type` filters
- Adds focused coverage for custom helper details

## Verification
- `uv run --extra dev pytest -q tests/test_query_validation.py`
- `uv run --extra dev pytest -q tests/test_account_routes.py -k 'transaction_type or account_action_urls_escape_query_accounts'`
- `uv run --extra dev ruff check app/query_validation.py app/accounts.py tests/test_query_validation.py`
- `uv run --extra dev ruff format --check app/query_validation.py app/accounts.py tests/test_query_validation.py`
- `git diff --check`
- Added-line security scan: `security_findings_count 0`
- Independent review: passed

Bounty #936


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal query parameter validation handling for better code maintainability.

* **Tests**
  * Added test coverage for enhanced error message customization in query validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->