### PR TITLE
Fix #946: Add structuredContent to list_bounties and get_bounty MCP tools

### DIFF
--- a/app/mcp_tools.py
+++ b/app/mcp_tools.py
@@ -234,7 +234,11 @@ def call_mcp_tool(
                 newest_bounties = session.scalars(
                     query.order_by(Bounty.id.desc()).limit(limit)
                 ).all()
-                return json.dumps(bounties_to_dict(newest_bounties, session=session))
+                bounty_dicts = bounties_to_dict(newest_bounties, session=session)
+                return MCPTextResult(
+                    text=json.dumps(bounty_dicts, indent=2),
+                    structured_content=bounty_dicts,
+                )
             bounties = session.scalars(query.order_by(Bounty.id.desc())).all()
             sorted_bounties = sort_bounties(
                 filter_bounties_by_availability(
@@ -243,7 +247,11 @@ def call_mcp_tool(
                 ),
                 sort,
             )
-            return json.dumps(sorted_bounties[:limit])
+            result = sorted_bounties[:limit]
+            return MCPTextResult(
+                text=json.dumps(result, indent=2),
+                structured_content=result,
+            )
         if name == "get_bounty":
             bounty = selected_bounty("id", internal_id_aliases=("bounty_id",))
             if bounty is None:
@@ -251,7 +259,10 @@ def call_mcp_tool(
             bounty_data = bounty_to_dict(bounty, session=session)
             if optional_bool_arg("include_awards"):
                 bounty_data["awards"] = bounty_awards_to_dict(session, bounty.id)
-            return json.dumps(bounty_data)
+            return MCPTextResult(
+                text=json.dumps(bounty_data, indent=2),
+                structured_content=bounty_data,
+            )
         if name == "list_bounty_attempts":
             bounty = selected_bounty("bounty_id", internal_id_aliases=("id",))
             if bounty is None:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -9,6 +9,15 @@ from app.ledger.service import create_bounty, ensure_genesis
 from app.mcp_tools import call_mcp_tool
 
 
+from app.mcp_results import MCPTextResult
+
+def _get_content(r: str | dict[str, object] | MCPTextResult) -> list | dict:
+    """Extract json content from MCPTextResult or raw string."""
+    if isinstance(r, MCPTextResult):
+        return r.structured_content
+    return json.loads(r)
+
+
 def test_call_mcp_tool_lists_bounties_from_extracted_dispatcher(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     with session_scope(sqlite_url) as session:
@@ -25,9 +34,13 @@ def test_call_mcp_tool_lists_bounties_from_extracted_dispatcher(sqlite_url: str)
 
     result = call_mcp_tool(sqlite_url, "list_bounties", {"status": "open"})
 
-    bounties = json.loads(result)
+    bounties = _get_content(result)
     assert bounties[0]["issue_number"] == 390
     assert bounties[0]["title"] == "Code health bounty"
+    # Verify structured content is returned
+    if isinstance(result, MCPTextResult):
+        assert isinstance(result.structured_content, list)
+        assert "structuredContent" in dir(result) or hasattr(result, "structured_content")
 
 
 def test_call_mcp_tool_filters_bounties_by_repo_and_issue_number(sqlite_url: str) -> None:
@@ -59,7 +72,7 @@ def test_call_mcp_tool_filters_bounties_by_repo_and_issue_number(sqlite_url: str
         {"repo": "example/mergework", "issue_number": 390},
     )
 
-    bounties = json.loads(result)
+    bounties = _get_content(result)
     assert [bounty["id"] for bounty in bounties] == [target.id]
 
 
@@ -168,3 +181,71 @@ def test_call_mcp_tool_rejects_c1_nonce_before_integer_parsing(sqlite_url: str) 
                 "signature_hex": "00" * 64,
             },
         )
+
+
+# ─── Conformance: structuredContent output ────────────────────
+
+def test_mcp_tool_list_bounties_returns_structured_content(sqlite_url: str) -> None:
+    """Conformance: list_bounties returns structuredContent with full bounty payload."""
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=395,
+            issue_url="https://github.com/ramimbo/mergework/issues/395",
+            title="Conformance test bounty",
+            reward_mrwk="100",
+            acceptance="Structured conformance.",
+        )
+
+    result = call_mcp_tool(sqlite_url, "list_bounties", {"status": "open"})
+    assert isinstance(result, MCPTextResult), "list_bounties should return MCPTextResult"
+    assert result.structured_content is not None, "structured_content should not be None"
+    assert isinstance(result.structured_content, list), "structured_content should be a list"
+    assert len(result.structured_content) > 0, "structured_content should not be empty"
+    assert result.structured_content[0]["issue_number"] == 395
+    assert result.structured_content[0]["reward_mrwk"] == "100"
+    assert "title" in result.structured_content[0]
+    assert "id" in result.structured_content[0]
+    # Human-readable text preserved
+    assert "Conformance test bounty" in result.text
+
+
+def test_mcp_tool_get_bounty_returns_structured_content(sqlite_url: str) -> None:
+    """Conformance: get_bounty returns structuredContent with full bounty payload."""
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+        bounty = create_bounty(
+            session,
+            repo="ramimbo/mergework",
+            issue_number=396,
+            issue_url="https://github.com/ramimbo/mergework/issues/396",
+            title="Get bounty conformance",
+            reward_mrwk="150",
+            acceptance="Structured conformance for get_bounty.",
+        )
+
+    result = call_mcp_tool(sqlite_url, "get_bounty", {"id": bounty.id})
+    assert isinstance(result, MCPTextResult), "get_bounty should return MCPTextResult"
+    assert result.structured_content is not None
+    assert result.structured_content["issue_number"] == 396
+    assert result.structured_content["reward_mrwk"] == "150"
+    assert result.structured_content["title"] == "Get bounty conformance"
+    assert "Get bounty conformance" in result.text
+
+
+def test_mcp_tool_get_balance_returns_structured_content(sqlite_url: str) -> None:
+    """Conformance: get_balance returns structuredContent with account and balance."""
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    result = call_mcp_tool(sqlite_url, "get_balance", {"account": "treasury:mrwk"})
+    assert isinstance(result, MCPTextResult), "get_balance should return MCPTextResult"
+    assert result.structured_content is not None
+    assert "account" in result.structured_content
+    assert "balance_mrwk" in result.structured_content
+    assert result.structured_content["account"] == "treasury:mrwk"


### PR DESCRIPTION
### Fix Issue #946

MCP structured-output improvement for key JSON-returning tools:

**Changes:**
- `list_bounties` now returns `MCPTextResult` with explicit `structured_content`
- `get_bounty` now returns `MCPTextResult` with explicit `structured_content`
- Both preserve human-readable text (prettified JSON) while exposing machine-readable structured data

**Conformance tests added:**
- `test_mcp_tool_list_bounties_returns_structured_content`
- `test_mcp_tool_get_bounty_returns_structured_content`
- `test_mcp_tool_get_balance_returns_structured_content`

Backward compatible: all existing JSON output shapes preserved.

Closes #946

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool responses now include both human-readable text and structured data, making results easier to display and consume.
  * Bounty list and bounty detail outputs now return richer, more consistent response content.

* **Bug Fixes**
  * Improved handling of bounty-related responses so structured information is preserved alongside the visible text output.

* **Tests**
  * Updated and expanded coverage to verify structured response content and ensure key fields remain available in tool results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->