### PR TITLE
Harden live bounty checker source validation

### DIFF
--- a/app/me.py
+++ b/app/me.py
@@ -10,13 +10,19 @@ from app.ledger.service import format_mrwk, get_balance, linked_wallet_for_githu
 def me_page_context(session: Session, login: str | None) -> dict[str, Any]:
     github_balance_mrwk = "0"
     linked_wallet_address = ""
+    github_account_url = ""
+    linked_wallet_url = ""
     if login:
         github_balance_mrwk = format_mrwk(get_balance(session, f"github:{login}"))
+        github_account_url = f"/accounts/github:{login}"
         linked_wallet = linked_wallet_for_github(session, login)
         if linked_wallet:
             linked_wallet_address = linked_wallet.address
+            linked_wallet_url = f"/wallets/{linked_wallet.address}"
     return {
         "github_login": login,
         "github_balance_mrwk": github_balance_mrwk,
         "linked_wallet_address": linked_wallet_address,
+        "github_account_url": github_account_url,
+        "linked_wallet_url": linked_wallet_url,
     }

--- a/app/templates/me.html
+++ b/app/templates/me.html
@@ -7,6 +7,12 @@
   {% if github_login %}
   <p class="lead">Signed in as {{ github_login }}.</p>
   <p class="notice"><code>github:{{ github_login }}</code> has {{ github_balance_mrwk }} MRWK available to claim.</p>
+  <div class="actions" aria-label="Contributor account shortcuts">
+    <a href="{{ github_account_url }}">View GitHub account ledger</a>
+    {% if linked_wallet_url %}
+    <a href="{{ linked_wallet_url }}">View linked wallet</a>
+    {% endif %}
+  </div>
   <form method="post" action="/auth/logout" class="inline-form">
     <button type="submit">Sign out</button>
   </form>
@@ -22,6 +28,11 @@
 {% if github_login %}
 <section class="panel wallet-tool" data-github-tool data-github-login="{{ github_login }}">
   <h2>Link a wallet</h2>
+  {% if linked_wallet_address %}
+  <p class="notice">Linked wallet: <a href="{{ linked_wallet_url }}"><code>{{ linked_wallet_address }}</code></a></p>
+  {% else %}
+  <p class="notice">No wallet is linked yet. Register or open a wallet first, then sign the link action here.</p>
+  {% endif %}
   <form data-action="link-github">
     <label>Wallet address <input name="address" placeholder="mrwk1..." required></label>
     <label>Private key <textarea name="private_key_hex" rows="5" autocomplete="off" autocapitalize="none" spellcheck="false" required></textarea></label>

--- a/scripts/api_host_args.py
+++ b/scripts/api_host_args.py
@@ -4,6 +4,13 @@ import argparse
 import urllib.parse
 
 
+def nonblank_text(value: str, *, label: str) -> str:
+    clean = value.strip()
+    if not clean:
+        raise argparse.ArgumentTypeError(f"{label} must be a non-empty string")
+    return clean
+
+
 def public_http_url(value: str, *, label: str = "URL", forbid_credentials: bool = False) -> str:
     clean = value.strip()
     if not clean:

--- a/scripts/check_bounty_issue_states.py
+++ b/scripts/check_bounty_issue_states.py
@@ -12,7 +12,7 @@ from typing import Any
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.api_host_args import public_api_host
+from scripts.api_host_args import nonblank_text, public_api_host
 
 DEFAULT_API_HOST = "https://api.mrwk.online"
 GH_TIMEOUT_SECONDS = 30
@@ -228,8 +228,16 @@ def main(argv: list[str] | None = None) -> int:
         description="Verify open public MergeWork bounty rows still have open GitHub issues."
     )
     source = parser.add_mutually_exclusive_group(required=True)
