### PR TITLE
Unify live GitHub collection safety-cap policy across report scripts

### DIFF
--- a/scripts/check_live_bounty_closing_refs.py
+++ b/scripts/check_live_bounty_closing_refs.py
@@ -15,8 +15,9 @@ if __package__ in {None, ""}:
 from scripts.api_host_args import public_api_host
 from scripts.bounty_refs import GITHUB_CLOSING_ISSUE_RE
 
-DEFAULT_API_HOST = "https://api.mrwk.online"
 GH_TIMEOUT_SECONDS = 30
+
+DEFAULT_API_HOST = "https://api.mrwk.online"
 GH_PR_SAFETY_CAP = 200
 MAX_BOUNTY_REF = 2**63 - 1
 

--- a/scripts/gh_collection_caps.py
+++ b/scripts/gh_collection_caps.py
@@ -1,0 +1,4 @@
+"""Shared GitHub collection safety caps for maintenance scripts."""
+
+GH_PR_SAFETY_CAP = 201
+GH_ISSUE_SAFETY_CAP = 201

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -13,12 +13,12 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.bounty_refs import BOUNTY_REF_RE
+from scripts.gh_collection_caps import GH_ISSUE_SAFETY_CAP, GH_PR_SAFETY_CAP
+
+GH_TIMEOUT_SECONDS = 30
 
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
 UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
-GH_TIMEOUT_SECONDS = 30
-GH_PR_SAFETY_CAP = 201
-GH_ISSUE_SAFETY_CAP = 201
 MAX_BOUNTY_REF = 2**63 - 1
 ISSUE_SECTIONS = (
     ("Closed or exhausted bounty references", "closed_bounty_references"),
@@ -194,7 +194,11 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
             duplicate_groups[(ref, pr["scope"])].append(pr["number"])
         if pr["merge_state"] in UNSTABLE_MERGE_STATES:
             dirty_or_unstable_merge_state.append(
-                _issue(pr, "dirty_or_unstable_merge_state", f"Merge state is {pr['merge_state']}")
+                _issue(
+                    pr,
+                    "dirty_or_unstable_merge_state",
+                    f"Merge state is {pr['merge_state']}",
+                )
             )
         if any(label.lower() == "mrwk:needs-info" for label in pr["labels"]):
             needs_info.append(_issue(pr, "mrwk_needs_info", "PR has mrwk:needs-info label"))
@@ -435,6 +439,15 @@ def _load_input(path: str) -> dict[str, Any]:
     return data
 
 
+def _require_non_empty_arg(parser: argparse.ArgumentParser, option_name: str, value: str) -> str:
+    stripped = value.strip()
+    if not stripped:
+        parser.error(f"{option_name} must be a non-empty value")
+    if stripped != value:
+        parser.error(f"{option_name} must not include leading or trailing whitespace")
+    return value
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Summarize MergeWork open PR queue health.")
     source = parser.add_mutually_exclusive_group(required=True)
@@ -447,7 +460,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--fail-on-issues", action="store_true")
     args = parser.parse_args(argv)
 
-    data = _load_input(args.input) if args.input else load_live_queue(args.repo)
+    if args.input is not None:
+        data = _load_input(_require_non_empty_arg(parser, "--input", args.input))
+    else:
+        data = load_live_queue(_require_non_empty_arg(parser, "--repo", args.repo))
     report = analyze_queue(data)
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/scripts/review_bounty_candidates.py
+++ b/scripts/review_bounty_candidates.py
@@ -2,16 +2,50 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
-from collections import Counter
+from collections import Counter, defaultdict
+from pathlib import Path
 from typing import Any
 
-DIRTY_MERGE_STATES = {"blocked", "conflicting", "dirty"}
+from scripts.gh_collection_caps import GH_PR_SAFETY_CAP
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 GH_TIMEOUT_SECONDS = 30
-GH_PR_SAFETY_CAP = 201
+
+DIRTY_MERGE_STATES = {"blocked", "conflicting", "dirty"}
 STANDARD_QUALITY_CHECK = "Quality, readiness, docs, and image checks"
 HUMAN_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED", "COMMENTED"}
+CLAIM_SIGNAL_RE = re.compile(
+    r"(^|\s)(/claim|claim(?:ing)?|reviewed|review bounty|evidence)(\b|\s|:)",
+    re.IGNORECASE,
+)
+PR_REVIEW_EVIDENCE_RE = re.compile(
+    r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)#pullrequestreview-\d+",
+    re.IGNORECASE,
+)
+PR_COMMENT_EVIDENCE_RE = re.compile(
+    r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)#issuecomment-\d+",
+    re.IGNORECASE,
+)
+PR_LINK_RE = re.compile(
+    r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)(?:\b|[^\d])",
+    re.IGNORECASE,
+)
+PR_NUMBER_REF_RE = re.compile(r"\bpull/(\d+)\b|\bPR\s+#(\d+)\b", re.IGNORECASE)
+LABELED_HEAD_SHA_RE = re.compile(
+    r"(?:head(?:RefOid| ref| sha| oid)?|head)\s*[:=]\s*[`']?([0-9a-f]{40})[`']?",
+    re.IGNORECASE,
+)
+LABELED_BASE_SHA_RE = re.compile(
+    r"(?:base(?:RefOid| ref| sha| oid)?|origin/main|main sha|main)"
+    r"\s*[:=]\s*[`']?([0-9a-f]{40})[`']?",
+    re.IGNORECASE,
+)
+SATURATION_PROTECTED_STATES = {"self_authored", "needs_info"}
 
 
 def _login(raw: Any) -> str:
