### PR TITLE
Prefill wallet link form from wallet detail

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -338,10 +338,11 @@ def create_app(database_url: str | None = None, webhook_secret: str | None = Non
     )
 
     @app.get("/me", response_class=HTMLResponse)
-    def me_page(request: Request) -> HTMLResponse:
+    def me_page(request: Request, address: str | None = Query(None)) -> HTMLResponse:
+        reject_repeated_query_param(request, "address")
         login = auth.github_login_from_request(request)
         with session_scope(db_url) as session:
-            context = me_page_context(session, login)
+            context = me_page_context(session, login, address)
         return templates.TemplateResponse(
             request,
             "me.html",

--- a/app/me.py
+++ b/app/me.py
@@ -4,12 +4,17 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
+from app.accounts import normalized_wallet_address
 from app.ledger.service import format_mrwk, get_balance, linked_wallet_for_github
 
 
-def me_page_context(session: Session, login: str | None) -> dict[str, Any]:
+def me_page_context(
+    session: Session, login: str | None, link_address: str | None = None
+) -> dict[str, Any]:
     github_balance_mrwk = "0"
     linked_wallet_address = ""
+    link_wallet_address = normalized_wallet_address(link_address) if link_address else ""
+    sign_in_next_path = f"/me?address={link_wallet_address}" if link_wallet_address else "/me"
     if login:
         github_balance_mrwk = format_mrwk(get_balance(session, f"github:{login}"))
         linked_wallet = linked_wallet_for_github(session, login)
@@ -19,4 +24,6 @@ def me_page_context(session: Session, login: str | None) -> dict[str, Any]:
         "github_login": login,
         "github_balance_mrwk": github_balance_mrwk,
         "linked_wallet_address": linked_wallet_address,
+        "link_wallet_address": link_wallet_address,
+        "sign_in_url": f"/auth/github/login?next={sign_in_next_path}",
     }

--- a/app/templates/me.html
+++ b/app/templates/me.html
@@ -14,7 +14,7 @@
   <p class="lead">Sign in to link a wallet and claim any older <code>github:*</code> balance.</p>
   <h2>Link a wallet</h2>
   <div class="actions">
-    <a href="/auth/github/login?next=/me">Sign in with GitHub</a>
+    <a href="{{ sign_in_url }}">Sign in with GitHub</a>
   </div>
   {% endif %}
 </section>
@@ -23,9 +23,12 @@
 <section class="panel wallet-tool" data-github-tool data-github-login="{{ github_login }}">
   <h2>Link a wallet</h2>
   <form data-action="link-github">
-    <label>Wallet address <input name="address" placeholder="mrwk1..." required></label>
+    <label>Wallet address <input name="address" placeholder="mrwk1..." value="{{ link_wallet_address }}" required></label>
     <label>Private key <textarea name="private_key_hex" rows="5" autocomplete="off" autocapitalize="none" spellcheck="false" required></textarea></label>
     <p class="notice">Use the private key for this wallet address; a different key will be rejected. Clear this field after use. Never share your private key.</p>
+    {% if link_wallet_address %}
+    <p class="notice">Link form is prefilled from the selected wallet.</p>
+    {% endif %}
     <p class="notice" data-link-nonce-status>Transaction number is handled automatically.</p>
     <button type="submit">Sign and link</button>
   </form>

--- a/app/templates/wallet_detail.html
+++ b/app/templates/wallet_detail.html
@@ -28,7 +28,7 @@
   </dl>
   <div class="actions">
     <a href="/transfer">Send MRWK</a>
-    <a href="/me">Link GitHub</a>
+    <a href="/me?address={{ wallet.address }}">Link GitHub</a>
   </div>
   <p class="notice">To claim GitHub bounty balance, sign in and link this wallet from your contributor account.</p>
 </section>

--- a/tests/test_me_page.py
+++ b/tests/test_me_page.py
@@ -32,6 +32,8 @@ def test_me_page_context_defaults_for_anonymous_user(sqlite_url: str) -> None:
         "github_login": None,
         "github_balance_mrwk": "0",
         "linked_wallet_address": "",
+        "link_wallet_address": "",
+        "sign_in_url": "/auth/github/login?next=/me",
     }
 
 
@@ -57,4 +59,19 @@ def test_me_page_context_reports_balance_and_linked_wallet(sqlite_url: str) -> N
         "github_login": "alice",
         "github_balance_mrwk": "4",
         "linked_wallet_address": address,
+        "link_wallet_address": "",
+        "sign_in_url": "/auth/github/login?next=/me",
     }
