### PR TITLE
Reject transaction filters on account accepted-work API

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -200,8 +200,13 @@ def register_account_routes(app: FastAPI, *, db_url: str, templates: Jinja2Templ
             return account_api_context(session, account)
 
     @app.get("/api/v1/accounts/{account}/accepted-work")
-    def api_account_accepted_work(account: str) -> dict[str, Any]:
+    def api_account_accepted_work(request: Request, account: str) -> dict[str, Any]:
         reject_path_whitespace_padding(account, "account")
+        reject_unsupported_query_params(
+            request,
+            ("type", "tx_type"),
+            context="account accepted-work JSON detail",
+        )
         with session_scope(db_url) as session:
             return account_accepted_work_context(session, account)
 

--- a/tests/test_account_routes.py
+++ b/tests/test_account_routes.py
@@ -100,6 +100,12 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     api_type_filter_response = client.get("/api/v1/accounts/github:bob?type=github_claim")
     api_tx_type_filter_response = client.get("/api/v1/accounts/github:bob?tx_type=github_claim")
     accepted_response = client.get("/api/v1/accounts/github:bob/accepted-work")
+    accepted_type_filter = client.get(
+        "/api/v1/accounts/github:bob/accepted-work?type=bounty_payment"
+    )
+    accepted_tx_type_filter = client.get(
+        "/api/v1/accounts/github:bob/accepted-work?tx_type=bounty_payment"
+    )
     page_response = client.get("/accounts/github:bob")
 
     assert api_response.status_code == 200
@@ -116,6 +122,14 @@ def test_registered_account_routes_preserve_api_and_page_shapes(sqlite_url: str)
     assert accepted_response.status_code == 200
     assert accepted_response.json()["summary"]["accepted_mrwk"] == "25"
     assert accepted_response.json()["accepted_work"][0]["submission_url"].endswith("/pull/178")
+    assert accepted_type_filter.status_code == 400
+    assert accepted_type_filter.json()["detail"] == (
+        "type is not supported on account accepted-work JSON detail"
+    )
+    assert accepted_tx_type_filter.status_code == 400
+    assert accepted_tx_type_filter.json()["detail"] == (
+        "tx_type is not supported on account accepted-work JSON detail"
+    )
     assert page_response.status_code == 200
     assert "github:bob" in page_response.text
     assert "25 MRWK" in page_response.text


### PR DESCRIPTION
## Summary
Implements proposed work for #1114.

- Reject 	ype and 	x_type query parameters on GET /api/v1/accounts/{account}/accepted-work with the same bounded 400 behavior used by the parent account JSON route.
- Add regression coverage in 	ests/test_account_routes.py.

## Test plan
- [x] Accepted-work API returns 400 for 	ype / 	x_type filters
- [x] Unfiltered accepted-work JSON still returns 200

Related to #1114
