### PR TITLE
Guard PR bodies against premature payment-status wording

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,16 @@ jobs:
         run: python scripts/check_deploy_ready.py
       - name: Docs smoke
         run: python scripts/docs_smoke.py
+
+      - name: Check PR payment language
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          python scripts/check_pr_payment_language.py
+          --repo ramimbo/mergework
+          --pr ${{ github.event.pull_request.number }}
+          --fail-on-issues
+
       - name: Build Docker image
         run: docker build -t mergework:ci .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,3 +80,10 @@ Run these before opening a PR:
 
 Private findings stay private until maintainers approve disclosure. Public
 ledger entries for security work must use redacted proof metadata only.
+
+PR bodies and submission drafts must not use premature payment/status wording such as
+`Payout boundary`, legacy "not confirmed or withdrawable" phrasing, or reserved
+paid/settled/received/withdrawable claim assertions. Use neutral `Submission status`
+language instead. CI runs `scripts/check_pr_payment_language.py` on each pull request,
+and `scripts/submission_quality_gate.py` enforces the same rule for draft checks.
+

--- a/scripts/check_pr_payment_language.py
+++ b/scripts/check_pr_payment_language.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.public_payment_language import (
+    find_payment_language_violations,
+    format_violation_report,
+)
+
+DEFAULT_TIMEOUT_SECONDS = 30
+
+
+def _github_token() -> str:
+    for name in ("GH_TOKEN", "GITHUB_TOKEN"):
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    raise RuntimeError("GitHub token required; set GH_TOKEN or GITHUB_TOKEN")
+
+
+def _load_pull_request(repo: str, number: int) -> dict[str, Any]:
+    owner, name = repo.split("/", 1)
+    url = f"https://api.github.com/repos/{owner}/{name}/pulls/{number}"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {_github_token()}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "mergework-pr-payment-language-check",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=DEFAULT_TIMEOUT_SECONDS) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"failed to fetch PR #{number} from GitHub API: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"GitHub API returned non-object JSON for PR #{number}")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail when a PR body uses premature payment/status wording."
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--text-file", help="Read submission/PR body text from a file.")
+    source.add_argument("--repo", help="GitHub repository, for example ramimbo/mergework.")
+    parser.add_argument("--pr", type=int, help="Pull request number (required with --repo).")
+    parser.add_argument("--format", choices=["json", "text"], default="text")
+    parser.add_argument("--fail-on-issues", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.repo and args.pr is None:
+        parser.error("--pr is required when using --repo")
+    if args.text_file:
+        text = Path(args.text_file).read_text(encoding="utf-8")
+        context = {"source": "text_file", "pull_request": None}
+    else:
+        assert args.repo is not None and args.pr is not None
+        pr = _load_pull_request(args.repo, args.pr)
+        text = "\n".join(str(pr.get(key) or "") for key in ("title", "body"))
+        context = {
+            "source": "github_api",
+            "pull_request": args.pr,
+            "url": pr.get("html_url"),
+        }
+
+    violations = find_payment_language_violations(text)
+    report = {"context": context, "violations": violations}
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(format_violation_report(violations))
+    return 1 if args.fail_on_issues and violations else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/public_payment_language.py
+++ b/scripts/public_payment_language.py
@@ -1,0 +1,115 @@
+"""Detect premature payment/status wording in public submission text."""
+
+from __future__ import annotations
+
+import re
+
+SUGGESTED_REPLACEMENT = (
+    "Use a neutral 'Submission status' section and note that acceptance and any "
+    "later proof or ledger outcome are tracked by maintainers through the bounty "
+    "issue and public rows."
+)
+
+_PAYOUT_BOUNDARY_RE = re.compile(r"payout\s+boundary", re.IGNORECASE)
+_LEGACY_WITHDRAWABLE_RE = re.compile(
+    r"not\s+(?:confirmed|earned)\s+or\s+withdrawable",
+    re.IGNORECASE,
+)
+_HEADING_PREFIX_RE = re.compile(r"^#{1,6}\s+")
+
+_ALLOWLIST_LINE_RES = (
+    re.compile(r"no payout execution", re.IGNORECASE),
+    re.compile(r"payment lifecycle", re.IGNORECASE),
+    re.compile(r"pay_bounty proposal", re.IGNORECASE),
+    re.compile(r"proof-backed", re.IGNORECASE),
+    re.compile(r"does not (?:create|execute|trigger|mutate)", re.IGNORECASE),
+    re.compile(r"pending payout", re.IGNORECASE),
+    re.compile(r"accepted for payout review", re.IGNORECASE),
+    re.compile(r"reserve(?:s|d)? words", re.IGNORECASE),
+    re.compile(r"do not (?:write|describe|claim)", re.IGNORECASE),
+)
+
+_RESERVED_STATUS_ASSERTION_RES = (
+    re.compile(
+        r"\b(?:is|was|are|were|already|marked as|considered)\s+"
+        r"(?:paid|settled|received|withdrawable)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:paid|settled|received|withdrawable)\s+(?:claim|status|reward|payout)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:claim|submission|work)\s+(?:is|was)\s+(?:paid|settled|received|withdrawable)\b",
+        re.IGNORECASE,
+    ),
+)
+
+
+def _line_is_allowlisted(line: str) -> bool:
+    return any(pattern.search(line) for pattern in _ALLOWLIST_LINE_RES)
+
+
+def _content_line(line: str) -> str:
+    """Strip markdown heading markers so heading wording is still checked."""
+    stripped = line.strip()
+    if not stripped:
+        return ""
+    return _HEADING_PREFIX_RE.sub("", stripped).strip()
+
+
+def find_payment_language_violations(text: str) -> list[str]:
+    """Return human-readable violations for premature payment/status wording."""
+    if not text or not text.strip():
+        return []
+
+    violations: list[str] = []
+    for line in text.splitlines():
+        content = _content_line(line)
+        if not content:
+            continue
+        if _line_is_allowlisted(line) or _line_is_allowlisted(content):
+            continue
+        if _PAYOUT_BOUNDARY_RE.search(content):
+            violations.append(
+                "deprecated 'Payout boundary' heading found; prefer neutral "
+                "'Submission status' wording"
+            )
+            break
+        if _LEGACY_WITHDRAWABLE_RE.search(content):
+            violations.append(
+                "legacy 'not confirmed or withdrawable' phrasing found; "
+                "use neutral submission status language"
+            )
+            break
+
+    for line in text.splitlines():
+        content = _content_line(line)
+        if not content:
+            continue
+        if _line_is_allowlisted(line) or _line_is_allowlisted(content):
+            continue
+        for pattern in _RESERVED_STATUS_ASSERTION_RES:
+            if pattern.search(content):
+                violations.append(
+                    f"reserved payment/status wording used as a claim assertion: {content[:120]}"
+                )
+                break
+
+    seen: set[str] = set()
+    unique: list[str] = []
+    for item in violations:
+        if item in seen:
+            continue
+        seen.add(item)
+        unique.append(item)
+    return unique
+
+
+def format_violation_report(violations: list[str]) -> str:
+    if not violations:
+        return "No premature payment/status wording found."
+    lines = ["Premature payment/status wording:"]
+    lines.extend(f"- {item}" for item in violations)
+    lines.append(f"Suggestion: {SUGGESTED_REPLACEMENT}")
+    return "\n".join(lines)

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -16,7 +16,15 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.api_host_args import public_api_host
-from scripts.bounty_refs import BOUNTY_REF_RE, GITHUB_LINKED_ISSUE_RE, LEADING_BOUNTY_REF_RE
+from scripts.bounty_refs import (
+    BOUNTY_REF_RE,
+    GITHUB_LINKED_ISSUE_RE,
+    LEADING_BOUNTY_REF_RE,
+)
+from scripts.public_payment_language import (
+    SUGGESTED_REPLACEMENT,
+    find_payment_language_violations,
+)
 
 
 def _non_negative_int(value: str) -> int:
@@ -427,7 +435,9 @@ def evaluate_submission(data: dict[str, Any]) -> dict[str, Any]:
         else:
             checks.append(
                 _check(
-                    "bounty_payable", "pass", _bounty_payability_pass_message(bounty_ref, bounty)
+                    "bounty_payable",
+                    "pass",
+                    _bounty_payability_pass_message(bounty_ref, bounty),
                 )
             )
             availability_warning = _bounty_availability_warning(bounty_ref, bounty)
@@ -478,6 +488,27 @@ def evaluate_submission(data: dict[str, Any]) -> dict[str, Any]:
                 "evidence_present",
                 "warn",
                 "include concrete test or validation evidence before submission",
+            )
+        )
+
+    payment_violations = find_payment_language_violations(text)
+    if payment_violations:
+        preview = "; ".join(payment_violations[:2])
+        if len(payment_violations) > 2:
+            preview += f" (+{len(payment_violations) - 2} more)"
+        checks.append(
+            _check(
+                "payment_language",
+                "fail",
+                f"{preview}. {SUGGESTED_REPLACEMENT}",
+            )
+        )
+    else:
+        checks.append(
+            _check(
+                "payment_language",
+                "pass",
+                "no premature payment/status wording found",
             )
         )
 
