### PR TITLE
Link work discovery from hub starting points

### DIFF
--- a/app/hub.py
+++ b/app/hub.py
@@ -38,6 +38,13 @@ MERGEWORK_CONTRIBUTOR_STARTING_POINTS = (
         ),
     },
     {
+        "title": "Work discovery queue",
+        "href": "/api/v1/work-discovery",
+        "description": (
+            "Use the unified public queue to separate claimable bounties from pending work."
+        ),
+    },
+    {
         "title": "Current bounty JSON",
         "href": "/api/v1/bounties?status=open&availability=effectively_open",
         "description": "Use the public API to verify live status, capacity, and requirements.",

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -67,6 +67,13 @@ def test_mergework_hub_context_preserves_status_and_base_url() -> None:
             ),
         },
         {
+            "title": "Work discovery queue",
+            "href": "/api/v1/work-discovery",
+            "description": (
+                "Use the unified public queue to separate claimable bounties from pending work."
+            ),
+        },
+        {
             "title": "Current bounty JSON",
             "href": "/api/v1/bounties?status=open&availability=effectively_open",
             "description": "Use the public API to verify live status, capacity, and requirements.",
@@ -98,5 +105,7 @@ def test_mergework_hub_renders_contributor_starting_points(sqlite_url: str) -> N
     assert 'href="/bounties?status=open&amp;availability=effectively_open"' in response.text
     assert "Accepted work activity" in response.text
     assert 'href="/activity"' in response.text
+    assert "Work discovery queue" in response.text
+    assert 'href="/api/v1/work-discovery"' in response.text
     assert "Current bounty JSON" in response.text
     assert 'href="/api/v1/bounties?status=open&amp;availability=effectively_open"' in response.text

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -158,6 +158,17 @@ def test_hub_marks_static_service_links_as_untrusted(sqlite_url: str) -> None:
         assert f'href="{url}" rel="nofollow noopener"' in page.text
 
 
+def test_hub_links_contributor_starting_points(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    page = client.get("/")
+
+    assert page.status_code == 200
+    assert 'href="/bounties?status=open&amp;availability=effectively_open"' in page.text
+    assert 'href="/api/v1/work-discovery"' in page.text
+    assert 'href="/api/v1/bounties?status=open&amp;availability=effectively_open"' in page.text
+
+
 def test_ltc_lab_project_links_are_marked_untrusted(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 


### PR DESCRIPTION
/claim

Bounty #935
Refs #935

delivery summary:
- Adds `GET /api/v1/work-discovery` to the MergeWork homepage contributor starting points.
- Gives contributors and agents a first-page route to the unified public work queue without needing to infer endpoint names from docs.
- Keeps the existing claimable bounties page link and current bounty JSON link, so the hub now routes users to both the human claimable lane and the machine-readable queue.
- Preserves bounty lifecycle semantics; this is homepage contributor routing and test coverage only.

Duplicate check:
- Rechecked #935 comments and open PR search for hub/homepage, work-discovery, docs page, bounty list/detail routing, and contributor starting-point overlap.
- Existing #935 submissions cover bounty list/detail routing, work-discovery row links, pending-create visibility, claimable filter notices, activity search notices, proposed-work discovery metadata, and docs-page links.
- I did not find an open #935 submission adding the work-discovery route to the homepage contributor starting points.

Validation:
- `C:\Users\Administrator\Documents\Codex\2026-06-04\100rmb-30\repos\ramimbo__mergework\.venv\Scripts\python.exe -m pytest tests\test_public_routes.py -q` -> 8 passed, 1 existing Starlette/httpx warning.
- `C:\Users\Administrator\Documents\Codex\2026-06-04\100rmb-30\repos\ramimbo__mergework\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok.
- `C:\Users\Administrator\Documents\Codex\2026-06-04\100rmb-30\repos\ramimbo__mergework\.venv\Scripts\ruff.exe check app\hub.py tests\test_public_routes.py` -> All checks passed.
- `C:\Users\Administrator\Documents\Codex\2026-06-04\100rmb-30\repos\ramimbo__mergework\.venv\Scripts\ruff.exe format --check app\hub.py tests\test_public_routes.py` -> 2 files already formatted.
- `C:\Users\Administrator\Documents\Codex\2026-06-04\100rmb-30\repos\ramimbo__mergework\.venv\Scripts\python.exe -m mypy app\hub.py` -> Success: no issues found in 1 source file.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `1d699935dedfe714911a3a19251826b5e8a930ca`.

Touched surfaces: `app/hub.py`, `tests/test_public_routes.py`. Scope is public homepage routing/test coverage only; no work-discovery payload changes, bounty claimability logic, proposal execution, payout execution, ledger mutation, wallet behavior, admin-token behavior, bridge/exchange/off-ramp/cash-out, MRWK price behavior, private data, or secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Work discovery queue" starting point in the contributor hub to let users browse a unified public queue and better distinguish claimable bounties from pending work.

* **Tests**
  * Added/updated tests to confirm the contributor hub renders the new work discovery entry and related bounty query links correctly on the homepage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->