### PR TITLE
Refactor treasury unsupported query guard

### DIFF
--- a/app/treasury_routes.py
+++ b/app/treasury_routes.py
@@ -17,6 +17,7 @@ from app.query_validation import (
     reject_control_char_query_param,
     reject_noncanonical_int_query_param,
     reject_repeated_query_param,
+    reject_unsupported_query_params,
 )
 from app.treasury import (
     TREASURY_ACTIONS,
@@ -101,22 +102,23 @@ def _proposal_payload_matches(
     )
 
 
+TREASURY_PROPOSAL_LIST_FILTERS = ("limit", "offset", "action", "status", "to_account", "bounty_id")
+
+
 def _reject_treasury_status_filters(request: Request) -> None:
-    for name in ("limit", "offset", "action", "status", "to_account", "bounty_id"):
-        if request.query_params.getlist(name):
-            raise HTTPException(
-                status_code=400,
-                detail=f"{name} is not supported on treasury status",
-            )
+    reject_unsupported_query_params(
+        request,
+        TREASURY_PROPOSAL_LIST_FILTERS,
+        context="treasury status",
+    )
 
 
 def _reject_treasury_proposal_detail_filters(request: Request) -> None:
-    for name in ("limit", "offset", "action", "status", "to_account", "bounty_id"):
-        if request.query_params.getlist(name):
-            raise HTTPException(
-                status_code=400,
-                detail=f"{name} is not supported on treasury proposal detail",
-            )
+    reject_unsupported_query_params(
+        request,
+        TREASURY_PROPOSAL_LIST_FILTERS,
+        context="treasury proposal detail",
+    )
 
 
 def register_treasury_routes(

--- a/tests/test_treasury_proposals.py
+++ b/tests/test_treasury_proposals.py
@@ -128,6 +128,14 @@ def test_admin_bounty_creation_creates_public_delayed_proposal(
             filtered_detail.json()["detail"]
             == f"{field} is not supported on treasury proposal detail"
         )
+    repeated_filter_detail = client.get(
+        f"/api/v1/treasury/proposals/{body['id']}?status=pending&status=blocked"
+    )
+    assert repeated_filter_detail.status_code == 400
+    assert (
+        repeated_filter_detail.json()["detail"]
+        == "status is not supported on treasury proposal detail"
+    )
     for noncanonical_id in (f"{body['id']}.0", f"+{body['id']}", f"%C2%85{body['id']}"):
         noncanonical_detail = client.get(f"/api/v1/treasury/proposals/{noncanonical_id}")
         assert noncanonical_detail.status_code == 400
@@ -267,6 +275,7 @@ def test_treasury_status_rejects_proposal_list_filters(
         ("limit=1", "limit"),
         ("offset=1", "offset"),
         ("status=pending", "status"),
+        ("status=pending&status=blocked", "status"),
         ("action=create_bounty", "action"),
         ("to_account=github:alice", "to_account"),
         ("bounty_id=1", "bounty_id"),


### PR DESCRIPTION
## Summary
- Shares the treasury unsupported-filter rejection through the existing query guard helper.
- Keeps the status and proposal-detail error messages unchanged while removing duplicate route-local loops.
- Adds regression coverage for repeated unsupported filters on treasury status and proposal detail routes.

## Verification
- `uv run --extra dev pytest tests/test_treasury_proposals.py::test_admin_bounty_creation_creates_public_delayed_proposal tests/test_treasury_proposals.py::test_treasury_status_rejects_proposal_list_filters -q`
- `uv run --extra dev ruff check app/treasury_routes.py tests/test_treasury_proposals.py`
- `git diff --check`
- Added-line security scan: `security_findings_count 0`
- Independent review: passed

Bounty #936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of error handling and error messages for invalid query parameters on treasury API endpoints.

* **Tests**
  * Extended test coverage to verify that treasury endpoints properly reject unsupported and repeated query parameters with standardized error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->