### PR TITLE
Surface MCP selector conflict error data

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -516,6 +516,7 @@ _KNOWN_FIELDLESS_MESSAGES: dict[str, str] = {
     "unknown tool": "unknown tool",
     "matches multiple bounties": "matches multiple bounties",
     "repo can only be used with issue_number": ("repo can only be used with issue_number"),
+    "use bounty_id or issue_number, not both": "use bounty_id or issue_number, not both",
 }
 
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -366,7 +366,7 @@ The shape is:
   arbitrary caller-supplied string into this slot, so the value is safe
   to surface to LLM prompts or logs.
 - `field` — the offending field name, or `null` for field-less phrases such
-  as `unknown tool`, `matches multiple bounties`, or
+  as `unknown tool`, `matches multiple bounties`,
   `repo can only be used with issue_number`, or
   `use bounty_id or issue_number, not both`. Some upstream messages are
   emitted as `"<field> <field-less phrase>"` (for example

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -367,7 +367,8 @@ The shape is:
   to surface to LLM prompts or logs.
 - `field` — the offending field name, or `null` for field-less phrases such
   as `unknown tool`, `matches multiple bounties`, or
-  `repo can only be used with issue_number`. Some upstream messages are
+  `repo can only be used with issue_number`, or
+  `use bounty_id or issue_number, not both`. Some upstream messages are
   emitted as `"<field> <field-less phrase>"` (for example
   `issue_number matches multiple bounties`); the classifier treats those
   as field-less and drops the leading field token from the response.

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -3305,6 +3305,40 @@ def test_mcp_field_error_data_attaches_repo_requires_issue_number(sqlite_url: st
     )
 
 
+def test_mcp_field_error_data_attaches_submit_work_proof_selector_conflict(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "tools/call",
+            "params": {
+                "name": "submit_work_proof",
+                "arguments": {"bounty_id": 1, "issue_number": 946},
+            },
+        },
+    )
+
+    _assert_invalid_tool_arguments_envelope(
+        response.json(),
+        request_id=10,
+        expected_data={
+            "code": "invalid_argument",
+            "tool": "submit_work_proof",
+            "field": None,
+            "message": "use bounty_id or issue_number, not both",
+        },
+    )
+
+
 def test_mcp_field_error_data_omitted_for_unmatched_value_error(sqlite_url: str) -> None:
     """A ``ValueError`` whose message is not on the whitelist must fall
     back to the legacy envelope *without* an ``error.data`` key, so the


### PR DESCRIPTION
Refs #946

## Summary
- Adds the existing `submit_work_proof` selector-conflict phrase to the bounded MCP `error.data` whitelist.
- Lets agents receive structured `invalid_argument` metadata when both `bounty_id` and `issue_number` are supplied together.
- Preserves the legacy JSON-RPC `-32602` / `invalid tool arguments` envelope and does not echo caller-supplied values.
- Updates the agent guide's field-less safe phrase list.

## Why this fits #946
This is a focused MCP safe error-usability improvement for an existing public MCP tool. The runtime already rejects the conflicting selector pair with a fixed safe phrase; this patch makes that error machine-readable in the same additive `error.data` contract used by nearby selector and field failures.

## Duplicate check
I checked the open #946 queue and issue comments for `submit_work_proof`, `error.data`, selector conflicts, `use bounty_id or issue_number`, and related MCP error work. Existing open work covers unknown-tool suggestions, unexpected-argument errors, lifecycle/ping handling, schema conformance tests, and output schemas. I did not find an active submission for this specific `submit_work_proof` selector-conflict `error.data` path.

## Validation
- `.venv/bin/python -m pytest tests/test_api_mcp.py::test_mcp_field_error_data_attaches_submit_work_proof_selector_conflict tests/test_api_mcp.py::test_mcp_field_error_data_attaches_repo_requires_issue_number tests/test_api_mcp.py::test_mcp_field_error_data_omitted_for_unmatched_value_error -q` -> 3 passed, 1 existing Starlette/httpx warning.
- `.venv/bin/python -m pytest tests/test_api_mcp.py -q` -> 141 passed, 1 existing Starlette/httpx warning.
- `.venv/bin/ruff check app/mcp.py tests/test_api_mcp.py docs/agent-guide.md` -> All checks passed.
- `.venv/bin/ruff format --check app/mcp.py tests/test_api_mcp.py` -> 2 files already formatted.
- `.venv/bin/python -m mypy app/mcp.py app/mcp_tools.py` -> Success: no issues found.
- `.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check upstream/main...HEAD` and `git diff --check` -> clean.
- `git merge-tree --write-tree upstream/main HEAD` -> clean tree `7762447113c0e738c8786f302ccb0b9ba7e09cef`.

## Scope
MCP dispatcher whitelist metadata, focused MCP API test coverage, and agent-facing docs only. No MCP tool behavior changes, no ledger mutation, no wallet custody, no transfer behavior, no treasury/proposal execution, no payout execution, no admin-token behavior, no bridge/exchange/off-ramp/cash-out behavior, no MRWK price behavior, no private data, and no secrets changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for the submit_work_proof flow: callers now receive a clear invalid-argument response when both bounty_id and issue_number are provided.

* **Documentation**
  * Updated MCP tool guidance to include the new message recommending "use bounty_id or issue_number, not both."

* **Tests**
  * Added end-to-end coverage to verify the conflicting-argument error and returned error data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->