### PR TITLE
Link wallet accounts to wallet detail pages

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -13,7 +13,7 @@ from app.control_chars import contains_control_character
 from app.db import session_scope
 from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
 from app.ledger_views import account_ledger_transactions
-from app.models import Account
+from app.models import Account, Wallet
 from app.path_params import SQLITE_INTEGER_MAX, reject_path_whitespace_padding
 from app.query_validation import reject_repeated_query_param, reject_unsupported_query_params
 from app.serializers import (
@@ -172,9 +172,12 @@ def account_page_context(
     account = normalized_account(account)
     selected_transaction_type, transaction_filter = _transaction_type_filter(transaction_type)
     account_context = _account_api_context_for_normalized_account(session, account)
+    action_urls = account_action_urls(account)
+    if account.startswith("mrwk1") and session.get(Wallet, account) is not None:
+        action_urls["wallet_detail"] = f"/wallets/{quote(account, safe='')}"
     return {
         "account": account_context,
-        "account_action_urls": account_action_urls(account),
+        "account_action_urls": action_urls,
         "accepted_summary": account_context["accepted_work"],
         "accepted_work": safe_accepted_work_for_account(session, account),
         "pending_summary": account_context["pending_summary"],

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -20,6 +20,9 @@
     <a href="{{ account_action_urls.account_json }}">Account JSON</a>
     <a href="{{ account_action_urls.accepted_work_json }}">Accepted-work JSON</a>
     <a href="{{ account_action_urls.activity }}">Activity for account</a>
+    {% if account_action_urls.wallet_detail %}
+    <a href="{{ account_action_urls.wallet_detail }}">Wallet detail</a>
+    {% endif %}
   </div>
 </section>
 

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -20,10 +20,12 @@ from app.ledger.service import (
     create_bounty,
     ensure_genesis,
     pay_bounty,
+    register_wallet,
 )
 from app.main import create_app
 from app.serializers import public_utc_timestamp
 from app.treasury import propose_treasury_action
+from app.wallets import address_from_public_key_hex
 
 
 def test_account_contexts_include_balance_status_and_proof_backed_rows(
@@ -132,6 +134,28 @@ def test_account_action_urls_escape_query_accounts() -> None:
         "accepted_work_json": "/api/v1/accounts/github:alice/accepted-work",
         "activity": "/api/v1/activity?account=github%3Aalice",
     }
+
+
+def test_registered_wallet_account_page_links_to_wallet_detail(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    public_key_hex = "11" * 32
+    registered_address = address_from_public_key_hex(public_key_hex)
+    unregistered_address = "mrwk1" + ("0" * 40)
+    with session_scope(sqlite_url) as session:
+        register_wallet(session, public_key_hex=public_key_hex, label="Ops wallet")
+        registered_context = account_page_context(session, registered_address.upper())
+        unregistered_context = account_page_context(session, unregistered_address)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    registered_page = client.get(f"/accounts/{registered_address.upper()}").text
+    unregistered_page = client.get(f"/accounts/{unregistered_address}").text
+
+    assert registered_context["account_action_urls"]["wallet_detail"] == (
+        f"/wallets/{registered_address}"
+    )
+    assert "wallet_detail" not in unregistered_context["account_action_urls"]
+    assert f'href="/wallets/{registered_address}">Wallet detail</a>' in registered_page
+    assert f'href="/wallets/{unregistered_address}">Wallet detail</a>' not in unregistered_page
 
 
 def test_account_routes_expose_pending_payouts_separately_from_paid_work(


### PR DESCRIPTION
Bounty #1011

This closes a small navigation gap in the public wallet-account flow.

When a user lands on `/accounts/<mrwk1...>`, the page already shows ledger balance, accepted work, pending payouts, and account activity links. If that account is also a registered wallet, the page now adds a `Wallet detail` action back to `/wallets/{address}` so the user can inspect the wallet label, public key, next transaction number, linked GitHub account, and wallet transaction history without manually editing the URL.

Unregistered wallet-shaped accounts keep the existing account-only actions, so the page does not imply that wallet metadata exists when there is no registered wallet row.

Changed surfaces:
- `app/accounts.py`: adds the wallet-detail action only for registered `mrwk1` wallet accounts.
- `app/templates/account.html`: renders the extra action when the context provides it.
- `tests/test_account_routes.py`: covers registered and unregistered wallet-account pages.

Validation:
- `python -m pytest --basetemp .pytest-tmp\pytest tests\test_account_routes.py tests\test_wallet_api.py -q` -> 55 passed, 1 existing Starlette/httpx warning.
- `python -m pytest --basetemp .pytest-tmp\pytest tests\test_account_routes.py tests\test_wallet_api.py::test_wallet_pages_expose_transfer_and_github_claim_flows tests\test_account_validation.py::test_account_views_accept_valid_mrwk_wallet_account tests\test_account_validation.py::test_account_views_reject_malformed_mrwk_wallet_accounts -q` -> 15 passed, 1 existing warning.
- `ruff check app\accounts.py tests\test_account_routes.py` -> passed.
- `ruff format --check app\accounts.py tests\test_account_routes.py` -> 2 files already formatted.
- `python -m mypy app\accounts.py` -> success.
- `python scripts\docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.
- `git merge-tree --write-tree upstream/main HEAD` -> clean tree `7762447113c0e738c8786f302ccb0b9ba7e09cef`.

Scope boundary: this is public account-page navigation only. It does not change wallet registration, signing payloads, transaction-number handling, replay protection, ledger mutation, balance accounting, wallet custody, treasury behavior, payout execution, private data, credentials, or public API response shapes.

Refs #1011.
