### PR TITLE
Tighten treasury challenge OpenAPI request schema

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -26,6 +26,7 @@ from app.ledger.service import (
     validate_public_url,
 )
 from app.models import Bounty, Proof, Submission
+from app.openapi_request_bodies import BOUNTY_CLOSE_BODY, BOUNTY_CREATE_BODY, BOUNTY_PAY_BODY
 from app.path_params import SQLITE_INTEGER_MAX, issue_number_search_value, positive_bounty_id
 from app.query_validation import (
     reject_control_char_query_param,
@@ -294,7 +295,7 @@ def register_bounty_api_routes(
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    @app.post("/api/v1/bounties")
+    @app.post("/api/v1/bounties", openapi_extra=BOUNTY_CREATE_BODY)
     async def api_create_bounty(
         request: Request, admin_login: str = Depends(require_admin_token)
     ) -> dict[str, Any]:
@@ -348,7 +349,7 @@ def register_bounty_api_routes(
                 "checks": [payout_reconciliation_to_dict(check) for check in checks],
             }
 
-    @app.post("/api/v1/bounties/{bounty_id}/pay")
+    @app.post("/api/v1/bounties/{bounty_id}/pay", openapi_extra=BOUNTY_PAY_BODY)
     async def api_pay_bounty(
         bounty_id: str,
         request: Request,
@@ -409,7 +410,7 @@ def register_bounty_api_routes(
                 raise _ledger_http_error(exc) from exc
             return proposal_to_dict(proposal)
 
-    @app.post("/api/v1/bounties/{bounty_id}/close")
+    @app.post("/api/v1/bounties/{bounty_id}/close", openapi_extra=BOUNTY_CLOSE_BODY)
     async def api_close_bounty(
         bounty_id: str,
         request: Request,

--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -26,7 +26,6 @@ from app.ledger.service import (
     validate_public_url,
 )
 from app.models import Bounty, Proof, Submission
-from app.openapi_request_bodies import BOUNTY_CLOSE_BODY, BOUNTY_CREATE_BODY, BOUNTY_PAY_BODY
 from app.path_params import SQLITE_INTEGER_MAX, issue_number_search_value, positive_bounty_id
 from app.query_validation import (
     reject_control_char_query_param,
@@ -295,7 +294,7 @@ def register_bounty_api_routes(
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    @app.post("/api/v1/bounties", openapi_extra=BOUNTY_CREATE_BODY)
+    @app.post("/api/v1/bounties")
     async def api_create_bounty(
         request: Request, admin_login: str = Depends(require_admin_token)
     ) -> dict[str, Any]:
@@ -349,7 +348,7 @@ def register_bounty_api_routes(
                 "checks": [payout_reconciliation_to_dict(check) for check in checks],
             }
 
-    @app.post("/api/v1/bounties/{bounty_id}/pay", openapi_extra=BOUNTY_PAY_BODY)
+    @app.post("/api/v1/bounties/{bounty_id}/pay")
     async def api_pay_bounty(
         bounty_id: str,
         request: Request,
@@ -410,7 +409,7 @@ def register_bounty_api_routes(
                 raise _ledger_http_error(exc) from exc
             return proposal_to_dict(proposal)
 
-    @app.post("/api/v1/bounties/{bounty_id}/close", openapi_extra=BOUNTY_CLOSE_BODY)
+    @app.post("/api/v1/bounties/{bounty_id}/close")
     async def api_close_bounty(
         bounty_id: str,
         request: Request,

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -220,21 +220,6 @@ TREASURY_PROPOSAL_RESPONSE_SCHEMA = _object_schema(
     }
 )
 
-PAYOUT_PROOF_RESPONSE_SCHEMA = _object_schema(
-    {
-        "status": {"type": "string"},
-        "bounty_id": {"type": "integer", "minimum": 1},
-        "to_account": {"type": "string", "nullable": True},
-        "submission_id": {"type": "integer", "minimum": 1, "nullable": True},
-        "submission_url": {"type": "string", "nullable": True},
-        "ledger_sequence": {"type": "integer", "minimum": 1},
-        "ledger_url": {"type": "string"},
-        "proof_hash": {**LOWERCASE_HEX_64_SCHEMA, "nullable": True},
-        "proof_url": {"type": "string", "nullable": True},
-    },
-    description="Existing proof-backed payout response returned for duplicate pay requests.",
-)
-
 MCP_JSONRPC_ID_SCHEMA = {
     "description": "JSON-RPC request id returned unchanged in the response.",
     "nullable": True,
@@ -506,128 +491,30 @@ TREASURY_CHALLENGE_BODY = {
     "requestBody": _request_body(
         _object_schema(
             {
-                "challenge_type": {"type": "string", "description": "Challenge category."},
-                "reason": {"type": "string", "description": "Public challenge reason."},
+                "challenge_type": {
+                    "type": "string",
+                    "description": "Challenge category accepted by treasury validation.",
+                    "enum": [
+                        "bounty_not_open",
+                        "duplicate_bounty",
+                        "epoch_cap_exceeded",
+                        "insufficient_reserve",
+                        "submission_already_paid",
+                        "subjective_note",
+                    ],
+                    "maxLength": 80,
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Public challenge reason, trimmed by the API.",
+                    "maxLength": 1000,
+                },
             },
             required=["challenge_type", "reason"],
         ),
     ),
     "responses": {
         "200": _json_response(TREASURY_CHALLENGE_RESPONSE_SCHEMA),
-    },
-}
-
-BOUNTY_CREATE_BODY = {
-    "requestBody": _request_body(
-        _object_schema(
-            {
-                "repo": {
-                    "type": "string",
-                    "description": "GitHub repository in owner/name form.",
-                    "maxLength": 500,
-                },
-                "issue_number": {
-                    **INTEGER_OR_STRING_SCHEMA,
-                    "description": "Positive GitHub issue number for the bounty.",
-                },
-                "issue_url": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "Public GitHub issue URL matching repo and issue_number.",
-                },
-                "title": {
-                    "type": "string",
-                    "description": "Public bounty title.",
-                    "maxLength": 500,
-                },
-                "reward_mrwk": MRWK_AMOUNT_SCHEMA,
-                "max_awards": {
-                    "anyOf": [
-                        {"type": "integer", "minimum": 1, "maximum": 1000},
-                        {
-                            "type": "string",
-                            "description": "Positive integer award count encoded as a string.",
-                            "pattern": r"^(?:[1-9][0-9]{0,2}|1000)$",
-                        },
-                    ],
-                    "default": 1,
-                    "description": "Maximum accepted awards reserved by this bounty.",
-                },
-                "acceptance": {
-                    "type": "string",
-                    "description": "Public acceptance criteria for award decisions.",
-                    "maxLength": 500,
-                },
-            },
-            required=["repo", "issue_number", "issue_url", "title", "reward_mrwk", "acceptance"],
-            description="Admin payload that creates a pending create_bounty treasury proposal.",
-        ),
-    ),
-    "responses": {
-        "200": _json_response(TREASURY_PROPOSAL_RESPONSE_SCHEMA),
-    },
-}
-
-BOUNTY_PAY_BODY = {
-    "requestBody": _request_body(
-        _object_schema(
-            {
-                "to_account": {
-                    "type": "string",
-                    "description": "Accepted contributor account, such as github:<login>.",
-                    "maxLength": 500,
-                },
-                "submission_url": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "Public PR, issue, report, or evidence URL being paid.",
-                },
-                "accepted_by": {
-                    "type": "string",
-                    "description": "Optional maintainer/account name recorded on the proposal.",
-                    "maxLength": 500,
-                },
-                "note": {
-                    "type": "string",
-                    "description": (
-                        "Optional public payout note, trimmed and capped at 240 characters."
-                    ),
-                    "maxLength": 240,
-                },
-            },
-            required=["to_account", "submission_url"],
-            description="Admin payload that creates a pending pay_bounty treasury proposal.",
-        ),
-    ),
-    "responses": {
-        "200": _json_response(TREASURY_PROPOSAL_RESPONSE_SCHEMA),
-        "409": _json_response(
-            PAYOUT_PROOF_RESPONSE_SCHEMA,
-            description="Submission already has a proof-backed bounty payment.",
-        ),
-    },
-}
-
-BOUNTY_CLOSE_BODY = {
-    "requestBody": _request_body(
-        _object_schema(
-            {
-                "closed_by": {
-                    "type": "string",
-                    "description": "Optional maintainer/account name recorded on the proposal.",
-                    "maxLength": 500,
-                },
-                "reference": {
-                    "type": "string",
-                    "description": "Optional public close reference or reason.",
-                    "maxLength": 500,
-                },
-            },
-            description="Admin payload that creates a pending close_bounty treasury proposal.",
-        ),
-    ),
-    "responses": {
-        "200": _json_response(TREASURY_PROPOSAL_RESPONSE_SCHEMA),
     },
 }
 

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -220,6 +220,21 @@ TREASURY_PROPOSAL_RESPONSE_SCHEMA = _object_schema(
     }
 )
 
+PAYOUT_PROOF_RESPONSE_SCHEMA = _object_schema(
+    {
+        "status": {"type": "string"},
+        "bounty_id": {"type": "integer", "minimum": 1},
+        "to_account": {"type": "string", "nullable": True},
+        "submission_id": {"type": "integer", "minimum": 1, "nullable": True},
+        "submission_url": {"type": "string", "nullable": True},
+        "ledger_sequence": {"type": "integer", "minimum": 1},
+        "ledger_url": {"type": "string"},
+        "proof_hash": {**LOWERCASE_HEX_64_SCHEMA, "nullable": True},
+        "proof_url": {"type": "string", "nullable": True},
+    },
+    description="Existing proof-backed payout response returned for duplicate pay requests.",
+)
+
 MCP_JSONRPC_ID_SCHEMA = {
     "description": "JSON-RPC request id returned unchanged in the response.",
     "nullable": True,
@@ -499,6 +514,120 @@ TREASURY_CHALLENGE_BODY = {
     ),
     "responses": {
         "200": _json_response(TREASURY_CHALLENGE_RESPONSE_SCHEMA),
+    },
+}
+
+BOUNTY_CREATE_BODY = {
+    "requestBody": _request_body(
+        _object_schema(
+            {
+                "repo": {
+                    "type": "string",
+                    "description": "GitHub repository in owner/name form.",
+                    "maxLength": 500,
+                },
+                "issue_number": {
+                    **INTEGER_OR_STRING_SCHEMA,
+                    "description": "Positive GitHub issue number for the bounty.",
+                },
+                "issue_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Public GitHub issue URL matching repo and issue_number.",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Public bounty title.",
+                    "maxLength": 500,
+                },
+                "reward_mrwk": MRWK_AMOUNT_SCHEMA,
+                "max_awards": {
+                    "anyOf": [
+                        {"type": "integer", "minimum": 1, "maximum": 1000},
+                        {
+                            "type": "string",
+                            "description": "Positive integer award count encoded as a string.",
+                            "pattern": r"^(?:[1-9][0-9]{0,2}|1000)$",
+                        },
+                    ],
+                    "default": 1,
+                    "description": "Maximum accepted awards reserved by this bounty.",
+                },
+                "acceptance": {
+                    "type": "string",
+                    "description": "Public acceptance criteria for award decisions.",
+                    "maxLength": 500,
+                },
+            },
+            required=["repo", "issue_number", "issue_url", "title", "reward_mrwk", "acceptance"],
+            description="Admin payload that creates a pending create_bounty treasury proposal.",
+        ),
+    ),
+    "responses": {
+        "200": _json_response(TREASURY_PROPOSAL_RESPONSE_SCHEMA),
+    },
+}
+
+BOUNTY_PAY_BODY = {
+    "requestBody": _request_body(
+        _object_schema(
+            {
+                "to_account": {
+                    "type": "string",
+                    "description": "Accepted contributor account, such as github:<login>.",
+                    "maxLength": 500,
+                },
+                "submission_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "Public PR, issue, report, or evidence URL being paid.",
+                },
+                "accepted_by": {
+                    "type": "string",
+                    "description": "Optional maintainer/account name recorded on the proposal.",
+                    "maxLength": 500,
+                },
+                "note": {
+                    "type": "string",
+                    "description": (
+                        "Optional public payout note, trimmed and capped at 240 characters."
+                    ),
+                    "maxLength": 240,
+                },
+            },
+            required=["to_account", "submission_url"],
+            description="Admin payload that creates a pending pay_bounty treasury proposal.",
+        ),
+    ),
+    "responses": {
+        "200": _json_response(TREASURY_PROPOSAL_RESPONSE_SCHEMA),
+        "409": _json_response(
+            PAYOUT_PROOF_RESPONSE_SCHEMA,
+            description="Submission already has a proof-backed bounty payment.",
+        ),
+    },
+}
+
+BOUNTY_CLOSE_BODY = {
+    "requestBody": _request_body(
+        _object_schema(
+            {
+                "closed_by": {
+                    "type": "string",
+                    "description": "Optional maintainer/account name recorded on the proposal.",
+                    "maxLength": 500,
+                },
+                "reference": {
+                    "type": "string",
+                    "description": "Optional public close reference or reason.",
+                    "maxLength": 500,
+                },
+            },
+            description="Admin payload that creates a pending close_bounty treasury proposal.",
+        ),
+    ),
+    "responses": {
+        "200": _json_response(TREASURY_PROPOSAL_RESPONSE_SCHEMA),
     },
 }
 

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -69,11 +69,27 @@ def test_public_post_openapi_request_bodies_expose_expected_fields(sqlite_url: s
     openapi = client.get("/openapi.json").json()
 
     expected_fields = {
+        "/api/v1/bounties": {
+            "repo",
+            "issue_number",
+            "issue_url",
+            "title",
+            "reward_mrwk",
+            "max_awards",
+            "acceptance",
+        },
         "/api/v1/bounties/{bounty_id}/attempts": {
             "submitter_account",
             "source_url",
             "ttl_seconds",
         },
+        "/api/v1/bounties/{bounty_id}/pay": {
+            "to_account",
+            "submission_url",
+            "accepted_by",
+            "note",
+        },
+        "/api/v1/bounties/{bounty_id}/close": {"closed_by", "reference"},
         "/api/v1/bounty-attempts/{attempt_id}/release": {"submitter_account"},
         "/api/v1/wallets/register": {"public_key_hex", "label"},
         "/api/v1/wallets/link-github": {"address", "nonce", "signature_hex"},
@@ -100,6 +116,19 @@ def test_public_post_openapi_request_bodies_mark_required_fields(sqlite_url: str
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
     openapi = client.get("/openapi.json").json()
 
+    assert set(_post_schema(openapi, "/api/v1/bounties")["required"]) == {
+        "repo",
+        "issue_number",
+        "issue_url",
+        "title",
+        "reward_mrwk",
+        "acceptance",
+    }
+    assert set(_post_schema(openapi, "/api/v1/bounties/{bounty_id}/pay")["required"]) == {
+        "to_account",
+        "submission_url",
+    }
+    assert "required" not in _post_schema(openapi, "/api/v1/bounties/{bounty_id}/close")
     assert set(_post_schema(openapi, "/api/v1/wallets/register")["required"]) == {"public_key_hex"}
     assert set(_post_schema(openapi, "/api/v1/wallets/link-github")["required"]) == {
         "address",
@@ -161,6 +190,20 @@ def test_public_post_openapi_request_bodies_publish_stable_constraints(
     assert transfer_props["from_address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
     assert transfer_props["to_address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
     assert transfer_props["memo"]["maxLength"] == 240
+
+    create_bounty_props = _post_schema(openapi, "/api/v1/bounties")["properties"]
+    assert create_bounty_props["issue_number"]["anyOf"][0]["minimum"] == 1
+    assert create_bounty_props["reward_mrwk"]["pattern"] == r"^(?=.*[1-9])\d+(?:\.\d{1,6})?$"
+    assert create_bounty_props["max_awards"]["anyOf"][0] == {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 1000,
+    }
+    assert create_bounty_props["max_awards"]["default"] == 1
+
+    pay_props = _post_schema(openapi, "/api/v1/bounties/{bounty_id}/pay")["properties"]
+    assert pay_props["submission_url"]["format"] == "uri"
+    assert pay_props["note"]["maxLength"] == 240
 
 
 def test_public_post_openapi_request_bodies_match_runtime_amount_and_ttl_bounds(
@@ -328,6 +371,42 @@ def test_public_post_openapi_response_schemas_expose_wallet_transfer_and_attempt
 def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
     openapi = client.get("/openapi.json").json()
+
+    for path in (
+        "/api/v1/bounties",
+        "/api/v1/bounties/{bounty_id}/pay",
+        "/api/v1/bounties/{bounty_id}/close",
+    ):
+        bounty_admin_schema = _post_response_schema(openapi, path)
+        _assert_properties(
+            bounty_admin_schema,
+            {
+                "id",
+                "type",
+                "action",
+                "status",
+                "payload_hash",
+                "payload",
+                "proposed_by",
+                "executes_after",
+            },
+        )
+
+    already_paid_schema = _post_response_schema(openapi, "/api/v1/bounties/{bounty_id}/pay", "409")
+    _assert_properties(
+        already_paid_schema,
+        {
+            "status",
+            "bounty_id",
+            "to_account",
+            "submission_id",
+            "submission_url",
+            "ledger_sequence",
+            "ledger_url",
+            "proof_hash",
+            "proof_url",
+        },
+    )
 
     proposal_schema = _post_response_schema(openapi, "/api/v1/treasury/proposals")
     _assert_properties(

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -69,27 +69,11 @@ def test_public_post_openapi_request_bodies_expose_expected_fields(sqlite_url: s
     openapi = client.get("/openapi.json").json()
 
     expected_fields = {
-        "/api/v1/bounties": {
-            "repo",
-            "issue_number",
-            "issue_url",
-            "title",
-            "reward_mrwk",
-            "max_awards",
-            "acceptance",
-        },
         "/api/v1/bounties/{bounty_id}/attempts": {
             "submitter_account",
             "source_url",
             "ttl_seconds",
         },
-        "/api/v1/bounties/{bounty_id}/pay": {
-            "to_account",
-            "submission_url",
-            "accepted_by",
-            "note",
-        },
-        "/api/v1/bounties/{bounty_id}/close": {"closed_by", "reference"},
         "/api/v1/bounty-attempts/{attempt_id}/release": {"submitter_account"},
         "/api/v1/wallets/register": {"public_key_hex", "label"},
         "/api/v1/wallets/link-github": {"address", "nonce", "signature_hex"},
@@ -116,19 +100,6 @@ def test_public_post_openapi_request_bodies_mark_required_fields(sqlite_url: str
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
     openapi = client.get("/openapi.json").json()
 
-    assert set(_post_schema(openapi, "/api/v1/bounties")["required"]) == {
-        "repo",
-        "issue_number",
-        "issue_url",
-        "title",
-        "reward_mrwk",
-        "acceptance",
-    }
-    assert set(_post_schema(openapi, "/api/v1/bounties/{bounty_id}/pay")["required"]) == {
-        "to_account",
-        "submission_url",
-    }
-    assert "required" not in _post_schema(openapi, "/api/v1/bounties/{bounty_id}/close")
     assert set(_post_schema(openapi, "/api/v1/wallets/register")["required"]) == {"public_key_hex"}
     assert set(_post_schema(openapi, "/api/v1/wallets/link-github")["required"]) == {
         "address",
@@ -191,19 +162,19 @@ def test_public_post_openapi_request_bodies_publish_stable_constraints(
     assert transfer_props["to_address"]["pattern"] == "^mrwk1[0-9a-f]{40}$"
     assert transfer_props["memo"]["maxLength"] == 240
 
-    create_bounty_props = _post_schema(openapi, "/api/v1/bounties")["properties"]
-    assert create_bounty_props["issue_number"]["anyOf"][0]["minimum"] == 1
-    assert create_bounty_props["reward_mrwk"]["pattern"] == r"^(?=.*[1-9])\d+(?:\.\d{1,6})?$"
-    assert create_bounty_props["max_awards"]["anyOf"][0] == {
-        "type": "integer",
-        "minimum": 1,
-        "maximum": 1000,
+    challenge_props = _post_schema(openapi, "/api/v1/treasury/proposals/{proposal_id}/challenges")[
+        "properties"
+    ]
+    assert challenge_props["challenge_type"]["maxLength"] == 80
+    assert set(challenge_props["challenge_type"]["enum"]) == {
+        "bounty_not_open",
+        "duplicate_bounty",
+        "epoch_cap_exceeded",
+        "insufficient_reserve",
+        "submission_already_paid",
+        "subjective_note",
     }
-    assert create_bounty_props["max_awards"]["default"] == 1
-
-    pay_props = _post_schema(openapi, "/api/v1/bounties/{bounty_id}/pay")["properties"]
-    assert pay_props["submission_url"]["format"] == "uri"
-    assert pay_props["note"]["maxLength"] == 240
+    assert challenge_props["reason"]["maxLength"] == 1000
 
 
 def test_public_post_openapi_request_bodies_match_runtime_amount_and_ttl_bounds(
@@ -371,42 +342,6 @@ def test_public_post_openapi_response_schemas_expose_wallet_transfer_and_attempt
 def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url: str) -> None:
     client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
     openapi = client.get("/openapi.json").json()
-
-    for path in (
-        "/api/v1/bounties",
-        "/api/v1/bounties/{bounty_id}/pay",
-        "/api/v1/bounties/{bounty_id}/close",
-    ):
-        bounty_admin_schema = _post_response_schema(openapi, path)
-        _assert_properties(
-            bounty_admin_schema,
-            {
-                "id",
-                "type",
-                "action",
-                "status",
-                "payload_hash",
-                "payload",
-                "proposed_by",
-                "executes_after",
-            },
-        )
-
-    already_paid_schema = _post_response_schema(openapi, "/api/v1/bounties/{bounty_id}/pay", "409")
-    _assert_properties(
-        already_paid_schema,
-        {
-            "status",
-            "bounty_id",
-            "to_account",
-            "submission_id",
-            "submission_url",
-            "ledger_sequence",
-            "ledger_url",
-            "proof_hash",
-            "proof_url",
-        },
-    )
 
     proposal_schema = _post_response_schema(openapi, "/api/v1/treasury/proposals")
     _assert_properties(


### PR DESCRIPTION
Bounty #944

## Summary
- Refocus this PR onto a public API/OpenAPI contract surface: `POST /api/v1/treasury/proposals/{proposal_id}/challenges`.
- Advertise the runtime-supported `challenge_type` values in OpenAPI.
- Publish the runtime string limits for `challenge_type` and `reason` so generated clients do not accept overlong challenge payloads.

## Scope
- Public challenge endpoint request schema only.
- No admin-only route documentation.
- No treasury execution, payout execution, ledger mutation, wallet custody, bridge, exchange, off-ramp, cash-out, price, or supply behavior changes.

## Validation
- `.\.venv\Scripts\python.exe -m pytest tests/test_openapi_request_bodies.py tests/test_treasury_proposals.py -q` -> 70 passed
- `.\.venv\Scripts\python.exe -m ruff check app/bounty_api.py app/openapi_request_bodies.py tests/test_openapi_request_bodies.py` -> passed
- `.\.venv\Scripts\python.exe -m ruff format --check app/bounty_api.py app/openapi_request_bodies.py tests/test_openapi_request_bodies.py` -> passed
- `git diff --check` -> passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for the treasury challenge endpoint: `challenge_type` is now restricted to specific allowed values, and `reason` field has a maximum character limit to prevent oversized submissions.

* **Tests**
  * Added validation tests for treasury challenge request constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->