-    source.add_argument("--input", help="Read bounties and issues from a JSON fixture.")
-    source.add_argument("--repo", help="GitHub repository, for example ramimbo/mergework.")
+    source.add_argument(
+        "--input",
+        type=lambda value: nonblank_text(value, label="input path"),
+        help="Read bounties and issues from a JSON fixture.",
+    )
+    source.add_argument(
+        "--repo",
+        type=lambda value: nonblank_text(value, label="repo"),
+        help="GitHub repository, for example ramimbo/mergework.",
+    )
     parser.add_argument("--api-host", type=public_api_host, default=DEFAULT_API_HOST)
     parser.add_argument("--format", choices=["json", "text"], default="text")
     parser.add_argument("--fail-on-issues", action="store_true")
@@ -240,10 +248,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    data = _load_input(args.input) if args.input else load_live_data(args.repo, args.api_host)
+    use_input = args.input is not None
+    data = _load_input(args.input) if use_input else load_live_data(args.repo, args.api_host)
     report = analyze_issue_states(data)
     if args.fix:
-        if args.input:
+        if use_input:
             raise SystemExit("--fix requires --repo, not --input")
         reopen_violations(args.repo, report["violations"])
         data = load_live_data(args.repo, args.api_host)

--- a/scripts/check_live_bounty_closing_refs.py
+++ b/scripts/check_live_bounty_closing_refs.py
@@ -12,7 +12,7 @@ from typing import Any
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.api_host_args import public_api_host
+from scripts.api_host_args import nonblank_text, public_api_host
 from scripts.bounty_refs import GITHUB_CLOSING_ISSUE_RE
 
 DEFAULT_API_HOST = "https://api.mrwk.online"
@@ -226,8 +226,16 @@ def main(argv: list[str] | None = None) -> int:
         )
     )
     source = parser.add_mutually_exclusive_group(required=True)
-    source.add_argument("--input", help="Read bounties and pull_requests from a JSON fixture.")
-    source.add_argument("--repo", help="GitHub repository, for example ramimbo/mergework.")
+    source.add_argument(
+        "--input",
+        type=lambda value: nonblank_text(value, label="input path"),
+        help="Read bounties and pull_requests from a JSON fixture.",
+    )
+    source.add_argument(
+        "--repo",
+        type=lambda value: nonblank_text(value, label="repo"),
+        help="GitHub repository, for example ramimbo/mergework.",
+    )
     parser.add_argument("--api-host", type=public_api_host, default=DEFAULT_API_HOST)
     parser.add_argument("--state", choices=["open", "closed", "merged", "all"], default="open")
     parser.add_argument("--pr", type=int, action="append", default=[], help="Specific PR to check.")
@@ -237,7 +245,7 @@ def main(argv: list[str] | None = None) -> int:
 
     data = (
         _load_input(args.input)
-        if args.input
+        if args.input is not None
         else load_live_data(args.repo, args.api_host, args.state, args.pr)
     )
     report = analyze_closing_refs(data)

--- a/scripts/docs_smoke.py
+++ b/scripts/docs_smoke.py
@@ -249,6 +249,43 @@ def _issue_template_labels(template: str) -> set[str]:
     return labels
 
 
+def _validate_issue_template(
+    root: Path,
+    relative_path: str,
+    *,
+    missing_message: str,
+    required_phrases: list[str] | None = None,
+    required_labels: list[str] | None = None,
+    forbidden_labels: list[str] | None = None,
+    required_fields: list[str] | None = None,
+) -> list[str]:
+    path = root / relative_path
+    if not path.exists():
+        return [missing_message]
+
+    template = path.read_text(encoding="utf-8").lower()
+    labels = _issue_template_labels(template)
+    errors: list[str] = []
+
+    for phrase in required_phrases or []:
+        if phrase not in template:
+            errors.append(f"{relative_path} missing required phrase: {phrase}")
+
+    for label in required_labels or []:
+        if label not in labels:
+            errors.append(f"{relative_path} must auto-apply the {label} label")
+
+    for label in forbidden_labels or []:
+        if label in labels:
+            errors.append(f"{relative_path} must not auto-apply {label}")
+
+    for field_id in required_fields or []:
+        if not _template_field_is_required(template, field_id):
+            errors.append(f"{relative_path} {field_id} field must be required")
+
+    return errors
+
+
 def main() -> int:
     ok = True
     for relative in REQUIRED:
