### PR TITLE
Add repo filters to MCP bounty listing

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -123,7 +123,8 @@ MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
         "description": (
-            "List MRWK bounties with optional status, q, sort, limit, and availability filters"
+            "List MRWK bounties with optional status, q, repo, issue_number, "
+            "sort, limit, and availability filters"
         ),
         "inputSchema": {
             "type": "object",
@@ -138,6 +139,16 @@ MCP_TOOLS: list[dict[str, Any]] = [
                     "type": "string",
                     "maxLength": 500,
                     "description": "Optional bounty text or issue-number search.",
+                },
+                "repo": {
+                    "type": "string",
+                    "maxLength": 200,
+                    "description": "Optional owner/name repository filter.",
+                },
+                "issue_number": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Optional GitHub issue-number filter.",
                 },
                 "sort": {
                     "type": "string",

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -191,6 +191,15 @@ def call_mcp_tool(
 
     with session_scope(database_url) as session:
         if name == "list_bounties":
+            require_known_fields(
+                "status",
+                "q",
+                "repo",
+                "issue_number",
+                "sort",
+                "limit",
+                "availability",
+            )
             status = optional_clean_str_arg("status") or "open"
             normalized_status = status.lower()
             if normalized_status not in {"open", "paid", "closed"}:
@@ -211,6 +220,11 @@ def call_mcp_tool(
                 if issue_number is not None:
                     text_filter = or_(text_filter, Bounty.issue_number == issue_number)
                 query = query.where(text_filter)
+            repo_selector = optional_repo_selector_arg()
+            if repo_selector is not None:
+                query = query.where(func.lower(Bounty.repo) == repo_selector)
+            if "issue_number" in args and args.get("issue_number") is not None:
+                query = query.where(Bounty.issue_number == positive_int_arg("issue_number"))
             sort = normalize_bounty_sort(optional_clean_str_arg("sort"))
             availability = normalize_bounty_availability_filter(
                 optional_clean_str_arg("availability")

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -270,6 +270,8 @@ curl -s -X POST "$MCP_HOST/mcp" \
 Use `{"availability":"effectively_open"}` with `list_bounties` when you only want
 raw-open bounties that still have positive effective award capacity after
 pending payout or close proposals are considered.
+Use `repo` and `issue_number` with `list_bounties` when you already know the
+GitHub issue and want an exact typed filter instead of free-text search.
 
 Inspect a bounty with `get_bounty` before preparing evidence. Use the `id`
 from `list_bounties`, pass the same value as `bounty_id` when reusing fields

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -825,6 +825,8 @@ curl -s -X POST "$MCP_HOST/mcp" \
 
 Pass `{"availability":"effectively_open"}` to `list_bounties` when an agent only
 wants bounty rows with positive effective award capacity.
+Pass `repo` and `issue_number` when the GitHub issue is already known and the
+agent needs an exact typed filter.
 
 Call `get_bounty` with the internal bounty `id` returned by `list_bounties`.
 Agents may also pass the same value as `bounty_id` when reusing fields from

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -306,12 +306,14 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"}).json()
     assert tools["result"]["tools"][0]["name"] == "list_bounties"
     assert (
-        "status, q, sort, limit, and availability filters"
+        "status, q, repo, issue_number, sort, limit, and availability filters"
         in tools["result"]["tools"][0]["description"]
     )
     list_bounties_schema = tools["result"]["tools"][0]["inputSchema"]
     assert list_bounties_schema["additionalProperties"] is False
     assert list_bounties_schema["properties"]["q"]["maxLength"] == 500
+    assert list_bounties_schema["properties"]["repo"]["maxLength"] == 200
+    assert list_bounties_schema["properties"]["issue_number"]["minimum"] == 1
     assert list_bounties_schema["properties"]["limit"]["maximum"] == 100
     list_bounties_output_schema = tools["result"]["tools"][0]["outputSchema"]
     assert list_bounties_output_schema["type"] == "array"
@@ -913,6 +915,63 @@ def test_mcp_list_bounties_filters_status_query_and_limit(sqlite_url: str) -> No
     assert max_length_search_payload == []
 
 
+def test_mcp_list_bounties_filters_repo_and_issue_number(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=391,
+            issue_url="https://github.com/ramimbo/mergework/issues/391",
+            title="Primary repo bounty",
+            reward_mrwk="150",
+            acceptance="MCP repo filtering should skip this bounty.",
+        )
+        target = create_bounty(
+            session,
+            repo="Example/MergeWork",
+            issue_number=391,
+            issue_url="https://github.com/example/mergework/issues/391",
+            title="Target repo bounty",
+            reward_mrwk="200",
+            acceptance="MCP repo and issue filters should find this bounty.",
+        )
+        create_bounty(
+            session,
+            repo="example/mergework",
+            issue_number=392,
+            issue_url="https://github.com/example/mergework/issues/392",
+            title="Same repo different issue",
+            reward_mrwk="50",
+            acceptance="Repo-only filters may include this bounty.",
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    filtered = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "tools/call",
+            "params": {
+                "name": "list_bounties",
+                "arguments": {
+                    "repo": " EXAMPLE/MERGEWORK ",
+                    "issue_number": 391,
+                },
+            },
+        },
+    ).json()
+
+    payload = json.loads(filtered["result"]["content"][0]["text"])
+    assert filtered["result"]["structuredContent"] == payload
+    assert [bounty["id"] for bounty in payload] == [target.id]
+    assert payload[0]["repo"] == "example/mergework"
+    assert payload[0]["issue_number"] == 391
+
+
 def test_mcp_list_bounties_honors_sort_argument(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -1026,6 +1085,12 @@ def test_mcp_list_bounties_filters_effective_availability(sqlite_url: str) -> No
         ({"sort": "invalid"}, 36),
         ({"availability": "maybe"}, 37),
         ({"q": "a" * 501}, 38),
+        ({"repo": 1}, 39),
+        ({"repo": "\u0085ramimbo/mergework"}, 40),
+        ({"repo": "a" * 201}, 41),
+        ({"issue_number": 0}, 42),
+        ({"issue_number": True}, 43),
+        ({"unexpected": "ignored"}, 44),
     ],
 )
 def test_mcp_list_bounties_rejects_invalid_filters(

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -30,6 +30,39 @@ def test_call_mcp_tool_lists_bounties_from_extracted_dispatcher(sqlite_url: str)
     assert bounties[0]["title"] == "Code health bounty"
 
 
+def test_call_mcp_tool_filters_bounties_by_repo_and_issue_number(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=390,
+            issue_url="https://github.com/ramimbo/mergework/issues/390",
+            title="Primary repo bounty",
+            reward_mrwk="200",
+            acceptance="Repo filters should skip this bounty.",
+        )
+        target = create_bounty(
+            session,
+            repo="Example/MergeWork",
+            issue_number=390,
+            issue_url="https://github.com/example/mergework/issues/390",
+            title="Target repo bounty",
+            reward_mrwk="200",
+            acceptance="Repo and issue filters should keep this bounty.",
+        )
+
+    result = call_mcp_tool(
+        sqlite_url,
+        "list_bounties",
+        {"repo": "example/mergework", "issue_number": 390},
+    )
+
+    bounties = json.loads(result)
+    assert [bounty["id"] for bounty in bounties] == [target.id]
+
+
 def test_submit_work_proof_repo_selector_matches_stored_repo_case(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
Summary
- Adds `repo` and `issue_number` filters to the MCP `list_bounties` schema and runtime.
- Rejects unknown `list_bounties` arguments so the advertised schema matches runtime behavior.
- Adds focused MCP tests and short agent docs for exact issue filtering.

Tested
- `.\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py tests\test_mcp_tools.py -q`
- `.\.venv\Scripts\ruff.exe check app\mcp.py app\mcp_tools.py tests\test_api_mcp.py tests\test_mcp_tools.py docs\agent-guide.md docs\api-examples.md`
- `.\.venv\Scripts\ruff.exe format --check app\mcp.py app\mcp_tools.py tests\test_api_mcp.py tests\test_mcp_tools.py`
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py`
- `.\.venv\Scripts\python.exe -m mypy app\mcp.py app\mcp_tools.py`
- `git diff --check`

Bounty #934
/claim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repository and issue number filters to bounty search for precise result retrieval.

* **Documentation**
  * Updated guidance on using exact repository and issue number filters.

* **Tests**
  * Added tests for repository and issue number filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->