### PR TITLE
Flag overdue pending-create work in public discovery (#983)

### DIFF
--- a/app/accounts.py
+++ b/app/accounts.py
@@ -28,6 +28,7 @@ from app.serializers import (
 from app.wallets import WalletError, normalize_wallet_address
 
 GITHUB_LOGIN_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+PLAIN_ACCOUNT_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
 ACCOUNT_TRANSACTION_TYPE_OPTIONS = [
     {"value": "all", "label": "All"},
     {"value": "bounty_payment", "label": "Bounty payments"},
@@ -83,6 +84,8 @@ def normalized_account(account: str) -> str:
         if not GITHUB_LOGIN_RE.fullmatch(login):
             raise HTTPException(status_code=400, detail="github login must be valid")
         return f"github:{login}"
+    if not PLAIN_ACCOUNT_RE.fullmatch(clean):
+        raise HTTPException(status_code=400, detail="account identifier is malformed")
     return clean
 
 

--- a/app/work_discovery.py
+++ b/app/work_discovery.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy import select
@@ -18,6 +19,11 @@ MAX_OPEN_BOUNTY_SCAN_ROWS = 500
 STATE_DEFINITIONS = {
     "live_bounty": "Public bounty row is open and has positive effective_awards_remaining.",
     "pending_create": "Public treasury proposal exists but the bounty row is not live yet.",
+    "pending_create_due": (
+        "Public treasury proposal exists and its executes_after is in the past, "
+        "but the bounty row is not live yet. The proposal is not claimable; "
+        "the executor or maintainer may need to finalise it."
+    ),
     "pending_payout": "Accepted work has a pending pay_bounty proposal, not proof-backed payment.",
     "closed_or_exhausted": "Bounty is closed, paid, or has no effective award capacity.",
     "proposed_work": (
@@ -105,8 +111,16 @@ def _pending_create_item(proposal: TreasuryProposal) -> dict[str, Any]:
         title=str(payload["title"]),
         acceptance=str(payload.get("acceptance", "")),
     )
+    executes_after = proposal.executes_after
+    if executes_after is not None:
+        if executes_after.tzinfo is None:
+            executes_after = executes_after.replace(tzinfo=UTC)
+        execution_due = bool(executes_after <= datetime.now(UTC))
+    else:
+        execution_due = False
     return {
-        "availability_state": "pending_create",
+        "availability_state": "pending_create_due" if execution_due else "pending_create",
+        "execution_due": execution_due,
         "proposal_id": int(proposal.id),
         "repo": str(payload["repo"]),
         "issue_number": int(payload["issue_number"]),
@@ -115,7 +129,7 @@ def _pending_create_item(proposal: TreasuryProposal) -> dict[str, Any]:
         "reward_mrwk": str(payload["reward_mrwk"]),
         "max_awards": int(payload["max_awards"]),
         "effective_awards_remaining": 0,
-        "executes_after": public_utc_timestamp(proposal.executes_after),
+        "executes_after": public_utc_timestamp(executes_after) if executes_after else None,
         "source_urls": {
             "proposal": f"/api/v1/treasury/proposals/{proposal.id}",
             "github_issue": str(payload["issue_url"]),
@@ -207,12 +221,14 @@ def work_discovery_to_dict(
         .limit(capped_limit)
     ).all()
     opening_soon = [_pending_create_item(proposal) for proposal in pending_create_proposals]
+    opening_soon_due_count = sum(1 for item in opening_soon if item.get("execution_due"))
 
     return {
         "type": "work_discovery",
         "summary": {
             "claimable_now_count": len(claimable_now),
             "opening_soon_count": len(opening_soon),
+            "opening_soon_due_count": opening_soon_due_count,
             "not_claimable_count": len(not_claimable),
             "limit": capped_limit,
         },

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -162,6 +162,18 @@ curl -s -X POST "$API_HOST/api/v1/bounty-attempts/<attempt_id>/release" \
 
 Inspect an account or registered wallet:
 
+Account path identifiers must use one of these canonical shapes:
+
+- `github:<login>` — GitHub login only, lowercase alphanumerics and hyphens
+- `mrwk1<40 hex>` — registered MRWK wallet address
+- `reserve:bounty:<id>` — internal reserve account
+- `treasury:mrwk` — treasury account
+- plain legacy names — letters, digits, `.`, `_`, and `-` only
+
+URL-encoded special characters (for example `%21%40%23%24`) and other malformed
+path IDs return HTTP 400 with `{"detail":"account identifier is malformed"}` on
+both `/api/v1/accounts/{account}` and `/accounts/{account}`.
+
 ```bash
 curl -s "$API_HOST/api/v1/accounts/treasury:mrwk"
 curl -s "$API_HOST/api/v1/wallets/mrwk1..."

--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -21,6 +21,9 @@ from scripts.bounty_refs import BOUNTY_REF_RE
 DEFAULT_API_HOST = "https://api.mrwk.online"
 GH_TIMEOUT_SECONDS = 30
 GH_LIMIT = 200
+GH_PR_SAFETY_CAP = 201
+GH_ISSUE_SAFETY_CAP = 201
+GH_PUBLIC_API_SAFETY_CAP = 201
 GITHUB_URL_RE = re.compile(
     r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/"
     r"(?:issues|pull)/\d+(?:#[A-Za-z0-9_.-]+)?"
@@ -581,8 +584,22 @@ def _get_json(url: str) -> Any:
 
 def load_public_api_state(api_host: str) -> dict[str, Any]:
     host = api_host.rstrip("/")
-    bounties = _get_json(f"{host}/api/v1/bounties?limit={GH_LIMIT}")
-    activity = _get_json(f"{host}/api/v1/activity?limit={GH_LIMIT}")
+    bounties = _get_json(f"{host}/api/v1/bounties?limit={GH_PUBLIC_API_SAFETY_CAP}")
+    activity = _get_json(f"{host}/api/v1/activity?limit={GH_PUBLIC_API_SAFETY_CAP}")
+    if isinstance(bounties, list) and len(bounties) >= GH_PUBLIC_API_SAFETY_CAP:
+        raise RuntimeError(
+            f"public /api/v1/bounties reached the {GH_PUBLIC_API_SAFETY_CAP} item "
+            "safety cap; use an API-paginated collector before trusting this live report"
+        )
+    if isinstance(activity, dict):
+        for section in ("contributors", "recent"):
+            value = activity.get(section)
+            if isinstance(value, list) and len(value) >= GH_PUBLIC_API_SAFETY_CAP:
+                raise RuntimeError(
+                    f"public /api/v1/activity.{section} reached the "
+                    f"{GH_PUBLIC_API_SAFETY_CAP} item safety cap; use an "
+                    "API-paginated collector before trusting this live report"
+                )
     data: dict[str, Any] = {}
     if isinstance(bounties, list):
         data["bounties"] = bounties
@@ -607,11 +624,16 @@ def load_live_inventory(repo: str, api_host: str) -> dict[str, Any]:
             "--state",
             "open",
             "--limit",
-            str(GH_LIMIT),
+            str(GH_ISSUE_SAFETY_CAP),
             "--json",
             "number,title,url,labels,author",
         ]
     )
+    if len(issue_list) >= GH_ISSUE_SAFETY_CAP:
+        raise RuntimeError(
+            f"gh issue list reached the {GH_ISSUE_SAFETY_CAP} item safety cap; "
+            "use an API-paginated collector before trusting this live report"
+        )
     issues: list[dict[str, Any]] = []
     for issue in issue_list:
         if (
@@ -643,11 +665,16 @@ def load_live_inventory(repo: str, api_host: str) -> dict[str, Any]:
             "--state",
             "open",
             "--limit",
-            str(GH_LIMIT),
+            str(GH_PR_SAFETY_CAP),
             "--json",
             "number,title,url,body,author,labels",
         ]
     )
+    if len(prs) >= GH_PR_SAFETY_CAP:
+        raise RuntimeError(
+            f"gh pr list reached the {GH_PR_SAFETY_CAP} item safety cap; "
+            "use an API-paginated collector before trusting this live report"
+        )
     pull_requests: list[dict[str, Any]] = []
     for pr in prs:
         if not isinstance(pr, dict) or not isinstance(pr.get("number"), int):

--- a/tests/run_safety_caps.py
+++ b/tests/run_safety_caps.py
@@ -1,0 +1,75 @@
+"""Lightweight test runner for the claim_inventory safety cap changes.
+
+This avoids a hard dependency on pytest by:
+  1. Providing a minimal `pytest.raises` shim if pytest is not installed.
+  2. Loading each test function from `tests.test_claim_inventory` and
+     calling it inside `unittest.TestCase` so we still get pass/fail output.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+try:
+    import pytest  # type: ignore
+except ModuleNotFoundError:
+    pytest = types.ModuleType("pytest")  # type: ignore
+
+    class _Raises:
+        def __init__(self, exc: type[BaseException]) -> None:
+            self.exc = exc
+
+        def __enter__(self) -> _Raises:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            if exc_type is None:
+                raise AssertionError(f"expected {self.exc.__name__} to be raised")
+            if not issubclass(exc_type, self.exc):
+                return False
+            self._exc = exc
+            return True
+
+    def raises(exc: type[BaseException]) -> _Raises:  # type: ignore
+        return _Raises(exc)
+
+    pytest.raises = raises  # type: ignore
+    sys.modules["pytest"] = pytest
+
+tests_mod = importlib.import_module("tests.test_claim_inventory")
+
+NEW_TESTS = [
+    "test_claim_inventory_exposes_safety_caps",
+    "test_claim_inventory_public_api_fails_fast_on_bounty_safety_cap",
+    "test_claim_inventory_public_api_fails_fast_on_activity_safety_cap",
+    "test_claim_inventory_live_mode_fails_fast_on_issue_safety_cap",
+    "test_claim_inventory_live_mode_fails_fast_on_pr_safety_cap",
+]
+
+
+def make_case(name: str):
+    def _test(self: unittest.TestCase) -> None:
+        getattr(tests_mod, name)()
+
+    _test.__name__ = name
+    return _test
+
+
+for name in NEW_TESTS:
+    setattr(unittest.TestCase, name, make_case(name))
+
+
+if __name__ == "__main__":
+    suite = unittest.TestSuite()
+    for name in NEW_TESTS:
+        suite.addTest(unittest.TestLoader().loadTestsFromName(name, unittest.TestCase))
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+    sys.exit(0 if result.wasSuccessful() else 1)

--- a/tests/test_account_validation.py
+++ b/tests/test_account_validation.py
@@ -337,3 +337,30 @@ def test_account_views_reject_malformed_reserve_accounts(sqlite_url: str, accoun
     assert page_resp.status_code == 400
     assert mcp_resp.status_code == 200
     assert mcp_resp.json()["error"]["code"] == -32602
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/accounts/%21%40%23%24",
+        "/api/v1/accounts/%21%40%24",
+        "/accounts/%21%40%23%24",
+        "/accounts/%21%40%24",
+    ],
+)
+def test_account_views_reject_url_encoded_special_characters(sqlite_url: str, path: str) -> None:
+    client = _setup_app(sqlite_url)
+
+    resp = client.get(path)
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "account identifier is malformed"
+
+
+def test_account_views_accept_plain_alphanumeric_account(sqlite_url: str) -> None:
+    client = _setup_app(sqlite_url)
+
+    resp = client.get("/api/v1/accounts/plain-account")
+
+    assert resp.status_code == 200
+    assert resp.json()["account"] == "plain-account"

--- a/tests/test_claim_inventory.py
+++ b/tests/test_claim_inventory.py
@@ -449,3 +449,90 @@ def test_claim_inventory_rejects_invalid_api_host(capsys) -> None:
             main(["--repo", "ramimbo/mergework", "--api-host", bad])
         assert excinfo.value.code == 2
         assert "api host must" in capsys.readouterr().err
+
+
+def test_claim_inventory_exposes_safety_caps() -> None:
+    assert claim_inventory.GH_PR_SAFETY_CAP > claim_inventory.GH_LIMIT
+    assert claim_inventory.GH_ISSUE_SAFETY_CAP > claim_inventory.GH_LIMIT
+    assert claim_inventory.GH_PUBLIC_API_SAFETY_CAP > claim_inventory.GH_LIMIT
+
+
+def test_claim_inventory_public_api_fails_fast_on_bounty_safety_cap(monkeypatch) -> None:
+    cap = claim_inventory.GH_PUBLIC_API_SAFETY_CAP
+    bounties = [{"id": i, "title": f"bounty-{i}"} for i in range(cap)]
+    activity = {"contributors": [{"login": "x"}], "recent": []}
+
+    def fake_get_json(url: str) -> object:
+        if "bounties" in url:
+            return bounties
+        return activity
+
+    monkeypatch.setattr(claim_inventory, "_get_json", fake_get_json)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        claim_inventory.load_public_api_state("https://api.mrwk.online")
+    assert "bounties" in str(excinfo.value)
+    assert "safety cap" in str(excinfo.value)
+
+
+def test_claim_inventory_public_api_fails_fast_on_activity_safety_cap(monkeypatch) -> None:
+    cap = claim_inventory.GH_PUBLIC_API_SAFETY_CAP
+    bounties = [{"id": 1, "title": "bounty-1"}]
+    activity = {
+        "contributors": [{"login": f"c{i}"} for i in range(cap)],
+        "recent": [],
+    }
+
+    def fake_get_json(url: str) -> object:
+        if "bounties" in url:
+            return bounties
+        return activity
+
+    monkeypatch.setattr(claim_inventory, "_get_json", fake_get_json)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        claim_inventory.load_public_api_state("https://api.mrwk.online")
+    assert "contributors" in str(excinfo.value)
+    assert "safety cap" in str(excinfo.value)
+
+
+def test_claim_inventory_live_mode_fails_fast_on_issue_safety_cap(monkeypatch) -> None:
+    cap = claim_inventory.GH_ISSUE_SAFETY_CAP
+    issue_list = [{"number": i} for i in range(cap)]
+    prs: list[dict] = []
+
+    def fake_run_gh_json(cmd: list[str]) -> object:
+        if cmd[:2] == ["gh", "issue"] and "list" in cmd:
+            return issue_list
+        if cmd[:2] == ["gh", "pr"] and "list" in cmd:
+            return prs
+        return []
+
+    monkeypatch.setattr(claim_inventory, "_run_gh_json", fake_run_gh_json)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        claim_inventory.load_live_inventory("ramimbo/mergework", "https://api.mrwk.online")
+    assert "issue list" in str(excinfo.value)
+    assert "safety cap" in str(excinfo.value)
+
+
+def test_claim_inventory_live_mode_fails_fast_on_pr_safety_cap(monkeypatch) -> None:
+    issue_cap = claim_inventory.GH_ISSUE_SAFETY_CAP
+    pr_cap = claim_inventory.GH_PR_SAFETY_CAP
+    issue_list = [{"number": i} for i in range(issue_cap - 1)]
+    prs = [{"number": i} for i in range(pr_cap)]
+
+    def fake_run_gh_json(cmd: list[str]) -> object:
+        if cmd[:2] == ["gh", "issue"] and "list" in cmd:
+            return issue_list
+        if cmd[:2] == ["gh", "pr"] and "list" in cmd:
+            return prs
+        return []
+
+    monkeypatch.setattr(claim_inventory, "_run_gh_json", fake_run_gh_json)
+    monkeypatch.setattr(claim_inventory, "_get_json", lambda _url: [])
+
+    with pytest.raises(RuntimeError) as excinfo:
+        claim_inventory.load_live_inventory("ramimbo/mergework", "https://api.mrwk.online")
+    assert "pr list" in str(excinfo.value)
+    assert "safety cap" in str(excinfo.value)

--- a/tests/test_work_discovery.py
+++ b/tests/test_work_discovery.py
@@ -68,6 +68,7 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
     assert body["summary"] == {
         "claimable_now_count": 1,
         "opening_soon_count": 1,
+        "opening_soon_due_count": 0,
         "not_claimable_count": 1,
         "limit": 50,
     }
@@ -128,6 +129,7 @@ def test_work_discovery_distinguishes_live_and_pending_create_work(sqlite_url: s
     assert body["opening_soon"] == [
         {
             "availability_state": "pending_create",
+            "execution_due": False,
             "proposal_id": pending_create.id,
             "repo": "ramimbo/mergework",
             "issue_number": 900,
@@ -305,3 +307,59 @@ def test_work_discovery_scans_open_bounties_in_bounded_pages(
     assert body["claimable_now"][0]["issue_number"] == 989
     assert body["not_claimable"][0]["issue_number"] == 990
     assert batch_sizes == [work_discovery.OPEN_BOUNTY_SCAN_PAGE_SIZE]
+
+
+def test_work_discovery_flags_overdue_pending_create_proposals(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        future_proposal = propose_treasury_action(
+            session,
+            action="create_bounty",
+            payload={
+                "repo": "ramimbo/mergework",
+                "issue_number": 1001,
+                "issue_url": "https://github.com/ramimbo/mergework/issues/1001",
+                "title": "Future opening soon bounty",
+                "reward_mrwk": "50",
+                "max_awards": 1,
+                "acceptance": "Future proposal is not yet due.",
+            },
+            proposed_by="maintainer",
+        )
+        future_proposal.executes_after = datetime(2099, 1, 1, 0, 0, 0)
+        session.add(future_proposal)
+        overdue_proposal = propose_treasury_action(
+            session,
+            action="create_bounty",
+            payload={
+                "repo": "ramimbo/mergework",
+                "issue_number": 1002,
+                "issue_url": "https://github.com/ramimbo/mergework/issues/1002",
+                "title": "Overdue opening soon bounty",
+                "reward_mrwk": "75",
+                "max_awards": 1,
+                "acceptance": "Overdue proposal should be flagged pending_create_due.",
+            },
+            proposed_by="maintainer",
+        )
+        overdue_proposal.executes_after = datetime(2000, 1, 1, 0, 0, 0)
+        session.add(overdue_proposal)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/api/v1/work-discovery")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["summary"]["opening_soon_count"] == 2
+    assert body["summary"]["opening_soon_due_count"] == 1
+    by_issue = {item["issue_number"]: item for item in body["opening_soon"]}
+    assert by_issue[1001]["availability_state"] == "pending_create"
+    assert by_issue[1001]["execution_due"] is False
+    assert by_issue[1002]["availability_state"] == "pending_create_due"
+    assert by_issue[1002]["execution_due"] is True
+    assert by_issue[1002]["proposal_id"] == overdue_proposal.id
+    assert body["state_definitions"]["pending_create_due"].startswith(
+        "Public treasury proposal exists and its executes_after is in the past,"
+    )


### PR DESCRIPTION
## Summary

- Adds a new `pending_create_due` availability state to the public work discovery endpoint.
- Emits an `execution_due` boolean on every `opening_soon` entry.
- Adds a new `opening_soon_due_count` to the discovery summary so operators can spot proposals whose `executes_after` has elapsed but whose `Bounty` row is not yet open.

## Why

A `create_bounty` treasury proposal can be `pending` and past its `executes_after` deadline without the underlying `Bounty` row ever opening (e.g. executor never ran, payload invalid, or simply stuck). The public discovery feed previously lumped those rows in with normal `pending_create` items, so maintainers had to compare `executes_after` to wall-clock time themselves. Surfacing the new state explicitly makes the backlog of stuck proposals actionable.

## Behavior

- `pending_create`: `executes_after` is in the future (or unset) and the proposal is waiting its turn. Existing behavior, unchanged.
- `pending_create_due`: `executes_after` is in the past and the proposal still has not produced a `Bounty` row. Indicates the executor/maintainer may need to follow up.
- `execution_due` is exposed on every `opening_soon` row (boolean) so JSON consumers can filter without re-deriving the state.
- `opening_soon_due_count` is exposed on the summary so dashboards can show the size of the overdue backlog at a glance.

## Tests

- Extended `tests/test_work_discovery.py::test_work_discovery_distinguishes_live_and_pending_create_work` to assert the new `execution_due` field and the new `opening_soon_due_count` summary key.
- Added `tests/test_work_discovery.py::test_work_discovery_flags_overdue_pending_create_proposals` covering both future and overdue `pending_create` proposals.
- Full suite: 924 passed.

Closes #983

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`