### PR TITLE
fix(scripts): reject empty report source args (#807)

### DIFF
--- a/scripts/claim_inventory.py
+++ b/scripts/claim_inventory.py
@@ -680,6 +680,15 @@ def _load_input(path: str) -> dict[str, Any]:
     return data
 
 
+def _require_non_empty_arg(parser: argparse.ArgumentParser, option_name: str, value: str) -> str:
+    stripped = value.strip()
+    if not stripped:
+        parser.error(f"{option_name} must be a non-empty value")
+    if stripped != value:
+        parser.error(f"{option_name} must not include leading or trailing whitespace")
+    return value
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Inventory public MergeWork claim surfaces and payout status."
@@ -691,7 +700,12 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--format", choices=["json", "markdown"], default="markdown")
     args = parser.parse_args(argv)
 
-    data = _load_input(args.input) if args.input else load_live_inventory(args.repo, args.api_host)
+    if args.input is not None:
+        data = _load_input(_require_non_empty_arg(parser, "--input", args.input))
+    else:
+        data = load_live_inventory(
+            _require_non_empty_arg(parser, "--repo", args.repo), args.api_host
+        )
     report = analyze_inventory(data, api_host=args.api_host)
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/scripts/pr_queue_health.py
+++ b/scripts/pr_queue_health.py
@@ -194,7 +194,11 @@ def analyze_queue(data: dict[str, Any]) -> dict[str, Any]:
             duplicate_groups[(ref, pr["scope"])].append(pr["number"])
         if pr["merge_state"] in UNSTABLE_MERGE_STATES:
             dirty_or_unstable_merge_state.append(
-                _issue(pr, "dirty_or_unstable_merge_state", f"Merge state is {pr['merge_state']}")
+                _issue(
+                    pr,
+                    "dirty_or_unstable_merge_state",
+                    f"Merge state is {pr['merge_state']}",
+                )
             )
         if any(label.lower() == "mrwk:needs-info" for label in pr["labels"]):
             needs_info.append(_issue(pr, "mrwk_needs_info", "PR has mrwk:needs-info label"))
@@ -435,6 +439,15 @@ def _load_input(path: str) -> dict[str, Any]:
     return data
 
 
+def _require_non_empty_arg(parser: argparse.ArgumentParser, option_name: str, value: str) -> str:
+    stripped = value.strip()
+    if not stripped:
+        parser.error(f"{option_name} must be a non-empty value")
+    if stripped != value:
+        parser.error(f"{option_name} must not include leading or trailing whitespace")
+    return value
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Summarize MergeWork open PR queue health.")
     source = parser.add_mutually_exclusive_group(required=True)
@@ -447,7 +460,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--fail-on-issues", action="store_true")
     args = parser.parse_args(argv)
 
-    data = _load_input(args.input) if args.input else load_live_queue(args.repo)
+    if args.input is not None:
+        data = _load_input(_require_non_empty_arg(parser, "--input", args.input))
+    else:
+        data = load_live_queue(_require_non_empty_arg(parser, "--repo", args.repo))
     report = analyze_queue(data)
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))


### PR DESCRIPTION
## Summary

Harden remaining maintainer report scripts so empty or whitespace-padded `--input` / `--repo` source arguments fail with bounded argparse errors instead of tracebacks or malformed live-mode calls.

## Changes

- `scripts/proposed_work_triage.py` — validate `--repo` and `--input` paths
- `scripts/claim_inventory.py` — validate `--input` / `--repo`
- `scripts/pr_queue_health.py` — validate `--input` / `--repo`
- Tests mirror `#801` / `#805` patterns for empty and whitespace-padded CLI args

Fixes #807

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter CLI input validation to reject empty values and any leading/trailing whitespace for source arguments.
  * Improved safety-limit enforcement for GitHub data collection so runs fail fast when result thresholds are reached.
* **New Features**
  * Introduced clearer separation of safety thresholds between public API and live repository collection.
* **Tests**
  * Expanded automated coverage for invalid CLI inputs and safety-cap behavior across inventory, queue health, and triage workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->