### PR TITLE
Validate gh JSON shapes in live scripts

### DIFF
--- a/scripts/api_host_args.py
+++ b/scripts/api_host_args.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import urllib.parse
+from typing import Any
 
 
 def public_http_url(value: str, *, label: str = "URL", forbid_credentials: bool = False) -> str:
@@ -21,3 +22,15 @@ def public_api_host(value: str) -> str:
         return public_http_url(value, label="api host")
     except ValueError as exc:
         raise argparse.ArgumentTypeError(str(exc)) from None
+
+
+def require_json_list(payload: Any, *, source: str) -> list[Any]:
+    if not isinstance(payload, list):
+        raise RuntimeError(f"{source} returned non-list JSON")
+    return payload
+
+
+def require_json_object(payload: Any, *, source: str) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{source} returned non-object JSON")
+    return payload

--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -15,7 +15,7 @@ from typing import Any
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.api_host_args import public_api_host
+from scripts.api_host_args import public_api_host, require_json_list, require_json_object
 from scripts.bounty_refs import BOUNTY_REF_RE
 
 DEFAULT_API_HOST = "https://api.mrwk.online"
@@ -547,16 +547,17 @@ def _run_gh_json(args: list[str]) -> Any:
 
 
 def _load_pr_review_comments(repo: str, pr_number: int) -> list[dict[str, Any]]:
-    raw_comments = _run_gh_json(
-        [
-            "gh",
-            "api",
-            f"repos/{repo}/pulls/{pr_number}/comments?per_page=100",
-        ]
+    raw_comments = require_json_list(
+        _run_gh_json(
+            [
+                "gh",
+                "api",
+                f"repos/{repo}/pulls/{pr_number}/comments?per_page=100",
+            ]
+        ),
+        source="gh api pull review comments",
     )
     comments: list[dict[str, Any]] = []
-    if not isinstance(raw_comments, list):
-        return comments
     for item in raw_comments:
         if not isinstance(item, dict):
             continue
@@ -597,20 +598,23 @@ def load_public_api_state(api_host: str) -> dict[str, Any]:
 
 
 def load_live_inventory(repo: str, api_host: str) -> dict[str, Any]:
-    issue_list = _run_gh_json(
-        [
-            "gh",
-            "issue",
-            "list",
-            "--repo",
-            repo,
-            "--state",
-            "open",
-            "--limit",
-            str(GH_LIMIT),
-            "--json",
-            "number,title,url,labels,author",
-        ]
+    issue_list = require_json_list(
+        _run_gh_json(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "open",
+                "--limit",
+                str(GH_LIMIT),
+                "--json",
+                "number,title,url,labels,author",
+            ]
+        ),
+        source="gh issue list",
     )
     issues: list[dict[str, Any]] = []
     for issue in issue_list:
@@ -620,52 +624,60 @@ def load_live_inventory(repo: str, api_host: str) -> dict[str, Any]:
             or not _is_bounty_issue(issue)
         ):
             continue