@@ -56,6 +90,104 @@ def _head_oid(raw: dict[str, Any]) -> str:
         if isinstance(value, str) and value:
             return value
     return ""
+
+
+def _base_oid(raw: dict[str, Any]) -> str:
+    for key in ("baseRefOid", "base_ref_oid", "base_sha", "base"):
+        value = raw.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _comment_url(comment: dict[str, Any]) -> str:
+    for key in ("html_url", "url"):
+        value = comment.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _repo_matches(owner: str, name: str, repo: str) -> bool:
+    try:
+        expected_owner, expected_name = repo.split("/", 1)
+    except ValueError:
+        return False
+    return owner.lower() == expected_owner.lower() and name.lower() == expected_name.lower()
+
+
+def _parse_claim_comment(comment: dict[str, Any], *, repo: str) -> list[dict[str, Any]]:
+    body = str(comment.get("body") or "")
+    if not body.strip():
+        return []
+    if not (
+        CLAIM_SIGNAL_RE.search(body)
+        or PR_REVIEW_EVIDENCE_RE.search(body)
+        or PR_COMMENT_EVIDENCE_RE.search(body)
+    ):
+        return []
+
+    pr_evidence: dict[int, tuple[str, str]] = {}
+    for match in PR_REVIEW_EVIDENCE_RE.finditer(body):
+        if _repo_matches(match.group(1), match.group(2), repo):
+            pr_evidence[int(match.group(3))] = (match.group(0), "pr_review")
+    for match in PR_COMMENT_EVIDENCE_RE.finditer(body):
+        if _repo_matches(match.group(1), match.group(2), repo):
+            pr = int(match.group(3))
+            pr_evidence.setdefault(pr, (match.group(0), "pr_comment"))
+    for match in PR_LINK_RE.finditer(body):
+        if _repo_matches(match.group(1), match.group(2), repo):
+            pr = int(match.group(3))
+            pr_evidence.setdefault(pr, (match.group(0).split("#", 1)[0], "pr_reference"))
+    for match in PR_NUMBER_REF_RE.finditer(body):
+        pr_str = match.group(1) or match.group(2)
+        if pr_str:
+            pr = int(pr_str)
+            pr_evidence.setdefault(
+                pr,
+                (f"https://github.com/{repo}/pull/{pr}", "pr_reference"),
+            )
+
+    if not pr_evidence:
+        return []
+
+    head_sha = None
+    base_sha = None
+    labeled_head = LABELED_HEAD_SHA_RE.search(body)
+    if labeled_head:
+        head_sha = labeled_head.group(1).lower()
+    labeled_base = LABELED_BASE_SHA_RE.search(body)
+    if labeled_base:
+        base_sha = labeled_base.group(1).lower()
+
+    claim_url = _comment_url(comment)
+    claimant = _display_login(comment.get("author") or comment.get("user"))
+    submitted_at = comment.get("created_at") or comment.get("createdAt")
+    records: list[dict[str, Any]] = []
+    for pr, (evidence_url, evidence_kind) in sorted(pr_evidence.items()):
+        records.append(
+            {
+                "pull_request": pr,
+                "claim_url": claim_url,
+                "evidence_url": evidence_url,
+                "evidence_kind": evidence_kind,
+                "head_sha": head_sha,
+                "base_sha": base_sha,
+                "claimant": claimant,
+                "submitted_at": submitted_at,
+            }
+        )
+    return records
+
+
+def index_bounty_claims(comments: list[Any], *, repo: str) -> dict[int, list[dict[str, Any]]]:
+    by_pr: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for comment in comments:
+        if not isinstance(comment, dict):
+            continue
+        for record in _parse_claim_comment(comment, repo=repo):
+            by_pr[int(record["pull_request"])].append(record)
+    return dict(by_pr)
 
 
 def _check_name(check: dict[str, Any]) -> str:
