### PR TITLE
Link bounty details to activity checks

### DIFF
--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -76,6 +76,8 @@
         submitted work
         {% endif %}
         after {{ proposal.executes_after }}.
+        <a href="/activity?q=%23{{ bounty.issue_number }}">Review activity for this issue</a>{% if proposal.to_account %}
+        · <a href="/activity?account={{ proposal.to_account | urlencode }}">Review {{ proposal.to_account }} activity</a>{% endif %}
       </li>
       {% endfor %}
     </ul>
@@ -148,6 +150,7 @@
     <div class="next-steps-actions" aria-label="Bounty action links">
       {% if issue_url %}<a href="{{ issue_url }}" rel="nofollow noopener">Open source issue</a>{% endif %}
       <a href="/bounties?repo={{ bounty.repo | urlencode }}&amp;issue_number={{ bounty.issue_number }}">View source bounty matches</a>
+      <a href="/activity?q=%23{{ bounty.issue_number }}">Review accepted and pending activity</a>
       <a href="/api/v1/bounties/{{ bounty.id }}">View JSON details</a>
       <a href="{{ requirements.attempt_endpoint }}">Check active attempts</a>
     </div>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -209,6 +209,11 @@ def test_bounties_page_shows_effective_capacity_after_pending_payout(
         'href="https://github.com/ramimbo/mergework/pull/67" rel="nofollow noopener">'
         "submitted work</a>"
     ) in detail.text
+    assert 'href="/activity?q=%2367">Review activity for this issue</a>' in detail.text
+    assert 'href="/activity?account=github%3Aalice">Review github:alice activity</a>' in (
+        detail.text
+    )
+    assert 'href="/activity?q=%2367">Review accepted and pending activity</a>' in detail.text
     assert "1 award still open for distinct accepted work after pending treasury proposals." in (
         detail.text
     )


### PR DESCRIPTION
## Summary
- Add bounty detail links to issue-scoped activity so contributors can review accepted and pending work before starting.
- Add pending-proposal links to the same issue view and to the proposed recipient's account activity.
- Cover the links in the pending-payout bounty page test.

Refs #935

## Validation
- `python3 -m pytest tests/test_bounty_pages.py::test_bounties_page_shows_effective_capacity_after_pending_payout`
- `python3 -m pytest tests/test_bounty_pages.py::test_bounties_page_shows_effective_capacity_after_pending_close`
- `python3 -m ruff check app tests/test_bounty_pages.py`
- `git diff --check`

Note: Jinja templates are not Python files, so template validation is covered by focused page tests plus `ruff check` and `git diff --check`.
