### PR TITLE
Expose repo in work discovery rows

### DIFF
--- a/app/work_discovery.py
+++ b/app/work_discovery.py
@@ -75,6 +75,7 @@ def _bounty_work_item(row: dict[str, Any], availability_state: str) -> dict[str,
     return {
         "availability_state": availability_state,
         "bounty_id": int(row["id"]),
+        "repo": str(row["repo"]),
         "issue_number": int(row["issue_number"]),
         "title": str(row["title"]),
         "issue_url": str(row["issue_url"]),
@@ -107,6 +108,7 @@ def _pending_create_item(proposal: TreasuryProposal) -> dict[str, Any]:
     return {
         "availability_state": "pending_create",
         "proposal_id": int(proposal.id),
+        "repo": str(payload["repo"]),
         "issue_number": int(payload["issue_number"]),
         "title": str(payload["title"]),
         "issue_url": str(payload["issue_url"]),

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -150,6 +150,9 @@ Use `/api/v1/work-discovery` when an agent needs a single read-only work queue.
 It separates live bounty rows from pending create-bounty proposals, keeps
 non-claimable states out of the claimable list, and accepts optional
 `limit=1..100` to cap each returned bucket:
+Each queue item includes the source `repo` next to `issue_number`, so clients
+do not need to parse GitHub URLs when the same issue number exists in multiple
+repositories.
 
 ```json
 {
@@ -172,6 +175,7 @@ non-claimable states out of the claimable list, and accepts optional
     {
       "availability_state": "live_bounty",
       "bounty_id": 108,
+      "repo": "ramimbo/mergework",
       "issue_number": 800,
       "title": "MRWK bounty: public work discovery",
       "issue_url": "https://github.com/ramimbo/mergework/issues/800",
@@ -196,6 +200,7 @@ non-claimable states out of the claimable list, and accepts optional
     {
       "availability_state": "pending_create",
       "proposal_id": 125,
+      "repo": "ramimbo/mergework",
       "issue_number": 798,
       "title": "MRWK bounty: live verification and bug reports, round 2",
       "issue_url": "https://github.com/ramimbo/mergework/issues/798",
@@ -218,6 +223,7 @@ non-claimable states out of the claimable list, and accepts optional
     {
       "availability_state": "closed_or_exhausted",
       "bounty_id": 102,
+      "repo": "ramimbo/mergework",
       "issue_number": 761,
       "title": "MRWK bounty: accepted proposed-work fixes, round 1",
       "issue_url": "https://github.com/ramimbo/mergework/issues/761",

--- a/tests/test_work_discovery.py
+++ b/tests/test_work_discovery.py
@@ -93,6 +93,7 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
         {
             "availability_state": "live_bounty",
             "bounty_id": live_bounty.id,
+            "repo": "ramimbo/mergework",
             "issue_number": 800,
             "title": "MRWK bounty: public work discovery",
             "issue_url": "https://github.com/ramimbo/mergework/issues/800",
@@ -128,6 +129,7 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
         {
             "availability_state": "pending_create",
             "proposal_id": pending_create.id,
+            "repo": "ramimbo/mergework",
             "issue_number": 900,
             "title": "Opening soon bounty",
             "issue_url": "https://github.com/ramimbo/mergework/issues/900",
@@ -150,6 +152,7 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
     assert pending_create_executes_after.endswith("Z")
     assert datetime.fromisoformat(pending_create_executes_after.replace("Z", "+00:00"))
     assert body["not_claimable"][0]["availability_state"] == "closed_or_exhausted"
+    assert body["not_claimable"][0]["repo"] == "ramimbo/mergework"
     assert body["not_claimable"][0]["issue_number"] == 761
     assert body["not_claimable"][0]["next_action"]["id"] == "choose_open_bounty"
 
@@ -236,9 +239,11 @@ def test_work_discovery_limit_keeps_older_claimable_bounty_visible(sqlite_url: s
     assert body["summary"]["limit"] == 1
     assert body["summary"]["claimable_now_count"] == 1
     assert body["claimable_now"][0]["bounty_id"] == older_live.id
+    assert body["claimable_now"][0]["repo"] == "ramimbo/mergework"
     assert body["claimable_now"][0]["issue_number"] == 910
     assert body["claimable_now"][0]["availability_state"] == "live_bounty"
     assert body["not_claimable"][0]["bounty_id"] == newer_pending_full.id
+    assert body["not_claimable"][0]["repo"] == "ramimbo/mergework"
     assert body["not_claimable"][0]["issue_number"] == 911
     assert body["not_claimable"][0]["availability_state"] == "pending_payout"
     assert body["not_claimable"][0]["next_action"]["id"] == "watch_for_award_slot"


### PR DESCRIPTION
Bounty #935

## Summary
- add `repo` to work-discovery rows for live, pending-create, and not-claimable bounties
- update the API example so clients can pair `repo` with `issue_number` without parsing GitHub URLs

## Evidence
- Bounty 116 is open with 4 effective awards remaining at submission time.
- Touched only `app/work_discovery.py`, `tests/test_work_discovery.py`, and `docs/api-examples.md`.
- No claimability, payout, ledger, wallet, treasury, admin, bridge, exchange, or cash-out behavior changed.

## Tested
- `python -m pytest tests\test_work_discovery.py -q`
- `python scripts\docs_smoke.py`
- `ruff check app\work_discovery.py tests\test_work_discovery.py docs\api-examples.md`
- `ruff format --check app\work_discovery.py tests\test_work_discovery.py`
- `python -m mypy app\work_discovery.py`

/claim