### PR TITLE
Add ledger snapshot Merkle proofs

### DIFF
--- a/app/ledger/merkle.py
+++ b/app/ledger/merkle.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from app.ledger.service import canonical_json
+
+MERKLE_ROOT_SCHEMA = "mergework.ledger_snapshot_merkle_root.v1"
+MERKLE_ROOT_SCHEMA_VERSION = 1
+MERKLE_ACCOUNT_LEAF_SCHEMA = "mergework.ledger_snapshot_account_leaf.v1"
+MERKLE_ACCOUNT_PROOF_SCHEMA = "mergework.ledger_snapshot_account_proof.v1"
+MERKLE_ACCOUNT_PROOF_SCHEMA_VERSION = 1
+MERKLE_HASH_ALGORITHM = "sha256"
+
+_EMPTY_DOMAIN = "mergework.ledger_snapshot_merkle_empty.v1"
+_LEAF_DOMAIN = "mergework.ledger_snapshot_merkle_leaf.v1"
+_NODE_DOMAIN = "mergework.ledger_snapshot_merkle_node.v1"
+_ROOT_DOMAIN = "mergework.ledger_snapshot_merkle_root.v1"
+
+
+class MerkleProofError(ValueError):
+    pass
+
+
+def ledger_snapshot_merkle_root(snapshot: dict[str, Any]) -> dict[str, Any]:
+    """Return the deterministic Merkle root object for a Phase 2A snapshot."""
+    ledger_anchor = _snapshot_ledger_anchor(snapshot)
+    leaves = _snapshot_account_leaves(snapshot)
+    merkle_tree_hash = _merkle_tree_hash([_leaf_hash(leaf) for leaf in leaves])
+    return {
+        "schema": MERKLE_ROOT_SCHEMA,
+        "schema_version": MERKLE_ROOT_SCHEMA_VERSION,
+        "hash_algorithm": MERKLE_HASH_ALGORITHM,
+        "leaf_schema": MERKLE_ACCOUNT_LEAF_SCHEMA,
+        "ledger_anchor": ledger_anchor,
+        "tree_size": len(leaves),
+        "merkle_tree_hash": merkle_tree_hash,
+        "root_hash": _root_hash(ledger_anchor, len(leaves), merkle_tree_hash),
+    }
+
+
+def ledger_snapshot_account_proof(snapshot: dict[str, Any], account: str) -> dict[str, Any]:
+    """Return an account-balance membership proof for a Phase 2A snapshot."""
+    if not isinstance(account, str) or not account:
+        raise MerkleProofError("account must be a non-empty string")
+
+    leaves = _snapshot_account_leaves(snapshot)
+    try:
+        leaf_index = next(index for index, leaf in enumerate(leaves) if leaf["account"] == account)
+    except StopIteration as exc:
+        raise MerkleProofError("account is not present in the snapshot") from exc
+
+    leaf = leaves[leaf_index]
+    leaf_hashes = [_leaf_hash(candidate) for candidate in leaves]
+    return {
+        "schema": MERKLE_ACCOUNT_PROOF_SCHEMA,
+        "schema_version": MERKLE_ACCOUNT_PROOF_SCHEMA_VERSION,
+        "hash_algorithm": MERKLE_HASH_ALGORITHM,
+        "root": ledger_snapshot_merkle_root(snapshot),
+        "leaf": leaf,
+        "leaf_index": leaf_index,
+        "leaf_hash": leaf_hashes[leaf_index],
+        "proof": _proof_path(leaf_hashes, leaf_index),
+    }
+
+
+def verify_ledger_snapshot_account_proof(
+    proof: dict[str, Any],
+    *,
+    root: dict[str, Any] | None = None,
+) -> bool:
+    """Verify a Phase 2B account proof against its root object."""
+    try:
+        _validate_proof_shape(proof)
+        proof_root = proof["root"]
+        if root is not None and proof_root != root:
+            return False
+        if proof["leaf_hash"] != _leaf_hash(proof["leaf"]):
+            return False
+        if proof_root["tree_size"] <= proof["leaf_index"]:
+            return False
+
+        leaf_hash = proof["leaf_hash"]
+        if not isinstance(leaf_hash, str):
+            return False
+        current_hash = leaf_hash
+        index = proof["leaf_index"]
+        layer_size = proof_root["tree_size"]
+        for sibling in proof["proof"]:
+            if layer_size <= 1:
+                return False
+            position = sibling["position"]
+            sibling_hash = sibling["hash"]
+            if not isinstance(position, str) or not isinstance(sibling_hash, str):
+                return False
+            if position == "left":
+                if index % 2 == 0:
+                    return False
+                current_hash = _node_hash(sibling_hash, current_hash)
+            elif position == "right":
+                if index % 2 != 0 or index + 1 >= layer_size:
+                    return False
+                current_hash = _node_hash(current_hash, sibling_hash)
+            else:
+                return False
+            index //= 2
+            layer_size = (layer_size + 1) // 2
+
+        merkle_tree_hash = proof_root["merkle_tree_hash"]
+        root_hash = proof_root["root_hash"]
+        if not isinstance(merkle_tree_hash, str) or not isinstance(root_hash, str):
+            return False
+        expected_root_hash = _root_hash(
+            proof_root["ledger_anchor"],
+            proof_root["tree_size"],
+            merkle_tree_hash,
+        )
+        return (
+            current_hash == merkle_tree_hash
+            and root_hash == expected_root_hash
+            and index == 0
+            and layer_size == 1
+        )
+    except (KeyError, TypeError, MerkleProofError):
+        return False
+
+
+def ledger_snapshot_merkle_root_json(snapshot: dict[str, Any]) -> str:
+    return canonical_json(ledger_snapshot_merkle_root(snapshot)) + "\n"
+
+
+def ledger_snapshot_account_proof_json(snapshot: dict[str, Any], account: str) -> str:
+    return canonical_json(ledger_snapshot_account_proof(snapshot, account)) + "\n"
+
+
+def _snapshot_ledger_anchor(snapshot: dict[str, Any]) -> dict[str, Any]:
+    try:
+        anchor = snapshot["ledger_anchor"]
+        latest_sequence = anchor["latest_sequence"]
+        latest_entry_hash = anchor["latest_entry_hash"]
+    except KeyError as exc:
+        raise MerkleProofError("snapshot must include a ledger anchor") from exc
+    if isinstance(latest_sequence, bool) or not isinstance(latest_sequence, int):
+        raise MerkleProofError("latest_sequence must be an integer")
+    if latest_entry_hash is not None and not _is_hash_hex(latest_entry_hash):
+        raise MerkleProofError("latest_entry_hash must be a SHA-256 hash or null")
+    return {
+        "latest_sequence": latest_sequence,
+        "latest_entry_hash": latest_entry_hash,
+    }
+
+
+def _snapshot_account_leaves(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    accounts = snapshot.get("accounts")
+    if not isinstance(accounts, list):
+        raise MerkleProofError("snapshot accounts must be a list")
+
+    leaves: list[dict[str, Any]] = []
+    seen_accounts: set[str] = set()
+    for row in accounts:
+        if not isinstance(row, dict):
+            raise MerkleProofError("snapshot account rows must be objects")
+        account = row.get("account")
+        balance = row.get("balance_microunits")
+        if not isinstance(account, str) or not account:
+            raise MerkleProofError("account must be a non-empty string")
+        if account in seen_accounts:
+            raise MerkleProofError("snapshot accounts must be unique")
+        if isinstance(balance, bool) or not isinstance(balance, int):
+            raise MerkleProofError("balance_microunits must be an integer")
+        seen_accounts.add(account)
+        leaves.append(
+            {
+                "schema": MERKLE_ACCOUNT_LEAF_SCHEMA,
+                "account": account,
+                "balance_microunits": balance,
+            }
+        )
+    return sorted(leaves, key=lambda leaf: leaf["account"])
+
+
+def _merkle_tree_hash(leaf_hashes: list[str]) -> str:
+    if not leaf_hashes:
+        return _hash_json(
+            _EMPTY_DOMAIN,
+            {
+                "schema": MERKLE_ROOT_SCHEMA,
+                "tree_size": 0,
+            },
+        )
+    layer = leaf_hashes
+    while len(layer) > 1:
+        layer = _next_layer(layer)
+    return layer[0]
+
+
+def _proof_path(leaf_hashes: list[str], leaf_index: int) -> list[dict[str, str]]:
+    proof: list[dict[str, str]] = []
+    index = leaf_index
+    layer = leaf_hashes
+    while len(layer) > 1:
+        if index % 2 == 0:
+            sibling_index = index + 1
+            if sibling_index < len(layer):
+                proof.append({"position": "right", "hash": layer[sibling_index]})
+        else:
+            proof.append({"position": "left", "hash": layer[index - 1]})
+        index //= 2
+        layer = _next_layer(layer)
+    return proof
+
+
+def _next_layer(layer: list[str]) -> list[str]:
+    next_layer: list[str] = []
+    for index in range(0, len(layer), 2):
+        if index + 1 >= len(layer):
+            next_layer.append(layer[index])
+        else:
+            next_layer.append(_node_hash(layer[index], layer[index + 1]))
+    return next_layer
+
+
+def _leaf_hash(leaf: dict[str, Any]) -> str:
+    if leaf.get("schema") != MERKLE_ACCOUNT_LEAF_SCHEMA:
+        raise MerkleProofError("unsupported account leaf schema")
+    account = leaf.get("account")
+    balance = leaf.get("balance_microunits")
+    if not isinstance(account, str) or not account:
+        raise MerkleProofError("account must be a non-empty string")
+    if isinstance(balance, bool) or not isinstance(balance, int):
+        raise MerkleProofError("balance_microunits must be an integer")
+    return _hash_json(
+        _LEAF_DOMAIN,
+        {
+            "schema": MERKLE_ACCOUNT_LEAF_SCHEMA,
+            "account": account,
+            "balance_microunits": balance,
+        },
+    )
+
+
+def _node_hash(left_hash: str, right_hash: str) -> str:
+    if not _is_hash_hex(left_hash) or not _is_hash_hex(right_hash):
+        raise MerkleProofError("Merkle node children must be SHA-256 hashes")
+    return _hash_json(
+        _NODE_DOMAIN,
+        {
+            "left": left_hash,
+            "right": right_hash,
+        },
+    )
+
+
+def _root_hash(ledger_anchor: dict[str, Any], tree_size: int, merkle_tree_hash: str) -> str:
+    if isinstance(tree_size, bool) or not isinstance(tree_size, int):
+        raise MerkleProofError("tree_size must be an integer")
+    if tree_size < 0:
+        raise MerkleProofError("tree_size must be non-negative")
+    if not _is_hash_hex(merkle_tree_hash):
+        raise MerkleProofError("merkle_tree_hash must be a SHA-256 hash")
+    return _hash_json(
+        _ROOT_DOMAIN,
+        {
+            "ledger_anchor": _snapshot_ledger_anchor({"ledger_anchor": ledger_anchor}),
+            "merkle_tree_hash": merkle_tree_hash,
+            "tree_size": tree_size,
+        },
+    )
+
+
+def _hash_json(domain: str, payload: dict[str, Any]) -> str:
+    body = canonical_json(
+        {
+            "domain": domain,
+            "payload": payload,
+        }
+    )
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _validate_proof_shape(proof: dict[str, Any]) -> None:
+    if proof.get("schema") != MERKLE_ACCOUNT_PROOF_SCHEMA:
+        raise MerkleProofError("unsupported proof schema")
+    if proof.get("schema_version") != MERKLE_ACCOUNT_PROOF_SCHEMA_VERSION:
+        raise MerkleProofError("unsupported proof schema version")
+    if proof.get("hash_algorithm") != MERKLE_HASH_ALGORITHM:
+        raise MerkleProofError("unsupported proof hash algorithm")
+    if not isinstance(proof.get("leaf_index"), int) or isinstance(proof.get("leaf_index"), bool):
+        raise MerkleProofError("leaf_index must be an integer")
+    if proof["leaf_index"] < 0:
+        raise MerkleProofError("leaf_index must be non-negative")
+    if not _is_hash_hex(proof.get("leaf_hash")):
+        raise MerkleProofError("leaf_hash must be a SHA-256 hash")
+    if not isinstance(proof.get("proof"), list):
+        raise MerkleProofError("proof path must be a list")
+    _validate_root_shape(proof.get("root"))
+    for sibling in proof["proof"]:
+        if not isinstance(sibling, dict):
+            raise MerkleProofError("proof sibling must be an object")
+        if sibling.get("position") not in {"left", "right"}:
+            raise MerkleProofError("proof sibling position is invalid")
+        if not _is_hash_hex(sibling.get("hash")):
+            raise MerkleProofError("proof sibling hash must be a SHA-256 hash")
+
+
+def _validate_root_shape(root: Any) -> None:
+    if not isinstance(root, dict):
+        raise MerkleProofError("root must be an object")
+    if root.get("schema") != MERKLE_ROOT_SCHEMA:
+        raise MerkleProofError("unsupported root schema")
+    if root.get("schema_version") != MERKLE_ROOT_SCHEMA_VERSION:
+        raise MerkleProofError("unsupported root schema version")
+    if root.get("hash_algorithm") != MERKLE_HASH_ALGORITHM:
+        raise MerkleProofError("unsupported root hash algorithm")
+    if root.get("leaf_schema") != MERKLE_ACCOUNT_LEAF_SCHEMA:
+        raise MerkleProofError("unsupported root leaf schema")
+    if not isinstance(root.get("tree_size"), int) or isinstance(root.get("tree_size"), bool):
+        raise MerkleProofError("tree_size must be an integer")
+    if root["tree_size"] <= 0:
+        raise MerkleProofError("account proofs require a non-empty tree")
+    if not _is_hash_hex(root.get("merkle_tree_hash")):
+        raise MerkleProofError("merkle_tree_hash must be a SHA-256 hash")
+    if not _is_hash_hex(root.get("root_hash")):
+        raise MerkleProofError("root_hash must be a SHA-256 hash")
+    anchor = root.get("ledger_anchor")
+    if not isinstance(anchor, dict):
+        raise MerkleProofError("root ledger anchor must be an object")
+    _snapshot_ledger_anchor({"ledger_anchor": anchor})
+
+
+def _is_hash_hex(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(char in "0123456789abcdef" for char in value)
+    )

--- a/app/ledger/merkle.py
+++ b/app/ledger/merkle.py
@@ -87,6 +87,9 @@ def verify_ledger_snapshot_account_proof(
         index = proof["leaf_index"]
         layer_size = proof_root["tree_size"]
         for sibling in proof["proof"]:
+            while layer_size > 1 and index % 2 == 0 and index + 1 >= layer_size:
+                index //= 2
+                layer_size = (layer_size + 1) // 2
             if layer_size <= 1:
                 return False
             position = sibling["position"]
@@ -103,6 +106,10 @@ def verify_ledger_snapshot_account_proof(
                 current_hash = _node_hash(current_hash, sibling_hash)
             else:
                 return False
+            index //= 2
+            layer_size = (layer_size + 1) // 2
+
+        while layer_size > 1 and index % 2 == 0 and index + 1 >= layer_size:
             index //= 2
             layer_size = (layer_size + 1) // 2
 

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -94,6 +94,24 @@ committed ledger entries, the hash chain, and fixed-supply conservation, but it
 does not replay every historical treasury proposal, challenge, or governance
 rule. Pending treasury proposals are not committed ledger state.
 
+Phase 2B adds read-only Merkle artifacts for those Phase 2A account balances:
+
+```bash
+python scripts/export_ledger_merkle_proof.py > ledger-merkle-root.json
+python scripts/export_ledger_merkle_proof.py --account github:alice > alice-proof.json
+```
+
+The Merkle root uses the snapshot account rows and ledger anchor only. Snapshot
+metadata such as `generated_at`, source host, or source mode does not affect the
+root for the same committed ledger state. Leaves, internal nodes, empty-tree
+roots, root objects, and proof objects are all versioned/domain-separated and
+hashed from canonical JSON rather than raw string concatenation.
+
+Account proofs include the versioned account leaf, leaf index, sibling path, and
+root object. Local verification recomputes the leaf and path and rejects changed
+account names, integer balances, sibling hashes, sibling directions, tree size,
+root hash, or ledger anchor.
+
 This snapshot is read-only infrastructure. It is not a bridge, exchange,
 off-ramp, custody path, relayer, redemption mechanism, price signal, or live
 external-value claim.

--- a/scripts/export_ledger_merkle_proof.py
+++ b/scripts/export_ledger_merkle_proof.py
@@ -36,6 +36,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     settings = get_settings()
     database_url = args.database_url or settings.database_url
+    if not database_url:
+        print(
+            "Error: database URL not provided. Set MERGEWORK_DATABASE_URL or use --database-url",
+            file=sys.stderr,
+        )
+        return 1
     source_host = args.source_host if args.source_host is not None else settings.public_base_url
     with read_only_session_scope(database_url) as session:
         snapshot = ledger_snapshot(
@@ -44,6 +50,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             source_host=source_host,
         )
         if args.account:
+            if not any(row.get("account") == args.account for row in snapshot.get("accounts", [])):
+                print(f"Error: account '{args.account}' not found in snapshot", file=sys.stderr)
+                return 1
             sys.stdout.write(ledger_snapshot_account_proof_json(snapshot, args.account))
         else:
             sys.stdout.write(ledger_snapshot_merkle_root_json(snapshot))

--- a/scripts/export_ledger_merkle_proof.py
+++ b/scripts/export_ledger_merkle_proof.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.config import get_settings
+from app.ledger.merkle import (
+    ledger_snapshot_account_proof_json,
+    ledger_snapshot_merkle_root_json,
+)
+from app.ledger.snapshot import ledger_snapshot
+from scripts.export_ledger_snapshot import read_only_session_scope
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Export read-only Merkle artifacts for a Phase 2A MRWK ledger snapshot."
+    )
+    parser.add_argument("--database-url", help="Database URL. Defaults to MERGEWORK_DATABASE_URL.")
+    parser.add_argument("--source-host", help="Public source host/origin for snapshot metadata.")
+    parser.add_argument(
+        "--source-mode",
+        default="database",
+        help="Source mode label for snapshot metadata. Defaults to database.",
+    )
+    parser.add_argument(
+        "--account",
+        help="Account to prove. When omitted, only the Merkle root object is printed.",
+    )
+    args = parser.parse_args(argv)
+
+    settings = get_settings()
+    database_url = args.database_url or settings.database_url
+    source_host = args.source_host if args.source_host is not None else settings.public_base_url
+    with read_only_session_scope(database_url) as session:
+        snapshot = ledger_snapshot(
+            session,
+            source_mode=args.source_mode,
+            source_host=source_host,
+        )
+        if args.account:
+            sys.stdout.write(ledger_snapshot_account_proof_json(snapshot, args.account))
+        else:
+            sys.stdout.write(ledger_snapshot_merkle_root_json(snapshot))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ledger_merkle.py
+++ b/tests/test_ledger_merkle.py
@@ -118,6 +118,29 @@ def test_merkle_account_proof_verifies_and_serializes_deterministically(
     assert proof_json == ledger_snapshot_account_proof_json(snapshot, "github:alice")
 
 
+def test_merkle_account_proof_verifies_promoted_last_leaf_in_odd_tree() -> None:
+    snapshot = {
+        "ledger_anchor": {
+            "latest_sequence": 3,
+            "latest_entry_hash": "a" * 64,
+        },
+        "accounts": [
+            {"account": "github:alice", "balance_microunits": 12_500_000},
+            {"account": "github:bob", "balance_microunits": 7_000_000},
+            {"account": "treasury:mrwk", "balance_microunits": -19_500_000},
+        ],
+    }
+
+    root = ledger_snapshot_merkle_root(snapshot)
+    proof = ledger_snapshot_account_proof(snapshot, "treasury:mrwk")
+
+    assert root["tree_size"] == 3
+    assert proof["leaf_index"] == 2
+    assert len(proof["proof"]) == 1
+    assert proof["proof"][0]["position"] == "left"
+    assert verify_ledger_snapshot_account_proof(proof, root=root) is True
+
+
 def test_merkle_proof_rejects_tampered_leaf_siblings_root_and_anchor(sqlite_url: str) -> None:
     snapshot = _multi_account_snapshot(sqlite_url)
     root = ledger_snapshot_merkle_root(snapshot)
@@ -140,6 +163,10 @@ def test_merkle_proof_rejects_tampered_leaf_siblings_root_and_anchor(sqlite_url:
         "left" if proof["proof"][0]["position"] == "right" else "right"
     )
     assert verify_ledger_snapshot_account_proof(tampered_direction, root=root) is False
+
+    tampered_proof_root_hash = copy.deepcopy(proof)
+    tampered_proof_root_hash["root"]["root_hash"] = "1" * 64
+    assert verify_ledger_snapshot_account_proof(tampered_proof_root_hash) is False
 
     tampered_root = copy.deepcopy(root)
     tampered_root["root_hash"] = "1" * 64

--- a/tests/test_ledger_merkle.py
+++ b/tests/test_ledger_merkle.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import copy
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from app.db import create_schema, session_scope
+from app.ledger.merkle import (
+    MERKLE_ACCOUNT_LEAF_SCHEMA,
+    MERKLE_ACCOUNT_PROOF_SCHEMA,
+    MERKLE_ROOT_SCHEMA,
+    MerkleProofError,
+    ledger_snapshot_account_proof,
+    ledger_snapshot_account_proof_json,
+    ledger_snapshot_merkle_root,
+    ledger_snapshot_merkle_root_json,
+    verify_ledger_snapshot_account_proof,
+)
+from app.ledger.service import TREASURY_ACCOUNT, create_bounty, ensure_genesis, pay_bounty
+from app.ledger.snapshot import ledger_snapshot
+from scripts.export_ledger_merkle_proof import main as export_ledger_merkle_proof_main
+
+
+def test_merkle_root_ignores_nondeterministic_snapshot_metadata(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=1027,
+            issue_url="https://github.com/ramimbo/mergework/issues/1027",
+            title="Snapshot proof bounty",
+            reward_mrwk="12.5",
+            max_awards=2,
+            acceptance="Focused read-only Merkle proof helpers.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/1200",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        first = ledger_snapshot(
+            session,
+            generated_at=datetime(2026, 6, 2, 12, 0, tzinfo=UTC),
+            source_mode="test",
+            source_host="https://one.example",
+        )
+        second = ledger_snapshot(
+            session,
+            generated_at=datetime(2026, 6, 3, 12, 0, tzinfo=UTC),
+            source_mode="other",
+            source_host="https://two.example",
+        )
+
+    first_root = ledger_snapshot_merkle_root(first)
+    second_root = ledger_snapshot_merkle_root(second)
+
+    assert first_root == second_root
+    assert first_root["schema"] == MERKLE_ROOT_SCHEMA
+    assert first_root["ledger_anchor"] == first["ledger_anchor"]
+    assert first_root["tree_size"] == len(first["accounts"])
+    assert json.loads(ledger_snapshot_merkle_root_json(first)) == first_root
+    assert ledger_snapshot_merkle_root_json(first) == ledger_snapshot_merkle_root_json(second)
+
+
+def test_merkle_root_defines_empty_and_single_leaf_behavior(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        empty_snapshot = ledger_snapshot(
+            session,
+            generated_at=datetime(2026, 6, 2, tzinfo=UTC),
+        )
+        ensure_genesis(session)
+        single_leaf_snapshot = ledger_snapshot(
+            session,
+            generated_at=datetime(2026, 6, 2, tzinfo=UTC),
+        )
+
+    empty_root = ledger_snapshot_merkle_root(empty_snapshot)
+    single_root = ledger_snapshot_merkle_root(single_leaf_snapshot)
+    single_proof = ledger_snapshot_account_proof(single_leaf_snapshot, TREASURY_ACCOUNT)
+
+    assert empty_root["tree_size"] == 0
+    assert len(empty_root["merkle_tree_hash"]) == 64
+    assert len(empty_root["root_hash"]) == 64
+    assert single_root["tree_size"] == 1
+    assert single_proof["proof"] == []
+    assert verify_ledger_snapshot_account_proof(single_proof, root=single_root) is True
+    with pytest.raises(MerkleProofError, match="account is not present"):
+        ledger_snapshot_account_proof(empty_snapshot, TREASURY_ACCOUNT)
+
+
+def test_merkle_account_proof_verifies_and_serializes_deterministically(
+    sqlite_url: str,
+) -> None:
+    snapshot = _multi_account_snapshot(sqlite_url)
+
+    root = ledger_snapshot_merkle_root(snapshot)
+    proof = ledger_snapshot_account_proof(snapshot, "github:alice")
+    proof_json = ledger_snapshot_account_proof_json(snapshot, "github:alice")
+
+    assert proof["schema"] == MERKLE_ACCOUNT_PROOF_SCHEMA
+    assert proof["root"] == root
+    assert proof["leaf"]["schema"] == MERKLE_ACCOUNT_LEAF_SCHEMA
+    assert proof["leaf"]["account"] == "github:alice"
+    assert proof["leaf"]["balance_microunits"] == 12_500_000
+    assert len(proof["proof"]) >= 1
+    assert verify_ledger_snapshot_account_proof(proof, root=root) is True
+    assert json.loads(proof_json) == proof
+    assert proof_json == ledger_snapshot_account_proof_json(snapshot, "github:alice")
+
+
+def test_merkle_proof_rejects_tampered_leaf_siblings_root_and_anchor(sqlite_url: str) -> None:
+    snapshot = _multi_account_snapshot(sqlite_url)
+    root = ledger_snapshot_merkle_root(snapshot)
+    proof = ledger_snapshot_account_proof(snapshot, "github:alice")
+
+    tampered_account = copy.deepcopy(proof)
+    tampered_account["leaf"]["account"] = "github:bob"
+    assert verify_ledger_snapshot_account_proof(tampered_account, root=root) is False
+
+    tampered_balance = copy.deepcopy(proof)
+    tampered_balance["leaf"]["balance_microunits"] += 1
+    assert verify_ledger_snapshot_account_proof(tampered_balance, root=root) is False
+
+    tampered_sibling_hash = copy.deepcopy(proof)
+    tampered_sibling_hash["proof"][0]["hash"] = "0" * 64
+    assert verify_ledger_snapshot_account_proof(tampered_sibling_hash, root=root) is False
+
+    tampered_direction = copy.deepcopy(proof)
+    tampered_direction["proof"][0]["position"] = (
+        "left" if proof["proof"][0]["position"] == "right" else "right"
+    )
+    assert verify_ledger_snapshot_account_proof(tampered_direction, root=root) is False
+
+    tampered_root = copy.deepcopy(root)
+    tampered_root["root_hash"] = "1" * 64
+    assert verify_ledger_snapshot_account_proof(proof, root=tampered_root) is False
+
+    tampered_anchor = copy.deepcopy(proof)
+    tampered_anchor["root"]["ledger_anchor"]["latest_sequence"] += 1
+    assert verify_ledger_snapshot_account_proof(tampered_anchor, root=root) is False
+    assert verify_ledger_snapshot_account_proof(tampered_anchor) is False
+
+    tampered_tree_size = copy.deepcopy(proof)
+    tampered_tree_size["root"]["tree_size"] += 1
+    assert verify_ledger_snapshot_account_proof(tampered_tree_size) is False
+
+
+def test_export_merkle_script_outputs_root_or_account_proof(
+    sqlite_url: str,
+    capsys,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    assert (
+        export_ledger_merkle_proof_main(
+            [
+                "--database-url",
+                sqlite_url,
+                "--source-host",
+                "https://mrwk.example",
+                "--source-mode",
+                "test",
+            ]
+        )
+        == 0
+    )
+    root = json.loads(capsys.readouterr().out)
+
+    assert root["schema"] == MERKLE_ROOT_SCHEMA
+    assert root["tree_size"] == 1
+
+    assert (
+        export_ledger_merkle_proof_main(
+            [
+                "--database-url",
+                sqlite_url,
+                "--source-host",
+                "https://mrwk.example",
+                "--source-mode",
+                "test",
+                "--account",
+                TREASURY_ACCOUNT,
+            ]
+        )
+        == 0
+    )
+    proof = json.loads(capsys.readouterr().out)
+
+    assert proof["schema"] == MERKLE_ACCOUNT_PROOF_SCHEMA
+    assert verify_ledger_snapshot_account_proof(proof, root=root) is True
+
+
+def _multi_account_snapshot(sqlite_url: str) -> dict:
+    create_schema(sqlite_url)
+
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=1027,
+            issue_url="https://github.com/ramimbo/mergework/issues/1027",
+            title="Snapshot proof bounty",
+            reward_mrwk="12.5",
+            max_awards=3,
+            acceptance="Focused read-only Merkle proof helpers.",
+        )
+        pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/1200",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:bob",
+            submission_url="https://github.com/ramimbo/mergework/pull/1201",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+        return ledger_snapshot(
+            session,
+            generated_at=datetime(2026, 6, 2, 12, 0, tzinfo=UTC),
+            source_mode="test",
+            source_host="https://mrwk.example",
+        )


### PR DESCRIPTION
Bounty #1027

## Summary

- Added read-only Phase 2B Merkle helpers for Phase 2A ledger snapshots.
- Added a CLI script that exports either a versioned Merkle root object or an account proof for a snapshot account.
- Bound the root hash to the snapshot ledger anchor, tree size, and Merkle tree hash so proofs reject ledger-anchor changes.
- Documented the read-only Merkle proof flow without bridge, exchange, off-ramp, custody, relayer, redemption, or external-value claims.

## JSON shape sample

Root objects include:

```json
{
  schema: mergework.ledger_snapshot_merkle_root.v1,
  schema_version: 1,
  hash_algorithm: sha256,
  leaf_schema: mergework.ledger_snapshot_account_leaf.v1,
  ledger_anchor: {latest_sequence: 1, latest_entry_hash: ...},
  tree_size: 1,
  merkle_tree_hash: ...,
  root_hash: ...
}
```

Account proofs include the root object, versioned account leaf, leaf index, leaf hash, and sibling path.

## Validation

- `python -m pytest`
- `python -m ruff format --check .`
- `python -m ruff check .`
- `python -m mypy app`

Public fork evidence from the earlier prepared branch: https://github.com/yZangEren/mergework/pull/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Merkle root and account proof generation for ledger snapshots with verification capabilities
  * Added command-line tool to export Merkle proofs and roots

* **Documentation**
  * Documented Phase 2B read-only Merkle artifact export and local verification procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->