### PR TITLE
Link proof pages to source issue activity

### DIFF
--- a/app/templates/proof.html
+++ b/app/templates/proof.html
@@ -73,6 +73,12 @@
       </strong>
     </article>
     <article>
+      <span>Source issue activity</span>
+      <strong>
+        <a href="/activity?q={{ issue_url | urlencode }}">Search source issue</a>
+      </strong>
+    </article>
+    <article>
       <span>Submission activity</span>
       <strong>
         <a href="/activity?q={{ proof.submission_url | urlencode }}">Search submission</a>

--- a/app/templates/proof.html
+++ b/app/templates/proof.html
@@ -75,7 +75,7 @@
     <article>
       <span>Source issue activity</span>
       <strong>
-        <a href="/activity?q={{ issue_url | urlencode }}">Search source issue</a>
+        <a href="/activity?q={{ ("https://github.com/" ~ proof.repo ~ "/issues/" ~ proof.issue_number) | urlencode }}">Search source issue</a>
       </strong>
     </article>
     <article>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -1194,6 +1194,7 @@ def test_ledger_and_proof_pages_make_bounty_payments_scannable(sqlite_url: str) 
     assert 'href="/activity?q=github%3Acontributor"' in proof_page.text
     assert f'href="/activity?q={proof_hash}"' in proof_page.text
     assert f'href="/activity?q={bounty.id}"' in proof_page.text
+    assert 'href="/activity?q=https%3A//github.com/ramimbo/mergework/issues/23"' in proof_page.text
     assert 'href="/activity?q=https%3A//github.com/ramimbo/mergework/pull/99"' in proof_page.text
 
     uppercase_proof_page = client.get(f"/proofs/{proof_hash.upper()}")


### PR DESCRIPTION
Bounty #1010
Refs #1010

## Summary
- Add a source issue activity link to bounty payment proof pages.
- Let contributors move from a proof page directly to `/activity?q=<source issue URL>` for the original bounty issue.
- Keep existing recipient, proof hash, bounty id, and submission activity links unchanged.

## Duplicate check
- Checked current #1010 claims and open PRs for proof/account/activity overlap.
- Existing work covers proof recipient account filtering, account-to-activity navigation, activity-to-account navigation, bounty-detail activity links, and ledger-entry activity links.
- I did not find an open submission adding a source-issue activity link from the proof page itself.

## Validation
- `uv run --extra dev python -m pytest tests\test_bounty_pages.py::test_ledger_and_proof_pages_make_bounty_payments_scannable -q` -> 1 passed, 1 existing Starlette/httpx warning.
- `uv run --extra dev ruff check tests\test_bounty_pages.py` -> All checks passed.
- `uv run --extra dev ruff format --check tests\test_bounty_pages.py` -> 1 file already formatted.
- `git diff --check` -> clean, with normal Windows LF-to-CRLF warnings for touched files.

## Scope
Touched surfaces: `app/templates/proof.html`, `tests/test_bounty_pages.py`.

This is public proof-page navigation and focused regression coverage only. No proof payload changes, no activity filtering semantics changes, no ledger mutation, no payout execution, no wallet signing/custody, no treasury/admin-token behavior, no bridge/exchange/off-ramp/cash-out behavior, no MRWK price behavior, no private data, and no secrets changed.

Payout boundary: this is a submitted #1010 bounty claim only. It is not earned or withdrawable unless maintainers accept it and record proof-backed payment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Source issue activity” card to the Related activity section on bounty payment pages.

* **Tests**
  * Updated bounty page tests to assert the new “/activity” link is rendered with the expected encoded source issue URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->