### PR TITLE
Advertise submit_work_proof MCP output schema

### DIFF
--- a/app/mcp.py
+++ b/app/mcp.py
@@ -119,6 +119,57 @@ MCP_BOUNTY_ATTEMPTS_OUTPUT_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
+MCP_WORK_PROOF_GUIDANCE_OUTPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "Machine-readable bounty submission guidance returned by submit_work_proof "
+        'when called with format: "json".'
+    ),
+    "properties": {
+        "bounty_id": {"type": ["integer", "null"], "minimum": 1},
+        "issue_number": {"type": ["integer", "null"], "minimum": 1},
+        "status": {"type": "string"},
+        "availability": {"type": "string"},
+        "can_submit": {"type": ["boolean", "null"]},
+        "availability_warnings": {"type": "array", "items": {"type": "string"}},
+        "awards_remaining": {"type": ["integer", "null"], "minimum": 0},
+        "effective_awards_remaining": {"type": ["integer", "null"], "minimum": 0},
+        "max_awards": {"type": ["integer", "null"], "minimum": 0},
+        "awards_paid": {"type": ["integer", "null"], "minimum": 0},
+        "reward_mrwk": {"type": ["string", "null"]},
+        "available_mrwk": {"type": ["string", "null"]},
+        "effective_available_mrwk": {"type": ["string", "null"]},
+        "repository": {"type": ["string", "null"]},
+        "issue_url": {"type": ["string", "null"]},
+        "title": {"type": ["string", "null"]},
+        "acceptance": {"type": ["string", "null"]},
+        "submission_format": {"type": "string"},
+        "submission_requirements": {"type": "object"},
+        "safety_rules": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": [
+        "bounty_id",
+        "issue_number",
+        "status",
+        "availability",
+        "can_submit",
+        "availability_warnings",
+        "awards_remaining",
+        "max_awards",
+        "awards_paid",
+        "reward_mrwk",
+        "available_mrwk",
+        "repository",
+        "issue_url",
+        "title",
+        "acceptance",
+        "submission_format",
+        "submission_requirements",
+        "safety_rules",
+    ],
+    "additionalProperties": True,
+}
+
 MCP_TOOLS: list[dict[str, Any]] = [
     {
         "name": "list_bounties",
@@ -441,6 +492,7 @@ MCP_TOOLS: list[dict[str, Any]] = [
                 {"if": {"required": ["bounty_id"]}, "then": {"not": {"required": ["repo"]}}},
             ],
         },
+        "outputSchema": MCP_WORK_PROOF_GUIDANCE_OUTPUT_SCHEMA,
     },
 ]
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -317,7 +317,7 @@ Tools:
 - `get_ledger_entry`
 - `get_proof`
 - `submit_work_proof` (`format: "json"` returns structuredContent; `tools/list`
-  advertises the selector and format schema)
+  advertises the selector, format, and JSON output schemas)
 
 `tools/list` advertises required selector schemas for proof and ledger lookups:
 `get_proof` requires a 64-character proof `hash`, and `get_ledger_entry`

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -399,6 +399,32 @@ def test_mcp_tools_list_and_call(sqlite_url: str) -> None:
         },
         {"if": {"required": ["bounty_id"]}, "then": {"not": {"required": ["repo"]}}},
     ]
+    submit_output_schema = submit_tool["outputSchema"]
+    assert "Machine-readable bounty submission guidance" in submit_output_schema["description"]
+    assert submit_output_schema["additionalProperties"] is True
+    assert submit_output_schema["properties"]["bounty_id"]["type"] == ["integer", "null"]
+    assert submit_output_schema["properties"]["can_submit"]["type"] == ["boolean", "null"]
+    assert submit_output_schema["properties"]["submission_requirements"]["type"] == "object"
+    assert submit_output_schema["required"] == [
+        "bounty_id",
+        "issue_number",
+        "status",
+        "availability",
+        "can_submit",
+        "availability_warnings",
+        "awards_remaining",
+        "max_awards",
+        "awards_paid",
+        "reward_mrwk",
+        "available_mrwk",
+        "repository",
+        "issue_url",
+        "title",
+        "acceptance",
+        "submission_format",
+        "submission_requirements",
+        "safety_rules",
+    ]
     bounty_tool = next(tool for tool in tools["result"]["tools"] if tool["name"] == "get_bounty")
     assert "accepted awards" in bounty_tool["description"]
     bounty_schema = bounty_tool["inputSchema"]
@@ -2127,6 +2153,11 @@ def test_mcp_submit_work_proof_returns_structured_bounty_guidance(sqlite_url: st
 
     structured = result["structuredContent"]
     assert json.loads(result["content"][0]["text"]) == structured
+    tools = client.post("/mcp", json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"}).json()
+    submit_tool = next(
+        tool for tool in tools["result"]["tools"] if tool["name"] == "submit_work_proof"
+    )
+    assert set(submit_tool["outputSchema"]["required"]).issubset(structured)
     assert structured["bounty_id"] == bounty_id
     assert structured["issue_number"] == 315
     assert structured["status"] == "open"


### PR DESCRIPTION
Bounty #946

## Summary
- Add an MCP outputSchema for submit_work_proof JSON guidance.
- Assert tools/list advertises the schema and runtime structuredContent includes required fields.
- Update the agent guide to mention the JSON output schema.

## Scope
- MCP tools/list schema metadata for submit_work_proof only.
- No payout, ledger mutation, wallet custody, bridge, exchange, off-ramp, or price behavior changes.

## Verification
- python -m pytest tests/test_api_mcp.py -q -> 140 passed, 1 warning
- python -m ruff format --check app/mcp.py tests/test_api_mcp.py -> 2 files already formatted
- python -m ruff check app/mcp.py tests/test_api_mcp.py docs/agent-guide.md -> All checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `submit_work_proof` MCP tool now includes output schema documentation.

* **Documentation**
  * Updated MCP tool documentation to clarify output schema definitions.

* **Tests**
  * Added validation tests for MCP tool output schema consistency and required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->