@@ -725,7 +756,11 @@ def _load_live_context(
                     "MergeWork API bounty id unavailable for attempts lookup"
                 )
         bounties.append(bounty_record)
-    data = {"submission_text": submission_text, "bounties": bounties, "pull_requests": prs}
+    data = {
+        "submission_text": submission_text,
+        "bounties": bounties,
+        "pull_requests": prs,
+    }
     if load_warnings:
         data["load_warning"] = "; ".join(load_warnings)
     return data

--- a/tests/test_public_payment_language.py
+++ b/tests/test_public_payment_language.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from scripts.public_payment_language import (
+    SUGGESTED_REPLACEMENT,
+    find_payment_language_violations,
+    format_violation_report,
+)
+
+
+def test_find_payment_language_flags_payout_boundary_heading() -> None:
+    violations = find_payment_language_violations(
+        "## Payout boundary\nThis submission awaits review."
+    )
+    assert any("Payout boundary" in item for item in violations)
+
+
+def test_find_payment_language_flags_legacy_withdrawable_phrasing() -> None:
+    violations = find_payment_language_violations(
+        "This reward is not confirmed or withdrawable yet."
+    )
+    assert any("withdrawable" in item for item in violations)
+
+
+def test_find_payment_language_flags_reserved_status_assertion() -> None:
+    violations = find_payment_language_violations("This submission is paid.")
+    assert any("reserved payment/status wording" in item for item in violations)
+
+
+def test_find_payment_language_allows_neutral_submission_status() -> None:
+    violations = find_payment_language_violations(
+        "## Submission status\nAcceptance and proof are tracked separately."
+    )
+    assert violations == []
+
+
+def test_find_payment_language_allowlists_instructional_lines() -> None:
+    violations = find_payment_language_violations(
+        'Do not write "not confirmed or withdrawable" in public drafts.\n'
+        "Reserve words such as paid/settled for ledger proofs only."
+    )
+    assert violations == []
+
+
+def test_format_violation_report_includes_suggestion() -> None:
+    report = format_violation_report(["example violation"])
+    assert "example violation" in report
+    assert SUGGESTED_REPLACEMENT in report

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -43,6 +43,7 @@ def test_submission_quality_gate_passes_open_bounty_with_evidence(capsys, tmp_pa
         "summary_present": "pass",
         "evidence_present": "pass",
         "similar_open_pr": "pass",
+        "payment_language": "pass",
     }
 
     input_path = tmp_path / "submission.json"