-        issue_view = _run_gh_json(
-            [
-                "gh",
-                "issue",
-                "view",
-                str(issue["number"]),
-                "--repo",
-                repo,
-                "--json",
-                "number,title,url,body,labels,author,comments",
-            ]
+        issue_view = require_json_object(
+            _run_gh_json(
+                [
+                    "gh",
+                    "issue",
+                    "view",
+                    str(issue["number"]),
+                    "--repo",
+                    repo,
+                    "--json",
+                    "number,title,url,body,labels,author,comments",
+                ]
+            ),
+            source="gh issue view",
         )
         issues.append(issue_view)
-    prs = _run_gh_json(
-        [
-            "gh",
-            "pr",
-            "list",
-            "--repo",
-            repo,
-            "--state",
-            "open",
-            "--limit",
-            str(GH_LIMIT),
-            "--json",
-            "number,title,url,body,author,labels",
-        ]
+    prs = require_json_list(
+        _run_gh_json(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "open",
+                "--limit",
+                str(GH_LIMIT),
+                "--json",
+                "number,title,url,body,author,labels",
+            ]
+        ),
+        source="gh pr list",
     )
     pull_requests: list[dict[str, Any]] = []
     for pr in prs:
         if not isinstance(pr, dict) or not isinstance(pr.get("number"), int):
             continue
-        pr_view = _run_gh_json(
-            [
-                "gh",
-                "pr",
-                "view",
-                str(pr["number"]),
-                "--repo",
-                repo,
-                "--json",
-                "number,title,url,body,author,labels,comments,reviews",
-            ]
+        pr_view = require_json_object(
+            _run_gh_json(
+                [
+                    "gh",
+                    "pr",
+                    "view",
+                    str(pr["number"]),
+                    "--repo",
+                    repo,
+                    "--json",
+                    "number,title,url,body,author,labels,comments,reviews",
+                ]
+            ),
+            source="gh pr view",
         )
-        if isinstance(pr_view, dict):
-            pr_view["review_comments"] = _load_pr_review_comments(repo, pr["number"])
+        pr_view["review_comments"] = _load_pr_review_comments(repo, pr["number"])
         pull_requests.append(pr_view)
     public_state = load_public_api_state(api_host)
     public_state.update({"issues": issues, "pull_requests": pull_requests})

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -12,6 +12,7 @@ from typing import Any
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from scripts.api_host_args import require_json_list, require_json_object
 from scripts.bounty_refs import BOUNTY_REF_RE
 
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
@@ -335,20 +336,23 @@ def _run_gh_json(args: list[str]) -> Any:
 
 
 def load_live_queue(repo: str) -> dict[str, Any]:
-    prs = _run_gh_json(
-        [
-            "gh",
-            "pr",
-            "list",
-            "--repo",
-            repo,
-            "--state",
-            "open",
-            "--limit",
-            str(GH_PR_SAFETY_CAP),
-            "--json",
-            "number,title,url,body,labels,mergeStateStatus",
-        ]
+    prs = require_json_list(
+        _run_gh_json(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "open",
+                "--limit",
+                str(GH_PR_SAFETY_CAP),
+                "--json",
+                "number,title,url,body,labels,mergeStateStatus",
+            ]
+        ),
+        source="gh pr list",
     )
     if len(prs) >= GH_PR_SAFETY_CAP:
         raise RuntimeError(
@@ -359,20 +363,23 @@ def load_live_queue(repo: str) -> dict[str, Any]:
         {ref for pr in prs if isinstance(pr, dict) for ref in _bounty_refs(pr)}
     )
     referenced_issue_numbers = set(referenced_issues)
-    issues = _run_gh_json(
-        [
-            "gh",
-            "issue",
-            "list",
-            "--repo",
-            repo,
-            "--state",
-            "all",
-            "--limit",
-            str(GH_ISSUE_SAFETY_CAP),
-            "--json",
-            "number,title,state,labels",
-        ]
+    issues = require_json_list(
+        _run_gh_json(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "all",
+                "--limit",
+                str(GH_ISSUE_SAFETY_CAP),
+                "--json",
+                "number,title,state,labels",
+            ]
+        ),
+        source="gh issue list",
     )
     if len(issues) >= GH_ISSUE_SAFETY_CAP:
         raise RuntimeError(
@@ -398,18 +405,21 @@ def load_live_queue(repo: str) -> dict[str, Any]:
         include_comments = number in referenced_issue_numbers
         if include_comments:
             try:
-                viewed_issue = _run_gh_json(
-                    [
-                        "gh",
-                        "issue",
-                        "view",
-                        str(number),
-                        "--repo",
-                        repo,
-                        "--comments",
-                        "--json",
-                        "number,title,state,labels,comments",
-                    ]
+                viewed_issue = require_json_object(
+                    _run_gh_json(
+                        [
+                            "gh",
+                            "issue",
+                            "view",
+                            str(number),
+                            "--repo",
+                            repo,
+                            "--comments",
+                            "--json",
+                            "number,title,state,labels,comments",
+                        ]
+                    ),
+                    source="gh issue view",
                 )
             except RuntimeError:
                 if number not in issues_by_number:

--- a/scripts/review_bounty_candidates.py
+++ b/scripts/review_bounty_candidates.py
@@ -7,6 +7,8 @@ import sys
 from collections import Counter
 from typing import Any
 
+from scripts.api_host_args import require_json_list
+
 DIRTY_MERGE_STATES = {"blocked", "conflicting", "dirty"}
 GH_TIMEOUT_SECONDS = 30
 GH_PR_SAFETY_CAP = 201
@@ -298,32 +300,35 @@ def _run_gh_json(args: list[str]) -> Any:
 
 
 def load_live_candidates(repo: str) -> dict[str, Any]:
-    prs = _run_gh_json(
-        [
-            "gh",
-            "pr",
-            "list",
-            "--repo",
-            repo,
-            "--state",
-            "open",
-            "--limit",
-            str(GH_PR_SAFETY_CAP),
-            "--json",
-            ",".join(
-                [
-                    "number",
-                    "title",
-                    "url",
-                    "author",
-                    "headRefOid",
-                    "mergeStateStatus",
-                    "labels",
-                    "statusCheckRollup",
-                    "reviews",
-                ]
-            ),
-        ]
+    prs = require_json_list(
+        _run_gh_json(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "open",
+                "--limit",
+                str(GH_PR_SAFETY_CAP),
+                "--json",
+                ",".join(
+                    [
+                        "number",
+                        "title",
+                        "url",
+                        "author",
+                        "headRefOid",
+                        "mergeStateStatus",
+                        "labels",
+                        "statusCheckRollup",
+                        "reviews",
+                    ]
+                ),
+            ]
+        ),
+        source="gh pr list",
     )
     if len(prs) >= GH_PR_SAFETY_CAP:
         raise RuntimeError(

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -15,7 +15,7 @@ from urllib.request import urlopen
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.api_host_args import public_api_host
+from scripts.api_host_args import public_api_host, require_json_list, require_json_object
 from scripts.bounty_refs import BOUNTY_REF_RE, GITHUB_LINKED_ISSUE_RE, LEADING_BOUNTY_REF_RE
 
 
@@ -533,17 +533,20 @@ def _run_gh_json(args: list[str]) -> Any:
 
 
 def _load_issue_maintainer_activity(repo: str, issue_number: int) -> dict[str, Any]:
-    issue = _run_gh_json(
-        [
-            "gh",
-            "issue",
-            "view",
-            str(issue_number),
-            "--repo",
-            repo,
-            "--json",
-            "author,comments,createdAt",
-        ]
+    issue = require_json_object(
+        _run_gh_json(
+            [
+                "gh",
+                "issue",
+                "view",
+                str(issue_number),
+                "--repo",
+                repo,
+                "--json",
+                "author,comments,createdAt",
+            ]
+        ),
+        source="gh issue view",
     )
     activity_times = []
     repo_owner = repo.split("/", 1)[0].lower()
@@ -625,35 +628,41 @@ def _load_live_context(
 ) -> dict[str, Any]:
     load_warnings: list[str] = []
     try:
-        prs = _run_gh_json(
-            [
-                "gh",
-                "pr",
-                "list",
-                "--repo",
-                repo,
-                "--state",
-                "open",
-                "--limit",
-                str(GH_PR_SAFETY_CAP),
-                "--json",
-                "number,title,url,body,state",
-            ]
+        prs = require_json_list(
+            _run_gh_json(
+                [
+                    "gh",
+                    "pr",
+                    "list",
+                    "--repo",
+                    repo,
+                    "--state",
+                    "open",
+                    "--limit",
+                    str(GH_PR_SAFETY_CAP),
+                    "--json",
+                    "number,title,url,body,state",
+                ]
+            ),
+            source="gh pr list",
         )
-        issues = _run_gh_json(
-            [
-                "gh",
-                "issue",
-                "list",
-                "--repo",
-                repo,
-                "--state",
-                "all",
-                "--limit",
-                str(GH_ISSUE_SAFETY_CAP),
-                "--json",
-                "number,title,state",
-            ]
+        issues = require_json_list(
+            _run_gh_json(
+                [
+                    "gh",
+                    "issue",
+                    "list",
+                    "--repo",
+                    repo,
+                    "--state",
+                    "all",
+                    "--limit",
+                    str(GH_ISSUE_SAFETY_CAP),
+                    "--json",
+                    "number,title,state",
+                ]
+            ),
+            source="gh issue list",
         )
     except (RuntimeError, FileNotFoundError, json.JSONDecodeError) as exc:
         return {

--- a/tests/test_api_host_args.py
+++ b/tests/test_api_host_args.py
@@ -4,7 +4,12 @@ import argparse
 
 import pytest
 
-from scripts.api_host_args import public_api_host, public_http_url
+from scripts.api_host_args import (
+    public_api_host,
+    public_http_url,
+    require_json_list,
+    require_json_object,
+)
 
 
 def test_public_http_url_rejects_blank_and_relative_values() -> None:
@@ -30,3 +35,13 @@ def test_public_http_url_can_reject_embedded_credentials() -> None:
 def test_public_api_host_preserves_argparse_error_type() -> None:
     with pytest.raises(argparse.ArgumentTypeError, match="api host must be an absolute"):
         public_api_host("localhost:8000")
+
+
+def test_require_json_list_rejects_non_list_payloads() -> None:
+    with pytest.raises(RuntimeError, match="gh pr list returned non-list JSON"):
+        require_json_list({"not": "a list"}, source="gh pr list")
+
+
+def test_require_json_object_rejects_non_object_payloads() -> None:
+    with pytest.raises(RuntimeError, match="gh issue view returned non-object JSON"):
+        require_json_object([], source="gh issue view")

--- a/tests/test_claim_inventory.py
+++ b/tests/test_claim_inventory.py
@@ -430,6 +430,18 @@ def test_run_gh_json_reports_missing_gh(monkeypatch) -> None:
         raise AssertionError("expected missing gh RuntimeError")
 
 
+def test_claim_inventory_live_mode_rejects_non_list_issue_list(monkeypatch) -> None:
+    monkeypatch.setattr(claim_inventory, "_run_gh_json", lambda args: {"not": "a list"})
+    monkeypatch.setattr(
+        claim_inventory,
+        "load_public_api_state",
+        lambda api_host: {"bounties": [], "proofs": [], "recent": []},
+    )
+
+    with pytest.raises(RuntimeError, match="gh issue list returned non-list JSON"):
+        claim_inventory.load_live_inventory("ramimbo/mergework", "https://api.example.test")
+
+
 def test_claim_inventory_script_entrypoint_loads_shared_parser() -> None:
     result = subprocess.run(
         [sys.executable, "scripts/claim_inventory.py", "--help"],

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -546,3 +546,17 @@ def test_pr_queue_health_fails_fast_when_pr_fetch_hits_cap(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="pr list reached the 201 item safety cap"):
         pr_queue_health.load_live_queue("ramimbo/mergework")
+
+
+def test_pr_queue_health_rejects_non_list_pr_payload(monkeypatch) -> None:
+    def fake_run(args, **kwargs):
+        if args[:3] == ["gh", "pr", "list"]:
+            stdout = json.dumps({"not": "a list"})
+        else:
+            raise AssertionError(args)
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(pr_queue_health.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="gh pr list returned non-list JSON"):
+        pr_queue_health.load_live_queue("ramimbo/mergework")

--- a/tests/test_review_bounty_candidates.py
+++ b/tests/test_review_bounty_candidates.py
@@ -276,3 +276,18 @@ def test_live_candidates_reports_missing_github_cli(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="GitHub CLI executable 'gh' was not found"):
         load_live_candidates("ramimbo/mergework")
+
+
+def test_live_candidates_rejects_non_list_payload(monkeypatch) -> None:
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=kwargs.get("args", args[0] if args else []),
+            returncode=0,
+            stdout=json.dumps({"not": "a list"}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="gh pr list returned non-list JSON"):
+        load_live_candidates("ramimbo/mergework")

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -959,6 +959,33 @@ def test_submission_quality_gate_live_bounties_use_api_award_capacity(monkeypatc
     } in result["checks"]
 
 
+def test_submission_quality_gate_warns_when_pr_list_shape_is_invalid(
+    monkeypatch, tmp_path, capsys
+) -> None:
+    def fake_run(args, **kwargs):
+        if args[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps({"not": "a list"}),
+                stderr="",
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(submission_quality_gate.subprocess, "run", fake_run)
+    text_path = tmp_path / "draft.md"
+    text_path.write_text(
+        "Summary: work\n\nRefs #319\n\nValidation: pytest passed",
+        encoding="utf-8",
+    )
+
+    assert main(["--text-file", str(text_path), "--format", "json"]) == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "warn"
+    assert "gh pr list returned non-list JSON" in output["load_warning"]
+
+
 def test_submission_quality_gate_live_context_preserves_effective_availability(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
﻿## Summary
- add shared helpers for requiring decoded gh JSON to be a list or object
- apply explicit gh JSON shape validation to live maintenance-script hot paths
- add focused regression tests for malformed gh JSON shapes in live mode

## Testing
- python -m pytest tests\test_api_host_args.py tests\test_claim_inventory.py tests\test_pr_queue_health.py tests\test_review_bounty_candidates.py tests\test_submission_quality_gate.py -q
- python -m ruff check scripts\api_host_args.py scripts\claim_inventory.py scripts\pr_queue_health.py scripts\review_bounty_candidates.py scripts\submission_quality_gate.py tests\test_api_host_args.py tests\test_claim_inventory.py tests\test_pr_queue_health.py tests\test_review_bounty_candidates.py tests\test_submission_quality_gate.py
