### PR TITLE
Link accepted-by reviewers on activity and bounty pages

### DIFF
--- a/app/serializers.py
+++ b/app/serializers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -26,6 +27,16 @@ from app.submission_requirements import (
 
 PendingBountyProposals = tuple[list[dict[str, Any]], dict[str, Any] | None]
 MRWK_MICROUNITS = Decimal(1_000_000)
+GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+
+
+def _github_account_url(login: Any) -> str | None:
+    if not isinstance(login, str):
+        return None
+    clean = login.strip().lower()
+    if not GITHUB_LOGIN_RE.fullmatch(clean):
+        return None
+    return f"/accounts/github:{clean}"
 
 
 def public_utc_timestamp(value: datetime) -> str:
@@ -164,6 +175,7 @@ def bounty_awards_to_dict(session: Session, bounty_id: int) -> list[dict[str, An
                 "amount_mrwk": data.get("amount_mrwk"),
                 "submission_url": data.get("submission_url"),
                 "accepted_by": data.get("accepted_by"),
+                "accepted_by_account_url": _github_account_url(data.get("accepted_by")),
                 "created_at": public_utc_timestamp(proof.created_at),
             }
         )
@@ -531,6 +543,7 @@ def _pending_activity_row(
     proposal: TreasuryProposal, payload: dict[str, Any], bounty: Bounty | None
 ) -> dict[str, Any]:
     amount_microunits = bounty.reward_microunits if bounty else 0
+    accepted_by = payload.get("accepted_by")
     return {
         "proposal_id": proposal.id,
         "proposal_url": f"/api/v1/treasury/proposals/{proposal.id}",
@@ -544,7 +557,8 @@ def _pending_activity_row(
         "bounty_issue_url": bounty.issue_url if bounty else None,
         "bounty_id": bounty.id if bounty else _proposal_bounty_id(payload),
         "bounty_url": _bounty_detail_url(bounty.id if bounty else _proposal_bounty_id(payload)),
-        "accepted_by": payload.get("accepted_by"),
+        "accepted_by": accepted_by,
+        "accepted_by_account_url": _github_account_url(accepted_by),
         "proposed_at": public_utc_timestamp(proposal.proposed_at),
         "executes_after": public_utc_timestamp(proposal.executes_after),
     }

--- a/app/templates/activity.html
+++ b/app/templates/activity.html
@@ -111,7 +111,13 @@
           </div>
           <div class="ledger-field">
             <dt>Accepted by</dt>
-            <dd>{{ row.accepted_by or "-" }}</dd>
+            <dd>
+              {% if row.accepted_by_account_url %}
+              <a href="{{ row.accepted_by_account_url }}">{{ row.accepted_by }}</a>
+              {% else %}
+              {{ row.accepted_by or "-" }}
+              {% endif %}
+            </dd>
           </div>
           <div class="ledger-field">
             <dt>Executes after</dt>

--- a/app/templates/bounty_detail.html
+++ b/app/templates/bounty_detail.html
@@ -187,7 +187,13 @@
           </div>
           <div class="ledger-field">
             <dt>Accepted by</dt>
-            <dd>{{ award.accepted_by or "-" }}</dd>
+            <dd>
+              {% if award.accepted_by_account_url %}
+              <a href="{{ award.accepted_by_account_url }}">{{ award.accepted_by }}</a>
+              {% else %}
+              {{ award.accepted_by or "-" }}
+              {% endif %}
+            </dd>
           </div>
         </dl>
       </div>

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -429,6 +429,7 @@ def test_activity_api_exposes_pending_payouts_separately_from_paid_work(
             "bounty_id": pending_bounty_id,
             "bounty_url": f"/bounties/{pending_bounty_id}",
             "accepted_by": "maintainer",
+            "accepted_by_account_url": "/accounts/github:maintainer",
             "proposed_at": proposal_proposed_at,
             "executes_after": proposal_executes_after,
         }
@@ -594,6 +595,7 @@ def test_activity_page_renders_pending_accepted_work(sqlite_url: str) -> None:
     assert "github:alice" in page.text
     assert "125 MRWK" in page.text
     assert 'href="https://github.com/ramimbo/mergework/pull/169"' in page.text
+    assert 'href="/accounts/github:maintainer"' in page.text
     assert "No proof-backed accepted work rows yet." in page.text
     assert "accepted MRWK" in page.text
     assert "pending MRWK" in page.text

--- a/tests/test_bounty_pages.py
+++ b/tests/test_bounty_pages.py
@@ -930,6 +930,9 @@ def test_bounty_detail_shows_accepted_award_history(sqlite_url: str) -> None:
         first_proof.hash,
     ]
     assert api_detail["accepted_awards"][0]["account"] == "github:bob"
+    assert (
+        api_detail["accepted_awards"][0]["accepted_by_account_url"] == "/accounts/github:reviewer"
+    )
     assert api_detail["accepted_awards"][0]["submission_url"] == (
         "https://github.com/ramimbo/mergework/pull/202"
     )
@@ -943,6 +946,7 @@ def test_bounty_detail_shows_accepted_award_history(sqlite_url: str) -> None:
     assert f'href="/proofs/{second_proof.hash}"' in page.text
     assert f'href="/ledger/{second_proof.ledger_sequence}"' in page.text
     assert "/accounts/github:bob" in page.text
+    assert 'href="/accounts/github:reviewer"' in page.text
 
 
 def test_bounty_detail_skips_malformed_award_proof_payloads(sqlite_url: str) -> None:


### PR DESCRIPTION
## Summary
- link `accepted_by` usernames to their GitHub ledger account pages on pending activity rows
- link `accepted_by` usernames on bounty accepted-award cards
- keep this PR focused on activity and bounty-detail navigation surfaces, distinct from proof/account accepted-work links

## Bounty
Bounty #1010

## Files Changed
- `app/serializers.py`
- `app/templates/activity.html`
- `app/templates/bounty_detail.html`
- `tests/test_activity.py`
- `tests/test_bounty_pages.py`

## Validation
- `python -m pytest tests/test_activity.py -q`
- `python -m pytest tests/test_bounty_pages.py -k test_bounty_detail_shows_accepted_award_history -q`
- `python -m ruff check app/serializers.py tests/test_activity.py tests/test_bounty_pages.py`
- `python -m ruff format app/serializers.py tests/test_activity.py tests/test_bounty_pages.py`
- `git diff --check`

## Scope Notes
This improves accepted-work inspection from the activity page and bounty detail page. It reuses existing `accepted_by` metadata and only adds navigation links for those two public entry points. It does not change proof payloads, ledger behavior, payout semantics, or the proof/account surface already covered by PR #1152.