### PR TITLE
Publish account OpenAPI response contracts

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -14,6 +14,10 @@ from app.db import session_scope
 from app.ledger.service import TREASURY_ACCOUNT, format_mrwk, get_balance
 from app.ledger_views import account_ledger_transactions
 from app.models import Account
+from app.openapi_request_bodies import (
+    ACCOUNT_ACCEPTED_WORK_RESPONSE_BODY,
+    ACCOUNT_RESPONSE_BODY,
+)
 from app.path_params import SQLITE_INTEGER_MAX, reject_path_whitespace_padding
 from app.query_validation import reject_repeated_query_param, reject_unsupported_query_params
 from app.serializers import (
@@ -188,7 +192,7 @@ def account_page_context(
 
 
 def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templates) -> None:
-    @app.get("/api/v1/accounts/{account}")
+    @app.get("/api/v1/accounts/{account}", openapi_extra=ACCOUNT_RESPONSE_BODY)
     def api_account(request: Request, account: str) -> dict[str, Any]:
         reject_path_whitespace_padding(account, "account")
         reject_unsupported_query_params(
@@ -199,7 +203,10 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
         with session_scope(db_url) as session:
             return account_api_context(session, account)
 
-    @app.get("/api/v1/accounts/{account}/accepted-work")
+    @app.get(
+        "/api/v1/accounts/{account}/accepted-work",
+        openapi_extra=ACCOUNT_ACCEPTED_WORK_RESPONSE_BODY,
+    )
     def api_account_accepted_work(account: str) -> dict[str, Any]:
         reject_path_whitespace_padding(account, "account")
         with session_scope(db_url) as session:

--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -165,6 +165,144 @@ BOUNTY_ATTEMPT_RESPONSE_SCHEMA = _object_schema(
     }
 )
 
+ACCEPTED_WORK_SUMMARY_RESPONSE_SCHEMA = _object_schema(
+    {
+        "accepted_awards": {"type": "integer", "minimum": 0},
+        "accepted_mrwk": MRWK_DECIMAL_SCHEMA,
+        "latest_ledger_sequence": {"type": "integer", "minimum": 1, "nullable": True},
+        "latest_submission_url": {"type": "string", "nullable": True},
+        "latest_proof_hash": {**LOWERCASE_HEX_64_SCHEMA, "nullable": True},
+        "latest_proof_url": {"type": "string", "nullable": True},
+        "latest_proof_public_url": {"type": "string", "nullable": True},
+    },
+    required=[
+        "accepted_awards",
+        "accepted_mrwk",
+        "latest_ledger_sequence",
+        "latest_submission_url",
+        "latest_proof_hash",
+        "latest_proof_url",
+        "latest_proof_public_url",
+    ],
+)
+
+PENDING_PAYOUT_SUMMARY_RESPONSE_SCHEMA = _object_schema(
+    {
+        "pending_awards": {"type": "integer", "minimum": 0},
+        "pending_mrwk": MRWK_DECIMAL_SCHEMA,
+        "next_executes_after": {"type": "string", "nullable": True},
+    },
+    required=["pending_awards", "pending_mrwk", "next_executes_after"],
+)
+
+PENDING_PAYOUT_RESPONSE_SCHEMA = _object_schema(
+    {
+        "proposal_id": {"type": "integer", "minimum": 1},
+        "proposal_url": {"type": "string"},
+        "status": {"type": "string"},
+        "amount_mrwk": {**MRWK_DECIMAL_SCHEMA, "nullable": True},
+        "bounty_id": {"type": "integer", "minimum": 1, "nullable": True},
+        "bounty_url": {"type": "string", "nullable": True},
+        "repo": {"type": "string", "nullable": True},
+        "issue_number": {"type": "integer", "minimum": 1, "nullable": True},
+        "issue_url": {"type": "string", "nullable": True},
+        "submission_url": {"type": "string", "nullable": True},
+        "accepted_by": {"type": "string", "nullable": True},
+        "proposed_at": {"type": "string"},
+        "executes_after": {"type": "string"},
+    },
+    required=[
+        "proposal_id",
+        "proposal_url",
+        "status",
+        "amount_mrwk",
+        "bounty_id",
+        "bounty_url",
+        "repo",
+        "issue_number",
+        "issue_url",
+        "submission_url",
+        "accepted_by",
+        "proposed_at",
+        "executes_after",
+    ],
+)
+
+ACCEPTED_WORK_ROW_RESPONSE_SCHEMA = _object_schema(
+    {
+        "ledger_sequence": {"type": "integer", "minimum": 1},
+        "ledger_url": {"type": "string"},
+        "ledger_public_url": {"type": "string", "nullable": True},
+        "proof_hash": LOWERCASE_HEX_64_SCHEMA,
+        "proof_url": {"type": "string"},
+        "proof_public_url": {"type": "string", "nullable": True},
+        "amount_mrwk": MRWK_DECIMAL_SCHEMA,
+        "submission_url": {"type": "string", "nullable": True},
+        "issue_url": {"type": "string", "nullable": True},
+        "repo": {"type": "string", "nullable": True},
+        "issue_number": {"type": "integer", "minimum": 1, "nullable": True},
+        "bounty_id": {"type": "integer", "minimum": 1, "nullable": True},
+        "bounty_url": {"type": "string", "nullable": True},
+        "bounty_public_url": {"type": "string", "nullable": True},
+        "accepted_by": {"type": "string", "nullable": True},
+        "created_at": {"type": "string"},
+    },
+    required=[
+        "ledger_sequence",
+        "ledger_url",
+        "ledger_public_url",
+        "proof_hash",
+        "proof_url",
+        "proof_public_url",
+        "amount_mrwk",
+        "submission_url",
+        "issue_url",
+        "repo",
+        "issue_number",
+        "bounty_id",
+        "bounty_url",
+        "bounty_public_url",
+        "accepted_by",
+        "created_at",
+    ],
+)
+
+ACCOUNT_RESPONSE_SCHEMA = _object_schema(
+    {
+        "account": {"type": "string"},
+        "ledger_address": {"type": "string"},
+        "github_login": {"type": "string", "nullable": True},
+        "exists": {"type": "boolean"},
+        "balance_mrwk": MRWK_DECIMAL_SCHEMA,
+        "transfer_status": {"type": "string"},
+        "accepted_work": ACCEPTED_WORK_SUMMARY_RESPONSE_SCHEMA,
+        "pending_summary": PENDING_PAYOUT_SUMMARY_RESPONSE_SCHEMA,
+        "pending_payouts": {"type": "array", "items": PENDING_PAYOUT_RESPONSE_SCHEMA},
+    },
+    required=[
+        "account",
+        "ledger_address",
+        "github_login",
+        "exists",
+        "balance_mrwk",
+        "transfer_status",
+        "accepted_work",
+        "pending_summary",
+        "pending_payouts",
+    ],
+)
+
+ACCOUNT_ACCEPTED_WORK_RESPONSE_SCHEMA = _object_schema(
+    {
+        "account": {"type": "string"},
+        "summary": ACCEPTED_WORK_SUMMARY_RESPONSE_SCHEMA,
+        "accepted_work": {"type": "array", "items": ACCEPTED_WORK_ROW_RESPONSE_SCHEMA},
+        "pending_summary": PENDING_PAYOUT_SUMMARY_RESPONSE_SCHEMA,
+        "pending_payouts": {"type": "array", "items": PENDING_PAYOUT_RESPONSE_SCHEMA},
+    },
+    required=["account", "summary", "accepted_work", "pending_summary", "pending_payouts"],
+)
+
 ATTEMPT_REGISTRATION_RESPONSE_SCHEMA = _object_schema(
     {
         "status": {"type": "string"},
@@ -391,6 +529,18 @@ OPTIONAL_ATTEMPT_RELEASE_BODY = {
     ),
     "responses": {
         "200": _json_response(ATTEMPT_RELEASE_RESPONSE_SCHEMA),
+    },
+}
+
+ACCOUNT_RESPONSE_BODY = {
+    "responses": {
+        "200": _json_response(ACCOUNT_RESPONSE_SCHEMA),
+    },
+}
+
+ACCOUNT_ACCEPTED_WORK_RESPONSE_BODY = {
+    "responses": {
+        "200": _json_response(ACCOUNT_ACCEPTED_WORK_RESPONSE_SCHEMA),
     },
 }
 

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -5,7 +5,11 @@ from collections.abc import Iterable
 
 from fastapi.testclient import TestClient
 
+from app.db import create_schema, session_scope
+from app.ledger.service import create_bounty, ensure_genesis, pay_bounty
 from app.main import create_app
+from app.serializers import public_utc_timestamp
+from app.treasury import propose_treasury_action
 
 EXPECTED_TTL_STRING_PATTERN = (
     r"^(?:[6-9][0-9]|[1-9][0-9]{2,4}|[1-5][0-9]{5}|"
@@ -19,6 +23,12 @@ def _post_schema(openapi: dict, path: str) -> dict:
 
 def _post_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
     return openapi["paths"][path]["post"]["responses"][status]["content"]["application/json"][
+        "schema"
+    ]
+
+
+def _get_response_schema(openapi: dict, path: str, status: str = "200") -> dict:
+    return openapi["paths"][path]["get"]["responses"][status]["content"]["application/json"][
         "schema"
     ]
 
@@ -365,6 +375,161 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
             "created_at",
         },
     )
+
+
+def test_public_account_openapi_response_schemas_match_runtime_fields(
+    sqlite_url: str,
+) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        pending_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=944,
+            issue_url="https://github.com/ramimbo/mergework/issues/944",
+            title="Account schema contract",
+            reward_mrwk="75",
+            acceptance="Accepted work should remain visible while pending execution.",
+        )
+        paid_bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=945,
+            issue_url="https://github.com/ramimbo/mergework/issues/945",
+            title="Paid account schema contract",
+            reward_mrwk="25",
+            acceptance="Paid work should remain proof-backed.",
+        )
+        proposal = propose_treasury_action(
+            session,
+            action="pay_bounty",
+            payload={
+                "bounty_id": pending_bounty.id,
+                "to_account": "github:alice",
+                "submission_url": "https://github.com/ramimbo/mergework/pull/944",
+                "accepted_by": "maintainer",
+            },
+            proposed_by="maintainer",
+        )
+        proof = pay_bounty(
+            session,
+            bounty_id=paid_bounty.id,
+            to_account="github:alice",
+            submission_url="https://github.com/ramimbo/mergework/pull/945",
+            accepted_by="maintainer",
+            verifier_result={"label": "mrwk:accepted"},
+        )
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+    account_schema = _get_response_schema(openapi, "/api/v1/accounts/{account}")
+    accepted_work_schema = _get_response_schema(openapi, "/api/v1/accounts/{account}/accepted-work")
+    account_body = client.get("/api/v1/accounts/github:alice").json()
+    accepted_work_body = client.get("/api/v1/accounts/github:alice/accepted-work").json()
+
+    _assert_properties(
+        account_schema,
+        {
+            "account",
+            "ledger_address",
+            "github_login",
+            "exists",
+            "balance_mrwk",
+            "transfer_status",
+            "accepted_work",
+            "pending_summary",
+            "pending_payouts",
+        },
+    )
+    assert set(account_schema["required"]) == {
+        "account",
+        "ledger_address",
+        "github_login",
+        "exists",
+        "balance_mrwk",
+        "transfer_status",
+        "accepted_work",
+        "pending_summary",
+        "pending_payouts",
+    }
+    _assert_properties(
+        account_schema["properties"]["accepted_work"],
+        {
+            "accepted_awards",
+            "accepted_mrwk",
+            "latest_ledger_sequence",
+            "latest_submission_url",
+            "latest_proof_hash",
+            "latest_proof_url",
+            "latest_proof_public_url",
+        },
+    )
+    _assert_properties(
+        account_schema["properties"]["pending_summary"],
+        {"pending_awards", "pending_mrwk", "next_executes_after"},
+    )
+    pending_item_schema = account_schema["properties"]["pending_payouts"]["items"]
+    _assert_properties(
+        pending_item_schema,
+        {
+            "proposal_id",
+            "proposal_url",
+            "status",
+            "amount_mrwk",
+            "bounty_id",
+            "bounty_url",
+            "repo",
+            "issue_number",
+            "issue_url",
+            "submission_url",
+            "accepted_by",
+            "proposed_at",
+            "executes_after",
+        },
+    )
+
+    _assert_properties(
+        accepted_work_schema,
+        {"account", "summary", "accepted_work", "pending_summary", "pending_payouts"},
+    )
+    accepted_item_schema = accepted_work_schema["properties"]["accepted_work"]["items"]
+    _assert_properties(
+        accepted_item_schema,
+        {
+            "ledger_sequence",
+            "ledger_url",
+            "ledger_public_url",
+            "proof_hash",
+            "proof_url",
+            "proof_public_url",
+            "amount_mrwk",
+            "submission_url",
+            "issue_url",
+            "repo",
+            "issue_number",
+            "bounty_id",
+            "bounty_url",
+            "bounty_public_url",
+            "accepted_by",
+            "created_at",
+        },
+    )
+
+    assert set(account_schema["properties"]).issubset(account_body)
+    assert set(accepted_work_schema["properties"]).issubset(accepted_work_body)
+    assert account_body["accepted_work"]["latest_proof_hash"] == proof.hash
+    assert account_body["pending_summary"] == {
+        "pending_awards": 1,
+        "pending_mrwk": "75",
+        "next_executes_after": public_utc_timestamp(proposal.executes_after),
+    }
+    assert accepted_work_body["summary"] == account_body["accepted_work"]
+    assert accepted_work_body["pending_summary"] == account_body["pending_summary"]
+    assert accepted_work_body["pending_payouts"] == account_body["pending_payouts"]
+    assert accepted_work_body["accepted_work"][0]["proof_hash"] == proof.hash
+    assert accepted_work_body["accepted_work"][0]["bounty_id"] == paid_bounty.id
+    assert accepted_work_body["pending_payouts"][0]["bounty_id"] == pending_bounty.id
 
 
 def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None:


