### PR TITLE
Publish treasury status OpenAPI response schema

### DIFF
--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -220,6 +220,113 @@ TREASURY_PROPOSAL_RESPONSE_SCHEMA = _object_schema(
     }
 )
 
+TREASURY_STATUS_PENDING_CREATE_SCHEMA = _object_schema(
+    {
+        "proposal_id": {"type": "integer", "minimum": 1},
+        "issue_number": {"type": "integer", "minimum": 1},
+        "issue_url": {"type": "string", "format": "uri"},
+        "title": {"type": "string"},
+        "reward_mrwk": MRWK_AMOUNT_SCHEMA,
+        "max_awards": {"type": "integer", "minimum": 1},
+        "reserve_mrwk": MRWK_DECIMAL_SCHEMA,
+        "proposed_at": {"type": "string"},
+        "executes_after": {"type": "string"},
+        "capacity_releases_at": {"type": "string"},
+    },
+    required=[
+        "proposal_id",
+        "issue_number",
+        "issue_url",
+        "title",
+        "reward_mrwk",
+        "max_awards",
+        "reserve_mrwk",
+        "proposed_at",
+        "executes_after",
+        "capacity_releases_at",
+    ],
+)
+
+TREASURY_STATUS_CAPACITY_EVENT_SCHEMA = _object_schema(
+    {
+        "at": {"type": "string"},
+        "event_type": {
+            "type": "string",
+            "enum": [
+                "recent_reserve_releases",
+                "pending_create_executes",
+                "pending_create_releases",
+            ],
+        },
+        "amount_mrwk": MRWK_DECIMAL_SCHEMA,
+        "available_create_reserve_mrwk": MRWK_DECIMAL_SCHEMA,
+        "note": {"type": "string"},
+    },
+    required=[
+        "at",
+        "event_type",
+        "amount_mrwk",
+        "available_create_reserve_mrwk",
+        "note",
+    ],
+)
+
+TREASURY_STATUS_RECENT_RESERVE_SCHEMA = _object_schema(
+    {
+        "ledger_sequence": {"type": "integer", "minimum": 1},
+        "amount_mrwk": MRWK_DECIMAL_SCHEMA,
+        "reference": {"type": "string", "nullable": True},
+        "created_at": {"type": "string"},
+        "expires_at": {"type": "string"},
+    },
+    required=[
+        "ledger_sequence",
+        "amount_mrwk",
+        "reference",
+        "created_at",
+        "expires_at",
+    ],
+)
+
+TREASURY_STATUS_RESPONSE_SCHEMA = _object_schema(
+    {
+        "type": {"type": "string", "enum": ["treasury_status"]},
+        "epoch_window_hours": {"type": "integer", "minimum": 1},
+        "reserve_cap_mrwk": MRWK_DECIMAL_SCHEMA,
+        "executed_reserve_24h_mrwk": MRWK_DECIMAL_SCHEMA,
+        "pending_create_reserve_mrwk": MRWK_DECIMAL_SCHEMA,
+        "available_create_reserve_mrwk": MRWK_DECIMAL_SCHEMA,
+        "next_capacity_release_at": {"type": "string", "nullable": True},
+        "next_projected_capacity_release_at": {"type": "string", "nullable": True},
+        "pending_create_bounties": {
+            "type": "array",
+            "items": TREASURY_STATUS_PENDING_CREATE_SCHEMA,
+        },
+        "projected_capacity_events": {
+            "type": "array",
+            "items": TREASURY_STATUS_CAPACITY_EVENT_SCHEMA,
+        },
+        "recent_reserves": {
+            "type": "array",
+            "items": TREASURY_STATUS_RECENT_RESERVE_SCHEMA,
+        },
+    },
+    required=[
+        "type",
+        "epoch_window_hours",
+        "reserve_cap_mrwk",
+        "executed_reserve_24h_mrwk",
+        "pending_create_reserve_mrwk",
+        "available_create_reserve_mrwk",
+        "next_capacity_release_at",
+        "next_projected_capacity_release_at",
+        "pending_create_bounties",
+        "projected_capacity_events",
+        "recent_reserves",
+    ],
+    description="Public treasury reserve capacity status.",
+)
+
 MCP_JSONRPC_ID_SCHEMA = {
     "description": "JSON-RPC request id returned unchanged in the response.",
     "nullable": True,
@@ -465,6 +572,12 @@ WALLET_TRANSFER_BODY = {
     ),
     "responses": {
         "200": _json_response(WALLET_TRANSFER_RESPONSE_SCHEMA),
+    },
+}
+
+TREASURY_STATUS_RESPONSE = {
+    "responses": {
+        "200": _json_response(TREASURY_STATUS_RESPONSE_SCHEMA),
     },
 }
 

