### PR TITLE
Link wallet accounts to recipient-prefilled transfers

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -110,11 +110,14 @@ def account_transfer_status(account: str) -> str:
 
 def account_action_urls(account: str) -> dict[str, str]:
     path_account = quote(account, safe=":")
-    return {
+    urls = {
         "account_json": f"/api/v1/accounts/{path_account}",
         "accepted_work_json": f"/api/v1/accounts/{path_account}/accepted-work",
         "activity": f"/api/v1/activity?{urlencode({'account': account})}",
     }
+    if account.startswith("mrwk1"):
+        urls["transfer_recipient"] = f"/transfer?{urlencode({'to_address': account})}"
+    return urls
 
 
 def _account_api_context_for_normalized_account(session: Session, account: str) -> dict[str, Any]:

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -451,8 +451,18 @@ def register_public_routes(
         return templates.TemplateResponse(request, "wallet_detail.html", context)
 
     @app.get("/transfer", response_class=HTMLResponse)
-    def transfer_page(request: Request) -> HTMLResponse:
-        return templates.TemplateResponse(request, "transfer.html")
+    def transfer_page(request: Request, to_address: str | None = Query(None)) -> HTMLResponse:
+        reject_repeated_query_param(request, "to_address")
+        transfer_defaults = {"to_address": ""}
+        if to_address is not None:
+            if contains_control_character(to_address):
+                raise HTTPException(
+                    status_code=400, detail="to_address must not contain control characters"
+                )
+            transfer_defaults["to_address"] = normalized_wallet_address(to_address)
+        return templates.TemplateResponse(
+            request, "transfer.html", {"transfer_defaults": transfer_defaults}
+        )
 
     @app.get("/proofs/{proof_hash}", response_class=HTMLResponse)
     def proof_page(request: Request, proof_hash: str) -> HTMLResponse:

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -20,6 +20,9 @@
     <a href="{{ account_action_urls.account_json }}">Account JSON</a>
     <a href="{{ account_action_urls.accepted_work_json }}">Accepted-work JSON</a>
     <a href="{{ account_action_urls.activity }}">Activity for account</a>
+    {% if account_action_urls.transfer_recipient %}
+    <a href="{{ account_action_urls.transfer_recipient }}">Send MRWK to this wallet</a>
+    {% endif %}
   </div>
 </section>
 

--- a/app/templates/transfer.html
+++ b/app/templates/transfer.html
@@ -10,7 +10,7 @@
 <section class="panel wallet-tool" data-transfer-tool>
   <form data-action="submit-transfer">
     <label>From address <input name="from_address" placeholder="mrwk1..." required></label>
-    <label>To address <input name="to_address" placeholder="mrwk1..." required></label>
+    <label>To address <input name="to_address" placeholder="mrwk1..." value="{{ transfer_defaults.to_address }}" required></label>
     <label>Amount MRWK <input name="amount_mrwk" inputmode="decimal" placeholder="1.5" required></label>
     <label>Memo <input name="memo" maxlength="240" placeholder="optional"></label>
     <label>Private key <textarea name="private_key_hex" rows="5" autocomplete="off" autocapitalize="none" spellcheck="false" required></textarea></label>

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -132,6 +132,29 @@ def test_account_action_urls_escape_query_accounts() -> None:
         "accepted_work_json": "/api/v1/accounts/github:alice/accepted-work",
         "activity": "/api/v1/activity?account=github%3Aalice",
     }
+    wallet_address = "mrwk1" + ("a" * 40)
+    assert account_action_urls(wallet_address) == {
+        "account_json": f"/api/v1/accounts/{wallet_address}",
+        "accepted_work_json": f"/api/v1/accounts/{wallet_address}/accepted-work",
+        "activity": f"/api/v1/activity?account={wallet_address}",
+        "transfer_recipient": f"/transfer?to_address={wallet_address}",
+    }
+
+
+def test_wallet_account_page_links_to_prefilled_transfer_recipient(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    wallet_address = "mrwk1" + ("b" * 40)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    wallet_account = client.get(f"/accounts/{wallet_address}")
+    github_account = client.get("/accounts/github:alice")
+
+    assert wallet_account.status_code == 200
+    assert f'href="/transfer?to_address={wallet_address}">Send MRWK to this wallet</a>' in (
+        wallet_account.text
+    )
+    assert github_account.status_code == 200
+    assert "Send MRWK to this wallet" not in github_account.text
 
 
 def test_account_routes_expose_pending_payouts_separately_from_paid_work(

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -744,6 +744,23 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Link a wallet" in me
 
 
+def test_transfer_page_prefills_valid_recipient_address(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    recipient_address = "mrwk1" + ("c" * 40)
+
+    transfer = client.get(f"/transfer?to_address={recipient_address}")
+    invalid_transfer = client.get("/transfer?to_address=github:alice")
+
+    assert transfer.status_code == 200
+    assert (
+        f'name="to_address" placeholder="mrwk1..." value="{recipient_address}" required'
+        in transfer.text
+    )
+    assert invalid_transfer.status_code == 400
+    assert invalid_transfer.json()["detail"] == "invalid MRWK wallet address"
+
+
 def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     _, public_hex, address = _keypair()


### PR DESCRIPTION
## Summary

- Add a `Send MRWK to this wallet` action on public `mrwk1...` account pages.
- Route that action to `/transfer?to_address=<wallet>` and prefill the transfer form recipient.
- Validate the query-provided recipient address with the existing MRWK wallet address normalization before rendering it.

## Evidence

### Confusion or Missing Step

Before this change, a reader on a public wallet ledger account page could inspect JSON, accepted work, and activity, but had to manually copy the `mrwk1...` account into `/transfer` to send MRWK to that wallet. The new action gives the safe direct path and only appears for wallet-shaped accounts.

### Bounty Capacity Check

Bounty #1011 is the wallet and account flow UX improvements bounty. This PR is distinct from existing #1011 claims for wallet-detail sender prefill, `/me` shortcuts, public account-to-linked-wallet navigation, and wallet-detail-to-GitHub-account navigation because this entry point starts on `/accounts/<mrwk1...>` and fills the transfer recipient only.

### Intended Surfaces

- `app/accounts.py`
- `app/public_routes.py`
- `app/templates/account.html`
- `app/templates/transfer.html`
- `tests/test_account_routes.py`
- `tests/test_wallet_api.py`

## Test Evidence

- [x] `.venv\Scripts\python.exe -m pytest tests\test_account_routes.py::test_account_action_urls_escape_query_accounts tests\test_account_routes.py::test_wallet_account_page_links_to_prefilled_transfer_recipient tests\test_wallet_api.py::test_transfer_page_prefills_valid_recipient_address -q`
- [x] `.venv\Scripts\ruff.exe check app\accounts.py app\public_routes.py tests\test_account_routes.py tests\test_wallet_api.py`
- [x] `.venv\Scripts\ruff.exe format --check app\accounts.py app\public_routes.py tests\test_account_routes.py tests\test_wallet_api.py`
- [x] `.venv\Scripts\python.exe -m pytest tests\test_account_routes.py tests\test_wallet_api.py -q`
- [x] `.venv\Scripts\python.exe -m mypy app\accounts.py app\public_routes.py`
- [x] `.venv\Scripts\python.exe scripts\docs_smoke.py`
- [x] `git diff --check origin/main...HEAD`
- [x] `git merge-tree --write-tree origin/main HEAD`

## Out Of Scope

No wallet signing payload changes, nonce/replay behavior changes, ledger mutation changes, balance accounting changes, wallet custody changes, treasury/admin-token behavior changes, payout execution changes, bridge/exchange/off-ramp/cash-out behavior, MRWK price claims, private data, or secrets.