+
+
+def test_me_page_context_prefills_selected_wallet_address(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    public_hex = _wallet_public_hex()
+    address = address_from_public_key_hex(public_hex)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+        context = me_page_context(session, None, address.upper())
+
+    assert context["link_wallet_address"] == address
+    assert context["sign_in_url"] == f"/auth/github/login?next=/me?address={address}"

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -719,6 +719,7 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "/accounts/github:" not in funded_row
     assert "No registered wallets match this search." in no_wallet_match
     assert "To claim GitHub bounty balance" in detail
+    assert f'href="/me?address={address}">Link GitHub</a>' in detail
     assert "No activity yet" in detail
     assert "No activity yet" not in funded_detail
     assert "Filter wallet transactions" in funded_detail
@@ -742,6 +743,31 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "both wallets are registered" in transfer
     assert "/static/wallet.js" in transfer
     assert "Link a wallet" in me
+
+
+def test_me_page_prefills_link_wallet_from_selected_wallet(sqlite_url: str, monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    create_schema(sqlite_url)
+    _, public_hex, address = _keypair()
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    _register_wallet(client, public_hex, "Link target")
+
+    anonymous_me = client.get(f"/me?address={address}").text
+    client.cookies.set("mrwk_user", _signed_value("alice", "test-cookie-secret"))
+    signed_in_me = client.get(f"/me?address={address.upper()}").text
+    invalid_prefill = client.get("/me?address=not-a-wallet")
+    repeated_prefill = client.get(f"/me?address={address}&address={address}")
+
+    assert f'href="/auth/github/login?next=/me?address={address}"' in anonymous_me
+    assert f'value="{address}" required' in signed_in_me
+    assert "Link form is prefilled from the selected wallet." in signed_in_me
+    assert invalid_prefill.status_code == 400
+    assert invalid_prefill.json()["detail"] == "invalid MRWK wallet address"
+    assert repeated_prefill.status_code == 400
+    assert repeated_prefill.json()["detail"] == "address must be provided at most once"
 
 
 def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- Link each wallet detail page's `Link GitHub` action to `/me?address=<wallet>`.
- Prefill the `/me` link-wallet form from that selected wallet address, including the anonymous sign-in `next` path.
- Keep the signed link action, nonce handling, wallet registration checks, and GitHub claim form behavior unchanged.

## Bounty scope
Refs #1011.

This is a focused wallet/account OAuth flow UX improvement: a contributor inspecting a registered wallet can start the GitHub-link flow without manually copying the wallet address into `/me` after signing in.

## Duplicate check
- Rechecked #1011 comments and open PRs for `me?address`, `link wallet prefill`, wallet-detail account links, and transfer prefill work.
- Existing #1011 submissions cover wallet detail -> transfer sender prefill (#1091), `/me` account/activity/linked-wallet shortcuts (#1092), public account -> linked wallet navigation (#1093), wallet detail -> GitHub account links (#1096), account -> transfer recipient prefill (#1101), and wallet search notice rendering (#1110).
- I did not find an open submission that preserves the wallet detail -> `/me` GitHub-link flow and prefills the link-wallet address.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests\test_me_page.py tests\test_wallet_api.py -q` -> 49 passed, 1 existing Starlette/httpx warning.
- `.\.venv\Scripts\ruff.exe check app\me.py app\main.py tests\test_me_page.py tests\test_wallet_api.py` -> All checks passed.
- `.\.venv\Scripts\ruff.exe format --check app\me.py app\main.py tests\test_me_page.py tests\test_wallet_api.py` -> 4 files already formatted.
- `.\.venv\Scripts\python.exe -m mypy app\me.py app\main.py` -> Success.
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check origin/main...HEAD` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `7762447113c0e738c8786f302ccb0b9ba7e09cef`.

## Scope
Touched surfaces: `app/templates/wallet_detail.html`, `app/templates/me.html`, `/me` route/context, and focused page/context tests.

No wallet custody, private key handling, signature payload, nonce/replay, transfer execution, GitHub claim execution, ledger mutation, treasury/admin-token behavior, payout execution, bridge/exchange/off-ramp, MRWK price, cash-out behavior, private data, or secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Wallet linking form now supports pre-filled wallet addresses when initiated from wallet detail pages.
  * Users can seamlessly link GitHub accounts with a specific wallet already selected.
  * Dynamic wallet address context is now included in the authentication flow.

* **Tests**
  * Added comprehensive test coverage for wallet address pre-filling and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->