--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -11,7 +11,11 @@ from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import LedgerError
 from app.models import TreasuryProposal
-from app.openapi_request_bodies import TREASURY_CHALLENGE_BODY, TREASURY_PROPOSAL_BODY
+from app.openapi_request_bodies import (
+    TREASURY_CHALLENGE_BODY,
+    TREASURY_PROPOSAL_BODY,
+    TREASURY_STATUS_RESPONSE,
+)
 from app.path_params import SQLITE_INTEGER_MAX, positive_proposal_id
 from app.query_validation import (
     reject_control_char_query_param,
@@ -194,7 +198,7 @@ def register_treasury_routes(
                     break
             return proposals
 
-    @app.get("/api/v1/treasury/status")
+    @app.get("/api/v1/treasury/status", openapi_extra=TREASURY_STATUS_RESPONSE)
     def api_treasury_status(request: Request) -> dict[str, Any]:
         _reject_treasury_status_filters(request)
         with session_scope(db_url) as session:

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 
 from fastapi.testclient import TestClient
 
+from app.db import create_schema
 from app.main import create_app
 
 EXPECTED_TTL_STRING_PATTERN = (
@@ -19,6 +20,12 @@ def _post_schema(openapi: dict, path: str) -> dict:
 
 def _post_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
     return openapi["paths"][path]["post"]["responses"][status]["content"]["application/json"][
+        "schema"
+    ]
+
+
+def _get_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
+    return openapi["paths"][path]["get"]["responses"][status]["content"]["application/json"][
         "schema"
     ]
 
@@ -365,6 +372,86 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
             "created_at",
         },
     )
+
+
+def test_treasury_status_openapi_response_schema_matches_runtime_fields(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    schema = _get_response_schema(openapi, "/api/v1/treasury/status")
+    expected_top_level = {
+        "type",
+        "epoch_window_hours",
+        "reserve_cap_mrwk",
+        "executed_reserve_24h_mrwk",
+        "pending_create_reserve_mrwk",
+        "available_create_reserve_mrwk",
+        "next_capacity_release_at",
+        "next_projected_capacity_release_at",
+        "pending_create_bounties",
+        "projected_capacity_events",
+        "recent_reserves",
+    }
+
+    assert schema["type"] == "object"
+    assert set(schema["required"]) == expected_top_level
+    _assert_properties(schema, expected_top_level)
+    assert schema["properties"]["type"]["enum"] == ["treasury_status"]
+    assert schema["properties"]["epoch_window_hours"]["minimum"] == 1
+    assert schema["properties"]["reserve_cap_mrwk"]["pattern"] == r"^\d+(?:\.\d{1,6})?$"
+    assert schema["properties"]["next_capacity_release_at"]["nullable"] is True
+    assert schema["properties"]["next_projected_capacity_release_at"]["nullable"] is True
+
+    pending_create = schema["properties"]["pending_create_bounties"]["items"]
+    assert set(pending_create["required"]) == {
+        "proposal_id",
+        "issue_number",
+        "issue_url",
+        "title",
+        "reward_mrwk",
+        "max_awards",
+        "reserve_mrwk",
+        "proposed_at",
+        "executes_after",
+        "capacity_releases_at",
+    }
+    assert pending_create["properties"]["issue_url"]["format"] == "uri"
+    assert pending_create["properties"]["proposal_id"]["minimum"] == 1
+    assert pending_create["properties"]["reward_mrwk"]["pattern"] == (
+        r"^(?=.*[1-9])\d+(?:\.\d{1,6})?$"
+    )
+
+    event = schema["properties"]["projected_capacity_events"]["items"]
+    assert set(event["required"]) == {
+        "at",
+        "event_type",
+        "amount_mrwk",
+        "available_create_reserve_mrwk",
+        "note",
+    }
+    assert set(event["properties"]["event_type"]["enum"]) == {
+        "recent_reserve_releases",
+        "pending_create_executes",
+        "pending_create_releases",
+    }
+
+    reserve = schema["properties"]["recent_reserves"]["items"]
+    assert set(reserve["required"]) == {
+        "ledger_sequence",
+        "amount_mrwk",
+        "reference",
+        "created_at",
+        "expires_at",
+    }
+    assert reserve["properties"]["reference"]["nullable"] is True
+
+    runtime = client.get("/api/v1/treasury/status")
+    assert runtime.status_code == 200
+    assert set(runtime.json()) == expected_top_level
+    assert runtime.json()["type"] == "treasury_status"
 
 
 def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #944
Refs #944

## Summary
- Publishes an explicit OpenAPI `200` response schema for `GET /api/v1/treasury/status`.
- Documents treasury reserve capacity fields, pending create-bounty rows, projected capacity events, and recent reserve rows for clients and SDK generators.
- Wires the schema into the existing public route without changing runtime JSON behavior.
- Adds OpenAPI/runtime contract coverage proving the advertised top-level fields match the live response shape.

## Duplicate check
- Rechecked #944 comments and open PRs for treasury status OpenAPI overlap.
- Existing PR #1018 covers the same endpoint but is currently `DIRTY` against current `main`.
- This PR is a clean current-main replacement using the established `openapi_extra` schema helper style and focused tests.
- Current `main` still does not advertise a `200` response schema for `/api/v1/treasury/status`.

## Validation
- `python -m pytest tests\test_openapi_request_bodies.py::test_treasury_status_openapi_response_schema_matches_runtime_fields tests\test_treasury_proposals.py::test_treasury_status_reports_reserve_capacity_and_pending_create_proposals tests\test_treasury_proposals.py::test_treasury_status_projects_pending_create_capacity_events -q` -> 3 passed, 1 existing Starlette/httpx warning.
- `python -m pytest tests\test_openapi_request_bodies.py tests\test_treasury_proposals.py::test_treasury_status_reports_reserve_capacity_and_pending_create_proposals tests\test_treasury_proposals.py::test_treasury_status_projects_pending_create_capacity_events tests\test_treasury_proposals.py::test_treasury_status_rejects_proposal_list_filters -q` -> 13 passed, 1 existing Starlette/httpx warning.
- `ruff check app\openapi_request_bodies.py app\treasury_routes.py tests\test_openapi_request_bodies.py` -> All checks passed.
- `ruff format --check app\openapi_request_bodies.py app\treasury_routes.py tests\test_openapi_request_bodies.py` -> 3 files already formatted.
- `python -m mypy app\openapi_request_bodies.py app\treasury_routes.py` -> Success: no issues found.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `2d98ba9bfeefccfcc24fac15a40f979665a674a2`.

## Scope
OpenAPI/client-contract metadata and focused tests only. No runtime treasury status JSON changes, no treasury proposal execution, no payout execution, no ledger mutation, no wallet custody, no admin-token behavior, no bridge/exchange/off-ramp/cash-out behavior, no MRWK price behavior, no private data, and no secrets changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Treasury status API endpoint now includes enhanced OpenAPI documentation with complete response schema specifications, including field types, validation constraints, and nested structures.

* **Tests**
  * Added test coverage verifying that actual API responses conform to the published OpenAPI specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->