### PR TITLE
Expose account profile URLs in activity feed

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import quote, urlencode
+from urllib.parse import urlencode
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
@@ -12,7 +12,7 @@ from app.accounts import normalized_account
 from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.query_validation import reject_control_char_query_param, reject_repeated_query_param
-from app.serializers import activity_to_dict
+from app.serializers import account_detail_url, activity_to_dict
 
 
 def activity_context(
@@ -24,12 +24,8 @@ def activity_context(
     context = activity_to_dict(session, query, account=normalized)
     context["api_activity_url"] = _activity_api_url(context["query"], context.get("account"))
     context["clear_activity_url"] = _activity_page_url(context.get("account"))
-    context["account_page_url"] = _account_page_url(context.get("account"))
+    context["account_page_url"] = account_detail_url(context.get("account"))
     return context
-
-
-def _account_page_url(account: str | None) -> str | None:
-    return f"/accounts/{quote(account, safe=':')}" if account else None
 
 
 def _activity_api_url(query: str, account: str | None) -> str:

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
+from urllib.parse import quote
 
 from sqlalchemy import or_, select
 from sqlalchemy.orm import Session
@@ -448,6 +449,10 @@ def _bounty_detail_url(bounty_id: int | None) -> str | None:
     return f"/bounties/{bounty_id}" if bounty_id is not None else None
 
 
+def _account_detail_url(account: str | None) -> str | None:
+    return f"/accounts/{quote(account, safe=':')}" if account else None
+
+
 def _public_page_url(path: str | None, public_base_url: str | None = None) -> str | None:
     if path is None:
         return None
@@ -478,6 +483,7 @@ def _activity_row(entry: LedgerEntry, proof: Proof) -> dict[str, Any] | None:
     return {
         "ledger_sequence": entry.sequence,
         "account": entry.to_account,
+        "account_url": _account_detail_url(entry.to_account),
         "amount_mrwk": format_mrwk(entry.amount_microunits),
         "amount_microunits": entry.amount_microunits,
         "submission_url": submission_url,
@@ -536,6 +542,7 @@ def _pending_activity_row(
         "proposal_url": f"/api/v1/treasury/proposals/{proposal.id}",
         "status": proposal.status,
         "account": payload.get("to_account"),
+        "account_url": _account_detail_url(payload.get("to_account")),
         "amount_mrwk": format_mrwk(amount_microunits) if bounty else None,
         "amount_microunits": amount_microunits,
         "submission_url": payload.get("submission_url"),
@@ -655,6 +662,7 @@ def activity_to_dict(
             contributor_account,
             {
                 "account": contributor_account,
+                "account_url": _account_detail_url(contributor_account),
                 "accepted_awards": 0,
                 "accepted_microunits": 0,
                 "accepted_mrwk": "0",

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -449,7 +449,7 @@ def _bounty_detail_url(bounty_id: int | None) -> str | None:
     return f"/bounties/{bounty_id}" if bounty_id is not None else None
 
 
-def _account_detail_url(account: str | None) -> str | None:
+def account_detail_url(account: str | None) -> str | None:
     return f"/accounts/{quote(account, safe=':')}" if account else None
 
 
@@ -483,7 +483,7 @@ def _activity_row(entry: LedgerEntry, proof: Proof) -> dict[str, Any] | None:
     return {
         "ledger_sequence": entry.sequence,
         "account": entry.to_account,
-        "account_url": _account_detail_url(entry.to_account),
+        "account_url": account_detail_url(entry.to_account),
         "amount_mrwk": format_mrwk(entry.amount_microunits),
         "amount_microunits": entry.amount_microunits,
         "submission_url": submission_url,
@@ -542,7 +542,7 @@ def _pending_activity_row(
         "proposal_url": f"/api/v1/treasury/proposals/{proposal.id}",
         "status": proposal.status,
         "account": payload.get("to_account"),
-        "account_url": _account_detail_url(payload.get("to_account")),
+        "account_url": account_detail_url(payload.get("to_account")),
         "amount_mrwk": format_mrwk(amount_microunits) if bounty else None,
         "amount_microunits": amount_microunits,
         "submission_url": payload.get("submission_url"),
@@ -662,7 +662,7 @@ def activity_to_dict(
             contributor_account,
             {
                 "account": contributor_account,
-                "account_url": _account_detail_url(contributor_account),
+                "account_url": account_detail_url(contributor_account),
                 "accepted_awards": 0,
                 "accepted_microunits": 0,
                 "accepted_mrwk": "0",

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -41,7 +41,7 @@
       <div class="ledger-entry-card">
         <div class="ledger-card-head">
           <div class="ledger-card-title">
-            <a class="ledger-entry-link" href="/accounts/{{ contributor.account }}">{{ contributor.account }}</a>
+            <a class="ledger-entry-link" href="{{ contributor.account_url }}">{{ contributor.account }}</a>
             <span class="ledger-scan-note">{{ contributor.accepted_awards }} accepted</span>
           </div>
           <strong class="ledger-amount">{{ contributor.accepted_mrwk }} MRWK</strong>
@@ -93,7 +93,7 @@
         <dl class="ledger-card-grid">
           <div class="ledger-field ledger-field--to">
             <dt>Contributor</dt>
-            <dd><a href="/accounts/{{ row.account }}">{{ row.account }}</a></dd>
+            <dd><a href="{{ row.account_url }}">{{ row.account }}</a></dd>
           </div>
           <div class="ledger-field ledger-field--reference reference-cell">
             <dt>Bounty</dt>
@@ -148,7 +148,7 @@
         <dl class="ledger-card-grid">
           <div class="ledger-field ledger-field--to">
             <dt>Contributor</dt>
-            <dd><a href="/accounts/{{ row.account }}">{{ row.account }}</a></dd>
+            <dd><a href="{{ row.account_url }}">{{ row.account }}</a></dd>
           </div>
           <div class="ledger-field ledger-field--reference reference-cell">
             <dt>Bounty</dt>

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -279,9 +279,7 @@ def test_activity_api_filters_by_exact_account(sqlite_url: str) -> None:
     assert [row["proof_hash"] for row in scoped["recent"]] == [alice_proof.hash]
     assert [row["account_url"] for row in scoped["recent"]] == ["/accounts/github:alice"]
     assert [row["proposal_id"] for row in scoped["pending_payouts"]] == [proposal_id]
-    assert [row["account_url"] for row in scoped["pending_payouts"]] == [
-        "/accounts/github:alice"
-    ]
+    assert [row["account_url"] for row in scoped["pending_payouts"]] == ["/accounts/github:alice"]
 
     assert scoped_with_query["account"] == "github:alice"
     assert scoped_with_query["query"] == "pull/166"

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -92,6 +92,7 @@ def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -
     assert payload["pending_payouts"] == []
     assert payload["contributors"][0] == {
         "account": "github:alice",
+        "account_url": "/accounts/github:alice",
         "accepted_awards": 2,
         "accepted_mrwk": "50",
         "latest_submission_url": "https://github.com/ramimbo/mergework/issues/10#issuecomment-1",
@@ -102,6 +103,7 @@ def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -
         "latest_proof_url": f"/proofs/{second_proof.hash}",
     }
     assert payload["contributors"][1]["account"] == "mrwk1abc"
+    assert payload["contributors"][1]["account_url"] == "/accounts/mrwk1abc"
     assert payload["contributors"][1]["accepted_mrwk"] == "40"
     assert payload["contributors"][1]["latest_proof_hash"] == wallet_proof.hash
     assert [row["proof_hash"] for row in payload["recent"]] == [
@@ -116,6 +118,7 @@ def test_activity_api_summarizes_proof_backed_bounty_payments(sqlite_url: str) -
     assert payload["recent"][0]["bounty_issue_number"] == 11
     assert payload["recent"][0]["bounty_id"] == second_bounty.id
     assert payload["recent"][0]["bounty_url"] == f"/bounties/{second_bounty.id}"
+    assert payload["recent"][0]["account_url"] == "/accounts/mrwk1abc"
     assert payload["recent"][0]["created_at"].endswith("Z")
     assert all("unproved" not in row["submission_url"] for row in payload["recent"])
 
@@ -272,8 +275,13 @@ def test_activity_api_filters_by_exact_account(sqlite_url: str) -> None:
         "pending_mrwk": "75",
     }
     assert [row["account"] for row in scoped["contributors"]] == ["github:alice"]
+    assert [row["account_url"] for row in scoped["contributors"]] == ["/accounts/github:alice"]
     assert [row["proof_hash"] for row in scoped["recent"]] == [alice_proof.hash]
+    assert [row["account_url"] for row in scoped["recent"]] == ["/accounts/github:alice"]
     assert [row["proposal_id"] for row in scoped["pending_payouts"]] == [proposal_id]
+    assert [row["account_url"] for row in scoped["pending_payouts"]] == [
+        "/accounts/github:alice"
+    ]
 
     assert scoped_with_query["account"] == "github:alice"
     assert scoped_with_query["query"] == "pull/166"
@@ -421,6 +429,7 @@ def test_activity_api_exposes_pending_payouts_separately_from_paid_work(
             "proposal_url": f"/api/v1/treasury/proposals/{proposal_id}",
             "status": "pending",
             "account": "github:alice",
+            "account_url": "/accounts/github:alice",
             "amount_mrwk": "75",
             "submission_url": "https://github.com/ramimbo/mergework/pull/167",
             "bounty_repo": "ramimbo/mergework",


### PR DESCRIPTION
## Summary
- add account_url fields to activity API contributors, recent payments, and pending payouts
- use those serializer-provided URLs on the activity page instead of reconstructing account paths in the template
- cover contributor, recent activity, and pending payout links in activity tests

Refs #1010.

## Tests
- .\.venv\Scripts\python.exe -m py_compile app\serializers.py tests\test_activity.py
- .\.venv\Scripts\python.exe -m pytest tests/test_activity.py::test_activity_api_summarizes_proof_backed_bounty_payments tests/test_activity.py::test_activity_api_filters_by_exact_account tests/test_activity.py::test_activity_api_exposes_pending_payouts_separately_from_paid_work tests/test_activity.py::test_activity_page_renders_empty_and_paid_states tests/test_activity.py::test_activity_page_renders_pending_accepted_work -q
- .\.venv\Scripts\python.exe -m ruff check app\serializers.py tests\test_activity.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account profile URLs are now included in activity API responses for contributors, pending payouts, and recent work entries. Activity pages use these URLs to link to contributor profiles across the contributors ledger, pending work section, and recent activity section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- GitHub Actions CI passed on c28b2fb after formatting follow-up: https://github.com/ramimbo/mergework/actions/runs/27465785974

- CodeRabbit account URL helper nit addressed in 358e361; GitHub Actions CI passed on the updated head: https://github.com/ramimbo/mergework/actions/runs/27465983213
