### PR TITLE
Publish treasury execute OpenAPI response schema

### DIFF
--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -372,6 +372,12 @@ TREASURY_PROPOSAL_BODY = {
     },
 }
 
+TREASURY_PROPOSAL_EXECUTE_RESPONSE = {
+    "responses": {
+        "200": _json_response(TREASURY_PROPOSAL_RESPONSE_SCHEMA),
+    },
+}
+
 TREASURY_CHALLENGE_BODY = {
     "requestBody": _request_body(
         _object_schema(

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -11,7 +11,11 @@ from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import LedgerError
 from app.models import TreasuryProposal
-from app.openapi_request_bodies import TREASURY_CHALLENGE_BODY, TREASURY_PROPOSAL_BODY
+from app.openapi_request_bodies import (
+    TREASURY_CHALLENGE_BODY,
+    TREASURY_PROPOSAL_BODY,
+    TREASURY_PROPOSAL_EXECUTE_RESPONSE,
+)
 from app.path_params import SQLITE_INTEGER_MAX, positive_proposal_id
 from app.query_validation import (
     reject_control_char_query_param,
@@ -234,7 +238,10 @@ def register_treasury_routes(
             except LedgerError as exc:
                 raise _proposal_error(exc) from exc
 
-    @app.post("/api/v1/treasury/proposals/{proposal_id}/execute")
+    @app.post(
+        "/api/v1/treasury/proposals/{proposal_id}/execute",
+        openapi_extra=TREASURY_PROPOSAL_EXECUTE_RESPONSE,
+    )
     def api_execute_treasury_proposal(
         proposal_id: str,
         admin_login: str = Depends(require_admin_token),

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -313,6 +313,33 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
         },
     )
 
+    execute_operation = openapi["paths"]["/api/v1/treasury/proposals/{proposal_id}/execute"]["post"]
+    assert "requestBody" not in execute_operation
+    execute_schema = _post_response_schema(
+        openapi, "/api/v1/treasury/proposals/{proposal_id}/execute"
+    )
+    _assert_properties(
+        execute_schema,
+        {
+            "id",
+            "type",
+            "action",
+            "status",
+            "payload_hash",
+            "payload",
+            "proposed_by",
+            "executed_by",
+            "proposed_at",
+            "executes_after",
+            "executed_at",
+            "executed_ledger_sequence",
+            "result",
+            "challenges",
+        },
+    )
+    assert execute_schema["properties"]["id"]["minimum"] == 1
+    assert execute_schema["properties"]["payload_hash"]["pattern"] == "^[0-9a-f]{64}$"
+
     challenge_schema = _post_response_schema(
         openapi, "/api/v1/treasury/proposals/{proposal_id}/challenges"
     )


### PR DESCRIPTION
Bounty #944
Refs #944

## Summary
- Publishes an explicit OpenAPI `200` response schema for `POST /api/v1/treasury/proposals/{proposal_id}/execute`.
- Reuses the existing `TREASURY_PROPOSAL_RESPONSE_SCHEMA` so clients see the same treasury proposal payload shape after execution.
- Keeps the execute route bodyless in OpenAPI and preserves existing runtime JSON behavior.

## Duplicate check
- Searched current PRs and #944 submissions for treasury execute/OpenAPI response schema overlap, including `treasury execute OpenAPI response schema`, `treasury proposal execute`, and `TREASURY_PROPOSAL_RESPONSE_SCHEMA execute`.
- Existing #944 work covers treasury enums, POST create response metadata, treasury GET proposal schemas, and challenge schemas; I did not find an open submission covering the execute route's `200` response contract.

## Validation
- `C:\Users\Administrator\Documents\Codex\2026-06-04\100rmb-30\repos\ramimbo__mergework\.venv\Scripts\python.exe -m pytest tests\test_openapi_request_bodies.py tests\test_treasury_proposals.py -q` -> 69 passed, 1 existing Starlette/httpx warning.
- `C:\Users\Administrator\Documents\Codex\2026-06-04\100rmb-30\repos\ramimbo__mergework\.venv\Scripts\ruff.exe check app\openapi_request_bodies.py app\treasury_routes.py tests\test_openapi_request_bodies.py` -> All checks passed.
- `C:\Users\Administrator\Documents\Codex\2026-06-04\100rmb-30\repos\ramimbo__mergework\.venv\Scripts\ruff.exe format --check app\openapi_request_bodies.py app\treasury_routes.py tests\test_openapi_request_bodies.py` -> 3 files already formatted.
- `C:\Users\Administrator\Documents\Codex\2026-06-04\100rmb-30\repos\ramimbo__mergework\.venv\Scripts\python.exe -m mypy app\openapi_request_bodies.py app\treasury_routes.py` -> Success: no issues found in 2 source files.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `1d699935dedfe714911a3a19251826b5e8a930ca`.

## Scope
Touched surfaces: `app/openapi_request_bodies.py`, `app/treasury_routes.py`, `tests/test_openapi_request_bodies.py`. Scope is OpenAPI/client response metadata only; no runtime treasury proposal execution changes, payout execution, ledger mutation, wallet custody, admin-token behavior, bridge/exchange/off-ramp/cash-out, MRWK price behavior, private data, or secrets changed.

Payout boundary: this is a submitted #944 bounty claim candidate only. It is not confirmed or withdrawable unless maintainers accept it and record payment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added OpenAPI response schema documentation for the treasury proposal execution endpoint, formally defining response structure, field types, and validation constraints.

* **Tests**
  * Extended test coverage to validate the treasury proposal execution endpoint's response schema and field constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->