### PR TITLE
Advertise MCP balance output schema

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -119,6 +119,28 @@ MCP_BOUNTY_ATTEMPTS_OUTPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
+MCP_BALANCE_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Structured balance payload returned by get_balance.",
+    "properties": {
+        "account": {
+            "type": "string",
+            "description": "Normalized account selector used for the balance lookup.",
+        },
+        "balance_mrwk": {
+            "type": "string",
+            "description": "MRWK balance formatted as a decimal string.",
+        },
+        "balance_microunits": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Raw integer balance in MRWK microunits.",
+        },
+    },
+    "required": ["account", "balance_mrwk", "balance_microunits"],
+    "additionalProperties": False,
+}
+
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
@@ -292,6 +314,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "required": ["account"],
             "additionalProperties": False,
         },
+        "outputSchema": MCP_BALANCE_OUTPUT_SCHEMA,
     },
     {
         "name": "register_wallet",

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -328,9 +328,10 @@ backward-compatible JSON string in `result.content[0].text` and parsed
 `result.structuredContent`. Prefer `structuredContent` when present, and fall
 back to text for human-readable not-found messages.
 
-`get_balance` keeps the legacy balance text and also includes
-`result.structuredContent.account`, `balance_mrwk`, and `balance_microunits` so
-callers do not need to parse the text response.
+`get_balance` keeps the legacy balance text, advertises its structured output
+schema through `tools/list`, and also includes `result.structuredContent.account`,
+`balance_mrwk`, and `balance_microunits` so callers do not need to parse the
+text response.
 
 ### Argument-validation errors
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -468,6 +468,15 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert balance_schema["additionalProperties"] is False
     assert balance_schema["properties"]["account"]["minLength"] == 1
     assert "github:<login>" in balance_schema["properties"]["account"]["description"]
+    balance_output_schema = balance_tool["outputSchema"]
+    assert balance_output_schema["required"] == [
+        "account",
+        "balance_mrwk",
+        "balance_microunits",
+    ]
+    assert balance_output_schema["additionalProperties"] is False
+    assert balance_output_schema["properties"]["balance_mrwk"]["type"] == "string"
+    assert balance_output_schema["properties"]["balance_microunits"]["minimum"] == 0
     ledger_tool = next(
         tool for tool in tools["result"]["tools"] if tool["name"] == "get_ledger_entry"
     )


### PR DESCRIPTION
## Summary
- Add an MCP `outputSchema` for `get_balance`, matching the structured balance payload already returned at runtime.
- Capture the stable `account`, `balance_mrwk`, and `balance_microunits` fields so schema-aware agents can rely on `tools/list` instead of parsing the legacy text response.
- Keep the existing `get_balance` text and `structuredContent` runtime behavior unchanged.
- Update the agent guide to note that `get_balance` advertises its structured output schema through `tools/list`.

## Bounty scope
Bounty #946
Refs #946

.

This is focused MCP structured-output metadata and conformance coverage.

## Duplicate / stale-work check
- Current `main` still returns `structuredContent` for `get_balance` but does not advertise `outputSchema` for the tool.
- Existing PR #1035 targets the same gap, but it is currently `DIRTY` and has not been accepted or paid.
- This PR is a current-main clean replacement with the minimal schema/docs/test change.

## Validation
- `python -m pytest tests\test_api_mcp.py::test_mcp_tools_list_and_call -q` -> 1 passed, 1 existing Starlette/httpx warning.
- `ruff check app\mcp.py tests\test_api_mcp.py docs\agent-guide.md` -> All checks passed.
- `ruff format --check app\mcp.py tests\test_api_mcp.py` -> 2 files already formatted.
- `python scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean, with the normal Windows LF-to-CRLF warning for `docs/agent-guide.md`.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `7762447113c0e738c8786f302ccb0b9ba7e09cef`.

## Out of scope
No MCP runtime behavior changes, no ledger mutation, no wallet custody, no transfers, no treasury/proposal execution, no payout execution, no admin-token behavior, no bridge/exchange/off-ramp/cash-out behavior, no MRWK price behavior, and no private data or secrets.

Payout boundary: this is a submitted bounty claim only. It is not confirmed or withdrawable unless maintainers accept it and record payment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `get_balance` tool now advertises a structured output schema with standardized fields for account and balance information, allowing callers to consume data programmatically instead of parsing text.

* **Documentation**
  * Updated agent guide to document the structured output schema and available fields for the `get_balance` tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->