### PR TITLE
refactor: share wallet page query guard

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -436,10 +436,11 @@ def register_public_routes(
         type: str | None = Query(None),  # noqa: A002
     ) -> HTMLResponse:
         reject_path_whitespace_padding(address, "MRWK wallet address")
-        if request.query_params.getlist("tx_type"):
-            raise HTTPException(
-                status_code=400, detail="tx_type is not supported on wallet pages; use type"
-            )
+        reject_unsupported_query_params(
+            request,
+            ("tx_type",),
+            context="wallet pages; use type",
+        )
         for value in request.query_params.getlist("type"):
             if contains_control_character(value):
                 raise HTTPException(

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -430,6 +430,18 @@ def test_wallet_lookup_rejects_invalid_addresses_before_lookup(sqlite_url: str) 
     assert unknown_wallet.json()["detail"] == "wallet not found"
 
 
+def test_wallet_page_rejects_unsupported_tx_type_with_shared_guard(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    _, public_hex, address = _keypair()
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _register_wallet(client, public_hex)
+
+    response = client.get(f"/wallets/{address}?tx_type=wallet_transfer&tx_type=bounty_payment")
+
+    assert response.status_code == 400
+    assert "tx_type is not supported on wallet pages; use type" in response.text
+
+
 @pytest.mark.parametrize(
     "path",
     ["/api/v1/wallets/register", "/api/v1/wallets/link-github"],


### PR DESCRIPTION
## Summary
- Reuses the shared unsupported-query guard for wallet page `tx_type` rejection
- Adds a regression test covering repeated unsupported `tx_type` values on wallet pages

## Verification
- `uv run --extra dev pytest -q tests/test_wallet_api.py tests/test_public_routes.py` (53 passed, 1 StarletteDeprecationWarning)
- `uv run --extra dev ruff check app/public_routes.py tests/test_wallet_api.py` (passed)
- `git diff --check` (passed)
- Added-line security scan: one test-only `webhook_secret="secret"` fixture; independent review accepted it as non-production
- Independent review: passed, no security concerns or logic errors

Closes #932

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of transaction type filters on wallet pages to consistently reject unsupported values and provide clearer guidance on correct parameter usage.

* **Tests**
  * Added test coverage for wallet page validation of transaction type query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->