### PR TITLE
Link pending payout accounts on bounty details

### DIFF
--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -68,7 +68,13 @@
       {% for proposal in bounty.pending_payout_proposals %}
       <li>
         <a href="/api/v1/treasury/proposals/{{ proposal.proposal_id }}">Proposal #{{ proposal.proposal_id }}</a>
-        would pay {{ proposal.to_account or "an account" }} for
+        would pay
+        {% if proposal.to_account %}
+        <a href="/accounts/{{ proposal.to_account }}">{{ proposal.to_account }}</a>
+        {% else %}
+        an account
+        {% endif %}
+        for
         {% set submission_url = safe_public_url(proposal.submission_url) %}
         {% if submission_url %}
         <a href="{{ submission_url }}" rel="nofollow noopener">submitted work</a>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -204,7 +204,10 @@ def test_bounties_page_shows_effective_capacity_after_pending_payout(
     assert f'href="/api/v1/treasury/proposals/{proposal_id}">Proposal #{proposal_id}</a>' in (
         detail.text
     )
-    assert "would pay github:alice for" in detail.text
+    assert re.search(
+        r'would pay\s*<a href="/accounts/github:alice">github:alice</a>\s*for',
+        detail.text,
+    )
     assert (
         'href="https://github.com/ramimbo/mergework/pull/67" rel="nofollow noopener">'
         "submitted work</a>"


### PR DESCRIPTION
Bounty #935
Refs #935

## Summary
- Link pending payout proposal recipients on public bounty detail pages to their account pages.
- Keep the existing fallback text when a pending payout proposal has no recipient account.
- Add regression coverage proving pending payout capacity notices expose the recipient account link.

## Duplicate check
- Checked #935 comments and open PR search for pending payout recipient/account-link overlap.
- Existing useful #935 work covers bounty list/detail routing, work-discovery row links, pending-create visibility, claimable filter notices, activity/account routing, docs links, and accepted-award account links.
- I did not find an open #935 submission linking `pending_payout_proposals[].to_account` from the bounty detail page to `/accounts/{account}`.

## Validation
- `python -m pytest tests\test_bounty_pages.py::test_bounties_page_shows_effective_capacity_after_pending_payout tests\test_bounty_pages.py::test_bounty_detail_shows_accepted_award_history -q` -> 2 passed, 1 existing Starlette/httpx warning.
- `ruff check tests\test_bounty_pages.py` -> All checks passed.
- `ruff format --check tests\test_bounty_pages.py` -> 1 file already formatted.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `a026e14acbcecc6e81fbab79fa2bd068e94a186c`.

## Scope
Public bounty detail template and focused page regression coverage only. No lifecycle, claimability, payout execution, ledger mutation, wallet behavior, treasury/admin-token behavior, bridge/exchange/off-ramp/cash-out behavior, MRWK price behavior, private data, or secrets changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of target accounts in pending treasury proposals to display as clickable links on the bounty detail page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->