### PR TITLE
Route proof recipient activity by account

### DIFF
--- a/app/templates/proof.html
+++ b/app/templates/proof.html
@@ -59,7 +59,7 @@
     <article>
       <span>Recipient activity</span>
       <strong>
-        <a href="/activity?q={{ proof.to_account | urlencode }}">Search {{ proof.to_account }}</a>
+        <a href="/activity?account={{ proof.to_account | urlencode }}">Search {{ proof.to_account }}</a>
       </strong>
     </article>
     <article>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -1191,7 +1191,7 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert "javascript:alert(1)" in unsafe_proof_page.text
     assert 'href="javascript:alert(1)"' not in unsafe_proof_page.text
     assert "Related activity" in proof_page.text
-    assert 'href="/activity?q=github%3Acontributor"' in proof_page.text
+    assert 'href="/activity?account=github%3Acontributor"' in proof_page.text
     assert f'href="/activity?q={proof_hash}"' in proof_page.text
     assert f'href="/activity?q={bounty.id}"' in proof_page.text
     assert 'href="/activity?q=https%3A//github.com/ramimbo/mergework/pull/99"' in proof_page.text


### PR DESCRIPTION
## Summary
- route proof-page recipient activity links through the exact `account=` activity filter
- keep proof hash, bounty, and submission activity links unchanged for broad proof-backed searches
- update the proof-page regression so recipient activity stays scoped to the paid account

Bounty #1010
Refs #1010

## Validation
- `python -m pytest tests\test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable -q` -> 1 passed, 1 existing Starlette/httpx warning
- `python -m pytest tests\test_bounty_pages.py tests\test_activity.py -q` -> 29 passed, 1 existing Starlette/httpx warning
- `ruff check tests\test_bounty_pages.py` -> All checks passed
- `ruff format --check tests\test_bounty_pages.py` -> 1 file already formatted
- `python scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean

## Scope
This is a proof explorer navigation improvement only. It does not change proof payloads, ledger entries, activity filtering semantics, payout execution, wallet custody/signing, treasury/admin behavior, bridges, exchanges, cash-out paths, private data, or secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the "Recipient activity" link to use a more precise query parameter for accurate activity filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