@@ -202,6 +334,7 @@ def _classify_pr(
         "state": state,
         "reason": reason,
         "headRefOid": head_oid or None,
+        "baseRefOid": _base_oid(raw) or None,
         "mergeStateStatus": merge_state,
         "standard_quality_check": quality_state,
         "labels": labels,
@@ -210,24 +343,116 @@ def _classify_pr(
     }
 
 
+def _attach_claim_metadata(row: dict[str, Any], claims: list[dict[str, Any]]) -> None:
+    if not claims:
+        return
+    row["bounty_claims"] = [
+        {key: value for key, value in claim.items() if key != "pull_request"} for claim in claims
+    ]
+    row["matched_claim_urls"] = [
+        str(claim["claim_url"]) for claim in claims if claim.get("claim_url")
+    ]
+    latest = claims[-1]
+    if latest.get("evidence_kind"):
+        row["claim_evidence_kind"] = latest["evidence_kind"]
+    if latest.get("evidence_url"):
+        row["matched_evidence_urls"] = [
+            str(claim["evidence_url"]) for claim in claims if claim.get("evidence_url")
+        ]
+
+
+def _apply_bounty_saturation(
+    row: dict[str, Any],
+    *,
+    claims: list[dict[str, Any]],
+    merge_state: str,
+    head_oid: str,
+    base_oid: str,
+) -> dict[str, Any]:
+    if not claims:
+        if merge_state in DIRTY_MERGE_STATES and row["state"] == "dirty_or_conflicted":
+            row["state"] = "dirty_unclaimed_current_base_candidate"
+            row["reason"] = (
+                "dirty/conflicted PR has no review-bounty claim; "
+                "current-base follow-up may be useful"
+            )
+        return row
+
+    _attach_claim_metadata(row, claims)
+    if row["state"] in SATURATION_PROTECTED_STATES:
+        return row
+
+    latest = claims[-1]
+    claim_head = str(latest.get("head_sha") or "").lower()
+    claim_base = str(latest.get("base_sha") or "").lower()
+    head = head_oid.lower()
+    base = base_oid.lower()
+    evidence_kind = str(latest.get("evidence_kind") or "")
+
+    stale = False
+    stale_reason = "review-bounty claim may be stale"
+    if claim_head and head and claim_head != head:
+        stale = True
+        stale_reason = f"claim head {claim_head[:7]} differs from current head {head[:7]}"
+    elif claim_base and base and claim_base != base:
+        stale = True
+        stale_reason = f"claim base {claim_base[:7]} differs from current base {base[:7]}"
+    elif merge_state in DIRTY_MERGE_STATES and claim_head and head and claim_head == head:
+        stale = True
+        stale_reason = "PR is dirty/conflicted after a clean-current-head bounty claim"
+
+    if stale:
+        row["state"] = "claimed_stale_head_or_base"
+        row["reason"] = stale_reason
+    elif evidence_kind == "pr_comment":
+        row["state"] = "claimed_by_pr_comment"
+        row["reason"] = "review-bounty claim uses PR comment evidence"
+    elif claim_head and head and claim_head == head:
+        row["state"] = "already_claimed_current_head"
+        row["reason"] = "review-bounty claim matches current PR head"
+    else:
+        row["state"] = "already_claimed_on_bounty_issue"
+        row["reason"] = "PR already referenced on review bounty issue"
+    return row
+
+
 def analyze_candidates(
     data: dict[str, Any],
     *,
     reviewer: str,
     sufficient_reviews: int = 1,
+    repo: str | None = None,
 ) -> dict[str, Any]:
     reviewer_login = reviewer.strip().lower()
     if not reviewer_login:
         raise ValueError("reviewer must not be empty")
     if sufficient_reviews < 1:
         raise ValueError("sufficient_reviews must be at least 1")
-    rows = [
-        _classify_pr(raw, reviewer=reviewer_login, sufficient_reviews=sufficient_reviews)
-        for raw in data.get("pull_requests", [])
-        if isinstance(raw, dict) and isinstance(raw.get("number"), int)
-    ]
+
+    effective_repo = repo or (data.get("repo") if isinstance(data.get("repo"), str) else None)
+    claims_by_pr: dict[int, list[dict[str, Any]]] = {}
+    raw_comments = data.get("bounty_claim_comments")
+    saturation_enabled = isinstance(effective_repo, str) and "bounty_claim_comments" in data
+    if saturation_enabled and isinstance(raw_comments, list):
+        claims_by_pr = index_bounty_claims(raw_comments, repo=effective_repo)
+
+    rows: list[dict[str, Any]] = []
+    for raw in data.get("pull_requests", []):
+        if not isinstance(raw, dict) or not isinstance(raw.get("number"), int):
+            continue
+        row = _classify_pr(raw, reviewer=reviewer_login, sufficient_reviews=sufficient_reviews)
+        if saturation_enabled:
+            row = _apply_bounty_saturation(
+                row,
+                claims=claims_by_pr.get(int(raw["number"]), []),
+                merge_state=_merge_state(raw),
+                head_oid=_head_oid(raw),
+                base_oid=_base_oid(raw),
+            )
+        rows.append(row)
+
     counts = Counter(row["state"] for row in rows)
-    return {
+    report: dict[str, Any] = {
         "reviewer": reviewer_login,
         "summary": {
             "pull_requests": len(rows),
@@ -235,6 +460,9 @@ def analyze_candidates(
         },
         "pull_requests": rows,
     }
+    if effective_repo and saturation_enabled:
+        report["bounty_issue_claims_indexed"] = sum(len(items) for items in claims_by_pr.values())
+    return report
 
 
 def _single_line(value: Any) -> str:
@@ -246,9 +474,12 @@ def format_text_report(report: dict[str, Any]) -> str:
     for key, value in report["summary"].items():
         lines.append(f"- {key.replace('_', ' ')}: {value}")
     for row in report["pull_requests"]:
+        claim_note = ""
+        if row.get("matched_claim_urls"):
+            claim_note = f" claims={','.join(row['matched_claim_urls'])}"
         lines.append(
             f"- PR #{row['pull_request']}: {row['state']} - "
-            f"{_single_line(row['title'])} ({_single_line(row['reason'])})"
+            f"{_single_line(row['title'])} ({_single_line(row['reason'])}){claim_note}"
         )
     return "\n".join(lines)
 
@@ -261,9 +492,13 @@ def format_markdown_report(report: dict[str, Any]) -> str:
         label = f"PR #{row['pull_request']}"
         if row.get("url"):
             label = f"[{label}]({row['url']})"
+        claim_note = ""
+        if row.get("matched_claim_urls"):
+            urls = ", ".join(f"`{url}`" for url in row["matched_claim_urls"])
+            claim_note = f" Claims: {urls}."
         lines.append(
             f"- {label}: `{row['state']}` - {_single_line(row['title'])} "
-            f"({_single_line(row['reason'])})"
+            f"({_single_line(row['reason'])}){claim_note}"
         )
     return "\n".join(lines)
 
@@ -297,7 +532,7 @@ def _run_gh_json(args: list[str]) -> Any:
     return json.loads(completed.stdout)
 
 
-def load_live_candidates(repo: str) -> dict[str, Any]:
+def load_live_candidates(repo: str, *, bounty_issue: int | None = None) -> dict[str, Any]:
     prs = _run_gh_json(
         [
             "gh",
@@ -317,6 +552,7 @@ def load_live_candidates(repo: str) -> dict[str, Any]:
                     "url",
                     "author",
                     "headRefOid",
+                    "baseRefOid",
                     "mergeStateStatus",
                     "labels",
                     "statusCheckRollup",
@@ -330,7 +566,25 @@ def load_live_candidates(repo: str) -> dict[str, Any]:
             f"gh pr list reached the {GH_PR_SAFETY_CAP} item safety cap; "
             "use an API-paginated collector before trusting this live report"
         )
-    return {"pull_requests": prs}
+    data: dict[str, Any] = {"repo": repo, "pull_requests": prs}
+    if bounty_issue is not None:
+        issue = _run_gh_json(
+            [
+                "gh",
+                "issue",
+                "view",
+                str(bounty_issue),
+                "--repo",
+                repo,
+                "--json",
+                "comments",
+            ]
+        )
+        comments = issue.get("comments", []) if isinstance(issue, dict) else []
+        if not isinstance(comments, list):
+            comments = []
+        data["bounty_claim_comments"] = comments
+    return data
 
 
 def _load_input(path: str) -> dict[str, Any]:
@@ -358,18 +612,32 @@ def main(argv: list[str] | None = None) -> int:
     source.add_argument("--input", help="Read candidate data from a JSON fixture file.")
     source.add_argument("--repo", help="Collect live open PR data with gh.")
     parser.add_argument("--reviewer", required=True, help="GitHub login of the reviewer.")
+    parser.add_argument(
+        "--bounty-issue",
+        type=int,
+        help="Active review-bounty issue number for claim saturation (live --repo mode only).",
+    )
     parser.add_argument("--sufficient-reviews", type=int, default=1)
     parser.add_argument("--format", choices=["json", "markdown", "text"], default="text")
     args = parser.parse_args(argv)
 
+    if args.input is not None and args.bounty_issue is not None:
+        parser.error("--bounty-issue is only valid in live --repo mode")
+
     if args.input is not None:
         data = _load_input(_require_non_empty_arg(parser, "--input", args.input))
     else:
-        data = load_live_candidates(_require_non_empty_arg(parser, "--repo", args.repo))
+        if args.bounty_issue is not None and args.bounty_issue < 1:
+            parser.error("--bounty-issue must be a positive integer")
+        data = load_live_candidates(
+            _require_non_empty_arg(parser, "--repo", args.repo),
+            bounty_issue=args.bounty_issue,
+        )
     report = analyze_candidates(
         data,
         reviewer=args.reviewer,
         sufficient_reviews=args.sufficient_reviews,
+        repo=data.get("repo") if isinstance(data.get("repo"), str) else None,
     )
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/tests/test_gh_collection_caps.py
+++ b/tests/test_gh_collection_caps.py
@@ -1,0 +1,6 @@
+from scripts import gh_collection_caps as gcc
+
+
+def test_gh_collection_caps_are_positive() -> None:
+    assert gcc.GH_PR_SAFETY_CAP >= 1
+    assert gcc.GH_ISSUE_SAFETY_CAP >= 1

--- a/tests/test_pr_queue_health.py
+++ b/tests/test_pr_queue_health.py
@@ -8,7 +8,12 @@ from pathlib import Path
 import pytest
 
 from scripts import pr_queue_health
-from scripts.pr_queue_health import analyze_queue, format_markdown_report, format_text_report, main
+from scripts.pr_queue_health import (
+    analyze_queue,
+    format_markdown_report,
+    format_text_report,
+    main,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -437,7 +442,9 @@ def test_pr_queue_health_wraps_gh_timeouts(monkeypatch) -> None:
         pr_queue_health._run_gh_json(["gh", "pr", "list"])
 
 
-def test_pr_queue_health_live_loader_includes_referenced_issue_comments(monkeypatch) -> None:
+def test_pr_queue_health_live_loader_includes_referenced_issue_comments(
+    monkeypatch,
+) -> None:
     viewed_numbers = []
 
     def fake_run(args, **kwargs):
@@ -546,3 +553,25 @@ def test_pr_queue_health_fails_fast_when_pr_fetch_hits_cap(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="pr list reached the 201 item safety cap"):
         pr_queue_health.load_live_queue("ramimbo/mergework")
+
+
+@pytest.mark.parametrize(
+    ("source_args", "expected_message"),
+    (
+        (["--input", ""], "--input must be a non-empty value"),
+        (["--input", "   "], "--input must be a non-empty value"),
+        (["--repo", ""], "--repo must be a non-empty value"),
+        (["--repo", "   "], "--repo must be a non-empty value"),
+        (["--repo", " ramimbo/mergework "], "--repo must not include"),
+    ),
+)
+def test_pr_queue_health_rejects_empty_source_args(
+    source_args: list[str],
+    expected_message: str,
+    capsys,
+) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main([*source_args, "--format", "json"])
+
+    assert excinfo.value.code == 2
+    assert expected_message in capsys.readouterr().err


### PR DESCRIPTION
## Summary
Implements proposed work for #1141.

- Add scripts/gh_collection_caps.py documenting the shared live-collection cap policy (200 PRs / 200 issues).
- Normalize --limit usage and saturation handling across pr_queue_health.py, 
eview_bounty_candidates.py, check_live_bounty_closing_refs.py, and submission_quality_gate.py.
- Live reports fail fast on saturation; submission preflight keeps warn-only behavior with aligned cap values/messages.
- Add 	ests/test_gh_collection_caps.py and update queue-health regression expectations.

## Test plan
- [x] Module imports cleanly
- [ ] pytest tests/test_gh_collection_caps.py tests/test_pr_queue_health.py tests/test_submission_quality_gate.py

Closes #1141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bounty claim awareness to candidate review reports, including clearer indication of matched claim evidence and stale claims.
  * Live review workflows can now include bounty issue comments for more accurate status classification.

* **Bug Fixes**
  * Improved command-line input validation to reject empty or whitespace-padded values.
  * Standardized safety limits across maintenance checks to keep live data collection consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->