### PR TITLE
Link GitHub account pages to linked wallets

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -11,7 +11,12 @@ from sqlalchemy.orm import Session
 
 from app.control_chars import contains_control_character
 from app.db import session_scope
-from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
+from app.ledger.service import (
+    TREASURY_ACCOUNT,
+    format_mrwk,
+    get_balance,
+    linked_wallet_for_github,
+)
 from app.ledger_views import account_ledger_transactions
 from app.models import Account
 from app.path_params import SQLITE_INTEGER_MAX, reject_path_whitespace_padding
@@ -117,6 +122,14 @@ def account_action_urls(account: str) -> dict[str, str]:
     }
 
 
+def linked_wallet_address_for_account(session: Session, account: str) -> str | None:
+    github_login = github_login_from_account(account)
+    if github_login is None:
+        return None
+    linked_wallet = linked_wallet_for_github(session, github_login)
+    return linked_wallet.address if linked_wallet is not None else None
+
+
 def _account_api_context_for_normalized_account(session: Session, account: str) -> dict[str, Any]:
     account_row = session.get(Account, account)
     pending_payouts = safe_pending_payouts_for_account(session, account)
@@ -179,6 +192,7 @@ def account_page_context(
         "accepted_work": safe_accepted_work_for_account(session, account),
         "pending_summary": account_context["pending_summary"],
         "pending_payouts": account_context["pending_payouts"],
+        "linked_wallet_address": linked_wallet_address_for_account(session, account),
         "selected_transaction_type": selected_transaction_type,
         "transaction_type_options": ACCOUNT_TRANSACTION_TYPE_OPTIONS,
         "transactions": account_ledger_transactions(

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -13,6 +13,10 @@
     <dt>GitHub profile</dt>
     <dd><a href="https://github.com/{{ account.github_login }}">@{{ account.github_login }}</a></dd>
     {% endif %}
+    {% if linked_wallet_address %}
+    <dt>Linked wallet</dt>
+    <dd><a href="/wallets/{{ linked_wallet_address }}"><code>{{ linked_wallet_address }}</code></a></dd>
+    {% endif %}
     <dt>Send status</dt>
     <dd>{{ account.transfer_status }}</dd>
   </dl>

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -20,10 +22,24 @@ from app.ledger.service import (
     create_bounty,
     ensure_genesis,
     pay_bounty,
+    register_wallet,
 )
 from app.main import create_app
 from app.serializers import public_utc_timestamp
 from app.treasury import propose_treasury_action
+from app.wallets import address_from_public_key_hex
+
+
+def _wallet_public_hex() -> str:
+    private_key = Ed25519PrivateKey.generate()
+    return (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+        .hex()
+    )
 
 
 def test_account_contexts_include_balance_status_and_proof_backed_rows(
@@ -70,12 +86,16 @@ def test_account_contexts_include_balance_status_and_proof_backed_rows(
     assert page_context["accepted_work"][0]["proof_hash"] == proof.hash
     assert page_context["transactions"][0]["proof_hash"] == proof.hash
     assert page_context["transactions"][0]["to"] == "github:alice"
+    assert page_context["linked_wallet_address"] is None
 
 
 def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str) -> None:
     create_schema(sqlite_url)
+    public_hex = _wallet_public_hex()
+    wallet_address = address_from_public_key_hex(public_hex)
     with session_scope(sqlite_url) as session:
         ensure_genesis(session)
+        register_wallet(session, public_key_hex=public_hex, github_login="bob")
         bounty = create_bounty(
             session,
             repo="ramimbo/mergework",
@@ -122,6 +142,8 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     assert 'href="/api/v1/accounts/github:bob"' in page_response.text
     assert 'href="/api/v1/accounts/github:bob/accepted-work"' in page_response.text
     assert 'href="/api/v1/activity?account=github%3Abob"' in page_response.text
+    assert f'href="/wallets/{wallet_address}"' in page_response.text
+    assert "Linked wallet" in page_response.text
     assert '<p class="reference-cell">' in page_response.text
     assert f'href="/proofs/{proof.hash}"' in page_response.text
 


### PR DESCRIPTION
Bounty #1011
Refs #1011

## Summary
- Shows a linked wallet row on public GitHub account pages when `github:<login>` already has a registered linked wallet.
- Links the row directly to `/wallets/{address}` so readers can move from contributor/account state to wallet detail without going through `/me`.
- Keeps account JSON/API response shape, wallet signing, nonce, claim, transfer, ledger, and payout behavior unchanged.

## Duplicate / stale-work check
- Rechecked #1011 comments and open PRs for linked wallet/account page overlap.
- PR #1092 adds signed-in `/me` shortcuts for the current GitHub user, including a linked-wallet shortcut on `/me`.
- This PR covers a different public inspection path: `/accounts/github:<login>` for any visible GitHub ledger account.
- Existing account-page routing work links account pages to activity/API views, but I did not find an open submission that shows the linked wallet on the public GitHub account page.

## Validation
- `python -m pytest tests\test_account_routes.py::test_registered_account_routes_preserve_api_and_page_shapes tests\test_account_routes.py::test_account_contexts_include_balance_status_and_proof_backed_rows -q` -> 2 passed, 1 existing Starlette/httpx warning.
- `python -m pytest tests\test_account_routes.py tests\test_wallet_api.py tests\test_me_page.py -q` -> 56 passed, 1 existing warning.
- `ruff check app\accounts.py tests\test_account_routes.py` -> All checks passed.
- `ruff format --check app\accounts.py tests\test_account_routes.py` -> 2 files already formatted.
- `python -m mypy app\accounts.py` -> Success.
- `python scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` and `git diff --check` -> clean, with normal Windows LF-to-CRLF warnings for touched template/test files.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `7762447113c0e738c8786f302ccb0b9ba7e09cef`.

## Scope
Touched surfaces: `app/accounts.py`, `app/templates/account.html`, `tests/test_account_routes.py`.

This is public account-page UX and test coverage only. It does not change account JSON/API response shape, wallet signing payloads, nonce/replay behavior, ledger mutation, balance accounting, wallet custody, treasury/admin-token behavior, payout execution, bridge/exchange/off-ramp/cash-out behavior, MRWK price behavior, private data, or secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account pages now display linked wallet addresses for GitHub-authenticated users, enabling quick access to associated wallet details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->