### PR TITLE
Add ledger snapshot Merkle proofs

### DIFF
--- a/app/ledger/snapshot_merkle.py
+++ b/app/ledger/snapshot_merkle.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any, cast
+
+from app.ledger.service import canonical_json
+
+LEDGER_SNAPSHOT_MERKLE_ROOT_SCHEMA = "mergework.ledger_snapshot_merkle_root.v1"
+LEDGER_SNAPSHOT_MERKLE_ROOT_SCHEMA_VERSION = 1
+LEDGER_SNAPSHOT_ACCOUNT_LEAF_SCHEMA = "mergework.ledger_snapshot_account_leaf.v1"
+LEDGER_SNAPSHOT_ACCOUNT_LEAF_SCHEMA_VERSION = 1
+LEDGER_SNAPSHOT_ACCOUNT_PROOF_SCHEMA = "mergework.ledger_snapshot_account_proof.v1"
+LEDGER_SNAPSHOT_ACCOUNT_PROOF_SCHEMA_VERSION = 1
+MERKLE_HASH_ALGORITHM = "sha256"
+
+_EMPTY_TREE_DOMAIN = "mergework.ledger_snapshot_merkle_empty.v1"
+_LEAF_HASH_DOMAIN = "mergework.ledger_snapshot_merkle_leaf_hash.v1"
+_NODE_HASH_DOMAIN = "mergework.ledger_snapshot_merkle_node.v1"
+_ROOT_HASH_DOMAIN = "mergework.ledger_snapshot_merkle_root_hash.v1"
+_HASH_HEX_LENGTH = 64
+
+
+def ledger_snapshot_merkle_root(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Return the versioned Merkle root object for a Phase 2A ledger snapshot."""
+    accounts = _snapshot_accounts(snapshot)
+    leaf_hashes = [
+        _account_leaf_hash(_account_leaf(row, index)) for index, row in enumerate(accounts)
+    ]
+    tree_hash = _merkle_tree_hash(leaf_hashes)
+    ledger_anchor = _snapshot_ledger_anchor(snapshot)
+    root = {
+        "schema": LEDGER_SNAPSHOT_MERKLE_ROOT_SCHEMA,
+        "schema_version": LEDGER_SNAPSHOT_MERKLE_ROOT_SCHEMA_VERSION,
+        "snapshot_schema": snapshot.get("schema"),
+        "hash_algorithm": MERKLE_HASH_ALGORITHM,
+        "leaf_schema": LEDGER_SNAPSHOT_ACCOUNT_LEAF_SCHEMA,
+        "leaf_count": len(accounts),
+        "ledger_anchor": ledger_anchor,
+        "tree_hash": tree_hash,
+    }
+    root["root_hash"] = _root_hash(root)
+    return root
+
+
+def ledger_snapshot_account_proof(snapshot: dict[str, Any], account: str) -> dict[str, Any] | None:
+    """Return a proof for one account row, or None when the account is absent."""
+    accounts = _snapshot_accounts(snapshot)
+    index_by_account = {str(row["account"]): index for index, row in enumerate(accounts)}
+    if account not in index_by_account:
+        return None
+    leaf_index = index_by_account[account]
+    leaves = [_account_leaf(row, index) for index, row in enumerate(accounts)]
+    leaf_hashes = [_account_leaf_hash(leaf) for leaf in leaves]
+    return {
+        "schema": LEDGER_SNAPSHOT_ACCOUNT_PROOF_SCHEMA,
+        "schema_version": LEDGER_SNAPSHOT_ACCOUNT_PROOF_SCHEMA_VERSION,
+        "root": ledger_snapshot_merkle_root(snapshot),
+        "tree_size": len(leaves),
+        "leaf_index": leaf_index,
+        "leaf": leaves[leaf_index],
+        "siblings": _proof_siblings(leaf_hashes, leaf_index),
+    }
+
+
+def verify_ledger_snapshot_account_proof(proof: dict[str, Any]) -> bool:
+    """Verify a generated account proof against its embedded root object."""
+    try:
+        if proof.get("schema") != LEDGER_SNAPSHOT_ACCOUNT_PROOF_SCHEMA:
+            return False
+        if proof.get("schema_version") != LEDGER_SNAPSHOT_ACCOUNT_PROOF_SCHEMA_VERSION:
+            return False
+        root = cast(dict[str, Any], proof["root"])
+        leaf = cast(dict[str, Any], proof["leaf"])
+        leaf_index = proof["leaf_index"]
+        tree_size = proof["tree_size"]
+        siblings = cast(list[dict[str, Any]], proof["siblings"])
+    except (KeyError, TypeError):
+        return False
+
+    if not _valid_root_shape(root):
+        return False
+    if not _valid_leaf_shape(leaf):
+        return False
+    if not isinstance(leaf_index, int) or not isinstance(tree_size, int):
+        return False
+    if tree_size <= 0 or leaf_index < 0 or leaf_index >= tree_size:
+        return False
+    if leaf.get("leaf_index") != leaf_index:
+        return False
+    if root.get("leaf_count") != tree_size:
+        return False
+    if not isinstance(siblings, list):
+        return False
+
+    current_hash = _account_leaf_hash(leaf)
+    for sibling in siblings:
+        if not isinstance(sibling, dict):
+            return False
+        direction = sibling.get("direction")
+        sibling_hash = sibling.get("hash")
+        if direction not in {"left", "right"} or not _is_hash_hex(sibling_hash):
+            return False
+        if direction == "left":
+            current_hash = _node_hash(str(sibling_hash), current_hash)
+        else:
+            current_hash = _node_hash(current_hash, str(sibling_hash))
+
+    if current_hash != root.get("tree_hash"):
+        return False
+    return _root_hash(root) == root.get("root_hash")
+
+
+def ledger_snapshot_merkle_root_json(root: dict[str, Any]) -> str:
+    return canonical_json(root) + "\n"
+
+
+def ledger_snapshot_account_proof_json(proof: dict[str, Any]) -> str:
+    return canonical_json(proof) + "\n"
+
+
+def _snapshot_accounts(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    accounts = snapshot.get("accounts", [])
+    if not isinstance(accounts, list):
+        raise ValueError("snapshot accounts must be a list")
+    normalized: list[dict[str, Any]] = []
+    for index, row in enumerate(accounts):
+        if not isinstance(row, dict):
+            raise ValueError("snapshot account rows must be objects")
+        account = row.get("account")
+        balance = row.get("balance_microunits")
+        if not isinstance(account, str) or not isinstance(balance, int):
+            raise ValueError("snapshot account rows require account and integer balance")
+        normalized.append({"account": account, "balance_microunits": balance})
+        if index > 0 and normalized[index - 1]["account"] > account:
+            raise ValueError("snapshot account rows must be sorted by account")
+    return normalized
+
+
+def _snapshot_ledger_anchor(snapshot: dict[str, Any]) -> dict[str, Any]:
+    anchor = snapshot.get("ledger_anchor")
+    if not isinstance(anchor, dict):
+        raise ValueError("snapshot ledger_anchor must be an object")
+    latest_sequence = anchor.get("latest_sequence")
+    latest_entry_hash = anchor.get("latest_entry_hash")
+    if not isinstance(latest_sequence, int):
+        raise ValueError("snapshot ledger_anchor.latest_sequence must be an integer")
+    if latest_entry_hash is not None and not _is_hash_hex(latest_entry_hash):
+        raise ValueError("snapshot ledger_anchor.latest_entry_hash must be a hash or null")
+    return {
+        "latest_sequence": latest_sequence,
+        "latest_entry_hash": latest_entry_hash,
+    }
+
+
+def _account_leaf(row: dict[str, Any], index: int) -> dict[str, Any]:
+    return {
+        "schema": LEDGER_SNAPSHOT_ACCOUNT_LEAF_SCHEMA,
+        "schema_version": LEDGER_SNAPSHOT_ACCOUNT_LEAF_SCHEMA_VERSION,
+        "leaf_index": index,
+        "account": row["account"],
+        "balance_microunits": row["balance_microunits"],
+    }
+
+
+def _account_leaf_hash(leaf: dict[str, Any]) -> str:
+    return _hash_object(_LEAF_HASH_DOMAIN, {"leaf": leaf})
+
+
+def _node_hash(left_hash: str, right_hash: str) -> str:
+    return _hash_object(_NODE_HASH_DOMAIN, {"left": left_hash, "right": right_hash})
+
+
+def _merkle_tree_hash(leaf_hashes: list[str]) -> str:
+    if not leaf_hashes:
+        return _hash_object(_EMPTY_TREE_DOMAIN, {"leaf_count": 0})
+    level = leaf_hashes
+    while len(level) > 1:
+        next_level: list[str] = []
+        for index in range(0, len(level), 2):
+            left_hash = level[index]
+            if index + 1 >= len(level):
+                next_level.append(left_hash)
+            else:
+                next_level.append(_node_hash(left_hash, level[index + 1]))
+        level = next_level
+    return level[0]
+
+
+def _proof_siblings(leaf_hashes: list[str], leaf_index: int) -> list[dict[str, str]]:
+    siblings: list[dict[str, str]] = []
+    index = leaf_index
+    level = leaf_hashes
+    while len(level) > 1:
+        if index % 2 == 0:
+            sibling_index = index + 1
+            if sibling_index < len(level):
+                siblings.append({"direction": "right", "hash": level[sibling_index]})
+        else:
+            sibling_index = index - 1
+            siblings.append({"direction": "left", "hash": level[sibling_index]})
+        index //= 2
+        level = [
+            level[pair_index]
+            if pair_index + 1 >= len(level)
+            else _node_hash(level[pair_index], level[pair_index + 1])
+            for pair_index in range(0, len(level), 2)
+        ]
+    return siblings
+
+
+def _root_hash(root: dict[str, Any]) -> str:
+    return _hash_object(
+        _ROOT_HASH_DOMAIN,
+        {
+            "snapshot_schema": root.get("snapshot_schema"),
+            "hash_algorithm": root.get("hash_algorithm"),
+            "leaf_schema": root.get("leaf_schema"),
+            "leaf_count": root.get("leaf_count"),
+            "ledger_anchor": root.get("ledger_anchor"),
+            "tree_hash": root.get("tree_hash"),
+        },
+    )
+
+
+def _valid_root_shape(root: dict[str, Any]) -> bool:
+    return (
+        root.get("schema") == LEDGER_SNAPSHOT_MERKLE_ROOT_SCHEMA
+        and root.get("schema_version") == LEDGER_SNAPSHOT_MERKLE_ROOT_SCHEMA_VERSION
+        and root.get("hash_algorithm") == MERKLE_HASH_ALGORITHM
+        and root.get("leaf_schema") == LEDGER_SNAPSHOT_ACCOUNT_LEAF_SCHEMA
+        and isinstance(root.get("leaf_count"), int)
+        and isinstance(root.get("ledger_anchor"), dict)
+        and _is_hash_hex(root.get("tree_hash"))
+        and _is_hash_hex(root.get("root_hash"))
+    )
+
+
+def _valid_leaf_shape(leaf: dict[str, Any]) -> bool:
+    return (
+        leaf.get("schema") == LEDGER_SNAPSHOT_ACCOUNT_LEAF_SCHEMA
+        and leaf.get("schema_version") == LEDGER_SNAPSHOT_ACCOUNT_LEAF_SCHEMA_VERSION
+        and isinstance(leaf.get("leaf_index"), int)
+        and isinstance(leaf.get("account"), str)
+        and isinstance(leaf.get("balance_microunits"), int)
+    )
+
+
+def _is_hash_hex(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == _HASH_HEX_LENGTH
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _hash_object(domain: str, payload: dict[str, Any]) -> str:
+    envelope = {"domain": domain, "payload": payload}
+    return hashlib.sha256(canonical_json(envelope).encode()).hexdigest()

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -89,14 +89,34 @@ integer microunits, deterministically sorted account balances in integer
 microunits, credited/debited/net supply totals, hash-chain verification, and
 fixed-supply conservation verification.
 
+Phase 2B adds local, read-only Merkle proof tooling for those snapshot account
+balances:
+
+```bash
+python scripts/export_ledger_snapshot_merkle.py > ledger-snapshot-root.json
+python scripts/export_ledger_snapshot_merkle.py --account github:alice > ledger-snapshot-proof.json
+```
+
+The Merkle root object is deterministic for the same committed ledger state and
+is bound to the snapshot ledger anchor: latest ledger sequence and latest entry
+hash. It does not include nondeterministic export metadata such as
+`generated_at`, `source.mode`, or `source.host`.
+
+Each account leaf uses a versioned canonical JSON shape with `leaf_index`,
+`account`, and integer `balance_microunits`. Internal node and root hash inputs
+are domain-separated canonical JSON objects, avoiding ambiguous raw string
+concatenation. Account proofs include the leaf, tree size, sibling path, and root
+object, and local verification rejects tampered accounts, balances, indexes,
+sibling hashes or directions, tree size, root hash, or ledger anchor.
+
 Snapshot `proposal_validation` is intentionally `partial`: the exporter verifies
 committed ledger entries, the hash chain, and fixed-supply conservation, but it
 does not replay every historical treasury proposal, challenge, or governance
 rule. Pending treasury proposals are not committed ledger state.
 
-This snapshot is read-only infrastructure. It is not a bridge, exchange,
-off-ramp, custody path, relayer, redemption mechanism, price signal, or live
-external-value claim.
+This snapshot and Merkle proof tooling are read-only infrastructure. They are
+not a bridge, exchange, off-ramp, custody path, relayer, redemption mechanism,
+price signal, or live external-value claim.
 
 ## Wallets and Sending
 

--- a/scripts/export_ledger_snapshot_merkle.py
+++ b/scripts/export_ledger_snapshot_merkle.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.config import get_settings
+from app.ledger.snapshot import ledger_snapshot
+from app.ledger.snapshot_merkle import (
+    ledger_snapshot_account_proof,
+    ledger_snapshot_account_proof_json,
+    ledger_snapshot_merkle_root,
+    ledger_snapshot_merkle_root_json,
+)
+from scripts.export_ledger_snapshot import read_only_session_scope
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Export a read-only Merkle root or account proof for an MRWK ledger snapshot."
+    )
+    parser.add_argument("--database-url", help="Database URL. Defaults to MERGEWORK_DATABASE_URL.")
+    parser.add_argument("--source-host", help="Public source host/origin for snapshot metadata.")
+    parser.add_argument(
+        "--source-mode",
+        default="database",
+        help="Source mode label for snapshot metadata. Defaults to database.",
+    )
+    parser.add_argument(
+        "--account",
+        help="Account to prove. Omit this to print the snapshot Merkle root object.",
+    )
+    args = parser.parse_args(argv)
+
+    settings = get_settings()
+    database_url = args.database_url or settings.database_url
+    source_host = args.source_host if args.source_host is not None else settings.public_base_url
+    with read_only_session_scope(database_url) as session:
+        snapshot = ledger_snapshot(
+            session,
+            source_mode=args.source_mode,
+            source_host=source_host,
+        )
+        if args.account:
+            proof = ledger_snapshot_account_proof(snapshot, args.account)
+            if proof is None:
+                parser.error(f"account not found in snapshot: {args.account}")
+            sys.stdout.write(ledger_snapshot_account_proof_json(proof))
+        else:
+            sys.stdout.write(
+                ledger_snapshot_merkle_root_json(ledger_snapshot_merkle_root(snapshot))
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ledger_snapshot_merkle.py
+++ b/tests/test_ledger_snapshot_merkle.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from datetime import UTC, datetime
+
+import pytest
+
+from app.db import create_schema, session_scope
+from app.ledger.service import TREASURY_ACCOUNT, create_bounty, ensure_genesis, pay_bounty
+from app.ledger.snapshot import ledger_snapshot
+from app.ledger.snapshot_merkle import (
+    LEDGER_SNAPSHOT_ACCOUNT_LEAF_SCHEMA,
+    LEDGER_SNAPSHOT_ACCOUNT_PROOF_SCHEMA,
+    LEDGER_SNAPSHOT_MERKLE_ROOT_SCHEMA,
+    ledger_snapshot_account_proof,
+    ledger_snapshot_account_proof_json,
+    ledger_snapshot_merkle_root,
+    ledger_snapshot_merkle_root_json,
+    verify_ledger_snapshot_account_proof,
+)
+from scripts.export_ledger_snapshot_merkle import main as export_merkle_main
+
+
+def test_merkle_root_is_deterministic_and_metadata_independent(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        _seed_multi_account_snapshot(session)
+        first_snapshot = ledger_snapshot(
+            session,
+            generated_at=datetime(2026, 6, 2, 12, 0, tzinfo=UTC),
+            source_mode="database",
+            source_host="https://one.example",
+        )
+        second_snapshot = ledger_snapshot(
+            session,
+            generated_at=datetime(2026, 6, 3, 12, 0, tzinfo=UTC),
+            source_mode="fixture",
+            source_host="https://two.example",
+        )
+
+    first_root = ledger_snapshot_merkle_root(first_snapshot)
+    second_root = ledger_snapshot_merkle_root(second_snapshot)
+
+    assert first_snapshot["generated_at"] != second_snapshot["generated_at"]
+    assert first_snapshot["source"] != second_snapshot["source"]
+    assert first_root == second_root
+    assert first_root["schema"] == LEDGER_SNAPSHOT_MERKLE_ROOT_SCHEMA
+    assert first_root["snapshot_schema"] == first_snapshot["schema"]
+    assert first_root["hash_algorithm"] == "sha256"
+    assert first_root["leaf_schema"] == LEDGER_SNAPSHOT_ACCOUNT_LEAF_SCHEMA
+    assert first_root["leaf_count"] == len(first_snapshot["accounts"])
+    assert first_root["ledger_anchor"] == first_snapshot["ledger_anchor"]
+    assert _is_hash(first_root["tree_hash"])
+    assert _is_hash(first_root["root_hash"])
+    assert json.loads(ledger_snapshot_merkle_root_json(first_root)) == first_root
+
+
+def test_merkle_root_defines_empty_and_single_leaf_behavior(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        empty_snapshot = ledger_snapshot(
+            session,
+            generated_at=datetime(2026, 6, 2, 12, 0, tzinfo=UTC),
+        )
+        ensure_genesis(session)
+        single_snapshot = ledger_snapshot(
+            session,
+            generated_at=datetime(2026, 6, 2, 12, 0, tzinfo=UTC),
+        )
+
+    empty_root = ledger_snapshot_merkle_root(empty_snapshot)
+    single_root = ledger_snapshot_merkle_root(single_snapshot)
+    single_proof = ledger_snapshot_account_proof(single_snapshot, TREASURY_ACCOUNT)
+
+    assert empty_root["leaf_count"] == 0
+    assert _is_hash(empty_root["tree_hash"])
+    assert _is_hash(empty_root["root_hash"])
+    assert ledger_snapshot_account_proof(empty_snapshot, TREASURY_ACCOUNT) is None
+    assert single_root["leaf_count"] == 1
+    assert single_proof is not None
+    assert single_proof["siblings"] == []
+    assert single_proof["leaf"]["leaf_index"] == 0
+    assert verify_ledger_snapshot_account_proof(single_proof) is True
+
+
+def test_account_merkle_proof_verifies_and_rejects_tampering(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        _seed_multi_account_snapshot(session)
+        snapshot = ledger_snapshot(
+            session,
+            generated_at=datetime(2026, 6, 2, 12, 0, tzinfo=UTC),
+        )
+
+    proof = ledger_snapshot_account_proof(snapshot, "github:alice")
+    assert proof is not None
+    assert proof["schema"] == LEDGER_SNAPSHOT_ACCOUNT_PROOF_SCHEMA
+    assert proof["root"] == ledger_snapshot_merkle_root(snapshot)
+    assert proof["tree_size"] == len(snapshot["accounts"])
+    assert proof["leaf"]["account"] == "github:alice"
+    assert proof["leaf"]["balance_microunits"] == 12_500_000
+    assert proof["siblings"]
+    assert verify_ledger_snapshot_account_proof(proof) is True
+    assert json.loads(ledger_snapshot_account_proof_json(proof)) == proof
+
+    tampered_cases = [
+        ("account", lambda item: item["leaf"].update({"account": "github:mallory"})),
+        ("balance", lambda item: item["leaf"].update({"balance_microunits": 12_500_001})),
+        ("leaf_index", lambda item: item.update({"leaf_index": item["leaf_index"] + 1})),
+        ("sibling_hash", lambda item: item["siblings"][0].update({"hash": "0" * 64})),
+        ("sibling_direction", lambda item: item["siblings"][0].update({"direction": "left"})),
+        ("tree_size", lambda item: item.update({"tree_size": item["tree_size"] + 1})),
+        ("root_hash", lambda item: item["root"].update({"root_hash": "0" * 64})),
+        (
+            "ledger_anchor",
+            lambda item: item["root"]["ledger_anchor"].update(
+                {"latest_sequence": item["root"]["ledger_anchor"]["latest_sequence"] + 1}
+            ),
+        ),
+    ]
+    for label, mutate in tampered_cases:
+        tampered = deepcopy(proof)
+        mutate(tampered)
+        assert verify_ledger_snapshot_account_proof(tampered) is False, label
+
+
+def test_export_merkle_script_prints_root_and_account_proof(sqlite_url: str, capsys) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        _seed_multi_account_snapshot(session)
+
+    assert (
+        export_merkle_main(
+            [
+                "--database-url",
+                sqlite_url,
+                "--source-host",
+                "https://mrwk.example",
+                "--source-mode",
+                "test",
+            ]
+        )
+        == 0
+    )
+    root = json.loads(capsys.readouterr().out)
+
+    assert root["schema"] == LEDGER_SNAPSHOT_MERKLE_ROOT_SCHEMA
+    assert root["leaf_count"] == 3
+
+    assert (
+        export_merkle_main(
+            [
+                "--database-url",
+                sqlite_url,
+                "--source-host",
+                "https://mrwk.example",
+                "--source-mode",
+                "test",
+                "--account",
+                "github:alice",
+            ]
+        )
+        == 0
+    )
+    proof = json.loads(capsys.readouterr().out)
+
+    assert proof["schema"] == LEDGER_SNAPSHOT_ACCOUNT_PROOF_SCHEMA
+    assert proof["root"] == root
+    assert verify_ledger_snapshot_account_proof(proof) is True
+
+
+def test_export_merkle_script_rejects_missing_account(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    with pytest.raises(SystemExit):
+        export_merkle_main(["--database-url", sqlite_url, "--account", "github:missing"])
+
+
+def _seed_multi_account_snapshot(session) -> None:
+    ensure_genesis(session)
+    bounty = create_bounty(
+        session,
+        repo="ramimbo/mergework",
+        issue_number=1027,
+        issue_url="https://github.com/ramimbo/mergework/issues/1027",
+        title="Snapshot Merkle proof",
+        reward_mrwk="12.5",
+        max_awards=2,
+        acceptance="Focused read-only ledger snapshot Merkle proof tooling.",
+    )
+    pay_bounty(
+        session,
+        bounty_id=bounty.id,
+        to_account="github:alice",
+        submission_url="https://github.com/ramimbo/mergework/pull/1027",
+        accepted_by="maintainer",
+        verifier_result={"label": "mrwk:accepted"},
+    )
+
+
+def _is_hash(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )


### PR DESCRIPTION
## Summary
- add read-only Phase 2B snapshot Merkle helpers for deterministic account-balance roots, account proofs, and local proof verification
- add `scripts/export_ledger_snapshot_merkle.py` to emit either the root object or one account proof from the Phase 2A snapshot exporter
- document the root/proof shape and read-only boundaries in `docs/ledger.md`

Bounty #1027.

## Merkle artifact shape
- root object: versioned schema, snapshot schema, hash algorithm, leaf schema, leaf count, ledger anchor, tree hash, and root hash
- account leaf: versioned schema, leaf index, account, and integer `balance_microunits`
- proof object: versioned schema, embedded root, tree size, leaf index, leaf, and sibling path

The root hash binds the tree hash to the Phase 2A ledger anchor (`latest_sequence` and `latest_entry_hash`) and ignores nondeterministic export metadata such as `generated_at`, source mode, and source host. Leaf, internal-node, empty-tree, and root hash inputs use domain-separated canonical JSON.

This is read-only proof infrastructure only. It does not add a bridge, exchange, off-ramp, custody path, relayer, onchain claim, payout behavior, treasury mutation, wallet transfer mutation, public API route, or UI.

## Tests
- `.\.venv\Scripts\python.exe -m pytest tests/test_ledger_snapshot.py tests/test_ledger_snapshot_merkle.py -q` -> 13 passed
- `.\.venv\Scripts\python.exe -m pytest -q` -> 910 passed
- `.\.venv\Scripts\python.exe -m ruff format --check .` -> 129 files already formatted
- `.\.venv\Scripts\python.exe -m ruff check .` -> All checks passed
- `.\.venv\Scripts\python.exe -m mypy app` -> Success: no issues found in 46 source files
- `.\.venv\Scripts\python.exe scripts\docs_smoke.py` -> docs smoke ok
- GitHub Actions CI passed on 8e319f3: https://github.com/ramimbo/mergework/actions/runs/27466254413
