### PR TITLE
Link ledger entries to account activity

### DIFF
--- a/app/templates/ledger_entry.html
+++ b/app/templates/ledger_entry.html
@@ -11,6 +11,9 @@
     {% if previous_sequence %}<a href="/ledger/{{ previous_sequence }}">Previous entry</a>{% endif %}
     {% if next_sequence %}<a href="/ledger/{{ next_sequence }}">Next entry</a>{% endif %}
     <a href="/api/v1/ledger/{{ entry.sequence }}">Entry JSON</a>
+    {% if entry.to and (entry.to.startswith("github:") or entry.to.startswith("mrwk1")) %}
+    <a href="/activity?account={{ entry.to | urlencode }}">Recipient activity</a>
+    {% endif %}
   </nav>
   <div class="meta-grid">
     {% if entry.type == "bounty_reserve" %}

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -1126,16 +1126,32 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert 'href="/ledger">All ledger entries</a>' in ledger_entry_page.text
     assert f'href="/ledger/{payment_sequence - 1}">Previous entry</a>' in ledger_entry_page.text
     assert f'href="/api/v1/ledger/{payment_sequence}">Entry JSON</a>' in ledger_entry_page.text
+    assert 'href="/activity?account=github%3Acontributor">Recipient activity</a>' in (
+        ledger_entry_page.text
+    )
+    assert "Sender activity</a>" not in ledger_entry_page.text
     assert f'href="/ledger/{payment_sequence + 1}">Next entry</a>' in ledger_entry_page.text
     assert (
         'href="https://github.com/ramimbo/mergework/pull/99" rel="nofollow noopener"'
         in ledger_entry_page.text
     )
+    reserve_entry_page = client.get(f"/ledger/{payment_sequence - 1}")
+    assert reserve_entry_page.status_code == 200
+    assert "Bounty Reserve" in reserve_entry_page.text
+    assert "Recipient activity</a>" not in reserve_entry_page.text
+    assert "Sender activity</a>" not in reserve_entry_page.text
+    release_entry_page = client.get(f"/ledger/{payment_sequence + 1}")
+    assert release_entry_page.status_code == 200
+    assert "Bounty Release" in release_entry_page.text
+    assert "Recipient activity</a>" not in release_entry_page.text
+    assert "Sender activity</a>" not in release_entry_page.text
     genesis_page = client.get("/ledger/1")
     assert genesis_page.status_code == 200
     assert 'href="/ledger">All ledger entries</a>' in genesis_page.text
     assert 'href="/ledger/0">Previous entry</a>' not in genesis_page.text
     assert 'href="/ledger/2">Next entry</a>' in genesis_page.text
+    assert "Recipient activity</a>" not in genesis_page.text
+    assert "Sender activity</a>" not in genesis_page.text
     latest_sequence = client.get("/api/v1/ledger?limit=1").json()[0]["sequence"]
     latest_page = client.get(f"/ledger/{latest_sequence}")
     assert latest_page.status_code == 200


### PR DESCRIPTION
Bounty #1010

## Summary
- Adds exact account-scoped activity links for contributor-capable payment recipients on ledger entry detail pages.
- Recipient activity links render only for `github:` and `mrwk1` recipient accounts that can produce accepted-work activity rows.
- Internal ledger accounts such as `reserve:*` and `treasury:*` do not render activity actions.
- Keeps existing ledger entry JSON, proof, account, previous/next, and reference behavior unchanged.

## Why
Ledger entry pages already link to account pages and proofs, but payment entries do not provide a direct way to continue from a specific contributor payout into the accepted-work activity view for the recipient account. This gives contributors a tighter ledger -> recipient activity workflow without changing ledger/proof payloads or surfacing misleading activity links for internal reserve/treasury accounts.

## Duplicate Check
Existing #1010 submissions I saw cover proof-recipient activity links, account-filtered activity back to account pages, account JSON activity URLs, and bounty detail accepted-work activity links. This PR targets the ledger entry detail page action area itself.

## Validation
- `.venv\Scripts\python.exe -m pytest tests\test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable -q`
- `.venv\Scripts\python.exe -m pytest tests\test_bounty_pages.py tests\test_activity.py -q`
- `.venv\Scripts\ruff.exe check tests\test_bounty_pages.py`
- `.venv\Scripts\ruff.exe format --check tests\test_bounty_pages.py`
- `.venv\Scripts\python.exe scripts\docs_smoke.py`
- `git diff --check origin/main...HEAD`

## Scope
Public template navigation and focused regression coverage only. No activity filtering semantics, ledger mutation, proof payload, payout execution, wallet signing/custody, treasury/admin-token behavior, bridge/exchange/off-ramp/cash-out behavior, MRWK price behavior, private data, or secrets changed.
