### PR TITLE
[agent] Add public MRWK link health checks (#1119)

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -352,8 +352,14 @@ the reviewer login:
 python scripts/review_bounty_candidates.py \
   --repo ramimbo/mergework \
   --reviewer reviewer-login \
+  --bounty-issue 654 \
   --format markdown
 ```
+
+When `--bounty-issue` is supplied in live mode, the report also ingests that
+issue's claim comments and classifies duplicate/stale claim risk (`already_claimed_on_bounty_issue`,
+`already_claimed_current_head`, `claimed_by_pr_comment`, `claimed_stale_head_or_base`,
+`dirty_unclaimed_current_base_candidate`) with matched claim URLs for auditability.
 
 The report classifies open PRs as fresh review candidates, self-authored,
 already reviewed at the current head by that reviewer, already covered by
@@ -437,6 +443,30 @@ balances. Keep the legacy callback
 `https://mrwk.ltclab.site/auth/github/callback` available only if old browser
 links still need it. If the GitHub app is rotated later, update deployment
 secrets outside the repository and restart Docker Compose.
+
+After deploy or when bounty comments look stale, run the public link health
+check against representative bounty, proposal, proof, and OAuth URLs:
+
+```bash
+python scripts/check_public_mrwk_links.py --input fixtures/public_mrwk_links.json --fail-on-issues
+# `--input` live-probes each listed URL (fixture stores URL + type only)
+# `--input` live-probes each listed URL (fixture stores URL + type only)
+```
+
+The script fails when a published link returns any non-2xx/3xx status (outside 200–399) or an Express
+`Cannot GET` shell instead of the expected public detail response. OAuth routes
+use a separate health rule: `422` or `503` from FastAPI means the route is
+registered, while `404` or an Express shell means production is serving the
+wrong app (see issue #1146).
+
+Post-deploy, also run:
+
+```bash
+docker compose run --rm app python scripts/check_deploy_ready.py
+```
+
+That gate now verifies GitHub OAuth login/callback routes are registered in
+the built app before a release goes live.
 
 ## Disputes
 

--- a/fixtures/public_mrwk_links.json
+++ b/fixtures/public_mrwk_links.json
@@ -1,0 +1,24 @@
+{
+  "links": [
+    {
+      "url": "https://mrwk.online/auth/github/login",
+      "type": "oauth"
+    },
+    {
+      "url": "https://mrwk.online/auth/github/callback",
+      "type": "oauth"
+    },
+    {
+      "url": "https://mrwk.online/bounties/120",
+      "type": "bounty"
+    },
+    {
+      "url": "https://api.mrwk.online/api/v1/treasury/proposals/211",
+      "type": "proposal"
+    },
+    {
+      "url": "https://mrwk.online/proofs/abc123",
+      "type": "proof"
+    }
+  ]
+}

--- a/scripts/check_public_mrwk_links.py
+++ b/scripts/check_public_mrwk_links.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, cast
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+EXPRESS_CANNOT_GET = "Cannot GET"
+DEFAULT_USER_AGENT = "mergework-public-link-health-check"
+GH_TIMEOUT_SECONDS = 30
+
+
+def is_healthy_oauth_route(status_code: int | None, body: str) -> bool:
+    if status_code is None:
+        return False
+    if EXPRESS_CANNOT_GET in body:
+        return False
+    if status_code == 404:
+        return False
+    return status_code in {200, 302, 422, 503}
+
+
+def is_healthy_link(status_code: int | None, body: str, *, link_type: str = "unknown") -> bool:
+    if link_type == "oauth":
+        return is_healthy_oauth_route(status_code, body)
+    if status_code is None or status_code < 200 or status_code >= 400:
+        return False
+    return EXPRESS_CANNOT_GET not in body
+
+
+def analyze_probe_results(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    violations: list[dict[str, Any]] = []
+    for row in rows:
+        url = str(row.get("url") or "")
+        status_code = row.get("status_code")
+        body = str(row.get("body") or "")
+        link_type = str(row.get("type") or "unknown")
+        if is_healthy_link(status_code, body, link_type=link_type):
+            continue
+        detail = f"{link_type} link unhealthy: HTTP {status_code}"
+        if EXPRESS_CANNOT_GET in body:
+            detail += " (Express Cannot GET shell)"
+        violations.append(
+            {
+                "url": url,
+                "type": link_type,
+                "status_code": status_code,
+                "detail": detail,
+                "source": row.get("source"),
+            }
+        )
+    return {
+        "summary": {
+            "checked_links": len(rows),
+            "unhealthy_links": len(violations),
+        },
+        "violations": violations,
+    }
+
+
+def probe_url(url: str, *, timeout: float = GH_TIMEOUT_SECONDS) -> dict[str, Any]:
+    if not url.lower().startswith(("http://", "https://")):
+        return {
+            "url": url,
+            "status_code": None,
+            "body": "unsupported URL scheme (http/https only)",
+        }
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "*/*",
+            "User-Agent": DEFAULT_USER_AGENT,
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read(4096).decode("utf-8", errors="replace")
+            return {
+                "url": url,
+                "status_code": response.status,
+                "body": body,
+            }
+    except urllib.error.HTTPError as exc:
+        body = exc.read(4096).decode("utf-8", errors="replace")
+        return {
+            "url": url,
+            "status_code": exc.code,
+            "body": body,
+        }
+    except urllib.error.URLError as exc:
+        return {
+            "url": url,
+            "status_code": None,
+            "body": str(exc.reason or exc),
+        }
+
+
+def load_input_rows(path: Path) -> list[dict[str, Any]]:
+    """Load URL targets from a fixture. Precomputed status/body fields are ignored."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        raw_rows = cast(list[dict[str, Any]], payload)
+    elif isinstance(payload, dict) and isinstance(payload.get("links"), list):
+        raw_rows = cast(list[dict[str, Any]], payload["links"])
+    else:
+        raise ValueError("Input JSON must be a list of link probes or an object with a links array")
+    rows: list[dict[str, Any]] = []
+    for item in raw_rows:
+        if not isinstance(item, dict):
+            continue
+        url = str(item.get("url") or "").strip()
+        if not url:
+            continue
+        rows.append(
+            {
+                "url": url,
+                "type": str(item.get("type") or "unknown"),
+                "source": str(item.get("source") or path.name),
+            }
+        )
+    return rows
+
+
+def format_report(report: dict[str, Any], *, fmt: str) -> str:
+    if fmt == "json":
+        return json.dumps(report, indent=2, sort_keys=True)
+    lines = [
+        "Public MRWK link health check",
+        f"- checked: {report['summary']['checked_links']}",
+        f"- unhealthy: {report['summary']['unhealthy_links']}",
+    ]
+    for violation in report["violations"]:
+        lines.append(f"- {violation['detail']}: {violation['url']}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate public MRWK bounty/proposal/proof links.",
+    )
+    parser.add_argument("--input", type=Path, help="JSON fixture with link URL targets")
+    parser.add_argument("--url", action="append", default=[], help="Live URL to probe")
+    parser.add_argument(
+        "--type",
+        default="unknown",
+        help="Default link type label for --url probes",
+    )
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--fail-on-issues", action="store_true")
+    args = parser.parse_args(argv)
+
+    rows: list[dict[str, Any]] = []
+    if args.input:
+        for target in load_input_rows(args.input):
+            probed = probe_url(str(target["url"]))
+            probed["type"] = target.get("type") or "unknown"
+            probed["source"] = target.get("source") or args.input.name
+            rows.append(probed)
+    for url in args.url:
+        row = probe_url(url)
+        row["type"] = args.type
+        row["source"] = "--url"
+        rows.append(row)
+
+    if not rows:
+        parser.error("Provide --input or at least one --url")
+
+    report = analyze_probe_results(rows)
+    print(format_report(report, fmt=args.format))
+    if args.fail_on_issues and report["summary"]["unhealthy_links"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_public_mrwk_links.py
+++ b/tests/test_check_public_mrwk_links.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts import check_public_mrwk_links
+from scripts.check_public_mrwk_links import analyze_probe_results, is_healthy_link, main
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_analyze_probe_results_flags_express_cannot_get() -> None:
+    report = analyze_probe_results(
+        [
+            {
+                "url": "https://mrwk.online/bounties/120",
+                "type": "bounty",
+                "status_code": 404,
+                "body": "Cannot GET /bounties/120",
+            },
+            {
+                "url": "https://api.mrwk.online/api/v1/treasury/proposals/211",
+                "type": "proposal",
+                "status_code": 404,
+                "body": "Cannot GET /api/v1/treasury/proposals/211",
+            },
+            {
+                "url": "https://mrwk.online/proofs/abc123",
+                "type": "proof",
+                "status_code": 200,
+                "body": '{"hash":"abc123","kind":"bounty_payment"}',
+            },
+        ]
+    )
+
+    assert report["summary"] == {"checked_links": 3, "unhealthy_links": 2}
+    assert [item["type"] for item in report["violations"]] == ["bounty", "proposal"]
+    assert all("Cannot GET" in item["detail"] for item in report["violations"])
+
+
+def test_is_healthy_link_accepts_redirect_ready_responses() -> None:
+    assert is_healthy_link(200, '{"status":"open"}')
+    assert is_healthy_link(302, "")
+    assert not is_healthy_link(404, "Cannot GET /proofs/x")
+    assert not is_healthy_link(None, "timed out")
+    assert is_healthy_link(422, '{"detail":[]}', link_type="oauth")
+    assert not is_healthy_link(422, '{"detail":[]}', link_type="bounty")
+
+
+def test_check_public_mrwk_links_cli_live_probes_input(tmp_path, capsys, monkeypatch) -> None:
+    fixture = {
+        "links": [
+            {
+                "url": "https://mrwk.online/bounties/120",
+                "type": "bounty",
+            }
+        ]
+    }
+    input_path = tmp_path / "links.json"
+    input_path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    def fake_probe(url: str, *, timeout: float = 30) -> dict:
+        assert url == "https://mrwk.online/bounties/120"
+        return {"url": url, "status_code": 200, "body": '{"id":120,"status":"open"}'}
+
+    monkeypatch.setattr(check_public_mrwk_links, "probe_url", fake_probe)
+    exit_code = main(["--input", str(input_path), "--format", "text"])
+    assert exit_code == 0
+    assert "unhealthy: 0" in capsys.readouterr().out
+
+
+def test_check_public_mrwk_links_fail_on_issues(tmp_path, monkeypatch) -> None:
+    fixture = {"links": [{"url": "https://mrwk.online/bounties/missing", "type": "bounty"}]}
+    input_path = tmp_path / "links.json"
+    input_path.write_text(json.dumps(fixture), encoding="utf-8")
+
+    monkeypatch.setattr(
+        check_public_mrwk_links,
+        "probe_url",
+        lambda url, *, timeout=30: {
+            "url": url,
+            "status_code": 404,
+            "body": "Cannot GET /bounties/missing",
+        },
+    )
+    assert main(["--input", str(input_path), "--fail-on-issues"]) == 1
+
+
+def test_check_public_mrwk_links_script_entrypoint() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "check_public_mrwk_links.py"), "--help"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "--fail-on-issues" in result.stdout


### PR DESCRIPTION
## Summary

Adds a read-only maintenance script that validates public bounty, proposal, and proof URLs published in GitHub bounty comments. It flags HTTP 4xx/5xx responses and Express `Cannot GET` shells so maintainers catch broken public links before contributors do.

## Changes

- `scripts/check_public_mrwk_links.py` — probe/analyze helper with `--input`, `--url`, and `--fail-on-issues`
- `tests/test_check_public_mrwk_links.py` — fixture coverage for bounty/proposal/proof pass and fail cases
- `docs/admin-runbook.md` — runbook note with example command

## Verification

```bash
pytest tests/test_check_public_mrwk_links.py -q
python scripts/check_public_mrwk_links.py --help
```

Fixes #1119

Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public MRWK link health-check CLI covering representative oauth, bounty, proposal, and proof endpoints.
  * Supports live URL probes or a JSON fixture, with text/JSON reporting and an option to fail when issues are found.
* **Bug Fixes**
  * Improved health evaluation with OAuth-specific rules and detection of unexpected “Cannot GET” responses.
* **Documentation**
  * Expanded the admin runbook with new post-deploy gates and maintenance steps, including public link checks, OAuth route readiness, and template/smoke maintenance.
* **Tests**
  * Added pytest coverage for health rules, reporting, and CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->