### PR TITLE
Link account pages to activity view

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -114,6 +114,7 @@ def account_action_urls(account: str) -> dict[str, str]:
         "account_json": f"/api/v1/accounts/{path_account}",
         "accepted_work_json": f"/api/v1/accounts/{path_account}/accepted-work",
         "activity": f"/api/v1/activity?{urlencode({'account': account})}",
+        "activity_page": f"/activity?{urlencode({'account': account})}",
     }
 
 

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -19,7 +19,8 @@
   <div class="next-steps-actions" aria-label="Account action links">
     <a href="{{ account_action_urls.account_json }}">Account JSON</a>
     <a href="{{ account_action_urls.accepted_work_json }}">Accepted-work JSON</a>
-    <a href="{{ account_action_urls.activity }}">Activity for account</a>
+    <a href="{{ account_action_urls.activity_page }}">Activity page</a>
+    <a href="{{ account_action_urls.activity }}">Activity JSON</a>
   </div>
 </section>
 

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -65,6 +65,7 @@ def test_account_contexts_include_balance_status_and_proof_backed_rows(
         "account_json": "/api/v1/accounts/github:alice",
         "accepted_work_json": "/api/v1/accounts/github:alice/accepted-work",
         "activity": "/api/v1/activity?account=github%3Aalice",
+        "activity_page": "/activity?account=github%3Aalice",
     }
     assert page_context["accepted_summary"]["accepted_mrwk"] == "40"
     assert page_context["accepted_work"][0]["proof_hash"] == proof.hash
@@ -121,7 +122,10 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     assert "25 MRWK" in page_response.text
     assert 'href="/api/v1/accounts/github:bob"' in page_response.text
     assert 'href="/api/v1/accounts/github:bob/accepted-work"' in page_response.text
+    assert 'href="/activity?account=github%3Abob"' in page_response.text
     assert 'href="/api/v1/activity?account=github%3Abob"' in page_response.text
+    assert "Activity page" in page_response.text
+    assert "Activity JSON" in page_response.text
     assert '<p class="reference-cell">' in page_response.text
     assert f'href="/proofs/{proof.hash}"' in page_response.text
 
@@ -131,6 +135,7 @@ def test_account_action_urls_escape_query_accounts() -> None:
         "account_json": "/api/v1/accounts/github:alice",
         "accepted_work_json": "/api/v1/accounts/github:alice/accepted-work",
         "activity": "/api/v1/activity?account=github%3Aalice",
+        "activity_page": "/activity?account=github%3Aalice",
     }
 
 


### PR DESCRIPTION
Bounty #935
Refs #935

## Summary
- Adds a human-readable `/activity?account=...` link to public account pages.
- Keeps the existing account JSON, accepted-work JSON, and activity JSON links available.
- Adds regression coverage so account pages expose both the human activity page and scoped JSON activity URL.

## Duplicate check
- Searched open PRs for `Activity page account_action_urls`, `/activity?account /accounts`, and `account activity page`.
- Existing related work covers activity search notices, activity response schemas, activity limits, and public query guards.
- I did not find an open #935 submission that adds a human activity-page route from `/accounts/{account}`.

## Validation
- `python -m pytest tests\test_account_routes.py tests\test_activity.py::test_activity_page_renders_empty_and_paid_states tests\test_activity.py::test_activity_page_renders_pending_accepted_work -q` -> 11 passed, 1 existing Starlette/httpx warning.
- `ruff check app\accounts.py tests\test_account_routes.py` -> All checks passed.
- `ruff format --check app\accounts.py tests\test_account_routes.py` -> 2 files already formatted.
- `python -m mypy app\accounts.py` -> Success.
- `python scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` and `git diff --check` -> clean, with the normal Windows LF-to-CRLF warning for the touched template.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `7762447113c0e738c8786f302ccb0b9ba7e09cef`.

## Scope
Public account-page routing and tests only. No payout execution, ledger mutation, wallet behavior, treasury/admin-token behavior, bridge/exchange/off-ramp/cash-out behavior, MRWK price behavior, private data, or secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Activity page" navigation link to the account section for direct access to account activity history.
  * Added an "Activity JSON" link to view activity data in JSON format.

* **Tests**
  * Updated tests to verify new activity navigation links render correctly in the account section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->