### PR TITLE
Link bounty details to accepted-work activity

### DIFF
--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -147,6 +147,7 @@
     </ol>
     <div class="next-steps-actions" aria-label="Bounty action links">
       {% if issue_url %}<a href="{{ issue_url }}" rel="nofollow noopener">Open source issue</a>{% endif %}
+      {% if issue_url %}<a href="/activity?q={{ issue_url | urlencode }}">Accepted-work activity</a>{% endif %}
       <a href="/bounties?repo={{ bounty.repo | urlencode }}&amp;issue_number={{ bounty.issue_number }}">View source bounty matches</a>
       <a href="/api/v1/bounties/{{ bounty.id }}">View JSON details</a>
       <a href="{{ requirements.attempt_endpoint }}">Check active attempts</a>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -84,6 +84,16 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert "Open public bounty" not in paid_rows_uppercase.text
     assert 'href="/bounties?status=paid" aria-current="page"' in paid_rows_uppercase.text
 
+    paid_detail = client.get(f"/bounties/{paid_bounty.id}")
+    bounty_activity_url = "https%3A//github.com/ramimbo/mergework/issues/51"
+    bounty_activity = client.get(f"/api/v1/activity?q={bounty_activity_url}").json()
+    assert paid_detail.status_code == 200
+    assert (
+        f'href="/activity?q={bounty_activity_url}">Accepted-work activity</a>' in paid_detail.text
+    )
+    assert [row["bounty_issue_number"] for row in bounty_activity["recent"]] == [51]
+    assert bounty_activity["totals"]["accepted_awards"] == 1
+
 
 def test_bounties_summary_api_matches_public_list_filters(sqlite_url: str) -> None:
     create_schema(sqlite_url)

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -95,6 +95,32 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert bounty_activity["totals"]["accepted_awards"] == 1
 
 
+def test_bounty_detail_hides_activity_link_without_issue_url(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=52,
+            issue_url="https://github.com/ramimbo/mergework/issues/52",
+            title="Imported bounty without source link",
+            reward_mrwk="50",
+            acceptance="Imported bounty details should still render without a source link.",
+        )
+        bounty.issue_url = ""
+        bounty_id = bounty.id
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    detail = client.get(f"/bounties/{bounty_id}")
+
+    assert detail.status_code == 200
+    assert "Imported bounty without source link" in detail.text
+    assert "Accepted-work activity" not in detail.text
+    assert "Open source issue" not in detail.text
+
+
 def test_bounties_summary_api_matches_public_list_filters(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:


### PR DESCRIPTION
## Summary

- Add an `Accepted-work activity` link on bounty detail pages when the bounty has a source issue URL.
- Point that link at `/activity?q=<source issue URL>` so reviewers can jump from a bounty to matching activity rows.
- Keep ledger, payout, wallet, and treasury behavior unchanged.

## Evidence

### Confusion or Missing Step

Before this change, a contributor could open a bounty detail page and inspect the source issue, JSON details, and attempts, but there was no direct path to the accepted-work activity feed for that exact source issue. Reviewers had to manually copy the issue URL into `/activity`.

### Bounty Capacity Check

Bounty #1010 is the contributor profiles and proof explorer improvements bounty. This PR is focused on contributor-facing bounty/activity navigation and does not overlap with proof recipient account links or activity-to-account links.

### Intended Surfaces

- `app/templates/bounty_detail.html`
- `tests/test_bounty_pages.py`

## Test Evidence

- [x] `.venv\Scripts\ruff.exe check tests\test_bounty_pages.py`
- [x] `.venv\Scripts\ruff.exe format --check tests\test_bounty_pages.py`
- [x] `.venv\Scripts\python.exe -m pytest tests\test_bounty_pages.py tests\test_activity.py -q`
- [x] `.venv\Scripts\python.exe scripts\docs_smoke.py`
- [x] `git diff --check origin/main...HEAD`
- [x] `git merge-tree --write-tree origin/main HEAD`

## Out Of Scope

No activity filtering semantics, ledger mutation, proof payload, payout execution, wallet signing/custody, treasury/admin-token behavior, bridge/exchange/off-ramp/cash-out behavior, MRWK price behavior, private data, or secrets changed.
