### PR TITLE
fix(mcp): suggest close tool names for unknown calls

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
+from difflib import get_close_matches
 from typing import Any
 
 from fastapi import HTTPException, Request
@@ -391,8 +392,22 @@ MCP_TOOLS: list[dict[str, Any]] = [
 ]
 
 
-def _jsonrpc_error(response_id: Any, code: int, message: str) -> dict[str, Any]:
-    return {"jsonrpc": "2.0", "id": response_id, "error": {"code": code, "message": message}}
+def _jsonrpc_error(
+    response_id: Any, code: int, message: str, data: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    error: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        error["data"] = data
+    return {"jsonrpc": "2.0", "id": response_id, "error": error}
+
+
+def _unknown_tool_error(response_id: Any, name: str) -> dict[str, Any]:
+    known_tools = [tool["name"] for tool in MCP_TOOLS]
+    data: dict[str, Any] = {"unknown_tool": name}
+    matches = get_close_matches(name, known_tools, n=1, cutoff=0.6)
+    if matches:
+        data["did_you_mean"] = matches[0]
+    return _jsonrpc_error(response_id, -32601, "unknown tool", data)
 
 
 def _initialize_response(response_id: Any, params: Any) -> dict[str, Any]:
@@ -497,7 +512,11 @@ async def handle_mcp_request(
 
     try:
         tool_result = call_tool(database_url, name, args)
-    except (KeyError, TypeError, ValueError, LedgerError, HTTPException):
+    except ValueError as exc:
+        if str(exc) == "unknown tool":
+            return _unknown_tool_error(response_id, name)
+        return _jsonrpc_error(response_id, -32602, "invalid tool arguments")
+    except (KeyError, TypeError, LedgerError, HTTPException):
         return _jsonrpc_error(response_id, -32602, "invalid tool arguments")
 
     return _tool_result_response(response_id, tool_result)

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -461,6 +461,89 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     }
 
 
+def test_mcp_unknown_tool_returns_actionable_suggestion(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "list_bounty", "arguments": {}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "error": {
+            "code": -32601,
+            "message": "unknown tool",
+            "data": {"unknown_tool": "list_bounty", "did_you_mean": "list_bounties"},
+        },
+    }
+
+
+def test_mcp_unknown_tool_without_close_match_omits_suggestion(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {"name": "totally_unrelated", "arguments": {}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 4,
+        "error": {
+            "code": -32601,
+            "message": "unknown tool",
+            "data": {"unknown_tool": "totally_unrelated"},
+        },
+    }
+
+
+def test_mcp_invalid_tool_arguments_still_use_invalid_params(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {"name": "get_balance", "arguments": {"account": ""}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "jsonrpc": "2.0",
+        "id": 5,
+        "error": {"code": -32602, "message": "invalid tool arguments"},
+    }
+
+
 def test_mcp_initialize_returns_server_capabilities(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
@@ -1139,7 +1222,11 @@ def test_mcp_rejects_unknown_tool_name(sqlite_url: str) -> None:
     assert response.json() == {
         "jsonrpc": "2.0",
         "id": 12,
-        "error": {"code": -32602, "message": "invalid tool arguments"},
+        "error": {
+            "code": -32601,
+            "message": "unknown tool",
+            "data": {"unknown_tool": "definitely_unknown"},
+        },
     }
 
 


### PR DESCRIPTION
## Summary
- Return a specific JSON-RPC `unknown tool` error for MCP `tools/call` requests whose tool name is not registered.
- Include safe `error.data` with the requested tool name and a `did_you_mean` hint when there is a close registered tool match.
- Preserve the existing `invalid tool arguments` response for known tools with invalid arguments.

## Validation
- `uv run --python python3.12 --extra dev python -m pytest tests/test_api_mcp.py tests/test_mcp_tools.py -q` -> 134 passed, 1 warning
- `uv run --python python3.12 --extra dev python -m ruff check app/mcp.py tests/test_api_mcp.py` -> all checks passed
- `git diff --check`
- Added-line security scan: only test-only dummy `webhook_secret="secret"` fixtures matched the hardcoded-secret pattern
- Independent review: passed

Bounty #946


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool invocations now provide intelligent "did_you_mean" suggestions when you request a tool name that closely matches an existing one, helping you quickly find the correct tool.

* **Bug Fixes**
  * Enhanced error handling to better distinguish between unknown tools and invalid tool arguments, ensuring you receive precise error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->