### PR TITLE
fix: reject URL-encoded special characters in account path identifiers

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -14,7 +14,11 @@ from app.db import session_scope
 from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
 from app.ledger_views import account_ledger_transactions
 from app.models import Account
-from app.path_params import SQLITE_INTEGER_MAX, reject_account_special_characters, reject_path_whitespace_padding
+from app.path_params import (
+    SQLITE_INTEGER_MAX,
+    reject_account_special_characters,
+    reject_path_whitespace_padding,
+)
 from app.query_validation import reject_repeated_query_param, reject_unsupported_query_params
 from app.serializers import (
     accepted_work_for_account,

--- a/app/accounts.py
+++ b/app/accounts.py
@@ -14,7 +14,7 @@ from app.db import session_scope
 from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
 from app.ledger_views import account_ledger_transactions
 from app.models import Account
-from app.path_params import SQLITE_INTEGER_MAX, reject_path_whitespace_padding
+from app.path_params import SQLITE_INTEGER_MAX, reject_account_special_characters, reject_path_whitespace_padding
 from app.query_validation import reject_repeated_query_param, reject_unsupported_query_params
 from app.serializers import (
     accepted_work_for_account,
@@ -191,6 +191,7 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
     @app.get("/api/v1/accounts/{account}")
     def api_account(request: Request, account: str) -> dict[str, Any]:
         reject_path_whitespace_padding(account, "account")
+        reject_account_special_characters(account)
         reject_unsupported_query_params(
             request,
             ("type", "tx_type"),
@@ -202,6 +203,7 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
     @app.get("/api/v1/accounts/{account}/accepted-work")
     def api_account_accepted_work(account: str) -> dict[str, Any]:
         reject_path_whitespace_padding(account, "account")
+        reject_account_special_characters(account)
         with session_scope(db_url) as session:
             return account_accepted_work_context(session, account)
 
@@ -210,6 +212,7 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
         request: Request, account: str, tx_type: str | None = Query(None)
     ) -> HTMLResponse:
         reject_path_whitespace_padding(account, "account")
+        reject_account_special_characters(account)
         if request.query_params.getlist("type"):
             raise HTTPException(
                 status_code=400,

--- a/app/path_params.py
+++ b/app/path_params.py
@@ -22,6 +22,20 @@ def reject_path_whitespace_padding(value: str, field: str) -> None:
         )
 
 
+_ACCOUNT_INVALID_SPECIAL_RE = re.compile(r"[!@#$%^&*()+\=\[\]{}\|\\;'\"<>?,]+")
+
+
+def reject_account_special_characters(account: str) -> None:
+    """Reject account identifiers that contain special characters not valid
+    in any canonical account shape (github:, mrwk1, treasury:, reserve:)."""
+    if not _ACCOUNT_INVALID_SPECIAL_RE.search(account):
+        return
+    raise HTTPException(
+        status_code=400,
+        detail="account must not contain URL-encoded special characters",
+    )
+
+
 def issue_number_search_value(query: str) -> int | None:
     """Return a bounded GitHub issue number from a plain numeric search query."""
     clean = query.removeprefix("#")

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -395,3 +395,51 @@ def test_account_api_does_not_advertise_wallet_transfers_for_plain_accounts(
 def test_normalized_account_keeps_existing_account_validation_boundaries() -> None:
     assert normalized_account(" Reserve:Bounty:001 ") == "reserve:bounty:1"
     assert normalized_account("MRWK1" + ("A" * 40)) == "mrwk1" + ("a" * 40)
+
+
+def test_account_path_rejects_url_encoded_special_characters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    special_inputs = [
+        "!@#$",
+        "%21%40%23%24",
+        "account!test",
+        "test@domain",
+        "#fragment",
+        "$money",
+    ]
+
+    for bad_input in special_inputs:
+        api_response = client.get(f"/api/v1/accounts/{bad_input}")
+        assert api_response.status_code == 400, (
+            f"expected 400 for /api/v1/accounts/{bad_input}, got {api_response.status_code}"
+        )
+        assert "URL-encoded special characters" in api_response.json()["detail"]
+
+        accepted_response = client.get(f"/api/v1/accounts/{bad_input}/accepted-work")
+        assert accepted_response.status_code == 400
+        assert "URL-encoded special characters" in accepted_response.json()["detail"]
+
+        page_response = client.get(f"/accounts/{bad_input}")
+        assert page_response.status_code == 400
+        assert "URL-encoded special characters" in page_response.json()["detail"]
+
+
+def test_account_path_allows_valid_canonical_identifiers() -> None:
+    valid_accounts = [
+        "github:alice",
+        "github:bob-123",
+        "mrwk1" + ("a" * 40),
+        "treasury:mrwk",
+        "reserve:bounty:42",
+        "plain-account",
+        "some.other_account",
+    ]
+    for account in valid_accounts:
+        normalized = normalized_account(account)
+        assert "!" not in normalized
+        assert "#" not in normalized

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -409,7 +409,7 @@ def test_account_path_rejects_url_encoded_special_characters(sqlite_url: str) ->
         "%21%40%23%24",
         "account!test",
         "test@domain",
-        "#fragment",
+        "%23fragment",
         "$money",
     ]
 


### PR DESCRIPTION
Added account path validation that rejects URL-encoded special characters (!@#$) returning 400 instead of silently normalizing them. Applied to all three account routes. Includes tests. References #1083.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account requests containing URL-encoded special characters in identifiers are now rejected with HTTP 400 and a clear error message. This validation is applied consistently to account JSON, accepted-work JSON, and HTML account pages.

* **Tests**
  * Added tests to assert rejection of invalid account identifiers and to verify acceptance/normalization of valid canonical account identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->