### PR TITLE
Link account-filtered activity to account pages

### DIFF
--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -22,6 +22,7 @@
 {% endif %}
 <nav class="actions detail-actions" aria-label="Activity inspection links">
   <a href="{{ api_activity_url }}">View JSON activity</a>
+  {% if account_page_url %}<a href="{{ account_page_url }}">View account page</a>{% endif %}
 </nav>
 
 <section class="grid">

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -488,6 +488,7 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert 'role="search"' in paid.text
     assert 'aria-label="Activity inspection links"' in paid.text
     assert 'href="/api/v1/activity">View JSON activity</a>' in paid.text
+    assert "View account page" not in paid.text
     assert 'name="account"' not in paid.text
     assert 'name="q"' in paid.text
     assert f'href="/bounties/{bounty.id}">Bounty #{bounty.id}</a>' in paid.text
@@ -506,6 +507,7 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert (
         'href="/api/v1/activity?account=github%3Abob">View JSON activity</a>' in scoped_account.text
     )
+    assert 'href="/accounts/github:bob">View account page</a>' in scoped_account.text
     assert "github:bob" in scoped_account.text
     assert "75 MRWK" in scoped_account.text
 
@@ -520,6 +522,7 @@ def test_activity_page_renders_empty_and_paid_states(sqlite_url: str) -> None:
     assert (
         'href="/api/v1/activity?q=pull%2F12&amp;account=github%3Abob">View JSON activity</a>'
     ) in scoped_account_query.text
+    assert 'href="/accounts/github:bob">View account page</a>' in scoped_account_query.text
 
     filtered = client.get("/activity?q=bob")
     issue_ref = client.get("/activity?q=%2312")


### PR DESCRIPTION
Bounty #1010
Refs #1010

## Summary
- Adds a `View account page` action on `/activity?account=...` pages.
- Uses the existing `account_page_url` activity context value, so account-scoped activity can move back to the public account profile without manual URL editing.
- Leaves unscoped activity pages unchanged and preserves existing activity API/query behavior.

## Duplicate / stale-work check
- Rechecked #1010 comments and open PRs for account-filtered activity/account-page return links.
- Existing PR #1074 links account pages to the activity view; this PR covers the reverse route from an account-filtered activity page back to the account page.
- Existing PR #1090 routes proof recipient activity through the exact account filter; this PR makes that resulting account-scoped activity page easier to continue from.
- I did not find an open submission that displays the existing `account_page_url` link in the activity page action area.

## Validation
- `python -m pytest tests\test_activity.py::test_activity_page_renders_empty_and_paid_states tests\test_activity_routes.py -q` -> 2 passed, 1 existing Starlette/httpx warning.
- `python -m pytest tests\test_activity.py tests\test_activity_routes.py tests\test_account_routes.py -q` -> 17 passed, 1 existing warning.
- `ruff check tests\test_activity.py app\activity.py` -> All checks passed.
- `ruff format --check tests\test_activity.py app\activity.py` -> 2 files already formatted.
- `python -m mypy app\activity.py` -> Success.
- `python scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` and `git diff --check` -> clean, with normal Windows LF-to-CRLF warning for the touched template file.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `7762447113c0e738c8786f302ccb0b9ba7e09cef`.

## Scope
Touched surfaces: `app/templates/activity.html`, `tests/test_activity.py`.

This is public activity/account navigation and page regression coverage only. No activity API payload shape changes, no filtering semantics changes, no ledger mutation, no proof payload changes, no payout execution, no wallet custody/signing, no treasury/admin-token behavior, no bridge/exchange/off-ramp/cash-out behavior, no MRWK price behavior, private data, or secrets changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a link to view the account page when accessing activity filtered by a specific account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->