### PR TITLE
Prefill wallet transfer actions

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -39,6 +39,8 @@ from app.status import (
 )
 
 WALLET_SEARCH_QUERY_MAX_LENGTH = 500
+TRANSFER_PREFILL_ADDRESS_FIELDS = ("from_address", "to_address")
+TRANSFER_SENSITIVE_QUERY_FIELDS = ("private_key_hex", "signature_hex", "nonce")
 
 
 def _bounty_filter_params(
@@ -325,6 +327,22 @@ def wallet_page_context(
     }
 
 
+def transfer_page_context(request: Request) -> dict[str, Any]:
+    reject_unsupported_query_params(
+        request,
+        TRANSFER_SENSITIVE_QUERY_FIELDS,
+        context="transfer prefill",
+    )
+    prefill = {name: "" for name in TRANSFER_PREFILL_ADDRESS_FIELDS}
+    for name in TRANSFER_PREFILL_ADDRESS_FIELDS:
+        reject_repeated_query_param(request, name)
+        reject_control_char_query_param(request, name)
+        value = request.query_params.get(name)
+        if value:
+            prefill[name] = normalized_wallet_address(value)
+    return {"transfer_prefill": prefill}
+
+
 def ledger_entry_page_context(
     sequence: str, api_ledger_entry: Callable[[str], dict[str, Any]]
 ) -> dict[str, Any]:
@@ -452,7 +470,7 @@ def register_public_routes(
 
     @app.get("/transfer", response_class=HTMLResponse)
     def transfer_page(request: Request) -> HTMLResponse:
-        return templates.TemplateResponse(request, "transfer.html")
+        return templates.TemplateResponse(request, "transfer.html", transfer_page_context(request))
 
     @app.get("/proofs/{proof_hash}", response_class=HTMLResponse)
     def proof_page(request: Request, proof_hash: str) -> HTMLResponse:

--- a/app/templates/transfer.html
+++ b/app/templates/transfer.html
@@ -9,8 +9,8 @@
 
 <section class="panel wallet-tool" data-transfer-tool>
   <form data-action="submit-transfer">
-    <label>From address <input name="from_address" placeholder="mrwk1..." required></label>
-    <label>To address <input name="to_address" placeholder="mrwk1..." required></label>
+    <label>From address <input name="from_address" placeholder="mrwk1..." value="{{ transfer_prefill.from_address }}" required></label>
+    <label>To address <input name="to_address" placeholder="mrwk1..." value="{{ transfer_prefill.to_address }}" required></label>
     <label>Amount MRWK <input name="amount_mrwk" inputmode="decimal" placeholder="1.5" required></label>
     <label>Memo <input name="memo" maxlength="240" placeholder="optional"></label>
     <label>Private key <textarea name="private_key_hex" rows="5" autocomplete="off" autocapitalize="none" spellcheck="false" required></textarea></label>

--- a/app/templates/wallet_detail.html
+++ b/app/templates/wallet_detail.html
@@ -27,10 +27,11 @@
     <dd><a href="/accounts/{{ wallet.address }}">ledger account</a></dd>
   </dl>
   <div class="actions">
-    <a href="/transfer">Send MRWK</a>
+    <a href="/transfer?from_address={{ wallet.address }}">Send MRWK</a>
+    <a href="/transfer?to_address={{ wallet.address }}">Receive MRWK</a>
     <a href="/me">Link GitHub</a>
   </div>
-  <p class="notice">To claim GitHub bounty balance, sign in and link this wallet from your contributor account.</p>
+  <p class="notice">Transfer links prefill this wallet as sender or recipient. To claim GitHub bounty balance, sign in and link this wallet from your contributor account.</p>
 </section>
 
 <section>

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -691,6 +691,8 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     funded_missing_type = client.get(f"/wallets/{funded_address}?type=bounty_payment").text
     funded_unknown_type = client.get(f"/wallets/{funded_address}?type=not_a_real_type")
     transfer = client.get("/transfer").text
+    transfer_from_prefill = client.get(f"/transfer?from_address={address}").text
+    transfer_to_prefill = client.get(f"/transfer?to_address={funded_address}").text
     me = client.get("/me").text
 
     assert "Generate wallet" in wallets
@@ -719,6 +721,9 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "/accounts/github:" not in funded_row
     assert "No registered wallets match this search." in no_wallet_match
     assert "To claim GitHub bounty balance" in detail
+    assert f'href="/transfer?from_address={address}"' in detail
+    assert f'href="/transfer?to_address={address}"' in detail
+    assert "Transfer links prefill this wallet as sender or recipient" in detail
     assert "No activity yet" in detail
     assert "No activity yet" not in funded_detail
     assert "Filter wallet transactions" in funded_detail
@@ -741,7 +746,43 @@ def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) ->
     assert "Signed transfer" in transfer
     assert "both wallets are registered" in transfer
     assert "/static/wallet.js" in transfer
+    assert (
+        f'name="from_address" placeholder="mrwk1..." value="{address}" required'
+        in transfer_from_prefill
+    )
+    assert (
+        f'name="to_address" placeholder="mrwk1..." value="{funded_address}" required'
+        in transfer_to_prefill
+    )
     assert "Link a wallet" in me
+
+
+def test_transfer_page_prefill_rejects_ambiguous_or_sensitive_query_params(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    _, public_hex, address = _keypair()
+    _, other_public_hex, other_address = _keypair()
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    _register_wallet(client, public_hex, "Main smoke wallet")
+    _register_wallet(client, other_public_hex, "Other smoke wallet")
+
+    repeated_from = client.get(f"/transfer?from_address={address}&from_address={other_address}")
+    control_to = client.get(f"/transfer?to_address=%C2%85{address}")
+    private_key = client.get("/transfer?private_key_hex=abc")
+    signature = client.get("/transfer?signature_hex=abc")
+    nonce = client.get("/transfer?nonce=1")
+
+    assert repeated_from.status_code == 400
+    assert repeated_from.json()["detail"] == "from_address must be provided at most once"
+    assert control_to.status_code == 400
+    assert control_to.json()["detail"] == "to_address must not contain control characters"
+    assert private_key.status_code == 400
+    assert private_key.json()["detail"] == "private_key_hex is not supported on transfer prefill"
+    assert signature.status_code == 400
+    assert signature.json()["detail"] == "signature_hex is not supported on transfer prefill"
+    assert nonce.status_code == 400
+    assert nonce.json()["detail"] == "nonce is not supported on transfer prefill"
 
 
 def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -785,6 +785,22 @@ def test_transfer_page_prefill_rejects_ambiguous_or_sensitive_query_params(
     assert nonce.json()["detail"] == "nonce is not supported on transfer prefill"
 
 
+def test_transfer_page_prefill_rejects_invalid_wallet_addresses(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    invalid_from = client.get("/transfer?from_address=invalid")
+    invalid_to = client.get("/transfer?to_address=not-a-wallet")
+    whitespace_from = client.get("/transfer?from_address=%20%20%20")
+
+    assert invalid_from.status_code == 400
+    assert "invalid MRWK wallet address" in invalid_from.json()["detail"]
+    assert invalid_to.status_code == 400
+    assert "invalid MRWK wallet address" in invalid_to.json()["detail"]
+    assert whitespace_from.status_code == 400
+    assert "invalid MRWK wallet address" in whitespace_from.json()["detail"]
+
+
 def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     _, public_hex, address = _keypair()


### PR DESCRIPTION
Bounty #1011

## Summary
- Add wallet-detail action links that open the transfer page with the selected account already placed in the intended side of the form.
- Preserve the normal transfer flow while making common send/receive navigation faster from wallet pages.
- Reject unsafe or ambiguous URL prefill input before rendering the page.

## Safety
- This is a UI/navigation prefill change only.
- It does not change authorization, signing, replay protection, balance calculation, supply, or transaction execution behavior.
- Prefill input is validated as a public wallet address before it is rendered.

## Validation
- `python -m pytest -q` -> 906 passed
- `python -m pytest tests/test_wallet_api.py tests/test_account_routes.py -q` -> 55 passed
- `python -m ruff check .` -> passed
- `python -m ruff format --check .` -> passed
- `python -m mypy app` -> passed
- `python scripts/docs_smoke.py` -> passed
- Follow-up invalid-prefill coverage: `python -m pytest tests/test_wallet_api.py -q` -> 56 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Transfer form can now be pre-filled with sender and recipient addresses through URL query parameters
- Added "Send MRWK" and "Receive MRWK" quick-action links on wallet detail pages for seamless transfers
- Enhanced validation to ensure address integrity in transfer requests and prevent sensitive parameter injection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->