### PR TITLE
fix: link activity account filters to profiles

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
@@ -24,7 +24,12 @@ def activity_context(
     context = activity_to_dict(session, query, account=normalized)
     context["api_activity_url"] = _activity_api_url(context["query"], context.get("account"))
     context["clear_activity_url"] = _activity_page_url(context.get("account"))
+    context["account_page_url"] = _account_page_url(context.get("account"))
     return context
+
+
+def _account_page_url(account: str | None) -> str | None:
+    return f"/accounts/{quote(account, safe=':')}" if account else None
 
 
 def _activity_api_url(query: str, account: str | None) -> str:

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -14,9 +14,9 @@
   </div>
 </form>
 {% if account and query %}
-<p class="notice">Showing accepted work for <code>{{ account }}</code> matching "{{ query }}"</p>
+<p class="notice">Showing accepted work for <code>{{ account }}</code> matching "{{ query }}"{% if account_page_url %} · <a href="{{ account_page_url }}">View account profile</a>{% endif %}</p>
 {% elif account %}
-<p class="notice">Showing accepted work for <code>{{ account }}</code></p>
+<p class="notice">Showing accepted work for <code>{{ account }}</code>{% if account_page_url %} · <a href="{{ account_page_url }}">View account profile</a>{% endif %}</p>
 {% elif query %}
 <p class="notice">Showing accepted work matching “{{ query }}”.</p>
 {% endif %}

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -261,6 +261,7 @@ def test_activity_api_filters_by_exact_account(sqlite_url: str) -> None:
 
     assert scoped["account"] == "github:alice"
     assert scoped["query"] == ""
+    assert scoped["account_page_url"] == "/accounts/github:alice"
     assert scoped["totals"] == {
         "accepted_awards": 1,
         "accepted_mrwk": "25",
@@ -581,10 +582,11 @@ def test_activity_page_renders_pending_accepted_work(sqlite_url: str) -> None:
 
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
-    page = client.get("/activity")
+    page = client.get("/activity?account=github:alice")
     filtered = client.get(f"/activity?q=%23{proposal.id}")
 
     assert page.status_code == 200
+    assert 'href="/accounts/github:alice">View account profile</a>' in page.text
     assert "Pending accepted work" in page.text
     assert "Queued for treasury execution, not proof-backed paid work." in page.text
     assert f'href="/api/v1/treasury/proposals/{proposal.id}"' in page.text

--- a/tests/test_activity_routes.py
+++ b/tests/test_activity_routes.py
@@ -12,6 +12,7 @@ def test_activity_context_preserves_empty_feed_shape(sqlite_url: str) -> None:
             "query": "",
             "api_activity_url": "/api/v1/activity",
             "clear_activity_url": "/activity",
+            "account_page_url": None,
             "totals": {
                 "accepted_awards": 0,
                 "accepted_mrwk": "0",


### PR DESCRIPTION
## Summary
- Add an account profile URL to activity feed context when the activity page/API is scoped by `account`.
- Surface a `View account profile` link in filtered activity notices so contributors can jump from scoped accepted-work results to the full account page.
- Cover the new context field and rendered account-profile link with focused activity tests.

Bounty #935
Affected route: `/activity?account=...`

## Duplicate check
- Checked open PRs for `View account profile`, `account_page_url`, `activity account profile`, and `activity profile link`; no open PR covered this exact activity notice/profile-link surface.

## Validation
- `uv run --extra dev pytest tests/test_activity.py tests/test_activity_routes.py -q` -> 8 passed, 1 existing Starlette/httpx deprecation warning.
- `uv run --extra dev ruff check app/activity.py tests/test_activity.py tests/test_activity_routes.py` -> All checks passed.
- `git diff --check` -> passed.
- Added-line security scan -> `security_findings_count 0`.
- Independent review -> passed; no security concerns or logic errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account profile links to activity pages. Users can now view an account's profile directly when filtering activity by that specific account, improving navigation and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->