### PR TITLE
test: cover bounty reference regexes

### DIFF
--- a/tests/test_bounty_refs.py
+++ b/tests/test_bounty_refs.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from scripts.bounty_refs import (
+    BOUNTY_REF_RE,
+    GITHUB_CLOSING_ISSUE_RE,
+    GITHUB_LINKED_ISSUE_RE,
+    LEADING_BOUNTY_REF_RE,
+)
+
+
+def test_bounty_ref_regex_accepts_claim_bounty_and_reference_forms() -> None:
+    text = "Bounty #936, /claim #935, refs: `#944`, and closes #1010"
+
+    assert BOUNTY_REF_RE.findall(text) == ["936", "935", "944", "1010"]
+
+
+def test_bounty_ref_regex_ignores_bare_or_embedded_issue_numbers() -> None:
+    text = "Bare #936 is just discussion, bounty #12abc is not a valid ref, claim #34_ok"
+
+    assert BOUNTY_REF_RE.findall(text) == []
+
+
+def test_linked_issue_regex_excludes_bounty_only_verbs() -> None:
+    text = "Bounty #936, claim #935, references #944, fixes: `#1010`"
+
+    assert GITHUB_LINKED_ISSUE_RE.findall(text) == ["944", "1010"]
+
+
+def test_closing_issue_regex_reports_verb_and_issue_number() -> None:
+    match = GITHUB_CLOSING_ISSUE_RE.search("This PR resolves: `#936` after review.")
+
+    assert match is not None
+    assert match.group("verb") == "resolves"
+    assert match.group("issue") == "936"
+
+
+def test_leading_bounty_ref_regex_strips_submission_prefix_only() -> None:
+    assert LEADING_BOUNTY_REF_RE.sub("", "/claim #936: tighten parser tests") == (
+        "tighten parser tests"
+    )
+    assert LEADING_BOUNTY_REF_RE.sub("", "Notes before Bounty #936") == ("Notes before Bounty #936")


### PR DESCRIPTION
## Summary

Bounty #936

Adds direct regression coverage for the shared bounty-reference regexes in `scripts/bounty_refs.py`.

## Changes

- Covers bounty/claim/reference forms such as `Bounty #936`, `/claim #935`, `refs: #944`, and `closes #1010`.
- Covers false-positive boundaries such as bare `#936`, `bounty #12abc`, and `claim #34_ok`.
- Verifies GitHub linked-issue regexes exclude bounty-only verbs while still handling references and closing verbs.
- Verifies leading bounty prefixes are stripped only at the start of submission titles.

## Duplicate check

I reviewed the visible #936 submissions and open PR titles before opening this. I did not find an existing PR adding direct tests for `scripts/bounty_refs.py`; related open work focuses on live GitHub command handling, docs smoke, query guards, API schemas, and route/link improvements.

## Validation

- `.\.venv\Scripts\python.exe -m pytest tests\test_bounty_refs.py tests\test_pr_queue_health.py tests\test_submission_quality_gate.py tests\test_claim_inventory.py -q` -> 80 passed
- `.\.venv\Scripts\ruff.exe check tests\test_bounty_refs.py` -> All checks passed
- `.\.venv\Scripts\ruff.exe format --check tests\test_bounty_refs.py` -> 1 file already formatted

Scope is test coverage only. No runtime behavior, ledger behavior, wallet behavior, treasury/payout execution, admin-token behavior, bridge/exchange/cash-out behavior, MRWK price behavior, private data, or secrets changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation suite for bounty reference extraction and issue linking functionality, ensuring accurate identification of references across multiple formats and proper filtering of invalid patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->