### PR TITLE
Centralize GH CLI timeout constant across maintenance scripts (#936)

### DIFF
--- a/scripts/check_bounty_issue_states.py
+++ b/scripts/check_bounty_issue_states.py
@@ -13,9 +13,9 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.api_host_args import public_api_host
+from scripts.gh_cli_constants import GH_TIMEOUT_SECONDS
 
 DEFAULT_API_HOST = "https://api.mrwk.online"
-GH_TIMEOUT_SECONDS = 30
 
 
 def _int_or_none(value: Any) -> int | None:

--- a/scripts/check_live_bounty_closing_refs.py
+++ b/scripts/check_live_bounty_closing_refs.py
@@ -14,9 +14,9 @@ if __package__ in {None, ""}:
 
 from scripts.api_host_args import public_api_host
 from scripts.bounty_refs import GITHUB_CLOSING_ISSUE_RE
+from scripts.gh_cli_constants import GH_TIMEOUT_SECONDS
 
 DEFAULT_API_HOST = "https://api.mrwk.online"
-GH_TIMEOUT_SECONDS = 30
 GH_PR_SAFETY_CAP = 200
 MAX_BOUNTY_REF = 2**63 - 1
 

--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -17,9 +17,9 @@ if __package__ in {None, ""}:
 
 from scripts.api_host_args import public_api_host
 from scripts.bounty_refs import BOUNTY_REF_RE
+from scripts.gh_cli_constants import GH_TIMEOUT_SECONDS
 
 DEFAULT_API_HOST = "https://api.mrwk.online"
-GH_TIMEOUT_SECONDS = 30
 GH_LIMIT = 200
 GITHUB_URL_RE = re.compile(
     r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/"

--- a/scripts/gh_cli_constants.py
+++ b/scripts/gh_cli_constants.py
@@ -1,0 +1,5 @@
+"""Shared constants for read-only GitHub CLI maintenance scripts."""
+
+from __future__ import annotations
+
+GH_TIMEOUT_SECONDS = 30

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -13,10 +13,10 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.bounty_refs import BOUNTY_REF_RE
+from scripts.gh_cli_constants import GH_TIMEOUT_SECONDS
 
 NOISY_TITLE_PREFIX_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)+")
 UNSTABLE_MERGE_STATES = {"blocked", "conflicting", "dirty", "unknown", "unstable"}
-GH_TIMEOUT_SECONDS = 30
 GH_PR_SAFETY_CAP = 201
 GH_ISSUE_SAFETY_CAP = 201
 MAX_BOUNTY_REF = 2**63 - 1

--- a/scripts/proposed_work_triage.py
+++ b/scripts/proposed_work_triage.py
@@ -16,6 +16,7 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from scripts.api_host_args import public_api_host
+from scripts.gh_cli_constants import GH_TIMEOUT_SECONDS
 
 
 def _positive_int(value: str) -> int:
@@ -79,7 +80,6 @@ STOPWORDS = {
     "to",
     "work",
 }
-GH_TIMEOUT_SECONDS = 30
 HTTP_TIMEOUT_SECONDS = 30
 DEFAULT_API_HOST = "https://api.mrwk.online"
 DEFAULT_PAYMENT_BOUNTY_ISSUE_NUMBERS = (649, 722)

--- a/scripts/review_bounty_candidates.py
+++ b/scripts/review_bounty_candidates.py
@@ -5,10 +5,15 @@ import json
 import subprocess
 import sys
 from collections import Counter
+from pathlib import Path
 from typing import Any
 
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from scripts.gh_cli_constants import GH_TIMEOUT_SECONDS
+
 DIRTY_MERGE_STATES = {"blocked", "conflicting", "dirty"}
-GH_TIMEOUT_SECONDS = 30
 GH_PR_SAFETY_CAP = 201
 STANDARD_QUALITY_CHECK = "Quality, readiness, docs, and image checks"
 HUMAN_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED", "COMMENTED"}

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -17,6 +17,7 @@ if __package__ in {None, ""}:
 
 from scripts.api_host_args import public_api_host
 from scripts.bounty_refs import BOUNTY_REF_RE, GITHUB_LINKED_ISSUE_RE, LEADING_BOUNTY_REF_RE
+from scripts.gh_cli_constants import GH_TIMEOUT_SECONDS
 
 
 def _non_negative_int(value: str) -> int:
@@ -40,7 +41,6 @@ EVIDENCE_RE = re.compile(
     re.IGNORECASE,
 )
 SUMMARY_RE = re.compile(r"\b(summary|what changed|changes?)\b", re.IGNORECASE)
-GH_TIMEOUT_SECONDS = 30
 DEFAULT_API_HOST = "https://api.mrwk.online"
 DEFAULT_MAX_MAINTAINER_AGE_DAYS = 14
 GH_PR_SAFETY_CAP = 101

--- a/tests/test_gh_cli_constants.py
+++ b/tests/test_gh_cli_constants.py
@@ -1,0 +1,10 @@
+"""Tests for shared gh CLI maintenance constants."""
+
+from __future__ import annotations
+
+from scripts.gh_cli_constants import GH_TIMEOUT_SECONDS
+
+
+def test_gh_timeout_is_positive_int() -> None:
+    assert isinstance(GH_TIMEOUT_SECONDS, int)
+    assert GH_TIMEOUT_SECONDS > 0


### PR DESCRIPTION
## Summary

Centralizes the duplicated `GH_TIMEOUT_SECONDS = 30` literal used across seven read-only GitHub CLI maintenance scripts into `scripts/gh_cli_constants.py`.

## Why

Several maintenance scripts already share safety-cap and JSON-shape helpers; the timeout constant was still duplicated by hand. A single module reduces drift when the timeout policy changes.

## Tests

```bash
python -m pytest tests/test_gh_cli_constants.py -q
```

Existing script behavior is unchanged aside from the shared import.

## Wallet

`Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

Closes #936
