### PR TITLE
Add public bounty OpenAPI response schemas

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -26,6 +26,12 @@ from app.ledger.service import (
     validate_public_url,
 )
 from app.models import Bounty, Proof, Submission
+from app.openapi_request_bodies import (
+    PUBLIC_BOUNTY_DETAIL_RESPONSE,
+    PUBLIC_BOUNTY_LIST_RESPONSE,
+    PUBLIC_BOUNTY_SUMMARY_RESPONSE,
+    PUBLIC_WORK_DISCOVERY_RESPONSE,
+)
 from app.path_params import SQLITE_INTEGER_MAX, issue_number_search_value, positive_bounty_id
 from app.query_validation import (
     reject_control_char_query_param,
@@ -218,7 +224,7 @@ def register_bounty_api_routes(
             context="bounty detail",
         )
 
-    @app.get("/api/v1/bounties")
+    @app.get("/api/v1/bounties", openapi_extra=PUBLIC_BOUNTY_LIST_RESPONSE)
     def api_bounties(
         request: Request,
         status: str | None = Query(None),
@@ -240,7 +246,7 @@ def register_bounty_api_routes(
             availability=availability,
         )
 
-    @app.get("/api/v1/bounties/summary")
+    @app.get("/api/v1/bounties/summary", openapi_extra=PUBLIC_BOUNTY_SUMMARY_RESPONSE)
     def api_bounties_summary(
         request: Request,
         status: str | None = Query(None),
@@ -264,7 +270,7 @@ def register_bounty_api_routes(
             )
         )
 
-    @app.get("/api/v1/work-discovery")
+    @app.get("/api/v1/work-discovery", openapi_extra=PUBLIC_WORK_DISCOVERY_RESPONSE)
     def api_work_discovery(
         request: Request,
         limit: Annotated[
@@ -331,7 +337,7 @@ def register_bounty_api_routes(
             result["accepted_awards"] = bounty_awards_to_dict(session, bounty.id)
             return result
 
-    @app.get("/api/v1/bounties/{bounty_id}")
+    @app.get("/api/v1/bounties/{bounty_id}", openapi_extra=PUBLIC_BOUNTY_DETAIL_RESPONSE)
     def api_bounty(request: Request, bounty_id: str) -> dict[str, Any]:
         _reject_bounty_detail_list_filters(request)
         return get_bounty_detail(bounty_id)

--- a/app/bounty_attempts.py
+++ b/app/bounty_attempts.py
@@ -14,7 +14,11 @@ from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import LedgerError, validate_public_url
 from app.models import Bounty, BountyAttempt
-from app.openapi_request_bodies import OPTIONAL_ATTEMPT_BODY, OPTIONAL_ATTEMPT_RELEASE_BODY
+from app.openapi_request_bodies import (
+    OPTIONAL_ATTEMPT_BODY,
+    OPTIONAL_ATTEMPT_RELEASE_BODY,
+    PUBLIC_BOUNTY_ATTEMPTS_RESPONSE,
+)
 from app.query_validation import (
     reject_noncanonical_bool_query_param,
     reject_noncanonical_int_query_param,
@@ -249,7 +253,10 @@ def register_bounty_attempt_routes(
             raise HTTPException(status_code=403, detail="submitter_account does not match login")
         return submitter_account
 
-    @app.get("/api/v1/bounties/{bounty_id}/attempts")
+    @app.get(
+        "/api/v1/bounties/{bounty_id}/attempts",
+        openapi_extra=PUBLIC_BOUNTY_ATTEMPTS_RESPONSE,
+    )
     def api_bounty_attempts(
         request: Request,
         bounty_id: str,

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -145,6 +145,216 @@ BOUNTY_ATTEMPT_RESPONSE_SCHEMA = _object_schema(
     }
 )
 
+SUBMISSION_REQUIREMENTS_RESPONSE_SCHEMA = _object_schema(
+    {
+        "submission_mode": {"type": "string"},
+        "submission_url_kind": {"type": "string"},
+        "expected_artifact": {"type": "string"},
+        "attempt_endpoint_applicability": {"type": "string"},
+        "reference_formats": {"type": "array", "items": {"type": "string"}},
+        "claim_command": {"type": "string"},
+        "attempt_endpoint": {"type": "string"},
+        "next_actions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": True,
+                "properties": {
+                    "id": {"type": "string"},
+                    "required": {"type": "boolean"},
+                    "text": {"type": "string"},
+                },
+            },
+        },
+    }
+)
+
+PENDING_BOUNTY_PROPOSAL_RESPONSE_SCHEMA = _object_schema(
+    {
+        "proposal_id": {"type": "integer", "minimum": 1},
+        "proposed_by": {"type": "string"},
+        "proposed_at": {"type": "string"},
+        "executes_after": {"type": "string"},
+        "to_account": {"type": "string", "nullable": True},
+        "submission_url": {"type": "string", "nullable": True},
+        "accepted_by": {"type": "string", "nullable": True},
+        "closed_by": {"type": "string", "nullable": True},
+        "reference": {"type": "string", "nullable": True},
+    }
+)
+
+BOUNTY_RESPONSE_SCHEMA = _object_schema(
+    {
+        "id": {"type": "integer", "minimum": 1},
+        "repo": {"type": "string"},
+        "issue_number": {"type": "integer", "minimum": 1},
+        "issue_url": {"type": "string", "format": "uri"},
+        "title": {"type": "string"},
+        "reward_mrwk": MRWK_DECIMAL_SCHEMA,
+        "available_mrwk": MRWK_DECIMAL_SCHEMA,
+        "reserved_mrwk": MRWK_DECIMAL_SCHEMA,
+        "max_awards": {"type": "integer", "minimum": 1},
+        "awards_paid": {"type": "integer", "minimum": 0},
+        "awards_remaining": {"type": "integer", "minimum": 0},
+        "effective_available_mrwk": MRWK_DECIMAL_SCHEMA,
+        "effective_awards_remaining": {"type": "integer", "minimum": 0},
+        "pending_payout_awards": {"type": "integer", "minimum": 0},
+        "pending_payout_proposals": {
+            "type": "array",
+            "items": PENDING_BOUNTY_PROPOSAL_RESPONSE_SCHEMA,
+        },
+        "pending_close_proposal": {
+            "anyOf": [
+                PENDING_BOUNTY_PROPOSAL_RESPONSE_SCHEMA,
+                {"type": "null"},
+            ],
+        },
+        "availability_state": {"type": "string"},
+        "availability_note": {"type": "string"},
+        "submission_requirements": SUBMISSION_REQUIREMENTS_RESPONSE_SCHEMA,
+        "active_attempt_count": {"type": "integer", "minimum": 0},
+        "active_attempt_warnings": {"type": "array", "items": {"type": "string"}},
+        "attempt_endpoint": {"type": "string"},
+        "status": {"type": "string"},
+        "acceptance": {"type": "string"},
+        "created_at": {"type": "string"},
+        "accepted_awards": {
+            "type": "array",
+            "items": _object_schema(
+                {
+                    "proof_hash": LOWERCASE_HEX_64_SCHEMA,
+                    "proof_url": {"type": "string"},
+                    "ledger_sequence": {"type": "integer", "minimum": 1},
+                    "ledger_url": {"type": "string"},
+                    "account": {"type": "string", "nullable": True},
+                    "amount_mrwk": MRWK_DECIMAL_SCHEMA,
+                    "submission_url": {"type": "string", "nullable": True},
+                    "accepted_by": {"type": "string", "nullable": True},
+                    "created_at": {"type": "string"},
+                }
+            ),
+        },
+    }
+)
+
+BOUNTY_SUMMARY_RESPONSE_SCHEMA = _object_schema(
+    {
+        "bounties_shown": {"type": "integer", "minimum": 0},
+        "open_awards": {"type": "integer", "minimum": 0},
+        "open_pool_mrwk": MRWK_DECIMAL_SCHEMA,
+        "effective_open_awards": {"type": "integer", "minimum": 0},
+        "effective_open_pool_mrwk": MRWK_DECIMAL_SCHEMA,
+        "availability_state_counts": {
+            "type": "object",
+            "additionalProperties": {"type": "integer", "minimum": 0},
+        },
+        "pending_payout_awards": {"type": "integer", "minimum": 0},
+        "reduced_capacity_bounties": {"type": "integer", "minimum": 0},
+        "effectively_unavailable_bounties": {"type": "integer", "minimum": 0},
+    }
+)
+
+BOUNTY_ATTEMPTS_LIST_RESPONSE_SCHEMA = _object_schema(
+    {
+        "bounty_id": {"type": "integer", "minimum": 1},
+        "warnings": {"type": "array", "items": {"type": "string"}},
+        "attempts": {"type": "array", "items": BOUNTY_ATTEMPT_RESPONSE_SCHEMA},
+    }
+)
+
+WORK_DISCOVERY_SOURCE_URLS_SCHEMA = _object_schema(
+    {
+        "bounty": {"type": "string"},
+        "attempts": {"type": "string"},
+        "github_issue": {"type": "string", "format": "uri"},
+        "proposal": {"type": "string"},
+    }
+)
+
+WORK_DISCOVERY_ITEM_SCHEMA = _object_schema(
+    {
+        "availability_state": {"type": "string"},
+        "bounty_id": {"type": "integer", "minimum": 1},
+        "proposal_id": {"type": "integer", "minimum": 1},
+        "issue_number": {"type": "integer", "minimum": 1},
+        "title": {"type": "string"},
+        "issue_url": {"type": "string", "format": "uri"},
+        "reward_mrwk": MRWK_DECIMAL_SCHEMA,
+        "max_awards": {"type": "integer", "minimum": 1},
+        "effective_awards_remaining": {"type": "integer", "minimum": 0},
+        "bounty_availability_state": {"type": "string"},
+        "pending_payout_awards": {"type": "integer", "minimum": 0},
+        "executes_after": {"type": "string"},
+        "source_urls": WORK_DISCOVERY_SOURCE_URLS_SCHEMA,
+    }
+)
+
+WORK_DISCOVERY_RESPONSE_SCHEMA = _object_schema(
+    {
+        "type": {"type": "string"},
+        "summary": _object_schema(
+            {
+                "claimable_now_count": {"type": "integer", "minimum": 0},
+                "opening_soon_count": {"type": "integer", "minimum": 0},
+                "not_claimable_count": {"type": "integer", "minimum": 0},
+                "limit": {"type": "integer", "minimum": 1},
+            }
+        ),
+        "state_definitions": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+        },
+        "claimable_now": {"type": "array", "items": WORK_DISCOVERY_ITEM_SCHEMA},
+        "opening_soon": {"type": "array", "items": WORK_DISCOVERY_ITEM_SCHEMA},
+        "not_claimable": {"type": "array", "items": WORK_DISCOVERY_ITEM_SCHEMA},
+        "non_claimable_issue_states": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": True,
+                "properties": {
+                    "availability_state": {"type": "string"},
+                    "repo": {"type": "string"},
+                    "issue_number": {"type": "integer"},
+                    "issue_url": {"type": "string"},
+                    "title": {"type": "string"},
+                    "note": {"type": "string"},
+                },
+            },
+        },
+    }
+)
+
+PUBLIC_BOUNTY_LIST_RESPONSE = {
+    "responses": {
+        "200": _json_response({"type": "array", "items": BOUNTY_RESPONSE_SCHEMA}),
+    },
+}
+
+PUBLIC_BOUNTY_SUMMARY_RESPONSE = {
+    "responses": {
+        "200": _json_response(BOUNTY_SUMMARY_RESPONSE_SCHEMA),
+    },
+}
+
+PUBLIC_BOUNTY_DETAIL_RESPONSE = {
+    "responses": {
+        "200": _json_response(BOUNTY_RESPONSE_SCHEMA),
+    },
+}
+
+PUBLIC_WORK_DISCOVERY_RESPONSE = {
+    "responses": {
+        "200": _json_response(WORK_DISCOVERY_RESPONSE_SCHEMA),
+    },
+}
+
+PUBLIC_BOUNTY_ATTEMPTS_RESPONSE = {
+    "responses": {
+        "200": _json_response(BOUNTY_ATTEMPTS_LIST_RESPONSE_SCHEMA),
+    },
+}
+
 ATTEMPT_REGISTRATION_RESPONSE_SCHEMA = _object_schema(
     {
         "status": {"type": "string"},

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -11,10 +11,10 @@ The legacy-compatible hosts remain available for existing clients:
 `https://api.mrwk.ltclab.site` and `https://mcp.mrwk.ltclab.site`.
 
 Machine-readable REST docs are available at `$API_HOST/openapi.json`,
-`$API_HOST/api/docs`, and `$API_HOST/api/redoc`. Public JSON POST endpoints
-publish request and response schemas for attempt reservations, wallet actions,
-transfers, and treasury challenges so clients can discover payload and result
-fields without reading source code.
+`$API_HOST/api/docs`, and `$API_HOST/api/redoc`. Public JSON GET and POST
+endpoints publish schemas for bounty discovery, attempt reservations, wallet
+actions, transfers, and treasury challenges so clients can discover payload and
+result fields without reading source code.
 
 ## Status And Bounties
 

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -23,6 +23,12 @@ def _post_response_schema(openapi: dict, path: str, status: str = "200") -> dict
     ]
 
 
+def _get_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
+    return openapi["paths"][path]["get"]["responses"][status]["content"]["application/json"][
+        "schema"
+    ]
+
+
 def _assert_properties(schema: dict, expected: Iterable[str]) -> None:
     assert set(expected).issubset(schema["properties"])
 
@@ -301,6 +307,141 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
             "status",
             "reason",
             "created_at",
+        },
+    )
+
+
+def test_public_get_openapi_response_schemas_expose_bounty_contracts(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    bounty_list_schema = _get_response_schema(openapi, "/api/v1/bounties")
+    assert bounty_list_schema["type"] == "array"
+    bounty_schema = bounty_list_schema["items"]
+    _assert_properties(
+        bounty_schema,
+        {
+            "id",
+            "repo",
+            "issue_number",
+            "issue_url",
+            "title",
+            "reward_mrwk",
+            "available_mrwk",
+            "reserved_mrwk",
+            "max_awards",
+            "awards_paid",
+            "awards_remaining",
+            "effective_available_mrwk",
+            "effective_awards_remaining",
+            "pending_payout_awards",
+            "availability_state",
+            "availability_note",
+            "submission_requirements",
+            "active_attempt_count",
+            "active_attempt_warnings",
+            "attempt_endpoint",
+            "status",
+            "acceptance",
+            "created_at",
+        },
+    )
+    _assert_properties(
+        bounty_schema["properties"]["submission_requirements"],
+        {
+            "submission_mode",
+            "submission_url_kind",
+            "expected_artifact",
+            "attempt_endpoint_applicability",
+            "reference_formats",
+            "claim_command",
+            "attempt_endpoint",
+            "next_actions",
+        },
+    )
+
+    detail_schema = _get_response_schema(openapi, "/api/v1/bounties/{bounty_id}")
+    _assert_properties(detail_schema, {"accepted_awards", "pending_payout_proposals"})
+
+    summary_schema = _get_response_schema(openapi, "/api/v1/bounties/summary")
+    _assert_properties(
+        summary_schema,
+        {
+            "bounties_shown",
+            "open_awards",
+            "open_pool_mrwk",
+            "effective_open_awards",
+            "effective_open_pool_mrwk",
+            "availability_state_counts",
+            "pending_payout_awards",
+            "reduced_capacity_bounties",
+            "effectively_unavailable_bounties",
+        },
+    )
+
+
+def test_public_get_openapi_response_schemas_expose_work_discovery_and_attempts(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    work_discovery_schema = _get_response_schema(openapi, "/api/v1/work-discovery")
+    _assert_properties(
+        work_discovery_schema,
+        {
+            "type",
+            "summary",
+            "state_definitions",
+            "claimable_now",
+            "opening_soon",
+            "not_claimable",
+            "non_claimable_issue_states",
+        },
+    )
+    _assert_properties(
+        work_discovery_schema["properties"]["summary"],
+        {
+            "claimable_now_count",
+            "opening_soon_count",
+            "not_claimable_count",
+            "limit",
+        },
+    )
+    claimable_item_schema = work_discovery_schema["properties"]["claimable_now"]["items"]
+    _assert_properties(
+        claimable_item_schema,
+        {
+            "availability_state",
+            "bounty_id",
+            "issue_number",
+            "title",
+            "issue_url",
+            "reward_mrwk",
+            "max_awards",
+            "effective_awards_remaining",
+            "bounty_availability_state",
+            "pending_payout_awards",
+            "source_urls",
+        },
+    )
+    _assert_properties(claimable_item_schema["properties"]["source_urls"], {"bounty", "attempts"})
+
+    attempts_schema = _get_response_schema(openapi, "/api/v1/bounties/{bounty_id}/attempts")
+    _assert_properties(attempts_schema, {"bounty_id", "warnings", "attempts"})
+    _assert_properties(
+        attempts_schema["properties"]["attempts"]["items"],
+        {
+            "id",
+            "bounty_id",
+            "submitter_account",
+            "source_url",
+            "status",
+            "expires_at",
+            "created_at",
+            "updated_at",
         },
     )
 


### PR DESCRIPTION
Refs #944

## Summary
- add explicit OpenAPI response schemas for public bounty list, detail, summary, work-discovery, and bounty-attempt endpoints
- keep runtime JSON behavior unchanged while giving generated clients field-level contracts for reward capacity, submission requirements, active attempts, and discovery buckets
- add focused contract tests that compare advertised schemas with representative runtime payloads

## Validation
- `git diff --check`
- `ruff check app/openapi_request_bodies.py app/bounty_api.py app/bounty_attempts.py tests/test_openapi_request_bodies.py`
- `ruff format --check app/openapi_request_bodies.py app/bounty_api.py app/bounty_attempts.py tests/test_openapi_request_bodies.py`
- `pytest tests/test_openapi_request_bodies.py tests/test_bounty_api.py tests/test_work_discovery.py -q` -> 40 passed, 1 existing Starlette/httpx warning

## Scope
OpenAPI/client-contract metadata and focused tests only. No bounty capacity logic, attempt state transitions, payment/proposal execution, wallet custody, private data, or secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced OpenAPI specifications for bounty-related endpoints with detailed response schemas for lists, summaries, details, work discovery, and attempts
  * Clarified availability of machine-readable REST API documentation at `/openapi.json`, `/api/docs`, and `/api/redoc`

* **Tests**
  * Added validation coverage for GET endpoint response structures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->