### PR TITLE
chore: harden deploy config validation

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -44,6 +44,10 @@ def _csv_env(name: str, default: str = "") -> tuple[str, ...]:
     return tuple(item.strip().lower() for item in raw_value.split(","))
 
 
+def _normalized_github_logins(logins: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(login.strip().lower() for login in logins)
+
+
 def _optional_positive_int_env(name: str) -> int | None:
     raw_value = os.environ.get(name, "").strip()
     if not raw_value:
@@ -81,25 +85,32 @@ def _required_env_value_errors(name: str, value: str) -> list[str]:
 
 
 def _invalid_github_logins(logins: tuple[str, ...]) -> list[str]:
-    return sorted({login for login in logins if login and not GITHUB_LOGIN_RE.fullmatch(login)})
+    return sorted(
+        {
+            login
+            for login in _normalized_github_logins(logins)
+            if login and not GITHUB_LOGIN_RE.fullmatch(login)
+        }
+    )
 
 
 def _duplicate_github_logins(logins: tuple[str, ...]) -> bool:
-    present_logins = [login for login in logins if login]
+    present_logins = [login for login in _normalized_github_logins(logins) if login]
     return len(set(present_logins)) != len(present_logins)
 
 
 def _github_login_list_errors(
     name: str, logins: tuple[str, ...], *, required_detail: str
 ) -> list[str]:
-    if not logins:
+    normalized_logins = _normalized_github_logins(logins)
+    if not normalized_logins:
         return [required_detail]
     errors: list[str] = []
-    if "" in logins:
+    if "" in normalized_logins:
         errors.append(f"{name} must not include empty entries")
-    if _duplicate_github_logins(logins):
+    if _duplicate_github_logins(normalized_logins):
         errors.append(f"{name} must not include duplicate logins")
-    if _invalid_github_logins(logins):
+    if _invalid_github_logins(normalized_logins):
         errors.append(f"{name} must contain valid GitHub logins")
     return errors
 
@@ -184,6 +195,10 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
     )
     errors.extend(_secret_errors("MERGEWORK_ADMIN_TOKEN", settings.admin_token))
     errors.extend(_secret_errors("MERGEWORK_COOKIE_SECRET", settings.cookie_secret))
+    if settings.github_issue_token:
+        errors.extend(
+            _required_env_value_errors("MERGEWORK_GITHUB_ISSUE_TOKEN", settings.github_issue_token)
+        )
     deploy_secrets = [
         settings.github_webhook_secret,
         settings.github_oauth_client_secret,
@@ -213,8 +228,12 @@ def validate_deploy_settings(settings: Settings) -> list[str]:
         )
     )
     if settings.admin_logins and settings.github_accepted_labelers:
-        admin_login_set = {login for login in settings.admin_logins if login}
-        accepted_labeler_set = {login for login in settings.github_accepted_labelers if login}
+        admin_login_set = {
+            login for login in _normalized_github_logins(settings.admin_logins) if login
+        }
+        accepted_labeler_set = {
+            login for login in _normalized_github_logins(settings.github_accepted_labelers) if login
+        }
         non_admin_labelers = sorted(accepted_labeler_set - admin_login_set)
         if non_admin_labelers:
             errors.append(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from app.config import Settings, validate_deploy_settings
+
+
+def _deploy_settings(**overrides: object) -> Settings:
+    values = {
+        "database_url": "sqlite:////tmp/mergework.sqlite3",
+        "public_base_url": "https://mrwk.example.com",
+        "github_webhook_secret": "abcdefghijklmnopqrstuvwxyz1234567890",
+        "github_issue_token": "",
+        "github_oauth_client_id": "oauth-client-id",
+        "github_oauth_client_secret": "bcdefghijklmnopqrstuvwxyz1234567890a",
+        "admin_logins": ("maintainer",),
+        "admin_token": "cdefghijklmnopqrstuvwxyz1234567890ab",
+        "cookie_secret": "defghijklmnopqrstuvwxyz1234567890abc",
+        "github_accepted_labelers": ("maintainer",),
+        "bounty_board_issue_number": 1,
+    }
+    values.update(overrides)
+    return Settings(**values)
+
+
+def test_validate_deploy_settings_ignores_empty_optional_github_issue_token() -> None:
+    errors = validate_deploy_settings(_deploy_settings(github_issue_token=""))
+
+    assert errors == []
+
+
+def test_validate_deploy_settings_rejects_malformed_github_issue_token() -> None:
+    errors = validate_deploy_settings(_deploy_settings(github_issue_token=" gh "))
+
+    assert "MERGEWORK_GITHUB_ISSUE_TOKEN must not include leading or trailing whitespace" in errors
+
+
+def test_validate_deploy_settings_rejects_duplicate_logins_case_insensitively() -> None:
+    errors = validate_deploy_settings(
+        _deploy_settings(
+            admin_logins=("maintainer", "Maintainer"),
+            github_accepted_labelers=("maintainer",),
+        )
+    )
+
+    assert "MERGEWORK_ADMIN_LOGINS must not include duplicate logins" in errors
+
+
+def test_validate_deploy_settings_rejects_whitespace_only_login_entries() -> None:
+    errors = validate_deploy_settings(
+        _deploy_settings(
+            admin_logins=("maintainer", " "),
+            github_accepted_labelers=("maintainer",),
+        )
+    )
+
+    assert "MERGEWORK_ADMIN_LOGINS must not include empty entries" in errors


### PR DESCRIPTION
## Summary
- Validate an optional `MERGEWORK_GITHUB_ISSUE_TOKEN` when it is configured so whitespace/control-character mistakes are caught during deploy checks.
- Normalize direct `Settings` login tuples before deploy validation comparisons so duplicate/empty/non-admin maintainer checks behave consistently with env-loaded settings.
- Add focused config regression tests for optional token handling and GitHub login normalization.

## Test Plan
- `uv run --extra dev pytest tests/test_config.py -q`
- `uv run --extra dev ruff check app/config.py tests/test_config.py`
- `git diff --check`
- Added-line security scan: 0 findings
- Independent reviewer: passed

Bounty #936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub login fields now consistently handle case variations and whitespace normalization
  * Configuration validation improved with optional token field handling
  * Enhanced duplicate detection and malformed entry identification for login fields

* **Tests**
  * Added test coverage for configuration validation including GitHub token and login validation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->