### PR TITLE
Advertise MCP wallet lookup output schema

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -119,6 +119,35 @@ MCP_BOUNTY_ATTEMPTS_OUTPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
+MCP_WALLET_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": "Serialized MRWK wallet payload returned in structuredContent.",
+    "properties": {
+        "address": {
+            "type": "string",
+            "pattern": "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$",
+        },
+        "public_key_hex": {"type": "string", "pattern": "^[0-9a-fA-F]{64}$"},
+        "label": {"type": ["string", "null"]},
+        "github_login": {"type": ["string", "null"]},
+        "balance_mrwk": {"type": "string"},
+        "nonce": {"type": "integer", "minimum": 0},
+        "next_nonce": {"type": "integer", "minimum": 1},
+        "created_at": {"type": "string"},
+    },
+    "required": [
+        "address",
+        "public_key_hex",
+        "label",
+        "github_login",
+        "balance_mrwk",
+        "nonce",
+        "next_nonce",
+        "created_at",
+    ],
+    "additionalProperties": True,
+}
+
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
@@ -312,33 +341,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "required": ["public_key_hex"],
             "additionalProperties": False,
         },
-        "outputSchema": {
-            "type": "object",
-            "properties": {
-                "address": {
-                    "type": "string",
-                    "pattern": "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$",
-                },
-                "public_key_hex": {"type": "string", "pattern": "^[0-9a-fA-F]{64}$"},
-                "label": {"type": ["string", "null"]},
-                "github_login": {"type": ["string", "null"]},
-                "balance_mrwk": {"type": "string"},
-                "nonce": {"type": "integer", "minimum": 0},
-                "next_nonce": {"type": "integer", "minimum": 1},
-                "created_at": {"type": "string"},
-            },
-            "required": [
-                "address",
-                "public_key_hex",
-                "label",
-                "github_login",
-                "balance_mrwk",
-                "nonce",
-                "next_nonce",
-                "created_at",
-            ],
-            "additionalProperties": True,
-        },
+        "outputSchema": MCP_WALLET_OUTPUT_SCHEMA,
     },
     {
         "name": "get_wallet",
@@ -355,6 +358,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
             "required": ["address"],
             "additionalProperties": False,
         },
+        "outputSchema": MCP_WALLET_OUTPUT_SCHEMA,
     },
     {
         "name": "submit_wallet_transfer",

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -312,7 +312,7 @@ Tools:
 - `get_balance`
 - `register_wallet` (`tools/list` advertises the public-key input schema and the
   registered wallet output schema)
-- `get_wallet`
+- `get_wallet` (`tools/list` advertises the wallet output schema)
 - `submit_wallet_transfer`
 - `get_ledger_entry`
 - `get_proof`

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -2944,10 +2944,15 @@ def test_mcp_can_register_and_fetch_wallet(sqlite_url: str) -> None:
     register_tool = next(
         tool for tool in tools["result"]["tools"] if tool["name"] == "register_wallet"
     )
+    get_wallet_tool = next(
+        tool for tool in tools["result"]["tools"] if tool["name"] == "get_wallet"
+    )
     assert register_tool["inputSchema"]["required"] == ["public_key_hex"]
     assert register_tool["inputSchema"]["additionalProperties"] is False
     assert set(register_tool["outputSchema"]["required"]) == set(registered_wallet)
     assert set(register_tool["outputSchema"]["properties"]) == set(registered_wallet)
+    assert get_wallet_tool["outputSchema"] == register_tool["outputSchema"]
+    assert set(get_wallet_tool["outputSchema"]["required"]) == set(registered_wallet)
 
     fetched = client.post(
         "/mcp",
@@ -2963,6 +2968,7 @@ def test_mcp_can_register_and_fetch_wallet(sqlite_url: str) -> None:
     ).json()
     fetched_wallet = json.loads(fetched["result"]["content"][0]["text"])
     assert fetched["result"]["structuredContent"] == fetched_wallet
+    assert set(get_wallet_tool["outputSchema"]["properties"]) == set(fetched_wallet)
 
     assert fetched_wallet["address"] == registered_wallet["address"]
     assert fetched_wallet["label"] == "MCP wallet"


### PR DESCRIPTION
Bounty #946
Refs #946

## Summary
- Adds an MCP `outputSchema` for the read-only `get_wallet` tool.
- Reuses the existing wallet output schema already advertised by `register_wallet`, so both wallet-returning tools expose the same structured contract.
- Preserves runtime text and `structuredContent` behavior; this is `tools/list` metadata, focused tests, and a concise agent-guide update only.

## Duplicate / stale-work check
- Current `main` returns structured wallet JSON for `get_wallet` but does not advertise an `outputSchema` for that tool.
- Existing PR #1013 covers the same `get_wallet` output-schema gap but is currently `DIRTY` against current `main`.
- This PR is a clean current-main replacement with the same focused MCP metadata/test/doc scope.
- This is distinct from wallet write-tool schema work and from `submit_wallet_transfer` output-schema work.

## Validation
- `python -m pytest tests\test_api_mcp.py::test_mcp_tools_list_and_call tests\test_api_mcp.py::test_mcp_can_register_and_fetch_wallet -q` -> 2 passed, 1 existing Starlette/httpx warning.
- `ruff check app\mcp.py tests\test_api_mcp.py docs\agent-guide.md` -> All checks passed.
- `ruff format --check app\mcp.py tests\test_api_mcp.py` -> 2 files already formatted.
- `python scripts\docs_smoke.py` -> docs smoke ok.
- `python -m mypy app\mcp.py` -> Success: no issues found.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `0145df4dd8522e5aee5474ca0c57a3fffc8bafef`.

## Scope
MCP `tools/list` output metadata, focused MCP tests, and agent guide text only. No MCP runtime behavior changes, no ledger mutation, no wallet custody changes, no transfer behavior, no treasury/proposal execution, no payout execution, no admin-token behavior, no bridge/exchange/off-ramp/cash-out behavior, no MRWK price behavior, no private data, and no secrets changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency and organization of wallet output schema definitions.

* **Documentation**
  * Updated agent guide documentation for wallet output schema reference.

* **Tests**
  * Enhanced validation of wallet schema consistency across MCP operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->