### PR TITLE
Publish treasury challenge OpenAPI length bounds

### DIFF
--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -189,14 +189,26 @@ ATTEMPT_RELEASE_RESPONSE_SCHEMA = _object_schema(
     }
 )
 
+TREASURY_CHALLENGE_TYPE_SCHEMA = {
+    "type": "string",
+    "description": "Challenge category, trimmed by the API and limited to 80 characters.",
+    "maxLength": 80,
+}
+
+TREASURY_CHALLENGE_REASON_SCHEMA = {
+    "type": "string",
+    "description": "Public challenge reason, trimmed by the API and limited to 1000 characters.",
+    "maxLength": 1000,
+}
+
 TREASURY_CHALLENGE_RESPONSE_SCHEMA = _object_schema(
     {
         "id": {"type": "integer", "minimum": 1},
         "proposal_id": {"type": "integer", "minimum": 1},
         "challenger_account": {"type": "string"},
-        "challenge_type": {"type": "string"},
+        "challenge_type": TREASURY_CHALLENGE_TYPE_SCHEMA,
         "status": {"type": "string"},
-        "reason": {"type": "string"},
+        "reason": TREASURY_CHALLENGE_REASON_SCHEMA,
         "created_at": {"type": "string"},
     }
 )
@@ -376,8 +388,8 @@ TREASURY_CHALLENGE_BODY = {
     "requestBody": _request_body(
         _object_schema(
             {
-                "challenge_type": {"type": "string", "description": "Challenge category."},
-                "reason": {"type": "string", "description": "Public challenge reason."},
+                "challenge_type": TREASURY_CHALLENGE_TYPE_SCHEMA,
+                "reason": TREASURY_CHALLENGE_REASON_SCHEMA,
             },
             required=["challenge_type", "reason"],
         ),

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -125,6 +125,12 @@ def test_public_post_openapi_request_bodies_publish_stable_constraints(
     assert transfer_props["to_address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
     assert transfer_props["memo"]["maxLength"] == 240
 
+    challenge_props = _post_schema(openapi, "/api/v1/treasury/proposals/{proposal_id}/challenges")[
+        "properties"
+    ]
+    assert challenge_props["challenge_type"]["maxLength"] == 80
+    assert challenge_props["reason"]["maxLength"] == 1000
+
 
 def test_public_post_openapi_request_bodies_match_runtime_amount_and_ttl_bounds(
     sqlite_url: str,
@@ -328,6 +334,9 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
             "created_at",
         },
     )
+    challenge_props = challenge_schema["properties"]
+    assert challenge_props["challenge_type"]["maxLength"] == 80
+    assert challenge_props["reason"]["maxLength"] == 1000
 
 
 def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None:

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import func, select
 
+import app.treasury as treasury_module
 from app.auth import signed_value
 from app.db import session_scope
 from app.ledger.service import (
@@ -1492,6 +1493,46 @@ def test_treasury_challenges_reject_raw_control_characters(
         assert session.scalar(select(func.count(TreasuryChallenge.id))) == 0
 
 
+def test_treasury_challenges_accept_documented_length_boundaries(
+    sqlite_url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    boundary_challenge_type = "x" * 80
+    monkeypatch.setattr(
+        treasury_module,
+        "CHALLENGE_TYPES",
+        treasury_module.CHALLENGE_TYPES | {boundary_challenge_type},
+    )
+    client = _client(sqlite_url, monkeypatch)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        _seed_accepted_work(session, "alice")
+    proposal = client.post(
+        "/api/v1/bounties",
+        headers=ADMIN_HEADERS,
+        json=_bounty_payload(issue_number=82, reward_mrwk="2"),
+    ).json()
+    client.cookies.set("mrwk_user", signed_value("alice", "test-cookie-secret"))
+
+    challenge_type_response = client.post(
+        f"/api/v1/treasury/proposals/{proposal['id']}/challenges",
+        json={
+            "challenge_type": boundary_challenge_type,
+            "reason": "Valid boundary challenge type.",
+        },
+    )
+    reason_response = client.post(
+        f"/api/v1/treasury/proposals/{proposal['id']}/challenges",
+        json={"challenge_type": "subjective_note", "reason": "x" * 1000},
+    )
+
+    assert challenge_type_response.status_code == 200
+    assert challenge_type_response.json()["challenge_type"] == boundary_challenge_type
+    assert reason_response.status_code == 200
+    assert len(reason_response.json()["reason"]) == 1000
+    with session_scope(sqlite_url) as session:
+        assert session.scalar(select(func.count(TreasuryChallenge.id))) == 2
+
+
 @pytest.mark.parametrize(
     ("challenge_body", "expected_detail"),
     [
@@ -1518,7 +1559,7 @@ def test_treasury_challenges_reject_too_long_fields(
     proposal = client.post(
         "/api/v1/bounties",
         headers=ADMIN_HEADERS,
-        json=_bounty_payload(issue_number=82, reward_mrwk="2"),
+        json=_bounty_payload(issue_number=83, reward_mrwk="2"),
     ).json()
     client.cookies.set("mrwk_user", signed_value("alice", "test-cookie-secret"))
 

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -1492,6 +1492,47 @@ def test_treasury_challenges_reject_raw_control_characters(
         assert session.scalar(select(func.count(TreasuryChallenge.id))) == 0
 
 
+@pytest.mark.parametrize(
+    ("challenge_body", "expected_detail"),
+    [
+        (
+            {"challenge_type": "x" * 81, "reason": "Needs more explanation."},
+            "challenge_type is too long",
+        ),
+        (
+            {"challenge_type": "subjective_note", "reason": "x" * 1001},
+            "reason is too long",
+        ),
+    ],
+)
+def test_treasury_challenges_reject_too_long_fields(
+    sqlite_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+    challenge_body: dict[str, str],
+    expected_detail: str,
+) -> None:
+    client = _client(sqlite_url, monkeypatch)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        _seed_accepted_work(session, "alice")
+    proposal = client.post(
+        "/api/v1/bounties",
+        headers=ADMIN_HEADERS,
+        json=_bounty_payload(issue_number=82, reward_mrwk="2"),
+    ).json()
+    client.cookies.set("mrwk_user", signed_value("alice", "test-cookie-secret"))
+
+    response = client.post(
+        f"/api/v1/treasury/proposals/{proposal['id']}/challenges",
+        json=challenge_body,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == expected_detail
+    with session_scope(sqlite_url) as session:
+        assert session.scalar(select(func.count(TreasuryChallenge.id))) == 0
+
+
 def test_close_bounty_rejects_missing_bounty_before_proposal_creation(
     sqlite_url: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
/claim

Bounty #944
Refs #944

delivery summary:
- Publishes the existing treasury challenge length bounds in OpenAPI for `POST /api/v1/treasury/proposals/{proposal_id}/challenges`.
- Adds shared challenge field schemas so both request and response contracts advertise `challenge_type.maxLength = 80` and `reason.maxLength = 1000`.
- Adds focused OpenAPI assertions for the request and response schemas.
- Adds runtime regression coverage proving the advertised limits match treasury challenge validation.

Duplicate check:
- Rechecked the live #944 issue comments and open PR search for `challenge_type`, `reason`, `maxLength`, and treasury challenge OpenAPI overlap.
- Existing submissions cover treasury enums/status/action values, required response fields, treasury proposal GET schemas, and other public API surfaces.
- I did not find a submission publishing the treasury challenge `challenge_type`/`reason` maxLength bounds in both request and response schemas.

Validation:
- `C:\Users\Administrator\Documents\Codex\2026-06-04\100rmb-30\repos\ramimbo__mergework\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py tests\test_treasury_proposals.py -q` -> 71 passed, 1 existing Starlette/httpx warning.
- `C:\Users\Administrator\Documents\Codex\2026-06-04\100rmb-30\repos\ramimbo__mergework\.venv\Scripts\ruff.exe check app\openapi_request_bodies.py tests\test_openapi_request_bodies.py tests\test_treasury_proposals.py` -> All checks passed.
- `C:\Users\Administrator\Documents\Codex\2026-06-04\100rmb-30\repos\ramimbo__mergework\.venv\Scripts\ruff.exe format --check app\openapi_request_bodies.py tests\test_openapi_request_bodies.py tests\test_treasury_proposals.py` -> 3 files already formatted.
- `C:\Users\Administrator\Documents\Codex\2026-06-04\100rmb-30\repos\ramimbo__mergework\.venv\Scripts\python.exe -m mypy app\openapi_request_bodies.py app\treasury.py` -> Success: no issues found in 2 source files.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `1d699935dedfe714911a3a19251826b5e8a930ca`.

Touched surfaces: `app/openapi_request_bodies.py`, `tests/test_openapi_request_bodies.py`, `tests/test_treasury_proposals.py`. Scope is treasury challenge OpenAPI metadata plus focused validation tests only; no treasury proposal execution, payout execution, ledger mutation, wallet custody, admin-token behavior, bridge/exchange/off-ramp/cash-out, MRWK price behavior, private data, or secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Treasury challenge endpoint enforces field length limits: challenge type (max 80 chars) and reason (max 1000 chars). Over-limit requests are rejected with clear errors.
  * Boundary-length submissions (80 / 1000) are accepted.

* **Documentation**
  * API schema/docs updated to reflect and reuse the enforced length constraints for treasury challenge submissions.

* **Tests**
  * Added tests asserting maxLength in schemas, accepting boundary values, and rejecting overly long values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->