### PR TITLE
Improve transfer query prefill feedback

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -344,6 +344,28 @@ def ledger_entry_page_context(
     }
 
 
+def _transfer_prefill_context(
+    from_address: str | None,
+    to_address: str | None,
+) -> dict[str, Any]:
+    values = {"from_address": "", "to_address": ""}
+    notices: list[str] = []
+    fields = (
+        ("from_address", from_address, "from address", "sender address"),
+        ("to_address", to_address, "to address", "recipient address"),
+    )
+    for field, raw_value, invalid_label, valid_label in fields:
+        if raw_value is None:
+            continue
+        try:
+            values[field] = normalized_wallet_address(raw_value)
+        except HTTPException:
+            notices.append(f"Ignored invalid {invalid_label} from the URL.")
+        else:
+            notices.append(f"The {valid_label} was prefilled from the URL.")
+    return {"transfer_prefill": values, "transfer_prefill_notices": notices}
+
+
 def register_public_routes(
     app: FastAPI,
     *,
@@ -451,8 +473,13 @@ def register_public_routes(
         return templates.TemplateResponse(request, "wallet_detail.html", context)
 
     @app.get("/transfer", response_class=HTMLResponse)
-    def transfer_page(request: Request) -> HTMLResponse:
-        return templates.TemplateResponse(request, "transfer.html")
+    def transfer_page(
+        request: Request,
+        from_address: str | None = Query(None),
+        to_address: str | None = Query(None),
+    ) -> HTMLResponse:
+        context = _transfer_prefill_context(from_address, to_address)
+        return templates.TemplateResponse(request, "transfer.html", context)
 
     @app.get("/proofs/{proof_hash}", response_class=HTMLResponse)
     def proof_page(request: Request, proof_hash: str) -> HTMLResponse:

--- a/app/templates/transfer.html
+++ b/app/templates/transfer.html
@@ -8,9 +8,12 @@
 </section>
 
 <section class="panel wallet-tool" data-transfer-tool>
+  {% for notice in transfer_prefill_notices %}
+    <p class="notice">{{ notice }}</p>
+  {% endfor %}
   <form data-action="submit-transfer">
-    <label>From address <input name="from_address" placeholder="mrwk1..." required></label>
-    <label>To address <input name="to_address" placeholder="mrwk1..." required></label>
+    <label>From address <input name="from_address" placeholder="mrwk1..." value="{{ transfer_prefill.from_address }}" required></label>
+    <label>To address <input name="to_address" placeholder="mrwk1..." value="{{ transfer_prefill.to_address }}" required></label>
     <label>Amount MRWK <input name="amount_mrwk" inputmode="decimal" placeholder="1.5" required></label>
     <label>Memo <input name="memo" maxlength="240" placeholder="optional"></label>
     <label>Private key <textarea name="private_key_hex" rows="5" autocomplete="off" autocapitalize="none" spellcheck="false" required></textarea></label>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -744,6 +744,27 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Link a wallet" in me
 
 
+def test_transfer_page_reports_invalid_prefill_query_addresses(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    _, public_hex, valid_address = _keypair()
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _register_wallet(client, public_hex, "Prefill smoke wallet")
+
+    response = client.get(
+        "/transfer",
+        params={"from_address": "not-a-wallet", "to_address": valid_address},
+    )
+
+    assert response.status_code == 200
+    assert 'name="from_address" placeholder="mrwk1..." value="" required>' in response.text
+    assert (
+        f'name="to_address" placeholder="mrwk1..." value="{valid_address}" required>'
+        in response.text
+    )
+    assert "Ignored invalid from address from the URL." in response.text
+    assert "The recipient address was prefilled from the URL." in response.text
+
+
 def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     _, public_hex, address = _keypair()


### PR DESCRIPTION
Bounty #1011
Refs #1011

Summary:
- Adds validated from_address/to_address query prefill support to /transfer.
- Shows notices when URL values are accepted or ignored.
- Keeps invalid wallet values out of the form instead of silently carrying them forward.

Duplicate check:
- Checked open/all PRs for transfer invalid prefill, invalid prefill query, query feedback, and prefilled from the URL.
- Existing #1091 and #1101 cover wallet-detail or public-account navigation into transfer. This PR covers direct URL query validation and visible feedback on /transfer.

Validation:
- .venv/bin/python -m pytest tests/test_wallet_api.py -q: 46 passed, 1 warning
- .venv/bin/python -m pytest tests/test_wallet_api.py tests/test_account_routes.py tests/test_public_routes.py -q: 62 passed, 1 warning
- .venv/bin/python -m pytest -q: 906 passed, 1 warning
- .venv/bin/ruff check .: passed
- .venv/bin/ruff format --check .: 126 files already formatted
- .venv/bin/python -m mypy app: passed
- .venv/bin/python scripts/docs_smoke.py: docs smoke ok

Scope notes:
- No changes to signature, nonce, replay, ledger, custody, treasury, bridge, exchange, off-ramp, MRWK price, private data, credentials, or payout behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transfer page now accepts optional query parameters to pre-fill sender and recipient wallet addresses
  * Displays informational notices indicating which fields were pre-filled and any validation issues encountered

* **Tests**
  * Added test coverage for address pre-fill functionality with invalid inputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->