### PR TITLE
Link bounty payment ledger entries to activity

### DIFF
--- a/app/templates/ledger_entry.html
+++ b/app/templates/ledger_entry.html
@@ -59,5 +59,29 @@
     <dd><a href="/proofs/{{ entry.proof_hash }}">{{ entry.proof_hash }}</a></dd>
     {% endif %}
   </dl>
+  {% if entry.type == "bounty_payment" and entry.proof_hash %}
+  <div class="section-head">
+    <h2>Related activity</h2>
+    <p>Open accepted-work searches for this ledger payment, recipient, or submission.</p>
+  </div>
+  <div class="meta-grid">
+    {% if entry.to %}
+    <article>
+      <span>Recipient activity</span>
+      <strong><a href="/activity?account={{ entry.to | urlencode }}">Filter {{ entry.to }}</a></strong>
+    </article>
+    {% endif %}
+    <article>
+      <span>Proof activity</span>
+      <strong><a href="/activity?q={{ entry.proof_hash | urlencode }}">Search proof hash</a></strong>
+    </article>
+    {% if entry.reference %}
+    <article>
+      <span>Submission activity</span>
+      <strong><a href="/activity?q={{ entry.reference | urlencode }}">Search submission</a></strong>
+    </article>
+    {% endif %}
+  </div>
+  {% endif %}
 </section>
 {% endblock %}

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -1131,9 +1131,16 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
         'href="https://github.com/ramimbo/mergework/pull/99" rel="nofollow noopener"'
         in ledger_entry_page.text
     )
+    assert "Related activity" in ledger_entry_page.text
+    assert 'href="/activity?account=github%3Acontributor"' in ledger_entry_page.text
+    assert f'href="/activity?q={proof_hash}"' in ledger_entry_page.text
+    assert 'href="/activity?q=https%3A//github.com/ramimbo/mergework/pull/99"' in (
+        ledger_entry_page.text
+    )
     genesis_page = client.get("/ledger/1")
     assert genesis_page.status_code == 200
     assert 'href="/ledger">All ledger entries</a>' in genesis_page.text
+    assert "Related activity" not in genesis_page.text
     assert 'href="/ledger/0">Previous entry</a>' not in genesis_page.text
     assert 'href="/ledger/2">Next entry</a>' in genesis_page.text
     latest_sequence = client.get("/api/v1/ledger?limit=1").json()[0]["sequence"]
@@ -1255,6 +1262,7 @@ def test_ledger_entry_reference_fallbacks(sqlite_url: str) -> None:
     assert unsafe_reference_page.status_code == 200
     assert "javascript:alert(1)" in unsafe_reference_page.text
     assert 'href="javascript:alert(1)"' not in unsafe_reference_page.text
+    assert 'href="/activity?q=javascript%3Aalert%281%29"' in unsafe_reference_page.text
 
 
 def test_bounties_list_cards_have_status_pills(sqlite_url: str) -> None:


### PR DESCRIPTION
Refs #1010

## Summary

- Adds a related-activity block to bounty-payment ledger entry pages.
- Links from a ledger payment to the recipient's exact activity filter, the payment proof hash search, and the submission search.
- Keeps external reference safety unchanged: unsafe references still render inertly, and the local activity search link is URL-encoded.

## Validation

- `.venv/bin/python -m pytest tests/test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable tests/test_bounty_pages.py::test_ledger_entry_reference_fallbacks -q` -> 2 passed
- `.venv/bin/python -m pytest tests/test_bounty_pages.py tests/test_activity.py -q` -> 29 passed
- `.venv/bin/python -m pytest -q` -> 905 passed
- `.venv/bin/ruff check .` -> passed
- `.venv/bin/ruff format --check .` -> 126 files already formatted
- `.venv/bin/python -m mypy app` -> passed
- `.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok
- `git diff --check` -> clean
- `git merge-tree --write-tree upstream/main HEAD` -> clean tree `a3e3c8186270c212afb256de0a8b1c5857869bbc`

## Scope

Public ledger-entry page navigation and regression coverage only. No wallet signature, nonce, replay, ledger mutation, payout execution, treasury/admin-token behavior, bridge, exchange, off-ramp, cash-out, MRWK price, private data, or secrets changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ledger entries for bounty payments now display a "Related activity" section with links to filter activity by recipient account, proof hash, and submission reference.

* **Tests**
  * Added test coverage for the "Related activity" section rendering on ledger pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->