### PR TITLE
Prefill transfer sender from wallet detail

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -451,8 +451,13 @@ def register_public_routes(
         return templates.TemplateResponse(request, "wallet_detail.html", context)
 
     @app.get("/transfer", response_class=HTMLResponse)
-    def transfer_page(request: Request) -> HTMLResponse:
-        return templates.TemplateResponse(request, "transfer.html")
+    def transfer_page(
+        request: Request,
+        from_address: str | None = Query(None),
+    ) -> HTMLResponse:
+        return templates.TemplateResponse(
+            request, "transfer.html", {"from_address": from_address or ""}
+        )
 
     @app.get("/proofs/{proof_hash}", response_class=HTMLResponse)
     def proof_page(request: Request, proof_hash: str) -> HTMLResponse:

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -455,6 +455,8 @@ def register_public_routes(
         request: Request,
         from_address: str | None = Query(None),
     ) -> HTMLResponse:
+        reject_control_char_query_param(request, "from_address")
+        reject_repeated_query_param(request, "from_address")
         return templates.TemplateResponse(
             request, "transfer.html", {"from_address": from_address or ""}
         )

--- a/app/templates/transfer.html
+++ b/app/templates/transfer.html
@@ -9,7 +9,7 @@
 
 <section class="panel wallet-tool" data-transfer-tool>
   <form data-action="submit-transfer">
-    <label>From address <input name="from_address" placeholder="mrwk1..." required></label>
+    <label>From address <input name="from_address" placeholder="mrwk1..." value="{{ from_address }}" required></label>
     <label>To address <input name="to_address" placeholder="mrwk1..." required></label>
     <label>Amount MRWK <input name="amount_mrwk" inputmode="decimal" placeholder="1.5" required></label>
     <label>Memo <input name="memo" maxlength="240" placeholder="optional"></label>

--- a/app/templates/wallet_detail.html
+++ b/app/templates/wallet_detail.html
@@ -27,7 +27,7 @@
     <dd><a href="/accounts/{{ wallet.address }}">ledger account</a></dd>
   </dl>
   <div class="actions">
-    <a href="/transfer">Send MRWK</a>
+    <a href="/transfer?from_address={{ wallet.address | urlencode }}">Send MRWK</a>
     <a href="/me">Link GitHub</a>
   </div>
   <p class="notice">To claim GitHub bounty balance, sign in and link this wallet from your contributor account.</p>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -691,6 +691,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     funded_missing_type = client.get(f"/wallets/{funded_address}?type=bounty_payment").text
     funded_unknown_type = client.get(f"/wallets/{funded_address}?type=not_a_real_type")
     transfer = client.get("/transfer").text
+    transfer_prefilled = client.get(f"/transfer?from_address={address}").text
     me = client.get("/me").text
 
     assert "Generate wallet" in wallets
@@ -719,6 +720,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "/accounts/github:" not in funded_row
     assert "No registered wallets match this search." in no_wallet_match
     assert "To claim GitHub bounty balance" in detail
+    assert f'href="/transfer?from_address={address}">Send MRWK</a>' in detail
     assert "No activity yet" in detail
     assert "No activity yet" not in funded_detail
     assert "Filter wallet transactions" in funded_detail
@@ -740,6 +742,9 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     )
     assert "Signed transfer" in transfer
     assert "both wallets are registered" in transfer
+    assert f'name="from_address" placeholder="mrwk1..." value="{address}" required' in (
+        transfer_prefilled
+    )
     assert "/static/wallet.js" in transfer
     assert "Link a wallet" in me
 

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -764,6 +764,10 @@ def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
     masked_type_response = client.get(f"/wallets/{address}?type=%C2%85test_funding&type=all")
     repeated_type_response = client.get(f"/wallets/{address}?type=test_funding&type=all")
     repeated_tx_type_response = client.get(f"/wallets/{address}?tx_type=test_funding&tx_type=all")
+    transfer_control_response = client.get("/transfer?from_address=%C2%85mrwk1")
+    repeated_transfer_response = client.get(
+        f"/transfer?from_address={address}&from_address=mrwk10000000000000000000000000000000000000000"
+    )
     max_length_search_response = client.get("/wallets", params={"q": "a" * 500})
     oversized_search_response = client.get("/wallets", params={"q": "a" * 501})
 
@@ -788,6 +792,14 @@ def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
     assert (
         repeated_tx_type_response.json()["detail"]
         == "tx_type is not supported on wallet pages; use type"
+    )
+    assert transfer_control_response.status_code == 400
+    assert transfer_control_response.json()["detail"] == (
+        "from_address must not contain control characters"
+    )
+    assert repeated_transfer_response.status_code == 400
+    assert (
+        repeated_transfer_response.json()["detail"] == "from_address must be provided at most once"
     )
     assert max_length_search_response.status_code == 200
     assert oversized_search_response.status_code == 400


### PR DESCRIPTION
## Summary
- link each wallet detail page's Send MRWK action to `/transfer?from_address=...`
- prefill the transfer form's sender address from that query parameter
- cover the wallet detail -> transfer prefill flow in the existing wallet page smoke test

Bounty #1011
Refs #1011

## Validation
- `python -m pytest tests\test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows -q` -> 1 passed, 1 existing Starlette/httpx warning
- `python -m pytest tests\test_wallet_api.py tests\test_public_routes.py -q` -> 52 passed, 1 existing Starlette/httpx warning
- `ruff check app\public_routes.py tests\test_wallet_api.py` -> All checks passed
- `ruff format --check app\public_routes.py tests\test_wallet_api.py` -> 2 files already formatted
- `python -m mypy app\public_routes.py` -> Success
- `python scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check origin/main...HEAD` -> clean
- `git merge-tree --write-tree origin/main HEAD` -> clean

## Scope
This is a public wallet/transfer page UX improvement only. It does not change transfer signing payloads, nonce handling, replay protection, ledger writes, balances, wallet custody, treasury/admin behavior, bridges, exchanges, cash-out paths, private data, or secrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transfer form now pre-fills the sender "From address" when launched from a wallet, reducing manual entry.

* **Bug Fixes**
  * Transfer page input now validates and rejects control characters and duplicate address inputs, returning an error for invalid requests.

* **Tests**
  * End-to-end coverage expanded to verify prefill behavior and new validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