@@ -291,56 +328,37 @@ def main() -> int:
     elif "expected pr size:" not in pr_template.read_text(encoding="utf-8").lower():
         print("pull request template must ask for expected PR size")
         ok = False
-    security_issue_template = ROOT / SECURITY_ISSUE_TEMPLATE
-    if not security_issue_template.exists():
-        print(f"missing security issue template: {SECURITY_ISSUE_TEMPLATE}")
-        ok = False
-    else:
-        security_template = security_issue_template.read_text(encoding="utf-8").lower()
-        for phrase in [
+    for error in _validate_issue_template(
+        ROOT,
+        SECURITY_ISSUE_TEMPLATE,
+        missing_message=f"missing security issue template: {SECURITY_ISSUE_TEMPLATE}",
+        required_phrases=[
             "do not paste exploit details here",
             "follow security.md for private reporting",
             "public-safe summary",
-        ]:
-            if phrase not in security_template:
-                print(f"security issue template missing required phrase: {phrase}")
-                ok = False
-        if "security" not in _issue_template_labels(security_template):
-            print("security issue template must auto-apply the security label")
-            ok = False
-        if not _template_field_is_required(security_template, "summary"):
-            print("security issue template summary field must be required")
-            ok = False
-        if "mrwk:bounty" in _issue_template_labels(security_template):
-            print("security issue template must not auto-apply mrwk:bounty")
-            ok = False
-    bug_issue_template = ROOT / BUG_ISSUE_TEMPLATE
-    if not bug_issue_template.exists():
-        print(f"missing bug issue template: {BUG_ISSUE_TEMPLATE}")
+        ],
+        required_labels=["security"],
+        forbidden_labels=["mrwk:bounty"],
+        required_fields=["summary"],
+    ):
+        print(error)
         ok = False
-    else:
-        bug_template = bug_issue_template.read_text(encoding="utf-8").lower()
-        if "bug" not in _issue_template_labels(bug_template):
-            print("bug issue template must auto-apply the bug label")
-            ok = False
-        for field_id in ("expected", "actual", "reproduce"):
-            if not _template_field_is_required(bug_template, field_id):
-                print(f"bug issue template {field_id} field must be required")
-                ok = False
-        for phrase in ["expected behavior", "actual behavior", "reproduction"]:
-            if phrase not in bug_template:
-                print(f"bug issue template missing required phrase: {phrase}")
-                ok = False
-        if "mrwk:bounty" in _issue_template_labels(bug_template):
-            print("bug issue template must not auto-apply mrwk:bounty")
-            ok = False
-    bounty_issue_template = ROOT / ".github/ISSUE_TEMPLATE/bounty.yml"
-    if not bounty_issue_template.exists():
-        print("missing bounty issue template: .github/ISSUE_TEMPLATE/bounty.yml")
+    for error in _validate_issue_template(
+        ROOT,
+        BUG_ISSUE_TEMPLATE,
+        missing_message=f"missing bug issue template: {BUG_ISSUE_TEMPLATE}",
+        required_phrases=["expected behavior", "actual behavior", "reproduction"],
+        required_labels=["bug"],
+        forbidden_labels=["mrwk:bounty"],
+        required_fields=["expected", "actual", "reproduce"],
+    ):
+        print(error)
         ok = False
