### PR TITLE
Flag superseded review bounty rounds

### DIFF
--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -191,7 +191,9 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
         if len(rounds) < 2:
             continue
         current_round = max(round_number for round_number, _bounty in rounds)
-        for round_number, bounty in sorted(rounds):
+        for round_number, bounty in sorted(
+            rounds, key=lambda item: (item[0], int(item[1]["number"]))
+        ):
             if round_number == current_round:
                 continue
             superseded_review_bounty_rounds.append(

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -16,7 +16,8 @@ from scripts.bounty_refs import BOUNTY_REF_RE
 
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
 REVIEW_ROUND_TITLE_RE = re.compile(
-    r"^\s*MRWK bounty\s*:\s*(?P<scope>.+?\breview\b.+?),\s*round\s+(?P<round>\d+)\b",
+    r"^\s*MRWK bounty\s*:\s*(?:\d+\s+MRWK\s*-\s*)?"
+    r"(?P<scope>.+?\breview\b.+?),\s*round\s+(?P<round>\d+)\b",
     re.IGNORECASE,
 )
 UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
@@ -131,9 +132,6 @@ def _review_round_key(raw: dict[str, Any]) -> tuple[str, int] | None:
     title = str(raw.get("title") or "")
     match = REVIEW_ROUND_TITLE_RE.search(title)
     if not match:
-        return None
-    labels = {label.lower() for label in _labels(raw)}
-    if labels and "review" not in labels:
         return None
     return (" ".join(match.group("scope").lower().split()), int(match.group("round")))
 

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -15,6 +15,10 @@ if __package__ in {None, ""}:
 from scripts.bounty_refs import BOUNTY_REF_RE
 
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
+REVIEW_ROUND_TITLE_RE = re.compile(
+    r"^\s*MRWK bounty\s*:\s*(?P<scope>.+?\breview\b.+?),\s*round\s+(?P<round>\d+)\b",
+    re.IGNORECASE,
+)
 UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
 GH_TIMEOUT_SECONDS = 30
 GH_PR_SAFETY_CAP = 201
@@ -123,6 +127,27 @@ def _issue(pr: dict[str, Any], reason: str, detail: str) -> dict[str, Any]:
     }
 
 
+def _review_round_key(raw: dict[str, Any]) -> tuple[str, int] | None:
+    title = str(raw.get("title") or "")
+    match = REVIEW_ROUND_TITLE_RE.search(title)
+    if not match:
+        return None
+    labels = {label.lower() for label in _labels(raw)}
+    if labels and "review" not in labels:
+        return None
+    return (" ".join(match.group("scope").lower().split()), int(match.group("round")))
+
+
+def _bounty_issue(raw: dict[str, Any], reason: str, detail: str) -> dict[str, Any]:
+    return {
+        "issue": raw["number"],
+        "title": raw.get("title") or "",
+        "url": raw.get("url"),
+        "reason": reason,
+        "detail": detail,
+    }
+
+
 def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
     bounties = {
         int(item["number"]): item
@@ -152,6 +177,33 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
     dirty_or_unstable_merge_state: list[dict[str, Any]] = []
     needs_info: list[dict[str, Any]] = []
     duplicate_groups: dict[tuple[int, str], list[int]] = defaultdict(list)
+    review_round_groups: dict[str, list[tuple[int, dict[str, Any]]]] = defaultdict(list)
+
+    for bounty in bounties.values():
+        if not _is_open_bounty(bounty):
+            continue
+        parsed = _review_round_key(bounty)
+        if parsed is None:
+            continue
+        scope, round_number = parsed
+        review_round_groups[scope].append((round_number, bounty))
+
+    superseded_review_bounty_rounds: list[dict[str, Any]] = []
+    for rounds in review_round_groups.values():
+        if len(rounds) < 2:
+            continue
+        current_round = max(round_number for round_number, _bounty in rounds)
+        for round_number, bounty in sorted(rounds):
+            if round_number == current_round:
+                continue
+            superseded_review_bounty_rounds.append(
+                _bounty_issue(
+                    bounty,
+                    "superseded_review_bounty_round",
+                    f"Review bounty round {round_number} is still open while round "
+                    f"{current_round} is the latest open round for this review scope",
+                )
+            )
 
     for pr in normalized_prs:
         if not pr["refs"]:
@@ -226,6 +278,7 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
             "dirty_or_unstable_merge_state": len(dirty_or_unstable_merge_state),
             "needs_info": len(needs_info),
             "duplicate_scope_groups": len(duplicate_scope_groups),
+            "superseded_review_bounty_rounds": len(superseded_review_bounty_rounds),
         },
         "closed_bounty_references": closed_bounty_references,
         "non_live_bounty_references": non_live_bounty_references,
@@ -233,6 +286,7 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
         "dirty_or_unstable_merge_state": dirty_or_unstable_merge_state,
         "needs_info": needs_info,
         "duplicate_scope_groups": duplicate_scope_groups,
+        "superseded_review_bounty_rounds": superseded_review_bounty_rounds,
     }
     return report
 
