### PR TITLE
Share public JSON fetch helper across scripts

### DIFF
--- a/scripts/api_host_args.py
+++ b/scripts/api_host_args.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import json
 import urllib.parse
+import urllib.request
+from typing import Any
 
 
 def public_http_url(value: str, *, label: str = "URL", forbid_credentials: bool = False) -> str:
@@ -21,3 +24,17 @@ def public_api_host(value: str) -> str:
         return public_http_url(value, label="api host")
     except ValueError as exc:
         raise argparse.ArgumentTypeError(str(exc)) from None
+
+
+def load_public_json(
+    url: str,
+    *,
+    timeout_seconds: int | float,
+    user_agent: str | None = None,
+) -> Any:
+    headers = {"Accept": "application/json"}
+    if user_agent:
+        headers["User-Agent"] = user_agent
+    request = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+        return json.loads(response.read().decode("utf-8"))

--- a/scripts/check_bounty_issue_states.py
+++ b/scripts/check_bounty_issue_states.py
@@ -4,15 +4,13 @@ import argparse
 import json
 import subprocess
 import sys
-import urllib.error
-import urllib.request
 from pathlib import Path
 from typing import Any
 
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.api_host_args import public_api_host
+from scripts.api_host_args import load_public_json, public_api_host
 
 DEFAULT_API_HOST = "https://api.mrwk.online"
 GH_TIMEOUT_SECONDS = 30
@@ -167,11 +165,9 @@ def _run_gh(args: list[str]) -> None:
 
 
 def _fetch_json(url: str) -> Any:
-    request = urllib.request.Request(url, headers={"Accept": "application/json"})
     try:
-        with urllib.request.urlopen(request, timeout=GH_TIMEOUT_SECONDS) as response:
-            return json.loads(response.read().decode("utf-8"))
-    except (TimeoutError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        return load_public_json(url, timeout_seconds=GH_TIMEOUT_SECONDS)
+    except (TimeoutError, OSError, json.JSONDecodeError) as exc:
         raise RuntimeError(f"failed to fetch JSON from {url}: {exc}") from exc
 
 

--- a/scripts/check_live_bounty_closing_refs.py
+++ b/scripts/check_live_bounty_closing_refs.py
@@ -4,15 +4,13 @@ import argparse
 import json
 import subprocess
 import sys
-import urllib.error
-import urllib.request
 from pathlib import Path
 from typing import Any
 
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.api_host_args import public_api_host
+from scripts.api_host_args import load_public_json, public_api_host
 from scripts.bounty_refs import GITHUB_CLOSING_ISSUE_RE
 
 DEFAULT_API_HOST = "https://api.mrwk.online"
@@ -147,11 +145,9 @@ def _run_gh_json(args: list[str]) -> Any:
 
 
 def _fetch_json(url: str) -> Any:
-    request = urllib.request.Request(url, headers={"Accept": "application/json"})
     try:
-        with urllib.request.urlopen(request, timeout=GH_TIMEOUT_SECONDS) as response:
-            return json.loads(response.read().decode("utf-8"))
-    except (TimeoutError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        return load_public_json(url, timeout_seconds=GH_TIMEOUT_SECONDS)
+    except (TimeoutError, OSError, json.JSONDecodeError) as exc:
         raise RuntimeError(f"failed to fetch JSON from {url}: {exc}") from exc
 
 

--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -5,8 +5,6 @@ import json
 import re
 import subprocess
 import sys
-import urllib.error
-import urllib.request
 from collections import Counter
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -15,7 +13,7 @@ from typing import Any
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.api_host_args import public_api_host
+from scripts.api_host_args import load_public_json, public_api_host
 from scripts.bounty_refs import BOUNTY_REF_RE
 
 DEFAULT_API_HOST = "https://api.mrwk.online"
@@ -571,11 +569,9 @@ def _load_pr_review_comments(repo: str, pr_number: int) -> list[dict[str, Any]]:
 
 
 def _get_json(url: str) -> Any:
-    request = urllib.request.Request(url, headers={"accept": "application/json"})
     try:
-        with urllib.request.urlopen(request, timeout=GH_TIMEOUT_SECONDS) as response:
-            return json.loads(response.read().decode("utf-8"))
-    except (urllib.error.URLError, TimeoutError) as exc:
+        return load_public_json(url, timeout_seconds=GH_TIMEOUT_SECONDS)
+    except (OSError, TimeoutError, json.JSONDecodeError) as exc:
         raise RuntimeError(f"public API request failed: {url}") from exc
 
 

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -5,9 +5,7 @@ import json
 import re
 import subprocess
 import sys
-import urllib.error
 import urllib.parse
-import urllib.request
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, cast
@@ -15,7 +13,7 @@ from typing import Any, cast
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.api_host_args import public_api_host
+from scripts.api_host_args import load_public_json, public_api_host
 
 
 def _positive_int(value: str) -> int:
@@ -422,9 +420,11 @@ def _gh_issue_search(repo: str, query: str, limit: int) -> list[dict[str, Any]]:
 
 
 def _load_public_json(url: str) -> Any:
-    request = urllib.request.Request(url, headers={"User-Agent": "mergework-proposed-work-triage"})
-    with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
-        return json.load(response)
+    return load_public_json(
+        url,
+        timeout_seconds=HTTP_TIMEOUT_SECONDS,
+        user_agent="mergework-proposed-work-triage",
+    )
 
 
 def _load_public_bounty_issue(
@@ -434,7 +434,7 @@ def _load_public_bounty_issue(
     warnings: list[str] = []
     try:
         rows = _load_public_json(f"{api_host.rstrip('/')}/api/v1/bounties?{query}")
-    except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+    except (OSError, json.JSONDecodeError) as exc:
         warnings.append(
             "payment_state_incomplete: failed to load public bounty list "
             f"for issue #{issue_number} ({type(exc).__name__})"
@@ -449,7 +449,7 @@ def _load_public_bounty_issue(
             continue
         try:
             detail = _load_public_json(f"{api_host.rstrip('/')}/api/v1/bounties/{bounty_id}")
-        except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        except (OSError, json.JSONDecodeError) as exc:
             warnings.append(
                 "payment_state_incomplete: failed to load public bounty "
                 f"detail for bounty {bounty_id}; using list row only ({type(exc).__name__})"

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -9,13 +9,11 @@ from datetime import UTC, datetime, timedelta
 from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any
-from urllib.error import HTTPError, URLError
-from urllib.request import urlopen
 
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.api_host_args import public_api_host
+from scripts.api_host_args import load_public_json, public_api_host
 from scripts.bounty_refs import BOUNTY_REF_RE, GITHUB_LINKED_ISSUE_RE, LEADING_BOUNTY_REF_RE
 
 
@@ -567,9 +565,8 @@ def _load_issue_maintainer_activity(repo: str, issue_number: int) -> dict[str, A
 
 def _load_json_url(url: str, *, description: str) -> Any:
     try:
-        with urlopen(url, timeout=GH_TIMEOUT_SECONDS) as response:
-            return json.loads(response.read().decode("utf-8"))
-    except (HTTPError, OSError, URLError, json.JSONDecodeError) as exc:
+        return load_public_json(url, timeout_seconds=GH_TIMEOUT_SECONDS)
+    except (OSError, json.JSONDecodeError) as exc:
         raise RuntimeError(f"{description} unavailable: {exc}") from exc
 
 

--- a/tests/test_api_host_args.py
+++ b/tests/test_api_host_args.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import json
+import urllib.error
 
 import pytest
 
-from scripts.api_host_args import public_api_host, public_http_url
+from scripts import api_host_args
+from scripts.api_host_args import load_public_json, public_api_host, public_http_url
 
 
 def test_public_http_url_rejects_blank_and_relative_values() -> None:
@@ -30,3 +33,63 @@ def test_public_http_url_can_reject_embedded_credentials() -> None:
 def test_public_api_host_preserves_argparse_error_type() -> None:
     with pytest.raises(argparse.ArgumentTypeError, match="api host must be an absolute"):
         public_api_host("localhost:8000")
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+def test_load_public_json_sets_json_accept_header_and_optional_user_agent(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(request, *, timeout):
+        captured["accept"] = request.headers.get("Accept")
+        captured["user_agent"] = request.headers.get("User-agent")
+        captured["timeout"] = timeout
+        return _FakeResponse(json.dumps({"ok": True}).encode("utf-8"))
+
+    monkeypatch.setattr(api_host_args.urllib.request, "urlopen", fake_urlopen)
+
+    payload = load_public_json(
+        "https://api.example.test/status",
+        timeout_seconds=12,
+        user_agent="mergework-tests",
+    )
+
+    assert payload == {"ok": True}
+    assert captured == {
+        "accept": "application/json",
+        "user_agent": "mergework-tests",
+        "timeout": 12,
+    }
+
+
+def test_load_public_json_raises_json_decode_error_for_malformed_payload(monkeypatch) -> None:
+    monkeypatch.setattr(
+        api_host_args.urllib.request,
+        "urlopen",
+        lambda request, *, timeout: _FakeResponse(b"{not-json"),
+    )
+
+    with pytest.raises(json.JSONDecodeError):
+        load_public_json("https://api.example.test/status", timeout_seconds=5)
+
+
+def test_load_public_json_propagates_network_failures(monkeypatch) -> None:
+    def fake_urlopen(request, *, timeout):
+        raise urllib.error.URLError("offline")
+
+    monkeypatch.setattr(api_host_args.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(urllib.error.URLError):
+        load_public_json("https://api.example.test/status", timeout_seconds=5)

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -799,12 +799,15 @@ class _JsonResponse:
 
 
 def test_submission_quality_gate_load_json_url_decodes_response(monkeypatch) -> None:
-    def fake_urlopen(url: str, *, timeout: int) -> _JsonResponse:
+    def fake_load_public_json(
+        url: str, *, timeout_seconds: int, user_agent=None
+    ) -> dict[str, bool]:
         assert url == "https://api.example.test/data"
-        assert timeout == submission_quality_gate.GH_TIMEOUT_SECONDS
-        return _JsonResponse({"ok": True})
+        assert timeout_seconds == submission_quality_gate.GH_TIMEOUT_SECONDS
+        assert user_agent is None
+        return {"ok": True}
 
-    monkeypatch.setattr(submission_quality_gate, "urlopen", fake_urlopen)
+    monkeypatch.setattr(submission_quality_gate, "load_public_json", fake_load_public_json)
 
     assert submission_quality_gate._load_json_url(
         "https://api.example.test/data", description="test data"
@@ -812,10 +815,11 @@ def test_submission_quality_gate_load_json_url_decodes_response(monkeypatch) -> 
 
 
 def test_submission_quality_gate_attempts_loader_keeps_contextual_error(monkeypatch) -> None:
-    def fake_urlopen(url: str, *, timeout: int) -> _JsonResponse:
-        return _JsonResponse({"attempts": "not-a-list"})
-
-    monkeypatch.setattr(submission_quality_gate, "urlopen", fake_urlopen)
+    monkeypatch.setattr(
+        submission_quality_gate,
+        "load_public_json",
+        lambda url, *, timeout_seconds, user_agent=None: {"attempts": "not-a-list"},
+    )
 
     with pytest.raises(RuntimeError, match="MergeWork API attempts data must be a list"):
         submission_quality_gate._load_api_attempts("https://api.example.test", 42)


### PR DESCRIPTION
﻿## Summary
- add a shared read-only public JSON fetch helper for maintenance scripts
- migrate the repeated `urllib` JSON loaders in bounty checks and report scripts to that helper
- add focused helper regression tests while preserving script-specific higher-level error handling

## Testing
- python -m pytest tests\test_api_host_args.py tests\test_check_bounty_issue_states.py tests\test_check_live_bounty_closing_refs.py tests\test_claim_inventory.py tests\test_proposed_work_triage.py tests\test_submission_quality_gate.py -q
- python -m ruff check scripts\api_host_args.py scripts\check_bounty_issue_states.py scripts\check_live_bounty_closing_refs.py scripts\claim_inventory.py scripts\proposed_work_triage.py scripts\submission_quality_gate.py tests\test_api_host_args.py tests\test_submission_quality_gate.py
