### PR TITLE
Add public template text smoke check (proposed-work #1111)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ small, verifiable, and easy for maintainers to review.
 - Add or update tests for changed behavior.
 - Update docs for public behavior changes.
 - Run `python scripts/docs_smoke.py` when changing docs, templates, examples, or onboarding.
+- Run `python scripts/template_text_smoke.py` when changing public template text or notices, to catch typographic quotes, mojibake, and raw `{{ }}` placeholder leakage before review.
 - Do not submit generated noise, duplicate reports, or unrelated rewrites.
 - Do not claim payout, acceptance, or ledger status that has not happened.
 

--- a/scripts/template_text_smoke.py
+++ b/scripts/template_text_smoke.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLIC_TEMPLATE_DIR = ROOT / "app" / "templates"
+
+# Typographic / "smart" quote characters that should not wrap dynamic public
+# notice text. The recurring activity/wallet/bounty search-notice fixes
+# (for example PR #1052 and PR #1110) all replaced these with plain ASCII
+# quotes so the rendered notice stays readable across browsers and terminals.
+SMART_QUOTES: tuple[str, ...] = (
+    "“",  # left double quotation mark
+    "”",  # right double quotation mark
+    "‘",  # left single quotation mark
+    "’",  # right single quotation mark
+    "„",  # double low-9 quotation mark
+    "‚",  # single low-9 quotation mark
+    "″",  # double prime
+    "′",  # single prime
+)
+
+# U+FFFD marks a decode failure; it is a reliable mojibake signal.
+REPLACEMENT_CHAR = "�"
+
+# Common "UTF-8 bytes decoded as Latin-1" mojibake sequences for the same
+# curly quotes/dashes above. These show up when notice text round-trips
+# through a mismatched encoding before it reaches the page.
+MOJIBAKE_SEQUENCES: tuple[str, ...] = (
+    "â€œ",  # curly left double quote
+    "â€",  # curly right double quote
+    "â€™",  # curly apostrophe
+    "â€˜",  # curly left single quote
+    "â€“",  # en dash
+)
+
+# Jinja delimiters that must never survive into rendered output a reader sees.
+RAW_PLACEHOLDER_OPEN = "{{"
+RAW_PLACEHOLDER_CLOSE = "}}"
+
+# A line carrying this marker is intentionally exempt (docs/code examples or
+# deliberately non-ASCII content). Keeps the rule bounded, per the issue.
+ALLOW_MARKER = "template-text-smoke: allow"
+
+
+@dataclass(frozen=True)
+class Finding:
+    source: str
+    line: int
+    kind: str
+    detail: str
+
+    def describe(self) -> str:
+        return f"{self.source}:{self.line}: {self.kind}: {self.detail}"
+
+
+def scan_text(text: str, *, source: str = "<text>", allow_jinja: bool = True) -> list[Finding]:
+    """Return rendering-hazard findings for ``text``.
+
+    ``allow_jinja=True`` treats the input as template source, where ``{{ ... }}``
+    placeholders are expected. ``allow_jinja=False`` treats the input as rendered
+    output, where a surviving ``{{ ... }}`` placeholder is a leak.
+    """
+
+    findings: list[Finding] = []
+    for index, line in enumerate(text.splitlines(), start=1):
+        if ALLOW_MARKER in line:
+            continue
+        for quote in SMART_QUOTES:
+            if quote in line:
+                findings.append(
+                    Finding(source, index, "smart-quote", f"typographic quote {quote!r}")
+                )
+                break
+        if REPLACEMENT_CHAR in line:
+            findings.append(
+                Finding(source, index, "replacement-char", "U+FFFD replacement character")
+            )
+        for sequence in MOJIBAKE_SEQUENCES:
+            if sequence in line:
+                findings.append(
+                    Finding(source, index, "mojibake", f"mojibake sequence {sequence!r}")
+                )
+                break
+        if not allow_jinja and RAW_PLACEHOLDER_OPEN in line and RAW_PLACEHOLDER_CLOSE in line:
+            findings.append(
+                Finding(source, index, "raw-placeholder", "raw Jinja placeholder in rendered text")
+            )
+    return findings
+
+
+def _display(path: Path) -> str:
+    """Show a repo-relative path when possible, otherwise the given path."""
+    try:
+        return path.resolve().relative_to(ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def iter_public_templates() -> list[Path]:
+    return sorted(PUBLIC_TEMPLATE_DIR.glob("*.html"))
+
+
+def scan_template_file(path: Path) -> list[Finding]:
+    return scan_text(path.read_text(encoding="utf-8"), source=_display(path), allow_jinja=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Smoke-check public template text for rendering hazards.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help="Files to scan. Defaults to app/templates/*.html.",
+    )
+    parser.add_argument(
+        "--rendered",
+        action="store_true",
+        help="Treat input as rendered HTML and also flag raw {{ }} placeholder leakage.",
+    )
+    args = parser.parse_args(argv)
+
+    targets = args.paths or iter_public_templates()
+    findings: list[Finding] = []
+    for path in targets:
+        if not path.exists():
+            print(f"missing: {path}")
+            return 1
+        text = path.read_text(encoding="utf-8")
+        findings.extend(scan_text(text, source=_display(path), allow_jinja=not args.rendered))
+
+    for finding in findings:
+        print(finding.describe())
+    if findings:
+        print(f"template text smoke found {len(findings)} hazard(s)")
+        return 1
+    print("template text smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_template_text_smoke.py
+++ b/tests/test_template_text_smoke.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from scripts.template_text_smoke import iter_public_templates, scan_text
+
+
+def test_smart_quote_search_notice_is_flagged() -> None:
+    bad = "Showing wallets matching “{{ query_text }}”."
+    findings = scan_text(bad, source="wallets.html")
+    assert any(f.kind == "smart-quote" for f in findings)
+
+
+def test_normalized_ascii_template_notice_passes() -> None:
+    good = 'Showing wallets matching "{{ query_text }}".'
+    assert scan_text(good, source="wallets.html") == []
+
+
+def test_rendered_ascii_notice_passes() -> None:
+    rendered = 'Showing wallets matching "alice".'
+    assert scan_text(rendered, source="rendered", allow_jinja=False) == []
+
+
+def test_raw_placeholder_leak_in_rendered_output_is_flagged() -> None:
+    leaked = "Showing accepted work matching {{ query }}."
+    findings = scan_text(leaked, source="rendered", allow_jinja=False)
+    assert any(f.kind == "raw-placeholder" for f in findings)
+
+
+def test_raw_placeholder_allowed_in_template_source() -> None:
+    template = 'Showing accepted work matching "{{ query }}".'
+    assert scan_text(template, allow_jinja=True) == []
+
+
+def test_replacement_character_is_flagged() -> None:
+    broken = "Showing wallets matching �Main�."
+    findings = scan_text(broken)
+    assert any(f.kind == "replacement-char" for f in findings)
+
+
+def test_mojibake_sequence_is_flagged() -> None:
+    moji = "Showing wallets matching â€œMainâ€."
+    findings = scan_text(moji)
+    assert any(f.kind == "mojibake" for f in findings)
+
+
+def test_allow_marker_suppresses_finding() -> None:
+    line = "intentional “curly” example {# template-text-smoke: allow #}"
+    assert scan_text(line) == []
+
+
+def test_line_number_is_reported() -> None:
+    text = "ok line\nbad “quote” line\n"
+    findings = scan_text(text)
+    assert findings
+    assert findings[0].line == 2
+
+
+def test_public_templates_are_discoverable() -> None:
+    templates = iter_public_templates()
+    assert any(p.name == "wallets.html" for p in templates)
+    assert all(p.suffix == ".html" for p in templates)


### PR DESCRIPTION
## Summary

Adds a small, reusable smoke check for the recurring public-page text hazard that PR #1052 (activity) and PR #1110 (wallets) each fixed one page at a time: dynamic search-state notices written with typographic quotes around a Jinja variable, plus related mojibake/placeholder leakage. Instead of every page test re-asserting its own string hygiene, contributors and agents get one focused command.

Refs #1111

## What it does

`scripts/template_text_smoke.py` scans public template text (and, with `--rendered`, rendered HTML) for:

- typographic / "smart" quotes (`“ ” ‘ ’` etc.) around dynamic notice text;
- U+FFFD replacement characters and common UTF-8-as-Latin-1 mojibake sequences (`â€œ`, `â€™`, …);
- raw `{{ ... }}` Jinja placeholder leakage in **rendered** output (`--rendered`).

Design notes:

- The scanning functions (`scan_text`) are pure and split from the CLI, so the rules unit-test without standing up the app.
- A line-level `template-text-smoke: allow` marker keeps intentional non-ASCII or documentation/code examples from over-blocking (the bounded-allowlist the issue asks for).
- It does not auto-rewrite templates, comment, label, or touch any bounty/ledger/treasury/wallet behavior.

## Files

- `scripts/template_text_smoke.py` — the checker (stdlib only).
- `tests/test_template_text_smoke.py` — focused fixtures (raw-placeholder case, mojibake case, replacement-char case, smart-quote case, normalized-ASCII passes, allow-marker, line numbers, template discovery).
- `CONTRIBUTING.md` — documents the command next to the existing `docs_smoke.py` line.

## How to run

```
python scripts/template_text_smoke.py            # scan app/templates/*.html
python scripts/template_text_smoke.py --rendered path/to/rendered.html
python -m pytest tests/test_template_text_smoke.py -q
```

Running it on the current tree surfaces three live notice instances — `app/templates/activity.html`, `app/templates/wallets.html` (both already addressed by the open PRs #1052 / #1110), and a third in `app/templates/bounties.html:38` that no open PR covers yet. This PR intentionally does **not** edit those templates, to stay focused on the reusable check and avoid colliding with the open page PRs.

## Verification

- `python -m pytest tests/test_template_text_smoke.py -q` → 10 passed.
- `ruff format --check .` → clean (128 files).
- `ruff check .` → All checks passed.
- `python scripts/docs_smoke.py` → docs smoke ok.
- CLI live: scan of `app/templates/` reports the three notices and exits 1; a normalized-ASCII rendered notice exits 0; a rendered `{{ query }}` leak is flagged.

(App-level tests under `tests/` are unchanged; they target Python 3.12 like the rest of the app and run under CI. The added module is stdlib-only and imports no app code.)

## Honest framing

This is a **proposed-work intake** issue, not a live `mrwk:bounty` row, so I used `Refs #1111` rather than a closing keyword. It is useful work toward a possible maintainer `mrwk:accepted` award per the issue's `100-500 MRWK` reference tier — a project-token outcome, not a cash payout, and not paid or accepted until a maintainer applies the label and a public proof exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to require template quality verification when modifying public template text.

* **New Features**
  * Added automated validation tool that detects template rendering issues including encoding problems, formatting anomalies, and unintended placeholder leakage.

* **Tests**
  * Added comprehensive test coverage for template validation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->