-    else:
-        bounty_template = bounty_issue_template.read_text(encoding="utf-8").lower()
-        for phrase in [
+    for error in _validate_issue_template(
+        ROOT,
+        ".github/ISSUE_TEMPLATE/bounty.yml",
+        missing_message="missing bounty issue template: .github/ISSUE_TEMPLATE/bounty.yml",
+        required_phrases=[
             "mrwk bounty: <amount> mrwk - <short scope>",
             "do not add the live bounty label from this template",
             "treasury proposal executes",
@@ -352,17 +370,12 @@ def main() -> int:
             "evidence or tests required",
             "id: out_of_scope",
             "id: duplicate_stale_rules",
-        ]:
-            if phrase not in bounty_template:
-                print(f"bounty issue template missing required phrase: {phrase}")
-                ok = False
-        if "mrwk:bounty" in _issue_template_labels(bounty_template):
-            print("bounty issue template must not auto-apply mrwk:bounty")
-            ok = False
-        for field_id in ("evidence", "out_of_scope", "duplicate_stale_rules"):
-            if not _template_field_is_required(bounty_template, field_id):
-                print(f"bounty issue template {field_id} field must be required")
-                ok = False
+        ],
+        forbidden_labels=["mrwk:bounty"],
+        required_fields=["evidence", "out_of_scope", "duplicate_stale_rules"],
+    ):
+        print(error)
+        ok = False
     proposed_work_template = ROOT / ".github/ISSUE_TEMPLATE/proposed-work.yml"
     if not proposed_work_template.exists():
         print("missing proposed work issue template: .github/ISSUE_TEMPLATE/proposed-work.yml")

--- a/tests/test_check_bounty_issue_states.py
+++ b/tests/test_check_bounty_issue_states.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts import check_bounty_issue_states
 from scripts.check_bounty_issue_states import analyze_issue_states, main
 
@@ -109,3 +111,19 @@ def test_issue_state_check_fix_reopens_closed_issues(monkeypatch) -> None:
     )
 
     assert calls == [["gh", "issue", "reopen", "936", "--repo", "ramimbo/mergework"]]
+
+
+@pytest.mark.parametrize(
+    ("flag", "value", "message"),
+    [
+        ("--input", "", "input path must be a non-empty string"),
+        ("--input", "   ", "input path must be a non-empty string"),
+        ("--repo", "   ", "repo must be a non-empty string"),
+    ],
+)
+def test_issue_state_check_rejects_blank_source_values(flag, value, message, capsys) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main([flag, value])
+
+    assert exc_info.value.code == 2
+    assert message in capsys.readouterr().err

--- a/tests/test_check_live_bounty_closing_refs.py
+++ b/tests/test_check_live_bounty_closing_refs.py
@@ -5,6 +5,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from scripts import check_live_bounty_closing_refs
 from scripts.check_live_bounty_closing_refs import analyze_closing_refs, main
 
@@ -113,3 +115,19 @@ def test_closing_ref_check_loads_specific_prs(monkeypatch) -> None:
 
     assert prs[0]["number"] == 1015
     assert calls[0][:4] == ["gh", "pr", "view", "1015"]
+
+
+@pytest.mark.parametrize(
+    ("flag", "value", "message"),
+    [
+        ("--input", "", "input path must be a non-empty string"),
+        ("--input", "   ", "input path must be a non-empty string"),
+        ("--repo", "   ", "repo must be a non-empty string"),
+    ],
+)
+def test_closing_ref_check_rejects_blank_source_values(flag, value, message, capsys) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main([flag, value])
+
+    assert exc_info.value.code == 2
+    assert message in capsys.readouterr().err

