### PR TITLE
refactor(scripts): unify live GitHub collection safety-cap policy

### DIFF
--- a/scripts/check_live_bounty_closing_refs.py
+++ b/scripts/check_live_bounty_closing_refs.py
@@ -14,10 +14,10 @@ if __package__ in {None, ""}:
 
 from scripts.api_host_args import public_api_host
 from scripts.bounty_refs import GITHUB_CLOSING_ISSUE_RE
+from scripts.gh_safety import GH_PR_SAFETY_CAP, safety_cap_message
 
 DEFAULT_API_HOST = "https://api.mrwk.online"
 GH_TIMEOUT_SECONDS = 30
-GH_PR_SAFETY_CAP = 200
 MAX_BOUNTY_REF = 2**63 - 1
 
 
@@ -197,8 +197,11 @@ def _load_pull_requests(repo: str, state: str, pr_numbers: list[int]) -> list[di
     )
     if len(prs) >= GH_PR_SAFETY_CAP:
         raise RuntimeError(
-            f"gh pr list reached the {GH_PR_SAFETY_CAP} item safety cap; "
-            "use --pr for a bounded check or an API-paginated collector"
+            safety_cap_message(
+                "pr",
+                GH_PR_SAFETY_CAP,
+                "use --pr for a bounded check or an API-paginated collector",
+            )
         )
     return [item for item in prs if isinstance(item, dict)]
 

--- a/scripts/gh_safety.py
+++ b/scripts/gh_safety.py
@@ -1,0 +1,29 @@
+"""Shared safety-cap policy for live GitHub collection scripts.
+
+Several read-only maintenance scripts list live ``gh`` pull requests and issues
+with a safety cap so a truncated ``gh`` result is never silently trusted as a
+complete live report. Historically each script defined its own cap value and
+its own saturation-message text, and those drifted apart: pull-request caps of
+200, 201, and 101, and issue caps of 201. This module is the single source of
+truth for the cap values and the shared saturation-message prefix, so every
+live report fails fast on the same boundary and describes it the same way.
+"""
+
+from __future__ import annotations
+
+# Canonical safety caps. ``gh ... list --limit`` is invoked with the cap, and a
+# returned collection whose length reaches the cap is treated as possibly
+# truncated and therefore not trusted as a complete live report.
+GH_PR_SAFETY_CAP = 201
+GH_ISSUE_SAFETY_CAP = 201
+
+
+def safety_cap_message(list_kind: str, cap: int, hint: str) -> str:
+    """Return the standard ``gh`` saturation message.
+
+    ``list_kind`` is the ``gh`` list noun (for example ``"pr"`` or ``"issue"``)
+    and ``hint`` is the script-specific remediation guidance appended after the
+    shared prefix. The shared prefix keeps the cap value and wording aligned
+    across every live report.
+    """
+    return f"gh {list_kind} list reached the {cap} item safety cap; {hint}"

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -13,12 +13,15 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.bounty_refs import BOUNTY_REF_RE
+from scripts.gh_safety import (
+    GH_ISSUE_SAFETY_CAP,
+    GH_PR_SAFETY_CAP,
+    safety_cap_message,
+)
 
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
 UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
 GH_TIMEOUT_SECONDS = 30
