### PR TITLE
Fix #935: MRWK bounty: 150 MRWK - public bounty discovery and contributor-flow f

### DIFF
--- a/app/hub.py
+++ b/app/hub.py
@@ -42,6 +42,11 @@ MERGEWORK_CONTRIBUTOR_STARTING_POINTS = (
         "href": "/api/v1/bounties?status=open&availability=effectively_open",
         "description": "Use the public API to verify live status, capacity, and requirements.",
     },
+    {
+        "title": "Work discovery",
+        "href": "/api/v1/work-discovery",
+        "description": "Explore grouped results: claimable bounties, opening-soon proposals, and paid or closed work.",
+    },
 )
 
 

--- a/app/hub.py
+++ b/app/hub.py
@@ -45,7 +45,7 @@ MERGEWORK_CONTRIBUTOR_STARTING_POINTS = (
     {
         "title": "Work discovery",
         "href": "/api/v1/work-discovery",
-        "description": "Explore grouped results: claimable bounties, opening-soon proposals, and paid or closed work.",
+        "description": "Explore grouped results: claimable, opening-soon, paid or closed work.",
     },
 )
 

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -189,6 +189,7 @@ def public_bounties_context(
         "selected_limit": limit,
         "selected_availability": selected_availability,
         "limit_options": limit_options,
+        "work_discovery_url": "/api/v1/work-discovery",
         "api_results_url": _bounties_api_url(
             selected_status,
             query_text,

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -70,7 +70,8 @@
   </article>
 </section>
 <p class="notice">
-  <a href="{{ api_results_url }}">View JSON results</a>
+  <a href="{{ api_results_url }}">View JSON results</a> ·
+  <a href="{{ work_discovery_url }}">Work discovery</a>
 </p>
 <div class="list">
   {% for bounty in bounties %}

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -74,7 +74,7 @@ def test_mergework_hub_context_preserves_status_and_base_url() -> None:
         {
             "title": "Work discovery",
             "href": "/api/v1/work-discovery",
-            "description": "Explore grouped results: claimable bounties, opening-soon proposals, and paid or closed work.",
+            "description": "Explore grouped results: claimable, opening-soon, paid or closed work.",
         },
     ]
 

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -71,6 +71,11 @@ def test_mergework_hub_context_preserves_status_and_base_url() -> None:
             "href": "/api/v1/bounties?status=open&availability=effectively_open",
             "description": "Use the public API to verify live status, capacity, and requirements.",
         },
+        {
+            "title": "Work discovery",
+            "href": "/api/v1/work-discovery",
+            "description": "Explore grouped results: claimable bounties, opening-soon proposals, and paid or closed work.",
+        },
     ]
 
     context["contributor_starting_points"][0]["title"] = "changed"
@@ -100,3 +105,5 @@ def test_mergework_hub_renders_contributor_starting_points(sqlite_url: str) -> N
     assert 'href="/activity"' in response.text
     assert "Current bounty JSON" in response.text
     assert 'href="/api/v1/bounties?status=open&amp;availability=effectively_open"' in response.text
+    assert "Work discovery" in response.text
+    assert 'href="/api/v1/work-discovery"' in response.text

--- a/tests/test_public_routes.py
+++ b/tests/test_public_routes.py
@@ -52,6 +52,7 @@ def test_public_bounties_context_normalizes_filter_state() -> None:
         "selected_limit": None,
         "selected_availability": "all",
         "limit_options": (10, 25, 50, 100, 200),
+        "work_discovery_url": "/api/v1/work-discovery",
         "api_results_url": (
             "/api/v1/bounties?status=open&q=proof&repo=ramimbo%2Fmergework"
             "&issue_number=649&sort=reward"


### PR DESCRIPTION
Fixes #935

Added the existing `/api/v1/work-discovery` endpoint to the hub's "Contributor starting points" and the bounties list page, making the full lifecycle view (claimable now, opening-soon proposals, not-claimable work) discoverable from both entry points to help contributors distinguish live bounties from pending and paid/closed states.

Local tests pass.

---
This change was prepared with AI assistance under human direction and review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced **Work discovery** to help users explore grouped results, including claimable bounties, opening-soon proposals, and paid or closed work.
  * Added a **Work discovery** link on the bounties page and included the corresponding API URL in the public page context.

* **Tests**
  * Updated homepage and context-related tests to verify the new **Work discovery** text and `/api/v1/work-discovery` link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->