### PR TITLE
Publish MCP OpenAPI contract

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -30,6 +30,7 @@ from app.me import me_page_context
 from app.models import (
     Proof,
 )
+from app.openapi_request_bodies import MCP_BODY
 from app.path_params import (
     SQLITE_INTEGER_MAX,
     positive_bounty_id,
@@ -306,7 +307,7 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
         code = 401 if result["status"] == "unauthorized" else 200
         return JSONResponse(result, status_code=code)
 
-    @app.post("/mcp")
+    @app.post("/mcp", openapi_extra=MCP_BODY)
     async def mcp(request: Request) -> Any:
         return await handle_mcp_request(request, db_url, call_mcp_tool)
 

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -220,6 +220,121 @@ TREASURY_PROPOSAL_RESPONSE_SCHEMA = _object_schema(
     }
 )
 
+MCP_JSONRPC_ID_SCHEMA = {
+    "description": "JSON-RPC request id returned unchanged in the response.",
+    "nullable": True,
+    "anyOf": [{"type": "string"}, {"type": "integer"}, {"type": "number"}],
+}
+
+MCP_REQUEST_SCHEMA = _object_schema(
+    {
+        "jsonrpc": {
+            "type": "string",
+            "enum": ["2.0"],
+            "description": "JSON-RPC protocol version.",
+        },
+        "id": MCP_JSONRPC_ID_SCHEMA,
+        "method": {
+            "type": "string",
+            "enum": ["initialize", "tools/list", "tools/call"],
+            "description": "Supported MCP JSON-RPC method.",
+        },
+        "params": {
+            "type": "object",
+            "additionalProperties": True,
+            "description": "Method-specific MCP parameters.",
+        },
+    },
+    required=["jsonrpc", "method"],
+    description="MCP JSON-RPC request accepted by the MergeWork MCP endpoint.",
+)
+
+MCP_ERROR_SCHEMA = _object_schema(
+    {
+        "code": {"type": "integer"},
+        "message": {"type": "string"},
+    },
+    required=["code", "message"],
+    description="JSON-RPC error object.",
+)
+
+MCP_TEXT_CONTENT_SCHEMA = _object_schema(
+    {
+        "type": {"type": "string"},
+        "text": {"type": "string"},
+    },
+    required=["type", "text"],
+    description="MCP text content item.",
+)
+
+MCP_TOOL_RESULT_SCHEMA = _object_schema(
+    {
+        "content": {"type": "array", "items": MCP_TEXT_CONTENT_SCHEMA},
+        "structuredContent": {
+            "description": "Optional structured JSON payload for tool results.",
+            "nullable": True,
+        },
+    },
+    required=["content"],
+    description="MCP tools/call result payload.",
+)
+
+MCP_INITIALIZE_RESULT_SCHEMA = _object_schema(
+    {
+        "protocolVersion": {"type": "string"},
+        "capabilities": {"type": "object", "additionalProperties": True},
+        "serverInfo": {"type": "object", "additionalProperties": True},
+    },
+    required=["protocolVersion", "capabilities", "serverInfo"],
+    description="MCP initialize result payload.",
+)
+
+MCP_TOOLS_LIST_RESULT_SCHEMA = _object_schema(
+    {
+        "tools": {
+            "type": "array",
+            "items": {"type": "object", "additionalProperties": True},
+        },
+    },
+    required=["tools"],
+    description="MCP tools/list result payload.",
+)
+
+MCP_RESPONSE_SCHEMA = _object_schema(
+    {
+        "jsonrpc": {"type": "string", "enum": ["2.0"]},
+        "id": MCP_JSONRPC_ID_SCHEMA,
+        "result": {
+            "oneOf": [
+                MCP_INITIALIZE_RESULT_SCHEMA,
+                MCP_TOOLS_LIST_RESULT_SCHEMA,
+                MCP_TOOL_RESULT_SCHEMA,
+            ],
+            "description": "Method-specific result for successful JSON-RPC responses.",
+        },
+        "error": MCP_ERROR_SCHEMA,
+    },
+    required=["jsonrpc", "id"],
+    description=(
+        "MCP JSON-RPC response. Successful responses include result; failures include error."
+    ),
+)
+MCP_RESPONSE_SCHEMA["oneOf"] = [
+    {"required": ["result"]},
+    {"required": ["error"]},
+]
+
+MCP_ERROR_RESPONSE_SCHEMA = _object_schema(
+    {
+        "jsonrpc": {"type": "string", "enum": ["2.0"]},
+        "id": MCP_JSONRPC_ID_SCHEMA,
+        "error": MCP_ERROR_SCHEMA,
+    },
+    required=["jsonrpc", "id", "error"],
+    description="MCP JSON-RPC error response.",
+)
+MCP_ERROR_RESPONSE_SCHEMA["not"] = {"required": ["result"]}
+
 OPTIONAL_ATTEMPT_BODY = {
     "requestBody": _request_body(
         _object_schema(
@@ -384,5 +499,16 @@ TREASURY_CHALLENGE_BODY = {
     ),
     "responses": {
         "200": _json_response(TREASURY_CHALLENGE_RESPONSE_SCHEMA),
+    },
+}
+
+MCP_BODY = {
+    "requestBody": _request_body(MCP_REQUEST_SCHEMA),
+    "responses": {
+        "200": _json_response(MCP_RESPONSE_SCHEMA, description="MCP JSON-RPC response."),
+        "400": _json_response(
+            MCP_ERROR_RESPONSE_SCHEMA,
+            description="MCP JSON-RPC parse or invalid request error.",
+        ),
     },
 }

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -27,6 +27,43 @@ def _assert_properties(schema: dict, expected: Iterable[str]) -> None:
     assert set(expected).issubset(schema["properties"])
 
 
+def test_mcp_openapi_contract_exposes_jsonrpc_request_and_response(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    operation = openapi["paths"]["/mcp"]["post"]
+    request_schema = operation["requestBody"]["content"]["application/json"]["schema"]
+    response_schema = operation["responses"]["200"]["content"]["application/json"]["schema"]
+    parse_error_schema = operation["responses"]["400"]["content"]["application/json"]["schema"]
+
+    assert set(request_schema["required"]) == {"jsonrpc", "method"}
+    request_props = request_schema["properties"]
+    assert request_props["jsonrpc"]["enum"] == ["2.0"]
+    assert set(request_props["method"]["enum"]) == {"initialize", "tools/list", "tools/call"}
+    assert request_props["id"]["nullable"] is True
+    assert request_props["params"]["additionalProperties"] is True
+
+    _assert_properties(response_schema, {"jsonrpc", "id", "result", "error"})
+    assert response_schema["properties"]["jsonrpc"]["enum"] == ["2.0"]
+    assert response_schema["properties"]["id"]["nullable"] is True
+    assert response_schema["oneOf"] == [{"required": ["result"]}, {"required": ["error"]}]
+
+    result_variants = response_schema["properties"]["result"]["oneOf"]
+    assert any(
+        {"protocolVersion", "capabilities", "serverInfo"}.issubset(variant["properties"])
+        for variant in result_variants
+    )
+    assert any("tools" in variant["properties"] for variant in result_variants)
+    assert any("content" in variant["properties"] for variant in result_variants)
+    _assert_properties(response_schema["properties"]["error"], {"code", "message"})
+
+    _assert_properties(parse_error_schema, {"jsonrpc", "id", "error"})
+    assert set(parse_error_schema["required"]) == {"jsonrpc", "id", "error"}
+    assert "result" not in parse_error_schema["properties"]
+    assert parse_error_schema["not"] == {"required": ["result"]}
+    assert parse_error_schema["properties"]["error"]["required"] == ["code", "message"]
+
+
 def test_public_post_openapi_request_bodies_expose_expected_fields(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
     openapi = client.get("/openapi.json").json()


### PR DESCRIPTION
Adds an explicit OpenAPI contract for the MCP JSON-RPC endpoint.

What changed:
- documents the `/mcp` request body for `initialize`, `tools/list`, and `tools/call`
- documents 200 success/error and 400 error-only JSON-RPC response envelopes
- adds focused OpenAPI coverage

Tests:
- `python -m pytest tests\test_openapi_request_bodies.py -q`
- `python -m pytest tests\test_api_mcp.py::test_mcp_tools_list_and_call tests\test_api_mcp.py::test_mcp_initialize_returns_server_capabilities tests\test_api_mcp.py::test_mcp_rejects_malformed_requests_without_500 -q`
- `ruff check app\openapi_request_bodies.py app\main.py tests\test_openapi_request_bodies.py`
- `ruff format --check app\openapi_request_bodies.py app\main.py tests\test_openapi_request_bodies.py`
- `python scripts\docs_smoke.py`
- `python -m mypy app\main.py app\openapi_request_bodies.py`
- `git diff --check`

Bounty #944: /claim