### PR TITLE
Link accepted-by reviewers from proof pages

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from typing import Any
 from urllib.parse import quote, urlencode
 
@@ -11,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from app.control_chars import contains_control_character
 from app.db import session_scope
+from app.github_accounts import GITHUB_LOGIN_RE
 from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
 from app.ledger_views import account_ledger_transactions
 from app.models import Account
@@ -27,7 +27,6 @@ from app.serializers import (
 )
 from app.wallets import WalletError, normalize_wallet_address
 
-GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 ACCOUNT_TRANSACTION_TYPE_OPTIONS = [
     {"value": "all", "label": "All"},
     {"value": "bounty_payment", "label": "Bounty payments"},

--- a/app/github_accounts.py
+++ b/app/github_accounts.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+
+
+def github_account_url(login: Any) -> str | None:
+    if not isinstance(login, str):
+        return None
+    clean = login.strip().lower()
+    if not GITHUB_LOGIN_RE.fullmatch(clean):
+        return None
+    return f"/accounts/github:{clean}"

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -41,6 +41,15 @@ from app.status import (
 WALLET_SEARCH_QUERY_MAX_LENGTH = 500
 
 
+def _github_account_url(login: object) -> str | None:
+    if not isinstance(login, str):
+        return None
+    clean = login.strip().lower()
+    if not clean:
+        return None
+    return f"/accounts/github:{clean}"
+
+
 def _bounty_filter_params(
     status: str | None,
     query_text: str,
@@ -457,10 +466,15 @@ def register_public_routes(
     @app.get("/proofs/{proof_hash}", response_class=HTMLResponse)
     def proof_page(request: Request, proof_hash: str) -> HTMLResponse:
         normalized_proof_hash = proof_hash_from_path(proof_hash)
+        proof = api_proof(normalized_proof_hash)
         return templates.TemplateResponse(
             request,
             "proof.html",
-            {"proof": api_proof(normalized_proof_hash), "proof_hash": normalized_proof_hash},
+            {
+                "proof": proof,
+                "proof_hash": normalized_proof_hash,
+                "proof_accepted_by_account_url": _github_account_url(proof.get("accepted_by")),
+            },
         )
 
     @app.get("/docs", response_class=HTMLResponse)

--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -22,6 +22,7 @@ from app.bounty_availability import (
 from app.bounty_sorting import BOUNTY_SORT_ERROR, BOUNTY_SORT_LABELS, normalize_bounty_sort
 from app.control_chars import contains_control_character
 from app.db import session_scope
+from app.github_accounts import github_account_url
 from app.ledger_views import account_ledger_transaction_types, account_ledger_transactions
 from app.models import Wallet
 from app.path_params import SQLITE_INTEGER_MAX, proof_hash_from_path, reject_path_whitespace_padding
@@ -39,15 +40,6 @@ from app.status import (
 )
 
 WALLET_SEARCH_QUERY_MAX_LENGTH = 500
-
-
-def _github_account_url(login: object) -> str | None:
-    if not isinstance(login, str):
-        return None
-    clean = login.strip().lower()
-    if not clean:
-        return None
-    return f"/accounts/github:{clean}"
 
 
 def _bounty_filter_params(
@@ -473,7 +465,7 @@ def register_public_routes(
             {
                 "proof": proof,
                 "proof_hash": normalized_proof_hash,
-                "proof_accepted_by_account_url": _github_account_url(proof.get("accepted_by")),
+                "proof_accepted_by_account_url": github_account_url(proof.get("accepted_by")),
             },
         )
 

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -26,6 +27,16 @@ from app.submission_requirements import (
 
 PendingBountyProposals = tuple[list[dict[str, Any]], dict[str, Any] | None]
 MRWK_MICROUNITS = Decimal(1_000_000)
+GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+
+
+def _github_account_url(login: Any) -> str | None:
+    if not isinstance(login, str):
+        return None
+    clean = login.strip().lower()
+    if not GITHUB_LOGIN_RE.fullmatch(clean):
+        return None
+    return f"/accounts/github:{clean}"
 
 
 def public_utc_timestamp(value: datetime) -> str:
@@ -164,6 +175,7 @@ def bounty_awards_to_dict(session: Session, bounty_id: int) -> list[dict[str, An
                 "amount_mrwk": data.get("amount_mrwk"),
                 "submission_url": data.get("submission_url"),
                 "accepted_by": data.get("accepted_by"),
+                "accepted_by_account_url": _github_account_url(data.get("accepted_by")),
                 "created_at": public_utc_timestamp(proof.created_at),
             }
         )
@@ -786,6 +798,7 @@ def accepted_work_for_account(session: Session, account: str) -> list[dict[str, 
                 "bounty_url": bounty_url,
                 "bounty_public_url": _public_page_url(bounty_url, public_base_url),
                 "accepted_by": data.get("accepted_by"),
+                "accepted_by_account_url": _github_account_url(data.get("accepted_by")),
                 "created_at": public_utc_timestamp(entry.created_at),
             }
         )

--- a/app/serializers.py
+++ b/app/serializers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import re
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -17,6 +16,7 @@ from app.bounty_attempts import (
     bounty_attempt_summary_from_count,
 )
 from app.config import get_settings
+from app.github_accounts import github_account_url
 from app.ledger.reconciliation import AcceptedPayoutCheck
 from app.ledger.service import format_mrwk, get_balance
 from app.models import Bounty, LedgerEntry, Proof, TreasuryProposal, Wallet, WalletTransfer
@@ -27,16 +27,6 @@ from app.submission_requirements import (
 
 PendingBountyProposals = tuple[list[dict[str, Any]], dict[str, Any] | None]
 MRWK_MICROUNITS = Decimal(1_000_000)
-GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
-
-
-def _github_account_url(login: Any) -> str | None:
-    if not isinstance(login, str):
-        return None
-    clean = login.strip().lower()
-    if not GITHUB_LOGIN_RE.fullmatch(clean):
-        return None
-    return f"/accounts/github:{clean}"
 
 
 def public_utc_timestamp(value: datetime) -> str:
@@ -175,7 +165,7 @@ def bounty_awards_to_dict(session: Session, bounty_id: int) -> list[dict[str, An
                 "amount_mrwk": data.get("amount_mrwk"),
                 "submission_url": data.get("submission_url"),
                 "accepted_by": data.get("accepted_by"),
-                "accepted_by_account_url": _github_account_url(data.get("accepted_by")),
+                "accepted_by_account_url": github_account_url(data.get("accepted_by")),
                 "created_at": public_utc_timestamp(proof.created_at),
             }
         )
@@ -798,7 +788,7 @@ def accepted_work_for_account(session: Session, account: str) -> list[dict[str, 
                 "bounty_url": bounty_url,
                 "bounty_public_url": _public_page_url(bounty_url, public_base_url),
                 "accepted_by": data.get("accepted_by"),
-                "accepted_by_account_url": _github_account_url(data.get("accepted_by")),
+                "accepted_by_account_url": github_account_url(data.get("accepted_by")),
                 "created_at": public_utc_timestamp(entry.created_at),
             }
         )

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -111,7 +111,13 @@
           </div>
           <div class="ledger-field">
             <dt>Accepted by</dt>
-            <dd>{{ payout.accepted_by or "-" }}</dd>
+            <dd>
+              {% if payout.accepted_by_account_url %}
+              <a href="{{ payout.accepted_by_account_url }}">{{ payout.accepted_by }}</a>
+              {% else %}
+              {{ payout.accepted_by or "-" }}
+              {% endif %}
+            </dd>
           </div>
           <div class="ledger-field">
             <dt>Executes after</dt>
@@ -165,7 +171,13 @@
           </div>
           <div class="ledger-field">
             <dt>Accepted by</dt>
-            <dd>{{ work.accepted_by or "-" }}</dd>
+            <dd>
+              {% if work.accepted_by_account_url %}
+              <a href="{{ work.accepted_by_account_url }}">{{ work.accepted_by }}</a>
+              {% else %}
+              {{ work.accepted_by or "-" }}
+              {% endif %}
+            </dd>
           </div>
         </dl>
       </div>

--- a/app/templates/proof.html
+++ b/app/templates/proof.html
@@ -37,7 +37,13 @@
     <dt>MergeWork bounty</dt>
     <dd><a href="/bounties/{{ proof.bounty_id }}">#{{ proof.bounty_id }}</a></dd>
     <dt>Accepted by</dt>
-    <dd>{{ proof.accepted_by }}</dd>
+    <dd>
+      {% if proof_accepted_by_account_url %}
+      <a href="{{ proof_accepted_by_account_url }}">{{ proof.accepted_by }}</a>
+      {% else %}
+      {{ proof.accepted_by }}
+      {% endif %}
+    </dd>
     <dt>Paid to</dt>
     <dd><a href="/accounts/{{ proof.to_account }}">{{ proof.to_account }}</a></dd>
     <dt>Amount</dt>

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -1294,6 +1294,7 @@ def test_mcp_get_bounty_can_include_accepted_awards(sqlite_url: str) -> None:
             "amount_mrwk": "75",
             "submission_url": "https://github.com/ramimbo/mergework/pull/284",
             "accepted_by": "maintainer",
+            "accepted_by_account_url": "/accounts/github:maintainer",
             "created_at": public_utc_timestamp(proof.created_at),
         }
     ]

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -2617,6 +2617,7 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     assert "ramimbo/mergework #2" in proof_page
     assert proof.hash in proof_page
     assert "maintainer" in proof_page
+    assert 'href="/accounts/github:maintainer"' in proof_page
     assert "github:alice" in proof_page
     assert "Ledger address" in account
     assert account_api["transfer_status"] == (
@@ -2652,6 +2653,7 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
         "bounty_url": f"/bounties/{bounty.id}",
         "bounty_public_url": f"https://mrwk.online/bounties/{bounty.id}",
         "accepted_by": "maintainer",
+        "accepted_by_account_url": "/accounts/github:maintainer",
         "created_at": "<checked>",
     }
     assert "Claim GitHub balances from /me" in account
@@ -2663,6 +2665,7 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     assert 'href="https://github.com/ramimbo/mergework/pull/3"' in account
     assert 'via <a href="/ledger/3">#3</a>' in account
     assert "Accepted work" in account
+    assert 'href="/accounts/github:maintainer"' in account
     assert "Proof-backed bounty payments made to this account." in account
     assert f'href="/bounties/{bounty.id}">Bounty #{bounty.id}</a>' in account
     assert 'href="https://github.com/ramimbo/mergework/issues/2"' in account

--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -2673,6 +2673,42 @@ def test_explorer_links_ledger_proof_and_account(sqlite_url: str) -> None:
     assert 'href="/accounts/github:alice"' in account
 
 
+def test_explorer_renders_malformed_accepted_by_without_account_links(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=22,
+            issue_url="https://github.com/ramimbo/mergework/issues/22",
+            title="Malformed accepted_by links",
+            reward_mrwk="25",
+            acceptance="Accepted label",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/22",
+            accepted_by="Bad Name!",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    proof_page = client.get(f"/proofs/{proof.hash}").text
+    accepted_work_api = client.get("/api/v1/accounts/github:alice/accepted-work").json()
+    account = client.get("/accounts/github:alice").text
+
+    assert "Bad Name!" in proof_page
+    assert 'href="/accounts/github:bad name!"' not in proof_page
+    assert accepted_work_api["accepted_work"][0]["accepted_by"] == "Bad Name!"
+    assert accepted_work_api["accepted_work"][0]["accepted_by_account_url"] is None
+    assert "Bad Name!" in account
+    assert 'href="/accounts/github:bad name!"' not in account
+
+
 def test_account_api_keeps_schema_when_accepted_work_proof_is_malformed(
     sqlite_url: str,
 ) -> None:


### PR DESCRIPTION
## Summary
- link `accepted_by` usernames to their GitHub ledger account pages from proof views
- expose the same accepted-by account link on account accepted-work rows
- keep raw proof API payloads unchanged while improving public navigation

## Bounty
Bounty #1010

## Files Changed
- `app/public_routes.py`
- `app/serializers.py`
- `app/templates/proof.html`
- `app/templates/account.html`
- `tests/test_api_mcp.py`

## Validation
- `python -m pytest tests/test_api_mcp.py -k test_explorer_links_ledger_proof_and_account -q`
- `python -m pytest tests/test_account_routes.py -q`
- `python -m ruff check app/accounts.py app/public_routes.py app/serializers.py tests/test_api_mcp.py tests/test_account_routes.py`
- `python -m ruff format app/accounts.py app/public_routes.py app/serializers.py tests/test_api_mcp.py tests/test_account_routes.py`
- `git diff --check`

## Scope Notes
This stays within the contributor/proof/account inspection workflow for #1010. It adds navigation for existing `accepted_by` data without changing ledger behavior, payout semantics, or the raw `/api/v1/proofs/{hash}` response shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * “Accepted by” now shows clickable GitHub account links for both bounty and accepted work entries when a valid account is available, improving navigation from proof and account pages.

* **Tests**
  * Added/updated end-to-end assertions to confirm the new account-link fields appear in API responses and rendered pages.
  * Added coverage for malformed “accepted by” values to ensure links are omitted and API returns a null account URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->