### PR TITLE
Cover MCP input schema runtime conformance

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -329,6 +329,11 @@ back to text for human-readable not-found messages.
 `result.structuredContent.account`, `balance_mrwk`, and `balance_microunits` so
 callers do not need to parse the text response.
 
+When changing an advertised MCP `inputSchema`, add a representative conformance
+test that reads the constraint from `tools/list`, verifies one valid
+`tools/call`, and verifies one invalid `tools/call` is rejected with JSON-RPC
+`-32602`.
+
 ## Contribution Rules
 
 - Read `AGENTS.md` before starting.

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -461,6 +461,116 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     }
 
 
+def test_mcp_input_schema_runtime_conformance_examples(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=942,
+            issue_url="https://github.com/ramimbo/mergework/issues/942",
+            title="MCP schema conformance",
+            reward_mrwk="150",
+            acceptance="MCP advertised schemas should match representative runtime behavior.",
+        )
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    tools_response = client.post(
+        "/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+    ).json()
+    tools_by_name = {tool["name"]: tool for tool in tools_response["result"]["tools"]}
+
+    conformance_cases = [
+        (
+            "list_bounties",
+            {"limit": 1},
+            ("properties", "limit", "maximum"),
+            100,
+            {"limit": 101},
+        ),
+        (
+            "get_bounty",
+            {"id": bounty_id, "include_awards": False},
+            ("properties", "include_awards", "type"),
+            "boolean",
+            {"id": bounty_id, "include_awards": "true"},
+        ),
+        (
+            "list_bounty_attempts",
+            {"bounty_id": bounty_id, "limit": 1},
+            ("properties", "limit", "maximum"),
+            100,
+            {"bounty_id": bounty_id, "limit": 101},
+        ),
+        (
+            "get_balance",
+            {"account": "treasury:mrwk"},
+            ("properties", "account", "minLength"),
+            1,
+            {"account": ""},
+        ),
+        (
+            "get_ledger_entry",
+            {"sequence": 1},
+            ("properties", "sequence", "minimum"),
+            1,
+            {"sequence": 0},
+        ),
+        (
+            "get_proof",
+            {"hash": "0" * 64},
+            ("properties", "hash", "pattern"),
+            "^[0-9a-fA-F]{64}$",
+            {"hash": "not-a-proof-hash"},
+        ),
+        (
+            "submit_work_proof",
+            {"bounty_id": bounty_id, "format": "json"},
+            ("properties", "format", "enum"),
+            ["text", "json"],
+            {"bounty_id": bounty_id, "format": "xml"},
+        ),
+    ]
+
+    for (
+        tool_name,
+        valid_args,
+        schema_path,
+        expected_schema_value,
+        invalid_args,
+    ) in conformance_cases:
+        tool_schema = tools_by_name[tool_name]["inputSchema"]
+        schema_value = tool_schema
+        for key in schema_path:
+            schema_value = schema_value[key]
+        assert schema_value == expected_schema_value
+
+        valid = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": f"{tool_name}-valid",
+                "method": "tools/call",
+                "params": {"name": tool_name, "arguments": valid_args},
+            },
+        ).json()
+        assert "error" not in valid, tool_name
+
+        invalid = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": f"{tool_name}-invalid",
+                "method": "tools/call",
+                "params": {"name": tool_name, "arguments": invalid_args},
+            },
+        ).json()
+        assert invalid["error"]["code"] == -32602
+        assert invalid["error"]["message"] == "invalid tool arguments"
+
+
 def test_mcp_initialize_returns_server_capabilities(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 


### PR DESCRIPTION
## Summary
- Add a reusable MCP schema/runtime conformance test that reads representative constraints from `tools/list` and verifies matching `tools/call` behavior.
- Cover valid and invalid calls for advertised constraints across `list_bounties`, `get_bounty`, `list_bounty_attempts`, `get_balance`, `get_ledger_entry`, `get_proof`, and `submit_work_proof`.
- Document the expectation that future MCP `inputSchema` changes include a valid-call and rejected-call conformance check.

## Bounty scope
Bounty #946
Refs #946

.

This targets the conformance-suite part of the bounty, not a duplicate single-tool `outputSchema` submission. I checked the open #946 queue and saw existing work for bounty/wallet/balance/proof/ledger/work-proof schema advertisement; this PR instead adds representative schema/runtime coverage for already advertised input constraints.

## Verification
- `.\\.venv\\Scripts\\python.exe -m pytest tests\\test_api_mcp.py::test_mcp_input_schema_runtime_conformance_examples tests\\test_api_mcp.py::test_mcp_tools_list_and_call -q` -> 2 passed, 1 existing Starlette/httpx warning.
- `.\\.venv\\Scripts\\python.exe -m pytest tests\\test_api_mcp.py tests\\test_mcp_tools.py -q` -> 132 passed, 1 existing Starlette/httpx warning.
- `.\\.venv\\Scripts\\ruff.exe check tests\\test_api_mcp.py docs\\agent-guide.md` -> All checks passed.
- `.\\.venv\\Scripts\\ruff.exe format --check tests\\test_api_mcp.py` -> 1 file already formatted.
- `.\\.venv\\Scripts\\python.exe scripts\\docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `35be7532452e9a5202ab8ea6a8c3910eb076243a`.

## Out of scope
No new MCP tools, no runtime behavior changes, no admin-token behavior, no ledger mutation, no payouts, no treasury mutation, no wallet custody, no bridge/exchange/off-ramp/cash-out behavior, no MRWK price behavior, and no private data or secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance requiring representative conformance examples when an MCP input schema changes, including one valid and one invalid case.

* **Tests**
  * Added an integration-style MCP conformance test that validates advertised input-schema constraints at runtime by exercising tools with valid and invalid payloads and asserting success or JSON-RPC error -32602 for invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->