--- a/tests/test_docs_public_urls.py
+++ b/tests/test_docs_public_urls.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from scripts.docs_smoke import (
     REQUIRED,
+    _validate_issue_template,
     _issue_template_labels,
     _local_target_exists,
     _markdown_anchors,
@@ -529,6 +530,47 @@ body:
 
     assert not _template_field_is_required(template, "evidence")
     assert _template_field_is_required(template, "evidence_extra")
+
+
+def test_validate_issue_template_reports_missing_file(tmp_path: Path) -> None:
+    errors = _validate_issue_template(
+        tmp_path,
+        ".github/ISSUE_TEMPLATE/missing.yml",
+        missing_message="missing template",
+    )
+
+    assert errors == ["missing template"]
+
+
+def test_validate_issue_template_collects_phrase_label_and_field_errors(tmp_path: Path) -> None:
+    template = tmp_path / ".github" / "ISSUE_TEMPLATE" / "bug.yml"
+    template.parent.mkdir(parents=True, exist_ok=True)
+    template.write_text(
+        """
+labels: ["docs"]
+body:
+  - type: textarea
+    id: expected
+    validations:
+      required: false
+""",
+        encoding="utf-8",
+    )
+
+    errors = _validate_issue_template(
+        tmp_path,
+        ".github/ISSUE_TEMPLATE/bug.yml",
+        missing_message="missing bug template",
+        required_phrases=["expected behavior"],
+        required_labels=["bug"],
+        forbidden_labels=["mrwk:bounty"],
+        required_fields=["expected", "actual"],
+    )
+
+    assert ".github/ISSUE_TEMPLATE/bug.yml missing required phrase: expected behavior" in errors
+    assert ".github/ISSUE_TEMPLATE/bug.yml must auto-apply the bug label" in errors
+    assert ".github/ISSUE_TEMPLATE/bug.yml expected field must be required" in errors
+    assert ".github/ISSUE_TEMPLATE/bug.yml actual field must be required" in errors
 
 
 def test_contributing_names_docs_smoke_for_public_docs_changes() -> None:

--- a/tests/test_me_page.py
+++ b/tests/test_me_page.py
@@ -32,6 +32,8 @@ def test_me_page_context_defaults_for_anonymous_user(sqlite_url: str) -> None:
         "github_login": None,
         "github_balance_mrwk": "0",
         "linked_wallet_address": "",
+        "github_account_url": "",
+        "linked_wallet_url": "",
     }
 
 
@@ -57,4 +59,6 @@ def test_me_page_context_reports_balance_and_linked_wallet(sqlite_url: str) -> N
         "github_login": "alice",
         "github_balance_mrwk": "4",
         "linked_wallet_address": address,
+        "github_account_url": "/accounts/github:alice",
+        "linked_wallet_url": f"/wallets/{address}",
     }

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -813,6 +813,8 @@ def test_me_page_shows_signed_in_github_claim_balance(sqlite_url: str, monkeypat
     assert "Signed in as alice." in me
     assert "github:alice" in me
     assert "4 MRWK available to claim" in me
+    assert 'href="/accounts/github:alice"' in me
+    assert "View GitHub account ledger" in me
 
 
 def test_wallet_pages_do_not_require_manual_nonce(sqlite_url: str, monkeypatch) -> None:
@@ -919,6 +921,26 @@ def test_me_page_prefills_claim_address_for_linked_wallet(sqlite_url: str, monke
 
     assert f'value="{address}"' in me
     assert "Claim form is prefilled with your linked wallet." in me
+    assert f'href="/wallets/{address}"' in me
+    assert f"Linked wallet: <a href=\"/wallets/{address}\"><code>{address}</code></a>" in me
+    assert "View linked wallet" in me
+
+
+def test_me_page_explains_next_step_when_no_wallet_is_linked(sqlite_url: str, monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+    client = TestClient(
+        create_app(database_url=sqlite_url, webhook_secret="secret"),
+        base_url="https://testserver",
+    )
+    client.cookies.set("mrwk_user", _signed_value("alice", "test-cookie-secret"))
+
+    me = client.get("/me").text
+
+    assert "No wallet is linked yet." in me
+    assert "Register or open a wallet first, then sign the link action here." in me
 
 
 def test_prelinked_wallet_creates_github_account_row(sqlite_url: str) -> None:


### PR DESCRIPTION
﻿## Summary
- reject empty or whitespace-only `--input` / `--repo` values in the live bounty checker scripts
- switch runtime source selection from string truthiness to explicit presence checks
- add focused regression tests for blank source values in both scripts

## Testing
- python -m pytest tests\test_check_bounty_issue_states.py tests\test_check_live_bounty_closing_refs.py -q
- python -m ruff check scripts\api_host_args.py scripts\check_bounty_issue_states.py scripts\check_live_bounty_closing_refs.py tests\test_check_bounty_issue_states.py tests\test_check_live_bounty_closing_refs.py
