### PR TITLE
Publish activity OpenAPI response schema

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from app.accounts import normalized_account
 from app.control_chars import contains_control_character
 from app.db import session_scope
+from app.openapi_request_bodies import ACTIVITY_RESPONSE
 from app.query_validation import reject_control_char_query_param, reject_repeated_query_param
 from app.serializers import activity_to_dict
 
@@ -52,7 +53,7 @@ def _validate_activity_filter_params(request: Request) -> None:
 
 
 def register_activity_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
-    @app.get("/api/v1/activity")
+    @app.get("/api/v1/activity", openapi_extra=ACTIVITY_RESPONSE)
     def api_activity(
         request: Request,
         q: str | None = Query(None),

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -220,6 +220,152 @@ TREASURY_PROPOSAL_RESPONSE_SCHEMA = _object_schema(
     }
 )
 
+ACTIVITY_TOTALS_RESPONSE_SCHEMA = _object_schema(
+    {
+        "accepted_awards": {"type": "integer", "minimum": 0},
+        "accepted_mrwk": MRWK_DECIMAL_SCHEMA,
+        "contributors": {"type": "integer", "minimum": 0},
+    },
+    required=["accepted_awards", "accepted_mrwk", "contributors"],
+)
+
+ACTIVITY_PENDING_TOTALS_RESPONSE_SCHEMA = _object_schema(
+    {
+        "pending_awards": {"type": "integer", "minimum": 0},
+        "pending_mrwk": MRWK_DECIMAL_SCHEMA,
+    },
+    required=["pending_awards", "pending_mrwk"],
+)
+
+ACTIVITY_CONTRIBUTOR_RESPONSE_SCHEMA = _object_schema(
+    {
+        "account": {"type": "string"},
+        "accepted_awards": {"type": "integer", "minimum": 0},
+        "accepted_mrwk": MRWK_DECIMAL_SCHEMA,
+        "latest_submission_url": {"type": "string", "nullable": True},
+        "latest_bounty_repo": {"type": "string", "nullable": True},
+        "latest_bounty_issue_number": {"type": "integer", "nullable": True},
+        "latest_bounty_issue_url": {"type": "string", "nullable": True},
+        "latest_proof_hash": {**LOWERCASE_HEX_64_SCHEMA, "nullable": True},
+        "latest_proof_url": {"type": "string", "nullable": True},
+    },
+    required=["account", "accepted_awards", "accepted_mrwk"],
+)
+
+ACTIVITY_PENDING_PAYOUT_RESPONSE_SCHEMA = _object_schema(
+    {
+        "proposal_id": {"type": "integer", "minimum": 1},
+        "proposal_url": {"type": "string"},
+        "status": {"type": "string"},
+        "account": {"type": "string"},
+        "amount_mrwk": {**MRWK_DECIMAL_SCHEMA, "nullable": True},
+        "submission_url": {"type": "string", "nullable": True},
+        "bounty_repo": {"type": "string", "nullable": True},
+        "bounty_issue_number": {"type": "integer", "nullable": True},
+        "bounty_issue_url": {"type": "string", "nullable": True},
+        "bounty_id": {"type": "integer", "nullable": True},
+        "bounty_url": {"type": "string", "nullable": True},
+        "accepted_by": {"type": "string", "nullable": True},
+        "proposed_at": {"type": "string"},
+        "executes_after": {"type": "string"},
+    },
+    required=[
+        "proposal_id",
+        "proposal_url",
+        "status",
+        "account",
+        "amount_mrwk",
+        "submission_url",
+        "bounty_repo",
+        "bounty_issue_number",
+        "bounty_issue_url",
+        "bounty_id",
+        "bounty_url",
+        "accepted_by",
+        "proposed_at",
+        "executes_after",
+    ],
+)
+
+ACTIVITY_RECENT_RESPONSE_SCHEMA = _object_schema(
+    {
+        "ledger_sequence": {"type": "integer", "minimum": 1},
+        "account": {"type": "string"},
+        "amount_mrwk": MRWK_DECIMAL_SCHEMA,
+        "submission_url": {"type": "string"},
+        "bounty_repo": {"type": "string", "nullable": True},
+        "bounty_issue_number": {"type": "integer", "nullable": True},
+        "bounty_issue_url": {"type": "string", "nullable": True},
+        "proof_hash": LOWERCASE_HEX_64_SCHEMA,
+        "proof_url": {"type": "string"},
+        "bounty_id": {"type": "integer", "nullable": True},
+        "bounty_url": {"type": "string", "nullable": True},
+        "created_at": {"type": "string"},
+    },
+    required=[
+        "ledger_sequence",
+        "account",
+        "amount_mrwk",
+        "submission_url",
+        "bounty_repo",
+        "bounty_issue_number",
+        "bounty_issue_url",
+        "proof_hash",
+        "proof_url",
+        "bounty_id",
+        "bounty_url",
+        "created_at",
+    ],
+)
+
+ACTIVITY_RESPONSE_SCHEMA = _object_schema(
+    {
+        "totals": ACTIVITY_TOTALS_RESPONSE_SCHEMA,
+        "pending_totals": ACTIVITY_PENDING_TOTALS_RESPONSE_SCHEMA,
+        "query": {"type": "string"},
+        "account": {"type": "string", "nullable": True},
+        "contributors": {
+            "type": "array",
+            "items": ACTIVITY_CONTRIBUTOR_RESPONSE_SCHEMA,
+            "maxItems": 100,
+        },
+        "pending_payouts": {
+            "type": "array",
+            "items": ACTIVITY_PENDING_PAYOUT_RESPONSE_SCHEMA,
+            "maxItems": 100,
+        },
+        "recent": {
+            "type": "array",
+            "items": ACTIVITY_RECENT_RESPONSE_SCHEMA,
+            "maxItems": 100,
+        },
+        "api_activity_url": {"type": "string"},
+        "clear_activity_url": {"type": "string"},
+        "account_page_url": {"type": "string", "nullable": True},
+    },
+    required=[
+        "totals",
+        "pending_totals",
+        "query",
+        "contributors",
+        "pending_payouts",
+        "recent",
+        "api_activity_url",
+        "clear_activity_url",
+        "account_page_url",
+    ],
+    description=(
+        "Public accepted-work activity feed with proof-backed payments and pending "
+        "accepted payout proposals."
+    ),
+)
+
+ACTIVITY_RESPONSE = {
+    "responses": {
+        "200": _json_response(ACTIVITY_RESPONSE_SCHEMA),
+    },
+}
+
 MCP_JSONRPC_ID_SCHEMA = {
     "description": "JSON-RPC request id returned unchanged in the response.",
     "nullable": True,

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -23,6 +23,12 @@ def _post_response_schema(openapi: dict, path: str, status: str = "200") -> dict
     ]
 
 
