### PR TITLE
Handle MCP initialized notification and ping

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -4,7 +4,7 @@ import json
 from collections.abc import Callable
 from typing import Any
 
-from fastapi import HTTPException, Request
+from fastapi import HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 
 from app.ledger.service import LedgerError
@@ -13,6 +13,8 @@ from app.mcp_results import MCPTextResult
 MCPToolHandler = Callable[[str, str, dict[str, Any]], str | dict[str, Any] | MCPTextResult]
 MCP_PROTOCOL_VERSION = "2025-06-18"
 MCP_SERVER_INFO = {"name": "mergework", "version": "0.1.0"}
+MCP_INITIALIZED_NOTIFICATION_METHOD = "notifications/initialized"
+MCP_PING_METHOD = "ping"
 
 
 MCP_BOUNTY_SUMMARY_OUTPUT_SCHEMA: dict[str, Any] = {
@@ -633,6 +635,10 @@ def _initialize_response(response_id: Any, params: Any) -> dict[str, Any]:
     }
 
 
+def _ping_response(response_id: Any) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": response_id, "result": {}}
+
+
 def _structured_json_payload(text: str) -> dict[str, Any] | list[Any] | None:
     try:
         payload = json.loads(text)
@@ -679,7 +685,7 @@ def _tool_result_response(
 
 async def handle_mcp_request(
     request: Request, database_url: str, call_tool: MCPToolHandler
-) -> dict[str, Any] | JSONResponse:
+) -> dict[str, Any] | Response:
     try:
         payload = await request.json()
     except ValueError:
@@ -690,8 +696,14 @@ async def handle_mcp_request(
 
     response_id = payload.get("id")
     method = payload.get("method")
+    if method == MCP_INITIALIZED_NOTIFICATION_METHOD and "id" not in payload:
+        return Response(status_code=204)
+
     if method == "initialize":
         return _initialize_response(response_id, payload.get("params"))
+
+    if method == MCP_PING_METHOD:
+        return _ping_response(response_id)
 
     if method == "tools/list":
         return {"jsonrpc": "2.0", "id": response_id, "result": {"tools": MCP_TOOLS}}

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -299,6 +299,8 @@ MCP_EMPTY_RESULT_SCHEMA = _object_schema(
     {},
     description="Empty MCP result payload.",
 )
+MCP_EMPTY_RESULT_SCHEMA["additionalProperties"] = False
+MCP_EMPTY_RESULT_SCHEMA["maxProperties"] = 0
 
 MCP_TOOLS_LIST_RESULT_SCHEMA = _object_schema(
     {

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -236,7 +236,13 @@ MCP_REQUEST_SCHEMA = _object_schema(
         "id": MCP_JSONRPC_ID_SCHEMA,
         "method": {
             "type": "string",
-            "enum": ["initialize", "tools/list", "tools/call"],
+            "enum": [
+                "initialize",
+                "notifications/initialized",
+                "ping",
+                "tools/list",
+                "tools/call",
+            ],
             "description": "Supported MCP JSON-RPC method.",
         },
         "params": {
@@ -289,6 +295,11 @@ MCP_INITIALIZE_RESULT_SCHEMA = _object_schema(
     description="MCP initialize result payload.",
 )
 
+MCP_EMPTY_RESULT_SCHEMA = _object_schema(
+    {},
+    description="Empty MCP result payload.",
+)
+
 MCP_TOOLS_LIST_RESULT_SCHEMA = _object_schema(
     {
         "tools": {
@@ -307,6 +318,7 @@ MCP_RESPONSE_SCHEMA = _object_schema(
         "result": {
             "oneOf": [
                 MCP_INITIALIZE_RESULT_SCHEMA,
+                MCP_EMPTY_RESULT_SCHEMA,
                 MCP_TOOLS_LIST_RESULT_SCHEMA,
                 MCP_TOOL_RESULT_SCHEMA,
             ],
@@ -506,6 +518,11 @@ MCP_BODY = {
     "requestBody": _request_body(MCP_REQUEST_SCHEMA),
     "responses": {
         "200": _json_response(MCP_RESPONSE_SCHEMA, description="MCP JSON-RPC response."),
+        "204": {
+            "description": (
+                "MCP notification accepted. JSON-RPC notifications do not return a response body."
+            )
+        },
         "400": _json_response(
             MCP_ERROR_RESPONSE_SCHEMA,
             description="MCP JSON-RPC parse or invalid request error.",

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -235,6 +235,12 @@ MCP_HOST=https://mcp.mrwk.online
 The legacy MCP host `https://mcp.mrwk.ltclab.site` remains available for
 existing clients.
 
+After a successful `initialize` request, clients may send the standard
+`notifications/initialized` JSON-RPC notification without an `id`. The server
+accepts it with `204 No Content`, because JSON-RPC notifications do not return a
+response body. Clients may also send the standard `ping` request and receive an
+empty JSON-RPC result.
+
 List tools:
 
 ```bash

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1179,6 +1179,30 @@ def test_mcp_rejects_malformed_requests_without_500(sqlite_url: str) -> None:
     }
 
 
+def test_mcp_accepts_initialized_notification_without_response(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+    )
+
+    assert response.status_code == 204
+    assert response.content == b""
+
+
+def test_mcp_ping_returns_empty_result(sqlite_url: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": "ping-1", "method": "ping"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"jsonrpc": "2.0", "id": "ping-1", "result": {}}
+
+
 @pytest.mark.parametrize(
     ("arguments", "request_id"),
     [

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -60,7 +60,11 @@ def test_mcp_openapi_contract_exposes_jsonrpc_request_and_response(sqlite_url: s
         {"protocolVersion", "capabilities", "serverInfo"}.issubset(variant["properties"])
         for variant in result_variants
     )
-    assert any(variant["properties"] == {} for variant in result_variants)
+    empty_result_variant = next(
+        variant for variant in result_variants if variant["properties"] == {}
+    )
+    assert empty_result_variant["additionalProperties"] is False
+    assert empty_result_variant["maxProperties"] == 0
     assert any("tools" in variant["properties"] for variant in result_variants)
     assert any("content" in variant["properties"] for variant in result_variants)
     _assert_properties(response_schema["properties"]["error"], {"code", "message"})

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -39,9 +39,16 @@ def test_mcp_openapi_contract_exposes_jsonrpc_request_and_response(sqlite_url: s
     assert set(request_schema["required"]) == {"jsonrpc", "method"}
     request_props = request_schema["properties"]
     assert request_props["jsonrpc"]["enum"] == ["2.0"]
-    assert set(request_props["method"]["enum"]) == {"initialize", "tools/list", "tools/call"}
+    assert set(request_props["method"]["enum"]) == {
+        "initialize",
+        "notifications/initialized",
+        "ping",
+        "tools/list",
+        "tools/call",
+    }
     assert request_props["id"]["nullable"] is True
     assert request_props["params"]["additionalProperties"] is True
+    assert "content" not in operation["responses"]["204"]
 
     _assert_properties(response_schema, {"jsonrpc", "id", "result", "error"})
     assert response_schema["properties"]["jsonrpc"]["enum"] == ["2.0"]
@@ -53,6 +60,7 @@ def test_mcp_openapi_contract_exposes_jsonrpc_request_and_response(sqlite_url: s
         {"protocolVersion", "capabilities", "serverInfo"}.issubset(variant["properties"])
         for variant in result_variants
     )
+    assert any(variant["properties"] == {} for variant in result_variants)
     assert any("tools" in variant["properties"] for variant in result_variants)
     assert any("content" in variant["properties"] for variant in result_variants)
     _assert_properties(response_schema["properties"]["error"], {"code", "message"})


### PR DESCRIPTION
Adds the remaining basic MCP lifecycle responses on the current server path.

What changed:
- accepts `notifications/initialized` without an `id` and returns `204 No Content`
- returns an empty JSON-RPC result for `ping`
- advertises both methods in the MCP OpenAPI contract and agent guide
- keeps the empty-result OpenAPI variant exact so it does not overlap other successful MCP result shapes

Tests:
- `pytest tests/test_openapi_request_bodies.py -q`
- focused MCP lifecycle/API tests
- `ruff check app/mcp.py app/openapi_request_bodies.py tests/test_api_mcp.py tests/test_openapi_request_bodies.py docs/agent-guide.md`
- `ruff format --check app/mcp.py app/openapi_request_bodies.py tests/test_api_mcp.py tests/test_openapi_request_bodies.py`
- `mypy app/mcp.py app/openapi_request_bodies.py`
- `python scripts/docs_smoke.py`
- `git diff --check`

Bounty #946