-GH_PR_SAFETY_CAP = 201
-GH_ISSUE_SAFETY_CAP = 201
 MAX_BOUNTY_REF = 2**63 - 1
 ISSUE_SECTIONS = (
     ("Closed or exhausted bounty references", "closed_bounty_references"),
@@ -352,8 +355,11 @@ def load_live_queue(repo: str) -> dict[str, Any]:
     )
     if len(prs) >= GH_PR_SAFETY_CAP:
         raise RuntimeError(
-            f"gh pr list reached the {GH_PR_SAFETY_CAP} item safety cap; "
-            "use an API-paginated collector before trusting this live report"
+            safety_cap_message(
+                "pr",
+                GH_PR_SAFETY_CAP,
+                "use an API-paginated collector before trusting this live report",
+            )
         )
     referenced_issues = sorted(
         {ref for pr in prs if isinstance(pr, dict) for ref in _bounty_refs(pr)}
@@ -376,8 +382,11 @@ def load_live_queue(repo: str) -> dict[str, Any]:
     )
     if len(issues) >= GH_ISSUE_SAFETY_CAP:
         raise RuntimeError(
-            f"gh issue list reached the {GH_ISSUE_SAFETY_CAP} item safety cap; "
-            "use an API-paginated collector before trusting this live report"
+            safety_cap_message(
+                "issue",
+                GH_ISSUE_SAFETY_CAP,
+                "use an API-paginated collector before trusting this live report",
+            )
         )
     issues_by_number = {
         int(issue["number"]): issue

--- a/scripts/review_bounty_candidates.py
+++ b/scripts/review_bounty_candidates.py
@@ -5,11 +5,16 @@ import json
 import subprocess
 import sys
 from collections import Counter
+from pathlib import Path
 from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.gh_safety import GH_PR_SAFETY_CAP, safety_cap_message
 
 DIRTY_MERGE_STATES = {"blocked", "conflicting", "dirty"}
 GH_TIMEOUT_SECONDS = 30
-GH_PR_SAFETY_CAP = 201
 STANDARD_QUALITY_CHECK = "Quality, readiness, docs, and image checks"
 HUMAN_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED", "COMMENTED"}
 
@@ -327,8 +332,11 @@ def load_live_candidates(repo: str) -> dict[str, Any]:
     )
     if len(prs) >= GH_PR_SAFETY_CAP:
         raise RuntimeError(
-            f"gh pr list reached the {GH_PR_SAFETY_CAP} item safety cap; "
-            "use an API-paginated collector before trusting this live report"
+            safety_cap_message(
+                "pr",
+                GH_PR_SAFETY_CAP,
+                "use an API-paginated collector before trusting this live report",
+            )
         )
     return {"pull_requests": prs}
 

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -17,6 +17,11 @@ if __package__ in {None, ""}:
 
 from scripts.api_host_args import public_api_host
 from scripts.bounty_refs import BOUNTY_REF_RE, GITHUB_LINKED_ISSUE_RE, LEADING_BOUNTY_REF_RE
+from scripts.gh_safety import (
+    GH_ISSUE_SAFETY_CAP,
+    GH_PR_SAFETY_CAP,
+    safety_cap_message,
+)
 
 
 def _non_negative_int(value: str) -> int:
@@ -43,8 +48,6 @@ SUMMARY_RE = re.compile(r"\b(summary|what changed|changes?)\b", re.IGNORECASE)
 GH_TIMEOUT_SECONDS = 30
 DEFAULT_API_HOST = "https://api.mrwk.online"
 DEFAULT_MAX_MAINTAINER_AGE_DAYS = 14
