### PR TITLE
Link contributor account routes from /me

### DIFF
--- a/app/templates/me.html
+++ b/app/templates/me.html
@@ -5,13 +5,14 @@
   <p class="eyebrow">GitHub</p>
   <h1>Contributor account</h1>
   {% if github_login %}
+  {% set github_account = "github:" ~ github_login %}
   <p class="lead">Signed in as {{ github_login }}.</p>
-  <p class="notice"><code>github:{{ github_login }}</code> has {{ github_balance_mrwk }} MRWK available to claim.</p>
-  <div class="next-steps-actions" aria-label="Contributor account links">
-    <a href="/accounts/github:{{ github_login }}">GitHub ledger account</a>
-    <a href="/activity?account=github:{{ github_login }}">GitHub account activity</a>
-    {% if linked_wallet_address %}<a href="/wallets/{{ linked_wallet_address }}">Linked wallet</a>{% endif %}
-  </div>
+  <p class="notice"><code>{{ github_account }}</code> has {{ github_balance_mrwk }} MRWK available to claim.</p>
+  <nav class="next-steps-actions" aria-label="Contributor account links">
+    <a href="/accounts/{{ github_account | urlencode }}">GitHub ledger account</a>
+    <a href="/activity?account={{ github_account | urlencode }}">GitHub account activity</a>
+    {% if linked_wallet_address %}<a href="/wallets/{{ linked_wallet_address | urlencode }}">Linked wallet</a>{% endif %}
+  </nav>
   <form method="post" action="/auth/logout" class="inline-form">
     <button type="submit">Sign out</button>
   </form>

--- a/app/templates/me.html
+++ b/app/templates/me.html
@@ -7,6 +7,11 @@
   {% if github_login %}
   <p class="lead">Signed in as {{ github_login }}.</p>
   <p class="notice"><code>github:{{ github_login }}</code> has {{ github_balance_mrwk }} MRWK available to claim.</p>
+  <div class="next-steps-actions" aria-label="Contributor account links">
+    <a href="/accounts/github:{{ github_login }}">GitHub ledger account</a>
+    <a href="/activity?account=github:{{ github_login }}">GitHub account activity</a>
+    {% if linked_wallet_address %}<a href="/wallets/{{ linked_wallet_address }}">Linked wallet</a>{% endif %}
+  </div>
   <form method="post" action="/auth/logout" class="inline-form">
     <button type="submit">Sign out</button>
   </form>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -813,8 +813,9 @@ def test_me_page_shows_signed_in_github_claim_balance(sqlite_url: str, monkeypat
     assert "Signed in as alice." in me
     assert "github:alice" in me
     assert "4 MRWK available to claim" in me
-    assert 'href="/accounts/github:alice"' in me
-    assert 'href="/activity?account=github:alice"' in me
+    assert 'href="/accounts/github%3Aalice"' in me
+    assert 'href="/activity?account=github%3Aalice"' in me
+    assert "Linked wallet" not in me
 
 
 def test_me_page_links_linked_wallet(sqlite_url: str, monkeypatch) -> None:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -813,6 +813,28 @@ def test_me_page_shows_signed_in_github_claim_balance(sqlite_url: str, monkeypat
     assert "Signed in as alice." in me
     assert "github:alice" in me
     assert "4 MRWK available to claim" in me
+    assert 'href="/accounts/github:alice"' in me
+    assert 'href="/activity?account=github:alice"' in me
+
+
+def test_me_page_links_linked_wallet(sqlite_url: str, monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    create_schema(sqlite_url)
+    _, public_hex, address = _keypair()
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        register_wallet(session, public_key_hex=public_hex, github_login="alice")
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    client.cookies.set("mrwk_user", _signed_value("alice", "test-cookie-secret"))
+
+    me = client.get("/me").text
+
+    assert 'aria-label="Contributor account links"' in me
+    assert f'href="/wallets/{address}"' in me
+    assert "Linked wallet" in me
 
 
 def test_wallet_pages_do_not_require_manual_nonce(sqlite_url: str, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Adds direct `/me` links to the signed-in `github:*` ledger account and account-filtered activity.
- Shows a linked wallet shortcut when the GitHub account already has one.
- Keeps wallet signing, nonce, claim, transfer, and ledger behavior unchanged.

Bounty #1011

## Confusion / bug addressed
GitHub-linked contributors could see their unclaimed MRWK status on `/me`, but there was no obvious next step to inspect the underlying `github:<login>` ledger account, review account-filtered activity, or jump to the linked wallet page after a wallet connection existed.

## Bounty capacity check
- One focused PR for the bounty.
- No duplicate PR from me for this same `/me` contributor-account navigation change.
- Public artifact/ledger wording only; no cash-out, investment, or fabricated payout claims.

## Intended files / surfaces
- `app/templates/me.html` — contributor-account navigation links only.
- `tests/test_wallet_api.py` — coverage for GitHub account/activity links and the conditional linked-wallet link.

## Expected PR size
Small / focused: template-only UI addition plus regression tests.

## Out of scope
- No wallet generation or private-key handling changes.
- No claim, transfer, ledger, OAuth, payout, or API behavior changes.
- No production deployment or data migration.

## Test Evidence
- [x] `./.venv/bin/python -m pytest tests/test_wallet_api.py::test_me_page_shows_signed_in_github_claim_balance tests/test_wallet_api.py::test_me_page_links_linked_wallet tests/test_wallet_api.py::test_me_page_prefills_claim_address_for_linked_wallet -q`
- [x] `./.venv/bin/python -m pytest tests/test_wallet_api.py -q`
- [x] `./.venv/bin/python -m pytest tests/test_wallet_api.py tests/test_me_page.py -q`
- [x] `./.venv/bin/python -m ruff check tests/test_wallet_api.py tests/test_me_page.py`
- [x] `./.venv/bin/python -m ruff format --check tests/test_wallet_api.py tests/test_me_page.py`
- [x] `./.venv/bin/python scripts/docs_smoke.py`
- [x] `git diff --check origin/main...HEAD`
- [x] GitHub CI: `Quality, readiness, docs, and image checks` passed.
- [x] CodeRabbit latest review: no actionable comments.

/claim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Next Steps" action section on the account page for GitHub-signed-in users, with links to the GitHub ledger account, activity history, and a conditional linked-wallet link; balance notice now highlights the GitHub account.

* **Tests**
  * Added and extended tests to verify the new links, conditional linked-wallet display, and accessibility labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
