### PR TITLE
fix(auth): reject repeated OAuth query params (#820)

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -12,6 +12,7 @@ from fastapi.responses import RedirectResponse
 
 from app.config import Settings
 from app.control_chars import contains_control_character
+from app.query_validation import reject_control_char_query_param, reject_repeated_query_param
 
 
 def oauth_configured(settings: Settings) -> bool:
@@ -109,7 +110,11 @@ def register_auth_routes(app: FastAPI, *, settings: Settings) -> AuthService:
     auth = AuthService(settings)
 
     @app.get("/auth/github/login")
-    def auth_github_login(next_path: str | None = Query(None, alias="next")) -> RedirectResponse:
+    def auth_github_login(
+        request: Request, next_path: str | None = Query(None, alias="next")
+    ) -> RedirectResponse:
+        reject_repeated_query_param(request, "next")
+        reject_control_char_query_param(request, "next")
         if not oauth_configured(settings):
             raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
         safe_next = safe_next_path(next_path)
@@ -133,6 +138,9 @@ def register_auth_routes(app: FastAPI, *, settings: Settings) -> AuthService:
 
     @app.get("/auth/github/callback")
     async def auth_github_callback(request: Request, code: str, state: str) -> RedirectResponse:
+        for name in ("code", "state"):
+            reject_repeated_query_param(request, name)
+            reject_control_char_query_param(request, name)
         if not oauth_configured(settings):
             raise HTTPException(status_code=503, detail="GitHub OAuth is not configured")
         cookie_state = request.cookies.get("mrwk_oauth_state")

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -656,6 +656,47 @@ def test_github_login_stores_safe_default_for_backslash_next(sqlite_url: str, mo
     assert next_path == "/me"
 
 
+def test_github_login_rejects_repeated_next(sqlite_url: str, monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    monkeypatch.setenv("MERGEWORK_PUBLIC_BASE_URL", "https://mrwk.example.test")
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/auth/github/login?next=/me&next=/admin", follow_redirects=False)
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "next must be provided at most once"
+
+
+def test_github_callback_rejects_repeated_state(sqlite_url: str, monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    monkeypatch.setenv("MERGEWORK_PUBLIC_BASE_URL", "https://mrwk.example.test")
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(
+        "/auth/github/callback?code=abc&code=def&state=xyz",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "code must be provided at most once"
+
+
+def test_github_oauth_callback_route_is_registered(sqlite_url: str, monkeypatch) -> None:
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_ID", "client-id")
+    monkeypatch.setenv("MERGEWORK_GITHUB_OAUTH_CLIENT_SECRET", "client-secret")
+    monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
+    monkeypatch.setenv("MERGEWORK_PUBLIC_BASE_URL", "https://mrwk.example.test")
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/auth/github/callback", follow_redirects=False)
+
+    assert response.status_code == 422
+
+
 def test_wallet_pages_expose_transfer_and_github_claim_flows(sqlite_url: str) -> None:
     create_schema(sqlite_url)
     _, public_hex, address = _keypair()


### PR DESCRIPTION
## Summary

Harden GitHub OAuth login and callback routes against repeated scalar query
parameters (`next`, `code`, `state`) using the existing
`reject_repeated_query_param` and `reject_control_char_query_param` helpers.
Closes #820.

## Changes

- `app/auth.py`
  - `/auth/github/login`: validate `next` before redirect.
  - `/auth/github/callback`: validate `code` and `state` before token exchange.
- `tests/test_wallet_api.py`
  - Reject repeated `next` on login (400).
  - Reject repeated `code` on callback (400).
  - Regression: `/auth/github/callback` is registered (422 without params, not 404).

## Why

FastAPI silently accepts the last value when a scalar query param is repeated.
For OAuth flows that is ambiguous and can mask proxy/cache bugs. Matching the
wallet API query validation pattern keeps behavior consistent and fail-fast.

## Test plan

```bash
python -m pytest tests/test_wallet_api.py -k github
```

## Wallet

`Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

Closes #820


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation on GitHub sign-in and callback requests to reject repeated query parameters and suspicious control characters.
  * Added safeguards so malformed OAuth request data is blocked before login or token exchange continues.

* **Tests**
  * Added coverage for duplicate query-parameter handling on GitHub login and callback flows.
  * Verified the GitHub callback route is registered and responds as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->