@@ -247,6 +301,7 @@ def has_queue_issues(report: dict[str, Any]) -> bool:
             "dirty_or_unstable_merge_state",
             "needs_info",
             "duplicate_scope_groups",
+            "superseded_review_bounty_rounds",
         )
     )
 
@@ -271,6 +326,11 @@ def format_text_report(report: dict[str, Any]) -> str:
         for item in report["duplicate_scope_groups"]:
             prs = ", ".join(f"#{number}" for number in item["pull_requests"])
             lines.append(f"- Bounty #{item['bounty']}: {item['scope']} ({prs})")
+    if report["superseded_review_bounty_rounds"]:
+        lines.append("")
+        lines.append("Superseded review bounty rounds")
+        for item in report["superseded_review_bounty_rounds"]:
+            lines.append(f"- Issue #{item['issue']}: {item['title']} ({item['detail']})")
     return "\n".join(lines)
 
 
@@ -284,6 +344,14 @@ def _markdown_pr_issue(item: dict[str, Any]) -> str:
     if isinstance(url, str) and url:
         pr_label = f"[{pr_label}]({url})"
     return f"- {pr_label}: {_single_line(item['title'])} ({_single_line(item['detail'])})"
+
+
+def _markdown_bounty_issue(item: dict[str, Any]) -> str:
+    issue_label = f"Issue #{item['issue']}"
+    url = item.get("url")
+    if isinstance(url, str) and url:
+        issue_label = f"[{issue_label}]({url})"
+    return f"- {issue_label}: {_single_line(item['title'])} ({_single_line(item['detail'])})"
 
 
 def format_markdown_report(report: dict[str, Any]) -> str:
@@ -307,6 +375,11 @@ def format_markdown_report(report: dict[str, Any]) -> str:
         for item in report["duplicate_scope_groups"]:
             prs = ", ".join(f"#{number}" for number in item["pull_requests"])
             lines.append(f"- Bounty #{item['bounty']}: {_single_line(item['scope'])} ({prs})")
+    if report["superseded_review_bounty_rounds"]:
+        lines.append("")
+        lines.append("### Superseded review bounty rounds")
+        for item in report["superseded_review_bounty_rounds"]:
+            lines.append(_markdown_bounty_issue(item))
     return "\n".join(lines)
 
 

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -443,6 +443,51 @@ def test_pr_queue_health_flags_superseded_review_bounty_rounds() -> None:
     assert "round 20 is the latest open round" in markdown
 
 
+def test_pr_queue_health_flags_live_review_rounds_with_reward_prefix_without_review_label() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [
+                {
+                    "number": 933,
+                    "title": (
+                        "MRWK bounty: 40 MRWK - review open MergeWork PRs with evidence, round 20"
+                    ),
+                    "state": "OPEN",
+                    "awards_remaining": 1,
+                    "labels": [{"name": "mrwk:bounty"}],
+                    "url": "https://github.com/ramimbo/mergework/issues/933",
+                },
+                {
+                    "number": 1009,
+                    "title": (
+                        "MRWK bounty: 40 MRWK - review open MergeWork PRs with evidence, round 21"
+                    ),
+                    "state": "OPEN",
+                    "awards_remaining": 30,
+                    "labels": [{"name": "mrwk:bounty"}],
+                    "url": "https://github.com/ramimbo/mergework/issues/1009",
+                },
+                {
+                    "number": 1010,
+                    "title": "MRWK bounty: 40 MRWK - bug reports and smoke checks, round 21",
+                    "state": "OPEN",
+                    "awards_remaining": 30,
+                    "labels": [{"name": "mrwk:bounty"}],
+                },
+            ],
+            "pull_requests": [],
+        }
+    )
+
+    assert report["summary"]["superseded_review_bounty_rounds"] == 1
+    assert report["superseded_review_bounty_rounds"][0]["issue"] == 933
+    assert (
+        report["superseded_review_bounty_rounds"][0]["detail"]
+        == "Review bounty round 20 is still open while round 21 is the latest open "
+        "round for this review scope"
+    )
+
+
 def test_pr_queue_health_markdown_no_issues_output_is_pasteable(tmp_path, capsys) -> None:
     fixture = {
         "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 5}],

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -488,6 +488,41 @@ def test_pr_queue_health_flags_live_review_rounds_with_reward_prefix_without_rev
     )
 
 
