### PR TITLE
Fix #935: Show availability state pills on bounty list and detail pages

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -402,8 +402,12 @@ button { cursor: pointer; color: white; background: var(--accent); border-color:
   margin: 0;
   min-width: 0;
 }
-.bounty-card-head .status-pill + .status-pill {
-  margin-left: 8px;
+.bounty-card-pill-group {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 .status-open {
   border-color: #86efac;

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -402,6 +402,9 @@ button { cursor: pointer; color: white; background: var(--accent); border-color:
   margin: 0;
   min-width: 0;
 }
+.bounty-card-head .status-pill + .status-pill {
+  margin-left: 8px;
+}
 .status-open {
   border-color: #86efac;
   color: #166534;

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -77,8 +77,10 @@
   <article class="bounty-card bounty-card--{{ bounty.status }}">
     <div class="bounty-card-head">
       <h2><a href="/bounties/{{ bounty.id }}">{{ bounty.title }}</a></h2>
-      <span class="status-pill status-{{ bounty.status }}">{{ bounty.status }}</span>
-      <span class="status-pill">{{ bounty.availability_state | replace("_", " ") }}</span>
+      <div class="bounty-card-pill-group">
+        <span class="status-pill status-{{ bounty.status }}">{{ bounty.status }}</span>
+        <span class="status-pill">{{ bounty.availability_state | replace("_", " ") }}</span>
+      </div>
     </div>
     <p class="bounty-card-meta">
       {% set issue_url = safe_public_url(bounty.issue_url) %}

--- a/app/templates/bounties.html
+++ b/app/templates/bounties.html
@@ -78,6 +78,7 @@
     <div class="bounty-card-head">
       <h2><a href="/bounties/{{ bounty.id }}">{{ bounty.title }}</a></h2>
       <span class="status-pill status-{{ bounty.status }}">{{ bounty.status }}</span>
+      <span class="status-pill">{{ bounty.availability_state | replace("_", " ") }}</span>
     </div>
     <p class="bounty-card-meta">
       {% set issue_url = safe_public_url(bounty.issue_url) %}

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -14,6 +14,7 @@
     <article>
       <span>Status</span>
       <strong class="status-pill status-{{ bounty.status }}">{{ bounty.status }}</strong>
+      <span class="status-pill">{{ bounty.availability_state | replace("_", " ") }}</span>
     </article>
     <article>
       <span>Reward per award</span>

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -51,6 +51,8 @@ def test_bounties_page_renders_and_filters_by_status(sqlite_url: str) -> None:
     assert all_rows.status_code == 200
     assert "Open public bounty" in all_rows.text
     assert "Paid public bounty" in all_rows.text
+    assert '<span class="status-pill">open</span>' in all_rows.text
+    assert '<span class="status-pill">paid</span>' in all_rows.text
     assert f'href="/bounties/{open_bounty.id}"' in all_rows.text
     assert f'aria-label="Bounty action links for {open_bounty.id}"' in all_rows.text
     assert f'href="/api/v1/bounties/{open_bounty.id}">JSON details</a>' in all_rows.text
@@ -195,6 +197,7 @@ def test_bounties_page_shows_effective_capacity_after_pending_payout(
     assert "50 MRWK still available before pending proposals" in page.text
     assert "25 MRWK effectively available" in page.text
     assert "1 award covered by pending payout proposal" in page.text
+    assert '<span class="status-pill">pending payouts partial</span>' in page.text
     assert detail.status_code == 200
     assert "<span>Effective remaining</span>" in detail.text
     assert "<span>Effective available</span>" in detail.text
@@ -254,6 +257,7 @@ def test_bounties_page_shows_effective_capacity_after_pending_close(
     assert "90 MRWK still available before pending proposals" in page.text
     assert "0 MRWK effectively available" in page.text
     assert "A pending close proposal would make this bounty unavailable if executed." in page.text
+    assert '<span class="status-pill">pending close</span>' in page.text
     assert detail.status_code == 200
     assert "Visible capacity before pending proposals: 3 awards, 90 MRWK." in detail.text
     assert "Pending treasury proposals" in detail.text
@@ -767,6 +771,7 @@ def test_bounty_detail_highlights_action_fields(sqlite_url: str) -> None:
     assert "<span>Awards</span>" in response.text
     assert "<span>Available</span>" in response.text
     assert "<span>Issue</span>" in response.text
+    assert '<span class="status-pill">open</span>' in response.text
     assert "100 MRWK" in response.text
     assert "What has to be true" in response.text
     assert "Focused PR improves status, reward, issue link, and acceptance text." in response.text

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -199,6 +199,7 @@ def test_bounties_page_shows_effective_capacity_after_pending_payout(
     assert "1 award covered by pending payout proposal" in page.text
     assert '<span class="status-pill">pending payouts partial</span>' in page.text
     assert detail.status_code == 200
+    assert '<span class="status-pill">pending payouts partial</span>' in detail.text
     assert "<span>Effective remaining</span>" in detail.text
     assert "<span>Effective available</span>" in detail.text
     assert "Visible capacity before pending proposals: 2 awards, 50 MRWK." in detail.text
@@ -259,6 +260,7 @@ def test_bounties_page_shows_effective_capacity_after_pending_close(
     assert "A pending close proposal would make this bounty unavailable if executed." in page.text
     assert '<span class="status-pill">pending close</span>' in page.text
     assert detail.status_code == 200
+    assert '<span class="status-pill">pending close</span>' in detail.text
     assert "Visible capacity before pending proposals: 3 awards, 90 MRWK." in detail.text
     assert "Pending treasury proposals" in detail.text
     assert f'href="/api/v1/treasury/proposals/{proposal_id}">Proposal #{proposal_id}</a>' in (


### PR DESCRIPTION
Fixes #935

Added `availability_state` visual indicator pills to bounty list cards (`bounties.html:81`) and detail page (`bounty_detail.html:17`), with CSS spacing (`style.css:405`) and test coverage verifying "open", "paid", "pending payouts partial", and "pending close" states — helping users instantly distinguish truly live bounties from pending-close, pending-payout, full, paid, or closed states at a glance. All 905 tests, ruff, and mypy pass.

Local tests pass.

---
This change was prepared with AI assistance under human direction and review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Status indicators on bounty listings and detail pages now display availability state with clearer formatting.

* **Bug Fixes**
  * Improved spacing between multiple status indicators on bounty cards for better visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->