### PR TITLE
Link wallet detail GitHub logins to accounts

### DIFF
--- a/app/templates/wallet_detail.html
+++ b/app/templates/wallet_detail.html
@@ -18,7 +18,7 @@
     <dt>Public key</dt>
     <dd><code>{{ wallet.public_key_hex }}</code></dd>
     <dt>GitHub login</dt>
-    <dd>{{ wallet.github_login or "-" }}</dd>
+    <dd>{% if wallet.github_login %}<a href="/accounts/github:{{ wallet.github_login }}">{{ wallet.github_login }}</a>{% else %}-{% endif %}</dd>
     <dt>Signed actions</dt>
     <dd>{{ wallet.nonce }}</dd>
     <dt>Next action number</dt>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -710,6 +710,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "alice-smoke" in github_search
     assert 'href="/accounts/github:alice-smoke">alice-smoke</a>' in wallets
     assert 'href="/accounts/github:alice-smoke">alice-smoke</a>' in github_search
+    assert 'href="/accounts/github:alice-smoke">alice-smoke</a>' in detail
     funded_row_start = wallets.index(
         f'<a href="/wallets/{funded_address}"><code>{funded_address}</code></a>'
     )
@@ -722,6 +723,14 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "No activity yet" in detail
     assert "No activity yet" not in funded_detail
     assert "Filter wallet transactions" in funded_detail
+    funded_github_login_start = funded_detail.index("<dt>GitHub login</dt>")
+    funded_github_login_row = funded_detail[
+        funded_github_login_start : funded_detail.index(
+            "<dt>Signed actions</dt>", funded_github_login_start
+        )
+    ]
+    assert "<dd>-</dd>" in funded_github_login_row
+    assert "/accounts/github:" not in funded_github_login_row
     assert 'value="test_funding" selected' in funded_type_filter
     assert "Showing test_funding transactions." in funded_type_filter
     assert "Showing all transactions." not in funded_all_type_filter


### PR DESCRIPTION
Bounty #1011
Refs #1011

## Summary
- Links a wallet detail page's linked GitHub login to `/accounts/github:<login>`.
- Keeps unlinked wallets on the existing `-` empty state.
- Completes the reverse navigation already present on the wallets list page, so a user can move from a specific linked wallet back to the contributor account without manual URL editing.

## Duplicate / stale-work check
- Rechecked #1011 comments and open PRs for wallet/account navigation overlap.
- PR #1091 covers wallet detail -> transfer prefill; this PR covers wallet detail -> GitHub account navigation.
- PR #1092 covers signed-in `/me` account shortcuts.
- PR #1093 covers public account page -> linked wallet navigation.
- I did not find an open submission that links the GitHub login shown on `/wallets/{address}` back to `/accounts/github:<login>`.

## Validation
- `..\..\.venv\Scripts\python.exe -m pytest tests\test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows -q` -> 1 passed, 1 existing Starlette/httpx warning.
- `..\..\.venv\Scripts\python.exe -m pytest tests\test_wallet_api.py tests\test_account_routes.py -q` -> 54 passed, 1 existing warning.
- `ruff check tests\test_wallet_api.py` -> All checks passed.
- `ruff format --check tests\test_wallet_api.py` -> 1 file already formatted.
- `..\..\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` and `git diff --check` -> clean, with the normal Windows LF-to-CRLF warning for the touched template.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `7762447113c0e738c8786f302ccb0b9ba7e09cef`.

## Scope
Touched surfaces: `app/templates/wallet_detail.html`, `tests/test_wallet_api.py`.

This is public wallet/account navigation and route-rendering test coverage only. No wallet signing payloads, nonce/replay behavior, transfer behavior, ledger mutation, balance accounting, wallet custody, account API response shape, treasury/admin-token behavior, payout execution, bridge/exchange/off-ramp/cash-out behavior, MRWK price behavior, private data, or secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * GitHub usernames on wallet detail pages now appear as clickable links to the linked account when present; otherwise a clear "-" fallback is shown.
* **Tests**
  * Updated tests to verify linked-account links appear when expected and that the "-" fallback is shown (with no link) when no GitHub account is linked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->