+def _get_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
+    return openapi["paths"][path]["get"]["responses"][status]["content"]["application/json"][
+        "schema"
+    ]
+
+
 def _assert_properties(schema: dict, expected: Iterable[str]) -> None:
     assert set(expected).issubset(schema["properties"])
 
@@ -365,6 +371,119 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
             "created_at",
         },
     )
+
+
+def test_public_get_openapi_activity_response_schema_matches_runtime_shape(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    activity_schema = _get_response_schema(openapi, "/api/v1/activity")
+    _assert_properties(
+        activity_schema,
+        {
+            "totals",
+            "pending_totals",
+            "query",
+            "account",
+            "contributors",
+            "pending_payouts",
+            "recent",
+            "api_activity_url",
+            "clear_activity_url",
+            "account_page_url",
+        },
+    )
+    assert set(activity_schema["required"]) == {
+        "totals",
+        "pending_totals",
+        "query",
+        "contributors",
+        "pending_payouts",
+        "recent",
+        "api_activity_url",
+        "clear_activity_url",
+        "account_page_url",
+    }
+
+    totals_schema = activity_schema["properties"]["totals"]
+    _assert_properties(totals_schema, {"accepted_awards", "accepted_mrwk", "contributors"})
+    assert set(totals_schema["required"]) == {
+        "accepted_awards",
+        "accepted_mrwk",
+        "contributors",
+    }
+
+    pending_totals_schema = activity_schema["properties"]["pending_totals"]
+    _assert_properties(pending_totals_schema, {"pending_awards", "pending_mrwk"})
+    assert set(pending_totals_schema["required"]) == {"pending_awards", "pending_mrwk"}
+
+    contributor_schema = activity_schema["properties"]["contributors"]["items"]
+    _assert_properties(
+        contributor_schema,
+        {
+            "account",
+            "accepted_awards",
+            "accepted_mrwk",
+            "latest_submission_url",
+            "latest_bounty_repo",
+            "latest_bounty_issue_number",
+            "latest_bounty_issue_url",
+            "latest_proof_hash",
+            "latest_proof_url",
+        },
+    )
+    assert set(contributor_schema["required"]) == {
+        "account",
+        "accepted_awards",
+        "accepted_mrwk",
+    }
+
+    pending_schema = activity_schema["properties"]["pending_payouts"]["items"]
+    _assert_properties(
+        pending_schema,
+        {
+            "proposal_id",
+            "proposal_url",
+            "status",
+            "account",
+            "amount_mrwk",
+            "submission_url",
+            "bounty_repo",
+            "bounty_issue_number",
+            "bounty_issue_url",
+            "bounty_id",
+            "bounty_url",
+            "accepted_by",
+            "proposed_at",
+            "executes_after",
+        },
+    )
+
+    recent_schema = activity_schema["properties"]["recent"]["items"]
+    _assert_properties(
+        recent_schema,
+        {
+            "ledger_sequence",
+            "account",
+            "amount_mrwk",
+            "submission_url",
+            "bounty_repo",
+            "bounty_issue_number",
+            "bounty_issue_url",
+            "proof_hash",
+            "proof_url",
+            "bounty_id",
+            "bounty_url",
+            "created_at",
+        },
+    )
+
+    runtime_payload = client.get("/api/v1/activity").json()
+    assert set(runtime_payload).issubset(set(activity_schema["properties"]))
+    assert runtime_payload["totals"].keys() <= totals_schema["properties"].keys()
+    assert runtime_payload["pending_totals"].keys() <= pending_totals_schema["properties"].keys()
 
 
 def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None:

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -482,6 +482,7 @@ def test_public_get_openapi_activity_response_schema_matches_runtime_shape(
 
     runtime_payload = client.get("/api/v1/activity").json()
     assert set(runtime_payload).issubset(set(activity_schema["properties"]))
+    assert set(activity_schema["required"]).issubset(runtime_payload.keys())
     assert runtime_payload["totals"].keys() <= totals_schema["properties"].keys()
     assert runtime_payload["pending_totals"].keys() <= pending_totals_schema["properties"].keys()
 


### PR DESCRIPTION
﻿Bounty #944
Refs #944

## Summary
- Publishes an explicit OpenAPI `200` response schema for `GET /api/v1/activity`.
- Keeps runtime activity serialization unchanged and wires the existing activity route to shared response-schema metadata.
- Documents accepted totals, pending payout totals, contributor rows, pending payout rows, recent proof-backed activity rows, and activity navigation URLs for clients and SDK generators.
- Adds regression coverage proving the OpenAPI schema covers the runtime top-level activity payload shape.

## Duplicate / stale-work check
- Current `origin/main` does not advertise a `200` response schema for `/api/v1/activity`.
- Existing PR #1041 targets the same endpoint but is currently `DIRTY` against current `main` and defines the schema inline in `app/activity.py`.
- This PR is a clean current-main replacement that keeps schema definitions in `app/openapi_request_bodies.py`, matching the repository's current shared OpenAPI schema pattern.
- This is distinct from other #944 schema PRs for auth, bounty, health/status, treasury, wallet, ledger/proof, work-discovery, and mutation endpoints.

## Validation
- `python -m pytest tests\test_openapi_request_bodies.py::test_public_get_openapi_activity_response_schema_matches_runtime_shape tests\test_activity_routes.py -q` -> 2 passed, 1 existing Starlette/httpx warning.
- `python -m pytest tests\test_openapi_request_bodies.py tests\test_activity.py tests\test_activity_routes.py -q` -> 18 passed, 1 existing Starlette/httpx warning.
- `ruff check app\activity.py app\openapi_request_bodies.py tests\test_openapi_request_bodies.py tests\test_activity.py tests\test_activity_routes.py` -> All checks passed.
- `ruff format --check app\activity.py app\openapi_request_bodies.py tests\test_openapi_request_bodies.py` -> 3 files already formatted.
- `python -m mypy app\activity.py app\openapi_request_bodies.py` -> Success: no issues found in 2 source files.
- `python scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `e165e233251f55fcb7aa1d3f1f34ff4a677e91f1`.

## Scope
OpenAPI/client-contract metadata and focused tests only. No runtime activity JSON behavior, activity filtering, ledger mutation, treasury/proposal execution, payout execution, wallet behavior, admin-token behavior, bridge/exchange/off-ramp/cash-out behavior, MRWK price behavior, private data, or secrets changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive OpenAPI documentation for the Activity API, including detailed response schemas for totals, pending totals, contributors, pending payouts, and recent activity entries; the endpoint now advertises the documented 200 response.

* **Tests**
  * Added a validation test to ensure the published OpenAPI activity response schema is compatible with the runtime response shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->