@@ -196,7 +197,9 @@ def test_submission_quality_gate_accepts_github_linking_keywords() -> None:
 
 
 @pytest.mark.parametrize("reference", ("Fixes #319abc", "Fixes #319_abc", "Fixes #319-abc"))
-def test_submission_quality_gate_rejects_linking_keyword_issue_suffix(reference: str) -> None:
+def test_submission_quality_gate_rejects_linking_keyword_issue_suffix(
+    reference: str,
+) -> None:
     result = evaluate_submission(
         {
             "submission_text": (
@@ -811,7 +814,9 @@ def test_submission_quality_gate_load_json_url_decodes_response(monkeypatch) -> 
     ) == {"ok": True}
 
 
-def test_submission_quality_gate_attempts_loader_keeps_contextual_error(monkeypatch) -> None:
+def test_submission_quality_gate_attempts_loader_keeps_contextual_error(
+    monkeypatch,
+) -> None:
     def fake_urlopen(url: str, *, timeout: int) -> _JsonResponse:
         return _JsonResponse({"attempts": "not-a-list"})
 
@@ -911,7 +916,9 @@ def test_submission_quality_gate_warns_when_live_collections_hit_safety_caps(
     } in result["checks"]
 
 
-def test_submission_quality_gate_live_bounties_use_api_award_capacity(monkeypatch) -> None:
+def test_submission_quality_gate_live_bounties_use_api_award_capacity(
+    monkeypatch,
+) -> None:
     def fake_run(args, **kwargs):
         if args[:3] == ["gh", "pr", "list"]:
             return subprocess.CompletedProcess(args=args, returncode=0, stdout="[]", stderr="")
@@ -1034,7 +1041,11 @@ def test_submission_quality_gate_live_context_scopes_referenced_bounty_checks(
                 returncode=0,
                 stdout=json.dumps(
                     [
-                        {"number": 318, "title": "MRWK bounty: unrelated", "state": "OPEN"},
+                        {
+                            "number": 318,
+                            "title": "MRWK bounty: unrelated",
+                            "state": "OPEN",
+                        },
                         {"number": 319, "title": "MRWK bounty: gate", "state": "OPEN"},
                     ]
                 ),
@@ -1139,7 +1150,9 @@ def test_submission_quality_gate_live_context_warns_when_attempt_id_missing(
     } in result["checks"]
 
 
-def test_submission_quality_gate_live_context_adds_maintainer_activity(monkeypatch) -> None:
+def test_submission_quality_gate_live_context_adds_maintainer_activity(
+    monkeypatch,
+) -> None:
     def fake_run(args, **kwargs):
         if args[:3] == ["gh", "pr", "list"]:
             return subprocess.CompletedProcess(args=args, returncode=0, stdout="[]", stderr="")
@@ -1432,3 +1445,38 @@ def test_quality_gate_cli_rejects_invalid_api_host(tmp_path, capsys) -> None:
             main(["--text-file", str(draft), "--api-host", bad])
         assert excinfo.value.code == 2
         assert "api host must" in capsys.readouterr().err
+
+
+def test_evaluate_submission_fails_on_premature_payment_wording() -> None:
+    data = {
+        "submission_text": (
+            "Summary: fix docs\n\nRefs #319\n\n"
+            "## Payout boundary\nThis submission is paid and withdrawable."
+        ),
+        "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+        "pull_requests": [],
+    }
+
+    result = evaluate_submission(data)
+
+    payment_checks = [check for check in result["checks"] if check["name"] == "payment_language"]
+    assert payment_checks
+    assert payment_checks[0]["status"] == "fail"
+    assert result["status"] == "fail"
+
+
+def test_evaluate_submission_passes_neutral_submission_status() -> None:
+    data = {
+        "submission_text": (
+            "Summary: fix docs\n\nRefs #319\n\n"
+            "## Submission status\nAcceptance and proof are tracked separately."
+        ),
+        "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+        "pull_requests": [],
+    }
+
+    result = evaluate_submission(data)
+
+    payment_checks = [check for check in result["checks"] if check["name"] == "payment_language"]
+    assert payment_checks
+    assert payment_checks[0]["status"] == "pass"


### PR DESCRIPTION
## Summary
Implements proposed work for #1107.

- Add scripts/public_payment_language.py to detect premature payment/status wording in PR bodies and drafts.
- Extend scripts/submission_quality_gate.py with a payment language check.
- Add scripts/check_pr_payment_language.py and wire it into PR CI.
- Document the rule and cover it with focused tests.

## Test plan
- [x] tests/test_public_payment_language.py
- [x] submission quality gate regression for banned status wording
- [x] CI runs the PR payment-language checker

Related to #1107