### PR DESCRIPTION
Bounty #944

This is a focused current-main slice of the public account API contract.

The account JSON routes already return stable fields for accepted work and accepted-but-not-yet-executed payout proposals, but `/openapi.json` only advertised a generic object. This publishes explicit `200` response schemas for:
- `GET /api/v1/accounts/{account}`
- `GET /api/v1/accounts/{account}/accepted-work`

The schema includes the current pending payout fields (`pending_summary`, `pending_payouts`) as well as the proof-backed accepted-work summary and row fields, so generated clients can distinguish paid accepted work from treasury proposals that are still waiting for execution.

Duplicate/current-main check:
- Older PR #699 covers account read schemas as part of a broader typed-response-model change, but it is currently dirty/stale against main and predates the current pending-payout account shape.
- I did not find a current-main #944 submission focused on account JSON / accepted-work JSON response schemas.
- This PR follows the current `openapi_extra` dictionary pattern used by the active #944 schema work and leaves runtime serializers unchanged.

Validation:
- `python -m pytest --basetemp .pytest-tmp\pytest tests\test_openapi_request_bodies.py tests\test_account_routes.py tests\test_account_validation.py -q`
- `ruff check app\openapi_request_bodies.py app\accounts.py tests\test_openapi_request_bodies.py`
- `ruff format --check app\openapi_request_bodies.py app\accounts.py tests\test_openapi_request_bodies.py`
- `python -m mypy app\openapi_request_bodies.py app\accounts.py`
- `python scripts\docs_smoke.py`
- `git diff --check`
- `git merge-tree --write-tree upstream/main HEAD`

Scope:
OpenAPI/client-contract metadata plus focused tests only. No runtime account normalization, balance calculation, accepted-work serialization, pending-payout serialization, ledger mutation, treasury execution, payout execution, wallet custody, admin-token behavior, bridge/exchange/off-ramp/cash-out behavior, MRWK price behavior, private data, or secrets changed.

Refs #944.