### PR TITLE
Tighten MCP unexpected argument errors

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -514,6 +514,7 @@ _KNOWN_FIELD_MESSAGES: dict[str, str] = {
 # field-prefixed (e.g. `unknown tool`).
 _KNOWN_FIELDLESS_MESSAGES: dict[str, str] = {
     "unknown tool": "unknown tool",
+    "unexpected argument": "unexpected argument",
     "matches multiple bounties": "matches multiple bounties",
     "repo can only be used with issue_number": ("repo can only be used with issue_number"),
 }

--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -36,6 +36,7 @@ from app.serializers import (
 
 MCP_INTEGER_RE = re.compile(r"^(?:0|-?[1-9][0-9]*)$")
 MCP_BOUNTY_SEARCH_QUERY_MAX_LENGTH = 500
+MCP_UNEXPECTED_ARGUMENT_MESSAGE = "unexpected argument"
 
 
 def call_mcp_tool(
@@ -142,7 +143,7 @@ def call_mcp_tool(
     def require_known_fields(*allowed_fields: str) -> None:
         unknown_fields = set(args) - set(allowed_fields)
         if unknown_fields:
-            raise ValueError(f"unknown argument: {sorted(unknown_fields)[0]}")
+            raise ValueError(MCP_UNEXPECTED_ARGUMENT_MESSAGE)
 
     def bounty_by_issue_number(repo_selector: str | None) -> Bounty | None:
         issue_query = select(Bounty).where(Bounty.issue_number == positive_int_arg("issue_number"))
@@ -183,11 +184,10 @@ def call_mcp_tool(
             return bounty_by_issue_number(repo_selector)
         raise ValueError(f"{internal_id_field} or issue_number is required")
 
-    def reject_unexpected_args(tool_name: str, allowed: set[str]) -> None:
+    def reject_unexpected_args(_tool_name: str, allowed: set[str]) -> None:
         unexpected = sorted(set(args) - allowed)
         if unexpected:
-            names = ", ".join(unexpected)
-            raise ValueError(f"{tool_name} received unexpected argument(s): {names}")
+            raise ValueError(MCP_UNEXPECTED_ARGUMENT_MESSAGE)
 
     with session_scope(database_url) as session:
         if name == "list_bounties":
@@ -245,6 +245,7 @@ def call_mcp_tool(
             )
             return json.dumps(sorted_bounties[:limit])
         if name == "get_bounty":
+            require_known_fields("id", "bounty_id", "issue_number", "repo", "include_awards")
             bounty = selected_bounty("id", internal_id_aliases=("bounty_id",))
             if bounty is None:
                 return "bounty not found"
@@ -253,6 +254,14 @@ def call_mcp_tool(
                 bounty_data["awards"] = bounty_awards_to_dict(session, bounty.id)
             return json.dumps(bounty_data)
         if name == "list_bounty_attempts":
+            require_known_fields(
+                "id",
+                "bounty_id",
+                "issue_number",
+                "repo",
+                "include_expired",
+                "limit",
+            )
             bounty = selected_bounty("bounty_id", internal_id_aliases=("id",))
             if bounty is None:
                 return "bounty not found"
@@ -270,6 +279,7 @@ def call_mcp_tool(
                 "attempts": attempt_listing["attempts"],
             }
         if name == "get_balance":
+            require_known_fields("account")
             account = normalized_account(str_arg("account"))
             balance_microunits = get_balance(session, account)
             balance_mrwk = format_mrwk(balance_microunits)
@@ -290,6 +300,7 @@ def call_mcp_tool(
             )
             return json.dumps(wallet_to_dict(session, wallet))
         if name == "get_wallet":
+            require_known_fields("address")
             wallet_row = session.get(Wallet, normalized_wallet_address(str_arg("address")))
             if wallet_row is None:
                 return "wallet not found"
@@ -317,11 +328,13 @@ def call_mcp_tool(
             )
             return json.dumps(wallet_transfer_to_dict(transfer))
         if name == "get_ledger_entry":
+            require_known_fields("sequence")
             entry = ledger_entry_to_dict(session, positive_int_arg("sequence"))
             if entry is None:
                 return "ledger entry not found"
             return json.dumps(entry)
         if name == "get_proof":
+            require_known_fields("hash")
             proof = session.get(Proof, proof_hash_from_path(str_arg("hash")))
             if proof is None:
                 return "proof not found"

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -366,13 +366,17 @@ The shape is:
   arbitrary caller-supplied string into this slot, so the value is safe
   to surface to LLM prompts or logs.
 - `field` — the offending field name, or `null` for field-less phrases such
-  as `unknown tool`, `matches multiple bounties`, or
+  as `unknown tool`, `unexpected argument`, `matches multiple bounties`, or
   `repo can only be used with issue_number`. Some upstream messages are
   emitted as `"<field> <field-less phrase>"` (for example
   `issue_number matches multiple bounties`); the classifier treats those
   as field-less and drops the leading field token from the response.
 - `message` — a static, whitelisted safe phrase. Caller input is never
   echoed, so the payload is safe to surface to LLM prompts or logs.
+
+Extra keys sent to tools that reject unknown arguments return
+`message: "unexpected argument"` with `field: null`; the rejected key name
+and value are not echoed.
 
 When the underlying `ValueError` does not match the whitelist, the
 `error.data` key is omitted and the response is byte-for-byte identical to

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -3305,6 +3305,73 @@ def test_mcp_field_error_data_attaches_repo_requires_issue_number(sqlite_url: st
     )
 
 
+@pytest.mark.parametrize(
+    ("tool_name", "arguments"),
+    [
+        ("list_bounties", {}),
+        ("get_bounty", {"id": 1}),
+        ("list_bounty_attempts", {"bounty_id": 1}),
+        ("get_balance", {"account": "treasury:mrwk"}),
+        ("register_wallet", {"public_key_hex": "22" * 32}),
+        ("get_wallet", {"address": "mrwk1" + "1" * 40}),
+        (
+            "submit_wallet_transfer",
+            {
+                "from_address": "mrwk1" + "1" * 40,
+                "to_address": "mrwk1" + "2" * 40,
+                "amount_mrwk": "1",
+                "nonce": 1,
+                "memo": "test",
+                "signature_hex": "aa" * 64,
+            },
+        ),
+        ("get_ledger_entry", {"sequence": 1}),
+        ("get_proof", {"hash": "a" * 64}),
+        ("submit_work_proof", {"format": "json"}),
+    ],
+)
+def test_mcp_field_error_data_attaches_unexpected_argument_without_echo(
+    sqlite_url: str,
+    tool_name: str,
+    arguments: dict[str, object],
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    sentinel_key = "caller_supplied_extra_probe"
+    sentinel_value = "do-not-echo-this-extra-value"
+    call_arguments = {**arguments, sentinel_key: sentinel_value}
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "tools/call",
+            "params": {
+                "name": tool_name,
+                "arguments": call_arguments,
+            },
+        },
+    )
+
+    body = response.text
+    assert sentinel_key not in body
+    assert sentinel_value not in body
+    _assert_invalid_tool_arguments_envelope(
+        response.json(),
+        request_id=10,
+        expected_data={
+            "code": "invalid_argument",
+            "tool": tool_name,
+            "field": None,
+            "message": "unexpected argument",
+        },
+    )
+
+
 def test_mcp_field_error_data_omitted_for_unmatched_value_error(sqlite_url: str) -> None:
     """A ``ValueError`` whose message is not on the whitelist must fall
     back to the legacy envelope *without* an ``error.data`` key, so the


### PR DESCRIPTION
Tightens MCP argument validation for tools that advertise closed input schemas.

What changed:
- rejects unexpected keys for the remaining affected MCP tools
- returns safe `error.data` with `unexpected argument` without echoing caller-supplied keys or values
- adds one parameterized MCP regression test and a short agent-guide note

Tests:
- `pytest tests/test_api_mcp.py tests/test_mcp_tools.py -q`
- `ruff check app/mcp.py app/mcp_tools.py tests/test_api_mcp.py docs/agent-guide.md`
- `ruff format --check app/mcp.py app/mcp_tools.py tests/test_api_mcp.py`
- `mypy app/mcp.py app/mcp_tools.py`
- `python scripts/docs_smoke.py`

Bounty #946