### PR TITLE
Handle failed git ls-files in check_agents

### DIFF
--- a/scripts/check_agents.py
+++ b/scripts/check_agents.py
@@ -16,13 +16,16 @@ def find_casefold_collisions(paths: list[str]) -> list[list[str]]:
 
 
 def tracked_paths() -> list[str]:
-    result = subprocess.run(
-        ["git", "ls-files"],
-        cwd=ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "ls-files"],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError("git ls-files failed") from exc
     return [line for line in result.stdout.splitlines() if line]
 
 

--- a/tests/test_check_agents.py
+++ b/tests/test_check_agents.py
@@ -71,3 +71,15 @@ def test_main_reports_count_for_all_tracked_agents_files(
 
     output = capsys.readouterr().out
     assert "AGENTS.md files ok (2 checked)" in output
+
+
+def test_tracked_paths_reports_failed_git_ls_files_cleanly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_run(*_args: object, **_kwargs: object) -> object:
+        raise check_agents.subprocess.CalledProcessError(1, ["git", "ls-files"])
+
+    monkeypatch.setattr(check_agents.subprocess, "run", fail_run)
+
+    with pytest.raises(RuntimeError, match="git ls-files failed"):
+        check_agents.tracked_paths()


### PR DESCRIPTION
## Summary
- handle `git ls-files` subprocess failures with a stable `RuntimeError("git ls-files failed")`
- add a focused regression test covering `subprocess.CalledProcessError`

## Validation
- `python -m pytest tests/test_check_agents.py -q`
- `python -m ruff check scripts/check_agents.py tests/test_check_agents.py`
- `python -m ruff format scripts/check_agents.py tests/test_check_agents.py`

Refs `#936`.
