### PR TITLE
Handle missing git in check_agents

### DIFF
--- a/scripts/check_agents.py
+++ b/scripts/check_agents.py
@@ -16,13 +16,16 @@ def find_casefold_collisions(paths: list[str]) -> list[list[str]]:
 
 
 def tracked_paths() -> list[str]:
-    result = subprocess.run(
-        ["git", "ls-files"],
-        cwd=ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "ls-files"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("git executable not found") from exc
     return [line for line in result.stdout.splitlines() if line]
 
 

--- a/tests/test_check_agents.py
+++ b/tests/test_check_agents.py
@@ -71,3 +71,13 @@ def test_main_reports_count_for_all_tracked_agents_files(
 
     output = capsys.readouterr().out
     assert "AGENTS.md files ok (2 checked)" in output
+
+
+def test_tracked_paths_reports_missing_git_cleanly(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_run(*_args: object, **_kwargs: object) -> object:
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(check_agents.subprocess, "run", fail_run)
+
+    with pytest.raises(RuntimeError, match="git executable not found"):
+        check_agents.tracked_paths()


### PR DESCRIPTION
## Summary
- make `scripts/check_agents.py` report a concise RuntimeError when `git` is unavailable
- keep tracked path collection read-only and behavior unchanged for the normal path
- add focused regression coverage for the missing-`git` case

## Bounty
Bounty #936

## Files Changed
- `scripts/check_agents.py`
- `tests/test_check_agents.py`

## Validation
- `python -m pytest tests/test_check_agents.py -q`
- `python -m ruff check scripts/check_agents.py tests/test_check_agents.py`
- `python -m ruff format scripts/check_agents.py tests/test_check_agents.py`
- `git diff --check`

## Scope Notes
This is a narrow CLI error-handling cleanup only. It does not change AGENTS.md size/collision logic, public behavior, ledger behavior, wallet behavior, treasury behavior, payout semantics, or docs smoke rules.