+def test_pr_queue_health_handles_duplicate_review_round_numbers_stably() -> None:
+    title = "MRWK bounty: 40 MRWK - review open MergeWork PRs with evidence, round "
+    report = analyze_queue(
+        {
+            "bounties": [
+                {
+                    "number": 1,
+                    "title": f"{title}20",
+                    "state": "OPEN",
+                    "awards_remaining": 1,
+                    "labels": [{"name": "mrwk:bounty"}],
+                },
+                {
+                    "number": 2,
+                    "title": f"{title}20",
+                    "state": "OPEN",
+                    "awards_remaining": 1,
+                    "labels": [{"name": "mrwk:bounty"}],
+                },
+                {
+                    "number": 3,
+                    "title": f"{title}21",
+                    "state": "OPEN",
+                    "awards_remaining": 1,
+                    "labels": [{"name": "mrwk:bounty"}],
+                },
+            ],
+            "pull_requests": [],
+        }
+    )
+
+    assert report["summary"]["superseded_review_bounty_rounds"] == 2
+    assert [item["issue"] for item in report["superseded_review_bounty_rounds"]] == [1, 2]
+
+
 def test_pr_queue_health_markdown_no_issues_output_is_pasteable(tmp_path, capsys) -> None:
     fixture = {
         "bounties": [{"number": 310, "state": "OPEN", "awards_remaining": 5}],

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -70,6 +70,7 @@ def test_pr_queue_health_flags_required_queue_cases(tmp_path, capsys) -> None:
         "dirty_or_unstable_merge_state": 2,
         "needs_info": 1,
         "duplicate_scope_groups": 1,
+        "superseded_review_bounty_rounds": 0,
     }
     assert report["closed_bounty_references"][0]["pull_request"] == 1
     assert report["missing_bounty_references"][0]["pull_request"] == 2
@@ -385,6 +386,61 @@ def test_pr_queue_health_markdown_report_includes_required_sections() -> None:
     assert "PR has mrwk:needs-info label" in markdown
     assert "### Likely duplicate bounty scope" in markdown
     assert "- Bounty #292: guard mcp bounty search oversized numeric query (#3, #4)" in markdown
+
+
+def test_pr_queue_health_flags_superseded_review_bounty_rounds() -> None:
+    report = analyze_queue(
+        {
+            "bounties": [
+                {
+                    "number": 643,
+                    "title": "MRWK bounty: review open MergeWork PRs with evidence, round 17",
+                    "state": "OPEN",
+                    "awards_remaining": 1,
+                    "labels": [{"name": "mrwk:bounty"}, {"name": "review"}],
+                    "url": "https://github.com/ramimbo/mergework/issues/643",
+                },
+                {
+                    "number": 654,
+                    "title": "MRWK bounty: review open MergeWork PRs with evidence, round 18",
+                    "state": "OPEN",
+                    "awards_remaining": 1,
+                    "labels": [{"name": "mrwk:bounty"}, {"name": "review"}],
+                    "url": "https://github.com/ramimbo/mergework/issues/654",
+                },
+                {
+                    "number": 933,
+                    "title": "MRWK bounty: review open MergeWork PRs with evidence, round 20",
+                    "state": "OPEN",
+                    "awards_remaining": 1,
+                    "labels": [{"name": "mrwk:bounty"}, {"name": "review"}],
+                    "url": "https://github.com/ramimbo/mergework/issues/933",
+                },
+                {
+                    "number": 944,
+                    "title": "MRWK bounty: bug reports and smoke checks, round 3",
+                    "state": "OPEN",
+                    "awards_remaining": 1,
+                    "labels": [{"name": "mrwk:bounty"}],
+                },
+            ],
+            "pull_requests": [],
+        }
+    )
+
+    assert report["summary"]["superseded_review_bounty_rounds"] == 2
+    assert [item["issue"] for item in report["superseded_review_bounty_rounds"]] == [643, 654]
+    assert (
+        report["superseded_review_bounty_rounds"][0]["detail"]
+        == "Review bounty round 17 is still open while round 20 is the latest open "
+        "round for this review scope"
+    )
+
+    markdown = format_markdown_report(report)
+
+    assert "### Superseded review bounty rounds" in markdown
+    assert "[Issue #643](https://github.com/ramimbo/mergework/issues/643)" in markdown
+    assert "round 20 is the latest open round" in markdown
 
 
 def test_pr_queue_health_markdown_no_issues_output_is_pasteable(tmp_path, capsys) -> None:


### PR DESCRIPTION
## Summary
- refs #1033
- teach `scripts/pr_queue_health.py` to detect open superseded review bounty rounds
- group review bounty issues by title scope and round number, then report older open rounds when a newer round is also open
- include text and markdown report sections plus fixture coverage for rounds 17/18/20

## Verification
- `.\.venv\Scripts\python.exe -m pytest tests/test_pr_queue_health.py -q` -> 19 passed
- `.\.venv\Scripts\python.exe -m pytest tests/test_pr_queue_health.py tests/test_docs_public_urls.py -q` -> 61 passed
- `.\.venv\Scripts\mypy.exe app` -> success
- `.\.venv\Scripts\ruff.exe check .` -> all checks passed
- `.\.venv\Scripts\ruff.exe format --check .` -> 126 files already formatted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue-health reports now detect and flag superseded review bounty rounds when multiple open rounds exist for the same review scope.
  * Summary reports include a count of these superseded rounds and list each with round comparison details and links to related issues; rendered text/markdown include a dedicated “Superseded review bounty rounds” section.

* **Tests**
  * Added tests validating detection, counts, detail messages, and rendered report sections for superseded review rounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->