### PR TITLE
Advertise wallet transfer MCP input schema

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -359,6 +359,50 @@ MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "submit_wallet_transfer",
         "description": "Submit a signed MRWK wallet transfer",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "from_address": {
+                    "type": "string",
+                    "pattern": "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$",
+                    "description": "Sender MRWK wallet address.",
+                },
+                "to_address": {
+                    "type": "string",
+                    "pattern": "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$",
+                    "description": "Receiver MRWK wallet address.",
+                },
+                "amount_mrwk": {
+                    "type": "string",
+                    "pattern": "^(?=.*[1-9])\\d+(?:\\.\\d{1,6})?$",
+                    "description": "Positive MRWK amount with up to six decimal places.",
+                },
+                "nonce": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Next wallet nonce signed in the transfer payload.",
+                },
+                "memo": {
+                    "type": "string",
+                    "maxLength": 240,
+                    "default": "",
+                    "description": "Optional transfer memo.",
+                },
+                "signature_hex": {
+                    "type": "string",
+                    "pattern": "^[0-9a-fA-F]{128}$",
+                    "description": "Ed25519 signature as 128 hex characters.",
+                },
+            },
+            "required": [
+                "from_address",
+                "to_address",
+                "amount_mrwk",
+                "nonce",
+                "signature_hex",
+            ],
+            "additionalProperties": False,
+        },
     },
     {
         "name": "get_ledger_entry",

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -313,7 +313,7 @@ Tools:
 - `register_wallet` (`tools/list` advertises the public-key input schema and the
   registered wallet output schema)
 - `get_wallet`
-- `submit_wallet_transfer`
+- `submit_wallet_transfer` (`tools/list` advertises the signed-transfer input schema)
 - `get_ledger_entry`
 - `get_proof`
 - `submit_work_proof` (`format: "json"` returns structuredContent; `tools/list`

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -462,6 +462,32 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
     assert wallet_schema["properties"]["address"]["pattern"] == (
         "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$"
     )
+    transfer_tool = next(
+        tool for tool in tools["result"]["tools"] if tool["name"] == "submit_wallet_transfer"
+    )
+    transfer_schema = transfer_tool["inputSchema"]
+    assert transfer_schema["required"] == [
+        "from_address",
+        "to_address",
+        "amount_mrwk",
+        "nonce",
+        "signature_hex",
+    ]
+    assert transfer_schema["additionalProperties"] is False
+    assert transfer_schema["properties"]["from_address"]["pattern"] == (
+        "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$"
+    )
+    assert transfer_schema["properties"]["to_address"]["pattern"] == (
+        "^[mM][rR][wW][kK]1[0-9a-fA-F]{40}$"
+    )
+    assert (
+        transfer_schema["properties"]["amount_mrwk"]["pattern"]
+        == "^(?=.*[1-9])\\d+(?:\\.\\d{1,6})?$"
+    )
+    assert transfer_schema["properties"]["nonce"]["minimum"] == 1
+    assert transfer_schema["properties"]["memo"]["maxLength"] == 240
+    assert transfer_schema["properties"]["memo"]["default"] == ""
+    assert transfer_schema["properties"]["signature_hex"]["pattern"] == "^[0-9a-fA-F]{128}$"
     balance_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_balance")
     balance_schema = balance_tool["inputSchema"]
     assert balance_schema["required"] == ["account"]


### PR DESCRIPTION
Bounty #934
Refs #934

## Summary
- Adds a `tools/list` `inputSchema` for the MCP `submit_wallet_transfer` tool.
- Advertises the existing signed-transfer arguments: `from_address`, `to_address`, `amount_mrwk`, `nonce`, optional `memo`, and `signature_hex`.
- Aligns the schema with existing runtime validation and `reject_unexpected_args(...)`; no transfer execution behavior changes.
- Updates the agent guide tool list to mention the advertised signed-transfer input schema.

## Duplicate / stale-work check
- Current `origin/main` already includes `register_wallet` input/output schema from #1038, but `submit_wallet_transfer` still has no advertised MCP `inputSchema`.
- Existing PR #989 covers wallet write-tool schemas but is currently `DIRTY` and still includes now-merged `register_wallet` schema work.
- This PR is a clean current-main replacement for only the remaining `submit_wallet_transfer` input-schema gap.
- This is distinct from #1048, which targets the transfer output schema, not the input argument contract.

## Validation
- `..\..\.venv\Scripts\python.exe -m pytest tests\test_api_mcp.py::test_mcp_tools_list_and_call tests\test_api_mcp.py::test_mcp_wallet_write_tools_reject_unexpected_arguments tests\test_mcp_tools.py::test_call_mcp_tool_rejects_c1_nonce_before_integer_parsing -q` -> 3 passed, 1 existing Starlette/httpx warning.
- `ruff check app\mcp.py tests\test_api_mcp.py docs\agent-guide.md` -> All checks passed.
- `ruff format --check app\mcp.py tests\test_api_mcp.py` -> 2 files already formatted.
- `..\..\.venv\Scripts\python.exe -m mypy app\mcp.py app\mcp_tools.py` -> Success: no issues found.
- `..\..\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` and `git diff --check` -> clean, with the normal Windows LF-to-CRLF warning for the touched doc file.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `7762447113c0e738c8786f302ccb0b9ba7e09cef`.

## Scope
MCP `tools/list` metadata, focused MCP tests, and one agent-guide sentence only. No MCP runtime dispatch changes, no wallet signing/custody changes, no transfer execution behavior, no ledger mutation behavior, no treasury/proposal execution, no payout execution, no admin-token behavior, no bridge/exchange/off-ramp/cash-out behavior, no MRWK price behavior, no private data, and no secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wallet transfer submission capability with comprehensive input validation.

* **Documentation**
  * Updated agent guide to reference wallet transfer tool schema details.

* **Tests**
  * Added schema validation tests for wallet transfer functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->