### PR TITLE
Run live bounty closing ref check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,10 @@ jobs:
         run: python scripts/check_deploy_ready.py
       - name: Docs smoke
         run: python scripts/docs_smoke.py
+      - name: Check live bounty closing references
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/check_live_bounty_closing_refs.py --repo ramimbo/mergework --pr ${{ github.event.pull_request.number }} --fail-on-issues
       - name: Build Docker image
         run: docker build -t mergework:ci .

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_ci_runs_live_bounty_closing_reference_check() -> None:
+    workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert "python scripts/check_live_bounty_closing_refs.py" in workflow
+    assert "if: github.event_name == 'pull_request'" in workflow
+    assert "GH_TOKEN: ${{ github.token }}" in workflow
+    assert "--repo ramimbo/mergework" in workflow
+    assert "--pr ${{ github.event.pull_request.number }}" in workflow
+    assert "--fail-on-issues" in workflow


### PR DESCRIPTION
## Summary
- refs #1104
- add the existing live bounty closing-reference checker to the standard CI readiness workflow
- pass the workflow `github.token` as `GH_TOKEN` so `gh pr list` can read pull request bodies on Actions
- add a regression test that keeps the CI workflow wired to this live check

## Verification
- `.\.venv\Scripts\python.exe -m pytest tests/test_ci_workflow.py tests/test_check_live_bounty_closing_refs.py -q` -> 5 passed
- `.\.venv\Scripts\ruff.exe format --check .` -> 127 files already formatted
- `.\.venv\Scripts\ruff.exe check .` -> All checks passed

Note: running `python scripts/check_live_bounty_closing_refs.py --repo ramimbo/mergework --fail-on-issues` locally on this Windows machine reaches the script but cannot complete because `gh` is not installed here. The workflow step runs on GitHub Actions, where `gh` is available on the hosted runner, and the step now provides `GH_TOKEN` explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs an additional pull-request-only validation that checks live bounty closing references and fails the PR if issues are found.

* **Tests**
  * Added a test to verify the CI workflow includes and correctly configures the new validation step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->