### PR TITLE
refactor: share wallet detail query rejection

### DIFF
--- a/app/wallet_api.py
+++ b/app/wallet_api.py
@@ -21,6 +21,7 @@ from app.openapi_request_bodies import (
     WALLET_TRANSFER_BODY,
 )
 from app.path_params import reject_path_whitespace_padding
+from app.query_validation import reject_unsupported_query_params
 from app.serializers import ledger_to_dict, wallet_to_dict, wallet_transfer_to_dict
 
 JsonObjectLoader = Callable[[Request], Awaitable[dict[str, Any]]]
@@ -69,11 +70,11 @@ def register_wallet_api_routes(
     @app.get("/api/v1/wallets/{address}")
     def api_wallet(request: Request, address: str) -> dict[str, Any]:
         reject_path_whitespace_padding(address, "MRWK wallet address")
-        if request.query_params.getlist("type") or request.query_params.getlist("tx_type"):
-            raise HTTPException(
-                status_code=400,
-                detail="transaction filters are not supported on wallet JSON detail",
-            )
+        reject_unsupported_query_params(
+            request,
+            ("type", "tx_type"),
+            context="wallet JSON detail",
+        )
         address = normalized_wallet_address(address)
         with session_scope(db_url) as session:
             wallet = session.get(Wallet, address)

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -106,17 +106,11 @@ def test_wallet_api_register_lookup_and_transfer(sqlite_url: str) -> None:
         f"/api/v1/wallets/{receiver_address}?type=github_claim&type=bounty_payment"
     )
     assert type_filter.status_code == 400
-    assert type_filter.json()["detail"] == (
-        "transaction filters are not supported on wallet JSON detail"
-    )
+    assert type_filter.json()["detail"] == "type is not supported on wallet JSON detail"
     assert tx_type_filter.status_code == 400
-    assert tx_type_filter.json()["detail"] == (
-        "transaction filters are not supported on wallet JSON detail"
-    )
+    assert tx_type_filter.json()["detail"] == "tx_type is not supported on wallet JSON detail"
     assert repeated_type_filter.status_code == 400
-    assert repeated_type_filter.json()["detail"] == (
-        "transaction filters are not supported on wallet JSON detail"
-    )
+    assert repeated_type_filter.json()["detail"] == "type is not supported on wallet JSON detail"
 
 
 def test_wallet_transfer_api_rejects_replayed_signed_body(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- Reuses the shared unsupported-query helper for wallet JSON detail filters.
- Returns field-specific 400 details for `type` and `tx_type`, matching the account/bounty detail guard pattern.
- Updates wallet API coverage for the helper-backed messages.

## Verification
- `uv run --extra dev pytest tests/test_wallet_api.py::test_wallet_api_register_lookup_and_transfer tests/test_query_validation.py::test_unsupported_query_params_reports_first_present_name -q` (2 passed, 1 existing Starlette/httpx deprecation warning)
- `uv run --extra dev ruff check app/wallet_api.py tests/test_wallet_api.py`
- `git diff --check`
- Added-line security scan: 0 findings
- Independent reviewer: passed

Closes #936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced query parameter validation for wallet detail endpoints to reject unsupported parameters and provide clearer error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->