-GH_PR_SAFETY_CAP = 101
-GH_ISSUE_SAFETY_CAP = 201
 MAINTAINER_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
 MAX_BOUNTY_REF = 2**63 - 1
 EFFECTIVE_AVAILABILITY_FIELDS = (
@@ -664,13 +667,19 @@ def _load_live_context(
         }
     if len(prs) >= GH_PR_SAFETY_CAP:
         load_warnings.append(
-            f"gh pr list reached the {GH_PR_SAFETY_CAP} item safety cap; "
-            "similar-open-PR checks may be incomplete"
+            safety_cap_message(
+                "pr",
+                GH_PR_SAFETY_CAP,
+                "similar-open-PR checks may be incomplete",
+            )
         )
     if len(issues) >= GH_ISSUE_SAFETY_CAP:
         load_warnings.append(
-            f"gh issue list reached the {GH_ISSUE_SAFETY_CAP} item safety cap; "
-            "bounty discovery may be incomplete"
+            safety_cap_message(
+                "issue",
+                GH_ISSUE_SAFETY_CAP,
+                "bounty discovery may be incomplete",
+            )
         )
     try:
         api_bounties = _load_api_bounties(repo, api_host)

--- a/tests/test_gh_safety.py
+++ b/tests/test_gh_safety.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from scripts import (
+    check_live_bounty_closing_refs,
+    pr_queue_health,
+    review_bounty_candidates,
+    submission_quality_gate,
+)
+from scripts.gh_safety import (
+    GH_ISSUE_SAFETY_CAP,
+    GH_PR_SAFETY_CAP,
+    safety_cap_message,
+)
+
+
+def test_safety_caps_are_unified() -> None:
+    assert GH_PR_SAFETY_CAP == 201
+    assert GH_ISSUE_SAFETY_CAP == 201
+
+
+def test_safety_cap_message_composes_prefix_and_hint() -> None:
+    message = safety_cap_message("pr", GH_PR_SAFETY_CAP, "use an API-paginated collector")
+    assert message == "gh pr list reached the 201 item safety cap; use an API-paginated collector"
+
+
+def test_safety_cap_message_supports_issue_kind() -> None:
+    message = safety_cap_message("issue", GH_ISSUE_SAFETY_CAP, "bounty discovery may be incomplete")
+    assert message.startswith("gh issue list reached the 201 item safety cap; ")
+    assert message.endswith("bounty discovery may be incomplete")
+
+
+def test_live_collection_scripts_share_the_policy() -> None:
+    assert pr_queue_health.GH_PR_SAFETY_CAP == GH_PR_SAFETY_CAP
+    assert pr_queue_health.GH_ISSUE_SAFETY_CAP == GH_ISSUE_SAFETY_CAP
+    assert check_live_bounty_closing_refs.GH_PR_SAFETY_CAP == GH_PR_SAFETY_CAP
+    assert review_bounty_candidates.GH_PR_SAFETY_CAP == GH_PR_SAFETY_CAP
+    assert submission_quality_gate.GH_PR_SAFETY_CAP == GH_PR_SAFETY_CAP
+    assert submission_quality_gate.GH_ISSUE_SAFETY_CAP == GH_ISSUE_SAFETY_CAP


### PR DESCRIPTION
## Summary

Closes #1141. Centralizes the live GitHub collection safety-cap policy that had drifted across the read-only maintenance scripts.

Before, four scripts each defined their own cap and built the saturation message inline:

- `pr_queue_health.py` — PR `201` / issue `201`
- `check_live_bounty_closing_refs.py` — PR `200`
- `review_bounty_candidates.py` — PR `201`
- `submission_quality_gate.py` — PR `101` / issue `201`

So the limit and the "reached the N item safety cap" wording could diverge per script.

## Change

- **New `scripts/gh_safety.py`** — single source of truth:
  - `GH_PR_SAFETY_CAP = 201`, `GH_ISSUE_SAFETY_CAP = 201`
  - `safety_cap_message(list_kind, cap, hint)` -> `"gh {list_kind} list reached the {cap} item safety cap; {hint}"`
- The four scripts now import the shared caps + helper and drop their local copies. `check_live_bounty_closing_refs` (`200` -> `201`) and `submission_quality_gate` (`101` -> `201`) align to the canonical `201`. Each call site keeps its own remediation hint, so the user-facing guidance text is unchanged apart from the unified cap number.
- `review_bounty_candidates.py` gains the standard `scripts` package bootstrap (matching the other scripts) so it can import the shared module while still running standalone.
- **New `tests/test_gh_safety.py`** covering the caps, the message helper, and that all four scripts share the policy.

## Behavior notes

- Public message text is identical except for the unified cap number; e.g. `pr_queue_health` still emits `gh pr list reached the 201 item safety cap; ...`.
- No `app/` or runtime modules are imported or touched — the change is confined to read-only maintenance scripts.

## Validation (Python 3.12.13)

- `pytest` on the four affected modules + the new test -> **87 passed**
- `ruff format` -> no changes; `ruff check scripts tests` -> **All checks passed**
- `mypy` (strict) on the 5 changed source files -> **Success: no issues found**
- `git diff --check` -> clean

The full FastAPI/SQLAlchemy service suite was not exercised in this headless environment; the change imports/alters no `app/` runtime module, so that surface is unaffected by construction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized GitHub API safety cap configuration into a shared utility module, replacing local definitions across multiple scripts for improved consistency and maintainability.

* **Tests**
  * Added tests validating unified safety cap constants and standardized messaging behavior across data collection workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->