### PR TITLE
Reject transaction filters on account accepted-work API (proposed-work #1114)

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -200,8 +200,13 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
             return account_api_context(session, account)
 
     @app.get("/api/v1/accounts/{account}/accepted-work")
-    def api_account_accepted_work(account: str) -> dict[str, Any]:
+    def api_account_accepted_work(request: Request, account: str) -> dict[str, Any]:
         reject_path_whitespace_padding(account, "account")
+        reject_unsupported_query_params(
+            request,
+            ("type", "tx_type"),
+            context="account accepted-work JSON",
+        )
         with session_scope(db_url) as session:
             return account_accepted_work_context(session, account)
 

--- a/tests/test_account_validation.py
+++ b/tests/test_account_validation.py
@@ -337,3 +337,27 @@ def test_account_views_reject_malformed_reserve_accounts(sqlite_url: str, accoun
     assert page_resp.status_code == 400
     assert mcp_resp.status_code == 200
     assert mcp_resp.json()["error"]["code"] == -32602
+
+
+def test_api_account_accepted_work_rejects_type(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.get("/api/v1/accounts/github:alice/accepted-work?type=github_claim")
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "type is not supported on account accepted-work JSON"
+
+
+def test_api_account_accepted_work_rejects_tx_type(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.get("/api/v1/accounts/github:alice/accepted-work?tx_type=github_claim")
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "tx_type is not supported on account accepted-work JSON"
+
+
+def test_api_account_accepted_work_accepts_without_transaction_filter(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+    resp = client.get("/api/v1/accounts/github:alice/accepted-work")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["account"] == "github:alice"
+    assert "accepted_work" in body
+    assert "summary" in body


### PR DESCRIPTION
Implements proposed work #1114.

## Problem

`GET /api/v1/accounts/{account}/accepted-work` accepted the `type` and
`tx_type` transaction-filter query names and returned `200`, even though the
sibling `GET /api/v1/accounts/{account}` route already rejects them via
`reject_unsupported_query_params(...)`. Because `app/templates/account.html`
exposes both the transaction-filter UI and the accepted-work JSON link on the
same page, a caller could append `?type=` / `?tx_type=` to the accepted-work
endpoint and be misled into thinking the payload was filtered by transaction
type, when the endpoint returns the same proof-backed accepted-work
summary/list shape regardless.

## Change

- `app/accounts.py`: add `request: Request` to `api_account_accepted_work`
  and apply the existing guard
  `reject_unsupported_query_params(request, ("type", "tx_type"),
  context="account accepted-work JSON")`, mirroring the sibling account JSON
  route. No behavior change for valid requests.
- `tests/test_account_validation.py`: add three route tests — `?type=` → 400,
  `?tx_type=` → 400 (each with the `... is not supported on account
  accepted-work JSON` detail), and the unfiltered path still → 200.

## Verification (Python 3.12 venv)

- `pytest tests/test_account_routes.py tests/test_account_validation.py tests/test_query_validation.py` — **62 passed**
- New guard tests — **3 passed**
- `ruff format --check` — clean · `ruff check` — All checks passed
- Live probe against a booted app: unfiltered `200`; `?type=` and `?tx_type=`
  → `400` with the expected detail; sibling account JSON route still `400`;
  `POST` still `405`.

Scoped to the one missing guard plus its tests; no other endpoints touched.

Refs #1114

---
Note: I saw @rock2089 expressed interest on #1114 on 2026-06-07. I didn't see
an open PR for it, so I'm offering this as a ready, tested implementation —
happy to defer or collaborate if a maintainer prefers their submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The accepted-work endpoint now validates query parameters and rejects requests with unsupported parameters using HTTP 400 error responses.

* **Tests**
  * Added comprehensive test coverage for query parameter validation on the accepted-work endpoint, including edge cases and successful requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->