### PR TITLE
fix(mcp): surface internal id selector conflicts

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -516,6 +516,9 @@ _KNOWN_FIELDLESS_MESSAGES: dict[str, str] = {
     "unknown tool": "unknown tool",
     "matches multiple bounties": "matches multiple bounties",
     "repo can only be used with issue_number": ("repo can only be used with issue_number"),
+    "use id or bounty_id, not multiple internal id fields": (
+        "use id or bounty_id, not multiple internal id fields"
+    ),
 }
 
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -370,7 +370,10 @@ The shape is:
   `repo can only be used with issue_number`. Some upstream messages are
   emitted as `"<field> <field-less phrase>"` (for example
   `issue_number matches multiple bounties`); the classifier treats those
-  as field-less and drops the leading field token from the response.
+  as field-less and drops the leading field token from the response. Internal
+  selector conflicts such as `use id or bounty_id, not multiple internal id
+  fields` are also surfaced as field-less phrases so agents can retry with one
+  selector.
 - `message` — a static, whitelisted safe phrase. Caller input is never
   echoed, so the payload is safe to surface to LLM prompts or logs.
 

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -3305,10 +3305,12 @@ def test_mcp_field_error_data_attaches_repo_requires_issue_number(sqlite_url: st
     )
 
 
-def test_mcp_field_error_data_omitted_for_unmatched_value_error(sqlite_url: str) -> None:
-    """A ``ValueError`` whose message is not on the whitelist must fall
-    back to the legacy envelope *without* an ``error.data`` key, so the
-    additive contract is opt-in and bounded.
+def test_mcp_field_error_data_attaches_internal_id_alias_conflict(
+    sqlite_url: str,
+) -> None:
+    """Mixing the two internal bounty id aliases is a static selector
+    error, so agents should get safe ``error.data`` instead of parsing the
+    legacy generic envelope.
     """
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -3325,11 +3327,6 @@ def test_mcp_field_error_data_omitted_for_unmatched_value_error(sqlite_url: str)
 
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
 
-    # Supplying both ``id`` and ``bounty_id`` (the two internal id aliases for
-    # ``get_bounty``) raises ``ValueError("use id or bounty_id, not multiple
-    # internal id fields")``. The first word ("use") is not in the tool-field
-    # whitelist, so the classifier must return ``None`` and the response must
-    # keep the legacy envelope with no ``error.data``.
     response = client.post(
         "/mcp",
         json={
@@ -3343,7 +3340,18 @@ def test_mcp_field_error_data_omitted_for_unmatched_value_error(sqlite_url: str)
         },
     )
 
-    _assert_invalid_tool_arguments_envelope(response.json(), request_id=7, expected_data=None)
+    body = response.text
+    assert str(bounty.id) not in body
+    _assert_invalid_tool_arguments_envelope(
+        response.json(),
+        request_id=7,
+        expected_data={
+            "code": "invalid_argument",
+            "tool": "get_bounty",
+            "field": None,
+            "message": "use id or bounty_id, not multiple internal id fields",
+        },
+    )
 
 
 def test_mcp_field_error_data_does_not_echo_caller_input(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #946

Summary:
- Adds the static internal-id alias conflict phrase to the MCP safe field-less error whitelist.
- Keeps the legacy JSON-RPC -32602 / invalid tool arguments envelope while adding bounded error.data for the get_bounty id+bounty_id conflict.
- Updates the agent guide so clients know this selector conflict is machine-readable and safe to surface.

Validation:
- .\\.venv\\Scripts\\python.exe -m pytest tests\\test_api_mcp.py::test_mcp_field_error_data_attaches_internal_id_alias_conflict -q -> 1 passed, 1 existing Starlette/httpx warning
- .\\.venv\\Scripts\\ruff.exe check app\\mcp.py tests\\test_api_mcp.py docs\\agent-guide.md -> All checks passed
- .\\.venv\\Scripts\\ruff.exe format --check app\\mcp.py tests\\test_api_mcp.py -> 2 files already formatted
- git diff --check -> clean, normal Windows CRLF warning for docs only

Scope: MCP error-usability metadata, focused MCP API test coverage, and agent-facing docs only. No MCP tool behavior changes, ledger mutation, wallet custody, transfer behavior, treasury/proposal execution, payout execution, admin-token behavior, bridge/exchange/off-ramp/cash-out behavior, MRWK price behavior, private data, or secrets changed.

Payout boundary: this is a submitted #946 bounty claim only. It is not confirmed or withdrawable unless maintainers accept it and record proof-backed payment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid tool arguments, providing safer error response payloads that properly handle validation failures without exposing caller input.

* **Documentation**
  * Updated agent guide to clarify how internal field-conflict validation errors are surfaced, enabling agents to understand and retry appropriately.

* **Tests**
  * Extended test coverage for scenarios involving conflicting internal id parameter usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->