### PR TITLE
Expose account activity links in account APIs

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -9,6 +9,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
+from app.config import get_settings
 from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
@@ -117,6 +118,15 @@ def account_action_urls(account: str) -> dict[str, str]:
     }
 
 
+def account_activity_urls(account: str) -> dict[str, str]:
+    activity_path = f"/activity?{urlencode({'account': account})}"
+    return {
+        "activity_url": activity_path,
+        "activity_public_url": f"{get_settings().public_base_url.rstrip('/')}{activity_path}",
+        "activity_api_url": f"/api/v1/activity?{urlencode({'account': account})}",
+    }
+
+
 def _account_api_context_for_normalized_account(session: Session, account: str) -> dict[str, Any]:
     account_row = session.get(Account, account)
     pending_payouts = safe_pending_payouts_for_account(session, account)
@@ -130,6 +140,7 @@ def _account_api_context_for_normalized_account(session: Session, account: str) 
         "accepted_work": safe_account_accepted_summary(session, account),
         "pending_summary": pending_payout_summary(pending_payouts),
         "pending_payouts": pending_payouts,
+        **account_activity_urls(account),
     }
 
 
@@ -146,6 +157,7 @@ def account_accepted_work_context(session: Session, account: str) -> dict[str, A
         "accepted_work": accepted_work_for_account(session, account),
         "pending_summary": pending_payout_summary(pending_payouts),
         "pending_payouts": pending_payouts,
+        **account_activity_urls(account),
     }
 
 

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -578,7 +578,9 @@ current nonce, next nonce to sign with, and registration timestamp:
 
 Account responses identify the normalized ledger address, optional GitHub login,
 existence, current balance, accepted-work summary, and whether the account can
-move funds directly:
+move funds directly. They also include scoped activity links so clients can move
+from an account response into the accepted-work activity feed without rebuilding
+URLs:
 
 ```json
 {
@@ -588,6 +590,9 @@ move funds directly:
   "exists": true,
   "balance_mrwk": "395",
   "transfer_status": "Claim GitHub balances from /me after linking a registered mrwk1 wallet.",
+  "activity_url": "/activity?account=github%3Atatelyman",
+  "activity_public_url": "https://mrwk.online/activity?account=github%3Atatelyman",
+  "activity_api_url": "/api/v1/activity?account=github%3Atatelyman",
   "accepted_work": {
     "accepted_awards": 5,
     "accepted_mrwk": "395",
@@ -620,6 +625,9 @@ curl -s "$API_HOST/api/v1/accounts/treasury:mrwk"
   "exists": true,
   "balance_mrwk": "99959140",
   "transfer_status": "Internal ledger account. MRWK wallet transfers are only available for registered mrwk1 addresses.",
+  "activity_url": "/activity?account=treasury%3Amrwk",
+  "activity_public_url": "https://mrwk.online/activity?account=treasury%3Amrwk",
+  "activity_api_url": "/api/v1/activity?account=treasury%3Amrwk",
   "accepted_work": {
     "accepted_awards": 0,
     "accepted_mrwk": "0",
@@ -654,6 +662,9 @@ be pasted directly into GitHub comments, reports, or reconciliation logs.
 ```json
 {
   "account": "github:carpedkm",
+  "activity_url": "/activity?account=github%3Acarpedkm",
+  "activity_public_url": "https://mrwk.online/activity?account=github%3Acarpedkm",
+  "activity_api_url": "/api/v1/activity?account=github%3Acarpedkm",
   "summary": {
     "accepted_awards": 6,
     "accepted_mrwk": "340",

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -9,6 +9,7 @@ import app.accounts as accounts_module
 import app.serializers as serializers_module
 from app.accounts import (
     account_action_urls,
+    account_activity_urls,
     account_api_context,
     account_page_context,
     normalized_account,
@@ -59,6 +60,11 @@ def test_account_contexts_include_balance_status_and_proof_backed_rows(
     assert api_context["transfer_status"].startswith("Claim GitHub balances")
     assert api_context["accepted_work"]["accepted_awards"] == 1
     assert api_context["accepted_work"]["latest_proof_hash"] == proof.hash
+    assert api_context["activity_url"] == "/activity?account=github%3Aalice"
+    assert api_context["activity_api_url"] == "/api/v1/activity?account=github%3Aalice"
+    assert (
+        api_context["activity_public_url"] == "https://mrwk.online/activity?account=github%3Aalice"
+    )
 
     assert page_context["account"]["account"] == "github:alice"
     assert page_context["account_action_urls"] == {
@@ -116,6 +122,8 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     assert accepted_response.status_code == 200
     assert accepted_response.json()["summary"]["accepted_mrwk"] == "25"
     assert accepted_response.json()["accepted_work"][0]["submission_url"].endswith("/pull/178")
+    assert accepted_response.json()["activity_url"] == "/activity?account=github%3Abob"
+    assert accepted_response.json()["activity_api_url"] == "/api/v1/activity?account=github%3Abob"
     assert page_response.status_code == 200
     assert "github:bob" in page_response.text
     assert "25 MRWK" in page_response.text
@@ -131,6 +139,14 @@ def test_account_action_urls_escape_query_accounts() -> None:
         "account_json": "/api/v1/accounts/github:alice",
         "accepted_work_json": "/api/v1/accounts/github:alice/accepted-work",
         "activity": "/api/v1/activity?account=github%3Aalice",
+    }
+
+
+def test_account_activity_urls_expose_page_and_api_links() -> None:
+    assert account_activity_urls("github:alice") == {
+        "activity_url": "/activity?account=github%3Aalice",
+        "activity_public_url": "https://mrwk.online/activity?account=github%3Aalice",
+        "activity_api_url": "/api/v1/activity?account=github%3Aalice",
     }
 
 
@@ -202,6 +218,10 @@ def test_account_routes_expose_pending_payouts_separately_from_paid_work(
     assert accepted_api["summary"] == account_api["accepted_work"]
     assert accepted_api["pending_summary"] == account_api["pending_summary"]
     assert account_api["pending_payouts"] == accepted_api["pending_payouts"]
+    assert accepted_api["activity_url"] == account_api["activity_url"]
+    assert accepted_api["activity_public_url"] == account_api["activity_public_url"]
+    assert accepted_api["activity_api_url"] == account_api["activity_api_url"]
+    assert account_api["activity_url"] == "/activity?account=github%3Aalice"
     assert accepted_api["pending_payouts"] == [
         {
             "proposal_id": proposal.id,


### PR DESCRIPTION
Bounty #1010

What changed:
- Added account-scoped activity links to account and accepted-work JSON responses.
- Documented the new fields in the API examples.

Tested:
- python -m pytest tests/test_account_routes.py -q
- python -m pytest tests/test_api_mcp.py::test_explorer_links_ledger_proof_and_account tests/test_api_mcp.py::test_account_api_keeps_schema_when_accepted_work_proof_is_malformed -q
- python -m pytest tests/test_docs_public_urls.py -q
- ruff check app/accounts.py tests/test_account_routes.py
- ruff format --check app/accounts.py tests/test_account_routes.py
- python -m mypy app/accounts.py
- python scripts/docs_smoke.py
- git diff --check
