### PR TITLE
Add scoped filters to work discovery

### DIFF
--- a/app/bounty_api.py
+++ b/app/bounty_api.py
@@ -44,6 +44,8 @@ from app.treasury import proposal_to_dict, propose_treasury_action
 from app.work_discovery import (
     DEFAULT_WORK_DISCOVERY_LIMIT,
     MAX_WORK_DISCOVERY_LIMIT,
+    WORK_DISCOVERY_REPO_FILTER_MAX_LENGTH,
+    WORK_DISCOVERY_SEARCH_QUERY_MAX_LENGTH,
     work_discovery_to_dict,
 )
 
@@ -267,15 +269,28 @@ def register_bounty_api_routes(
     @app.get("/api/v1/work-discovery")
     def api_work_discovery(
         request: Request,
+        q: str | None = Query(None, max_length=WORK_DISCOVERY_SEARCH_QUERY_MAX_LENGTH),
+        repo: str | None = Query(None, max_length=WORK_DISCOVERY_REPO_FILTER_MAX_LENGTH),
+        issue_number: Annotated[int | None, Query(ge=1, le=SQLITE_INTEGER_MAX)] = None,
         limit: Annotated[
             int,
             Query(ge=1, le=MAX_WORK_DISCOVERY_LIMIT),
         ] = DEFAULT_WORK_DISCOVERY_LIMIT,
     ) -> dict[str, Any]:
-        reject_repeated_query_param(request, "limit")
-        reject_noncanonical_int_query_param(request, "limit")
+        for name in ("q", "repo", "issue_number", "limit"):
+            reject_repeated_query_param(request, name)
+        for name in ("q", "repo"):
+            reject_control_char_query_param(request, name)
+        for name in ("issue_number", "limit"):
+            reject_noncanonical_int_query_param(request, name)
         with session_scope(db_url) as session:
-            return work_discovery_to_dict(session, limit=limit)
+            return work_discovery_to_dict(
+                session,
+                limit=limit,
+                query_text=q,
+                repo=repo,
+                issue_number=issue_number,
+            )
 
     @app.get("/api/v1/admin/webhook-events")
     def api_admin_webhook_events(

--- a/app/work_discovery.py
+++ b/app/work_discovery.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from app.models import Bounty, TreasuryProposal
+from app.path_params import issue_number_search_value
 from app.serializers import bounties_to_dict, public_utc_timestamp
 from app.submission_requirements import work_proof_submission_requirements
 from app.treasury import proposal_payload
@@ -14,6 +15,8 @@ DEFAULT_WORK_DISCOVERY_LIMIT = 50
 MAX_WORK_DISCOVERY_LIMIT = 100
 OPEN_BOUNTY_SCAN_PAGE_SIZE = 25
 MAX_OPEN_BOUNTY_SCAN_ROWS = 500
+WORK_DISCOVERY_REPO_FILTER_MAX_LENGTH = 200
+WORK_DISCOVERY_SEARCH_QUERY_MAX_LENGTH = 500
 
 STATE_DEFINITIONS = {
     "live_bounty": "Public bounty row is open and has positive effective_awards_remaining.",
@@ -68,6 +71,76 @@ def _next_action(requirements: dict[str, Any]) -> dict[str, Any]:
             "text": "Review submission requirements before opening or claiming work.",
         }
     return action
+
+
+def _normalized_text_filter(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _normalized_repo_filter(value: str | None) -> str | None:
+    normalized = _normalized_text_filter(value)
+    if normalized is None:
+        return None
+    return normalized.lower()
+
+
+def _query_like_value(value: str) -> str:
+    escaped = value.lower().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"%{escaped}%"
+
+
+def _filtered_bounty_query(
+    *,
+    query_text: str | None,
+    repo: str | None,
+    issue_number: int | None,
+) -> Any:
+    query = select(Bounty)
+    normalized_query = _normalized_text_filter(query_text)
+    if normalized_query is not None:
+        like_query = _query_like_value(normalized_query)
+        query_issue_number = issue_number_search_value(normalized_query)
+        text_filter = or_(
+            func.lower(Bounty.repo).like(like_query, escape="\\"),
+            func.lower(Bounty.title).like(like_query, escape="\\"),
+            func.lower(Bounty.acceptance).like(like_query, escape="\\"),
+        )
+        if query_issue_number is not None:
+            text_filter = or_(text_filter, Bounty.issue_number == query_issue_number)
+        query = query.where(text_filter)
+    normalized_repo = _normalized_repo_filter(repo)
+    if normalized_repo is not None:
+        query = query.where(func.lower(Bounty.repo) == normalized_repo)
+    if issue_number is not None:
+        query = query.where(Bounty.issue_number == issue_number)
+    return query
+
+
+def _payload_matches_filters(
+    payload: dict[str, Any],
+    *,
+    query_text: str | None,
+    repo: str | None,
+    issue_number: int | None,
+) -> bool:
+    if issue_number is not None and int(payload["issue_number"]) != issue_number:
+        return False
+    normalized_repo = _normalized_repo_filter(repo)
+    if normalized_repo is not None and str(payload.get("repo", "")).lower() != normalized_repo:
+        return False
+    normalized_query = _normalized_text_filter(query_text)
+    if normalized_query is None:
+        return True
+    query_issue_number = issue_number_search_value(normalized_query)
+    if query_issue_number is not None and int(payload["issue_number"]) == query_issue_number:
+        return True
+    needle = normalized_query.lower()
+    return any(
+        needle in str(payload.get(field, "")).lower() for field in ("repo", "title", "acceptance")
+    )
 
 
 def _bounty_work_item(row: dict[str, Any], availability_state: str) -> dict[str, Any]:
@@ -125,6 +198,21 @@ def _pending_create_item(proposal: TreasuryProposal) -> dict[str, Any]:
     }
 
 
+def _pending_create_matches_filters(
+    proposal: TreasuryProposal,
+    *,
+    query_text: str | None,
+    repo: str | None,
+    issue_number: int | None,
+) -> bool:
+    return _payload_matches_filters(
+        proposal_payload(proposal),
+        query_text=query_text,
+        repo=repo,
+        issue_number=issue_number,
+    )
+
+
 def _append_capped_item(bucket: list[dict[str, Any]], item: dict[str, Any], *, limit: int) -> None:
     if len(bucket) < limit:
         bucket.append(item)
@@ -134,6 +222,9 @@ def _scan_open_bounty_buckets(
     session: Session,
     *,
     limit: int,
+    query_text: str | None,
+    repo: str | None,
+    issue_number: int | None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     claimable_now: list[dict[str, Any]] = []
     not_claimable: list[dict[str, Any]] = []
@@ -143,7 +234,11 @@ def _scan_open_bounty_buckets(
 
     while scanned_rows < MAX_OPEN_BOUNTY_SCAN_ROWS:
         batch_limit = min(page_size, MAX_OPEN_BOUNTY_SCAN_ROWS - scanned_rows)
-        query = select(Bounty).where(Bounty.status == "open")
+        query = _filtered_bounty_query(
+            query_text=query_text,
+            repo=repo,
+            issue_number=issue_number,
+        ).where(Bounty.status == "open")
         if last_seen_id is not None:
             query = query.where(Bounty.id < last_seen_id)
         batch = session.scalars(query.order_by(Bounty.id.desc()).limit(batch_limit)).all()
@@ -179,15 +274,30 @@ def work_discovery_to_dict(
     session: Session,
     *,
     limit: int = DEFAULT_WORK_DISCOVERY_LIMIT,
+    query_text: str | None = None,
+    repo: str | None = None,
+    issue_number: int | None = None,
 ) -> dict[str, Any]:
     """Return public read-only work discovery grouped by claimability."""
     capped_limit = max(1, min(limit, MAX_WORK_DISCOVERY_LIMIT))
-    claimable_now, not_claimable = _scan_open_bounty_buckets(session, limit=capped_limit)
+    normalized_query = _normalized_text_filter(query_text)
+    normalized_repo = _normalized_repo_filter(repo)
+    claimable_now, not_claimable = _scan_open_bounty_buckets(
+        session,
+        limit=capped_limit,
+        query_text=normalized_query,
+        repo=normalized_repo,
+        issue_number=issue_number,
+    )
 
     if len(not_claimable) < capped_limit:
         remaining_not_claimable = capped_limit - len(not_claimable)
         terminal_bounties = session.scalars(
-            select(Bounty)
+            _filtered_bounty_query(
+                query_text=normalized_query,
+                repo=normalized_repo,
+                issue_number=issue_number,
+            )
             .where(Bounty.status != "open")
             .order_by(Bounty.id.desc())
             .limit(remaining_not_claimable)
@@ -204,9 +314,20 @@ def work_discovery_to_dict(
         select(TreasuryProposal)
         .where(TreasuryProposal.status == "pending", TreasuryProposal.action == "create_bounty")
         .order_by(TreasuryProposal.executes_after.asc(), TreasuryProposal.id.asc())
-        .limit(capped_limit)
+        .limit(MAX_OPEN_BOUNTY_SCAN_ROWS)
     ).all()
-    opening_soon = [_pending_create_item(proposal) for proposal in pending_create_proposals]
+    opening_soon: list[dict[str, Any]] = []
+    for proposal in pending_create_proposals:
+        if not _pending_create_matches_filters(
+            proposal,
+            query_text=normalized_query,
+            repo=normalized_repo,
+            issue_number=issue_number,
+        ):
+            continue
+        _append_capped_item(opening_soon, _pending_create_item(proposal), limit=capped_limit)
+        if len(opening_soon) >= capped_limit:
+            break
 
     return {
         "type": "work_discovery",
@@ -215,6 +336,11 @@ def work_discovery_to_dict(
             "opening_soon_count": len(opening_soon),
             "not_claimable_count": len(not_claimable),
             "limit": capped_limit,
+        },
+        "filters": {
+            "q": normalized_query,
+            "repo": normalized_repo,
+            "issue_number": issue_number,
         },
         "state_definitions": STATE_DEFINITIONS,
         "claimable_now": claimable_now,

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -115,7 +115,9 @@ claimable, proposed, pending, paid, and closed bounty states.
 
 Use `GET /api/v1/work-discovery` when an agent needs one stable read-only
 surface for current work. Use optional `limit=1..100` to cap each returned
-bucket. It groups `claimable_now` live bounty rows separately from
+bucket, `repo` plus `issue_number` to inspect one GitHub issue, or `q` for
+broader text and issue-number matching. It groups `claimable_now` live bounty
+rows separately from
 `opening_soon` pending `create_bounty` proposals, and keeps closed, paid,
 exhausted, pending payout, proposed-work, and board/index states out of the
 claimable bucket. Each work item includes issue number, title, issue URL,

--- a/docs/api-examples.md
+++ b/docs/api-examples.md
@@ -31,6 +31,8 @@ curl -s "$API_HOST/api/v1/bounties/summary?repo=ramimbo%2Fmergework"
 curl -s "$API_HOST/api/v1/bounties/summary?status=open&sort=awards&limit=5"
 curl -s "$API_HOST/api/v1/work-discovery"
 curl -s "$API_HOST/api/v1/work-discovery?limit=10"
+curl -s "$API_HOST/api/v1/work-discovery?repo=ramimbo%2Fmergework&issue_number=935"
+curl -s "$API_HOST/api/v1/work-discovery?q=proof"
 ```
 
 The bounties list returns public bounty rows. `status` can be omitted or set to
@@ -149,10 +151,12 @@ bounty row.
 Use `/api/v1/work-discovery` when an agent needs a single read-only work queue.
 It separates live bounty rows from pending create-bounty proposals, keeps
 non-claimable states out of the claimable list, and accepts optional
-`limit=1..100` to cap each returned bucket:
-Each queue item includes the source `repo` next to `issue_number`, so clients
-do not need to parse GitHub URLs when the same issue number exists in multiple
-repositories.
+`limit=1..100` to cap each returned bucket. Each queue item includes the source
+`repo` next to `issue_number`, so clients do not need to parse GitHub URLs when
+the same issue number exists in multiple repositories. It also accepts `q`,
+`repo`, and `issue_number` filters. Use `repo` plus `issue_number` when a
+contributor starts from one GitHub issue and needs to confirm whether that exact
+scope is claimable:
 
 ```json
 {
@@ -162,6 +166,11 @@ repositories.
     "opening_soon_count": 1,
     "not_claimable_count": 1,
     "limit": 50
+  },
+  "filters": {
+    "q": null,
+    "repo": null,
+    "issue_number": null
   },
   "state_definitions": {
     "live_bounty": "Public bounty row is open and has positive effective_awards_remaining.",

--- a/tests/test_work_discovery.py
+++ b/tests/test_work_discovery.py
@@ -305,3 +305,100 @@ def test_work_discovery_scans_open_bounties_in_bounded_pages(
     assert body["claimable_now"][0]["issue_number"] == 989
     assert body["not_claimable"][0]["issue_number"] == 990
     assert batch_sizes == [work_discovery.OPEN_BOUNTY_SCAN_PAGE_SIZE]
+
+
+def test_work_discovery_filters_scope_across_public_buckets(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        target = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=935,
+            issue_url="https://github.com/ramimbo/mergework/issues/935",
+            title="Contributor flow search filters",
+            reward_mrwk="150",
+            max_awards=2,
+            acceptance="Help contributors filter work discovery by issue scope.",
+        )
+        create_bounty(
+            session,
+            repo="other/project",
+            issue_number=935,
+            issue_url="https://github.com/other/project/issues/935",
+            title="Same issue number in another repo",
+            reward_mrwk="20",
+            acceptance="This should not match a MergeWork repo filter.",
+        )
+        pending = propose_treasury_action(
+            session,
+            action="create_bounty",
+            payload={
+                "repo": "ramimbo/mergework",
+                "issue_number": 936,
+                "issue_url": "https://github.com/ramimbo/mergework/issues/936",
+                "title": "Contributor flow opening soon",
+                "reward_mrwk": "75",
+                "max_awards": 1,
+                "acceptance": "Pending create proposal should honor discovery filters.",
+            },
+            proposed_by="maintainer",
+        )
+        closed = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=937,
+            issue_url="https://github.com/ramimbo/mergework/issues/937",
+            title="Contributor flow closed result",
+            reward_mrwk="50",
+            max_awards=1,
+            acceptance="Closed work should stay searchable in not_claimable.",
+        )
+        closed.status = "closed"
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    live = client.get(
+        "/api/v1/work-discovery?repo=RAMIMBO%2FMergeWork&issue_number=935&q=flow"
+    ).json()
+    assert live["filters"] == {
+        "q": "flow",
+        "repo": "ramimbo/mergework",
+        "issue_number": 935,
+    }
+    assert live["summary"]["claimable_now_count"] == 1
+    assert live["claimable_now"][0]["bounty_id"] == target.id
+    assert live["claimable_now"][0]["issue_number"] == 935
+    assert live["opening_soon"] == []
+    assert live["not_claimable"] == []
+
+    opening = client.get("/api/v1/work-discovery?repo=ramimbo%2Fmergework&q=936").json()
+    assert opening["claimable_now"] == []
+    assert opening["opening_soon"][0]["proposal_id"] == pending.id
+    assert opening["opening_soon"][0]["issue_number"] == 936
+
+    not_claimable = client.get("/api/v1/work-discovery?repo=ramimbo%2Fmergework&q=closed").json()
+    assert not_claimable["claimable_now"] == []
+    assert not_claimable["not_claimable"][0]["bounty_id"] == closed.id
+    assert not_claimable["not_claimable"][0]["issue_number"] == 937
+
+
+def test_work_discovery_rejects_ambiguous_filter_params(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    repeated = client.get("/api/v1/work-discovery?q=one&q=two")
+    controlled_repo = client.get("/api/v1/work-discovery?repo=ramimbo%C2%85mergework")
+    noncanonical_issue = client.get("/api/v1/work-discovery?issue_number=0935")
+    noncanonical_limit = client.get("/api/v1/work-discovery?limit=01")
+
+    assert repeated.status_code == 400
+    assert repeated.json()["detail"] == "q must be provided at most once"
+    assert controlled_repo.status_code == 400
+    assert controlled_repo.json()["detail"] == "repo must not contain control characters"
+    assert noncanonical_issue.status_code == 400
+    assert (
+        noncanonical_issue.json()["detail"] == "issue_number must be a canonical positive integer"
+    )
+    assert noncanonical_limit.status_code == 400
+    assert noncanonical_limit.json()["detail"] == "limit must be a canonical positive integer"


### PR DESCRIPTION
Refs #935

## Summary
- add `q`, `repo`, and `issue_number` filters to the read-only `/api/v1/work-discovery` queue
- apply the filters consistently across live, opening-soon, and not-claimable buckets
- echo normalized filters in the response so clients can confirm the exact scope they checked
- keep current lifecycle distinctions, submission requirements, and next-action guidance intact

## Validation
- `git diff --check`
- `ruff check app/work_discovery.py app/bounty_api.py tests/test_work_discovery.py`
- `ruff format --check app/work_discovery.py app/bounty_api.py tests/test_work_discovery.py`
- `pytest tests/test_work_discovery.py -q` -> 6 passed, 1 existing Starlette/httpx warning
- `python scripts/docs_smoke.py`

## Scope
Public work-discovery filtering, docs, and focused tests only. No bounty lifecycle, capacity, payout, ledger, wallet, treasury, admin-token, private data, or secret behavior changed.