### PR TITLE
feat(scripts): add review-bounty claim saturation checks (#797)

### DIFF
--- a/scripts/review_bounty_candidates.py
+++ b/scripts/review_bounty_candidates.py
@@ -2,16 +2,55 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
-from collections import Counter
+from collections import Counter, defaultdict
+from pathlib import Path
 from typing import Any
 
-DIRTY_MERGE_STATES = {"blocked", "conflicting", "dirty"}
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 GH_TIMEOUT_SECONDS = 30
+
+DIRTY_MERGE_STATES = {"blocked", "conflicting", "dirty"}
 GH_PR_SAFETY_CAP = 201
 STANDARD_QUALITY_CHECK = "Quality, readiness, docs, and image checks"
 HUMAN_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED", "COMMENTED"}
+CLAIM_SIGNAL_RE = re.compile(
+    r"(^|\s)(/claim|claim(?:ing)?|reviewed|review bounty|evidence)(\b|\s|:)",
+    re.IGNORECASE,
+)
+PR_REVIEW_EVIDENCE_RE = re.compile(
+    r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)#pullrequestreview-\d+",
+    re.IGNORECASE,
+)
+PR_COMMENT_EVIDENCE_RE = re.compile(
+    r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)#issuecomment-\d+",
+    re.IGNORECASE,
+)
+PR_LINK_RE = re.compile(
+    r"https://github\.com/([^/]+)/([^/]+)/pull/(\d+)",
+    re.IGNORECASE,
+)
+PR_NUMBER_REF_RE = re.compile(r"\bpull/(\d+)\b|\bPR\s+#(\d+)\b", re.IGNORECASE)
+LABELED_HEAD_SHA_RE = re.compile(
+    r"(?:head(?:RefOid| ref| sha| oid)?|head)\s*[:=]\s*[`']?([0-9a-f]{40})[`']?",
+    re.IGNORECASE,
+)
+LABELED_BASE_SHA_RE = re.compile(
+    r"(?:base(?:RefOid| ref| sha| oid)?|origin/main|main sha|main)"
+    r"\s*[:=]\s*[`']?([0-9a-f]{40})[`']?",
+    re.IGNORECASE,
+)
+SATURATION_PROTECTED_STATES = {
+    "self_authored",
+    "needs_info",
+    "already_reviewed_current_head_by_reviewer",
+    "already_has_sufficient_current_head_human_reviews",
+    "waiting_for_author_update",
+}
 
 
 def _login(raw: Any) -> str:
@@ -56,6 +95,104 @@ def _head_oid(raw: dict[str, Any]) -> str:
         if isinstance(value, str) and value:
             return value
     return ""
+
+
+def _base_oid(raw: dict[str, Any]) -> str:
+    for key in ("baseRefOid", "base_ref_oid", "base_sha", "base"):
+        value = raw.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _comment_url(comment: dict[str, Any]) -> str:
+    for key in ("html_url", "url"):
+        value = comment.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _repo_matches(owner: str, name: str, repo: str) -> bool:
+    try:
+        expected_owner, expected_name = repo.split("/", 1)
+    except ValueError:
+        return False
+    return owner.lower() == expected_owner.lower() and name.lower() == expected_name.lower()
+
+
+def _parse_claim_comment(comment: dict[str, Any], *, repo: str) -> list[dict[str, Any]]:
+    body = str(comment.get("body") or "")
+    if not body.strip():
+        return []
+    if not (
+        CLAIM_SIGNAL_RE.search(body)
+        or PR_REVIEW_EVIDENCE_RE.search(body)
+        or PR_COMMENT_EVIDENCE_RE.search(body)
+    ):
+        return []
+
+    pr_evidence: dict[int, tuple[str, str]] = {}
+    for match in PR_REVIEW_EVIDENCE_RE.finditer(body):
+        if _repo_matches(match.group(1), match.group(2), repo):
+            pr_evidence[int(match.group(3))] = (match.group(0), "pr_review")
+    for match in PR_COMMENT_EVIDENCE_RE.finditer(body):
+        if _repo_matches(match.group(1), match.group(2), repo):
+            pr = int(match.group(3))
+            pr_evidence.setdefault(pr, (match.group(0), "pr_comment"))
+    for match in PR_LINK_RE.finditer(body):
+        if _repo_matches(match.group(1), match.group(2), repo):
+            pr = int(match.group(3))
+            pr_evidence.setdefault(pr, (match.group(0).split("#", 1)[0], "pr_reference"))
+    for match in PR_NUMBER_REF_RE.finditer(body):
+        pr_str = match.group(1) or match.group(2)
+        if pr_str:
+            pr = int(pr_str)
+            pr_evidence.setdefault(
+                pr,
+                (f"https://github.com/{repo}/pull/{pr}", "pr_reference"),
+            )
+
+    if not pr_evidence:
+        return []
+
+    head_sha = None
+    base_sha = None
+    labeled_head = LABELED_HEAD_SHA_RE.search(body)
+    if labeled_head:
+        head_sha = labeled_head.group(1).lower()
+    labeled_base = LABELED_BASE_SHA_RE.search(body)
+    if labeled_base:
+        base_sha = labeled_base.group(1).lower()
+
+    claim_url = _comment_url(comment)
+    claimant = _display_login(comment.get("author") or comment.get("user"))
+    submitted_at = comment.get("created_at") or comment.get("createdAt")
+    records: list[dict[str, Any]] = []
+    for pr, (evidence_url, evidence_kind) in sorted(pr_evidence.items()):
+        records.append(
+            {
+                "pull_request": pr,
+                "claim_url": claim_url,
+                "evidence_url": evidence_url,
+                "evidence_kind": evidence_kind,
+                "head_sha": head_sha,
+                "base_sha": base_sha,
+                "claimant": claimant,
+                "submitted_at": submitted_at,
+            }
+        )
+    return records
+
+
+def index_bounty_claims(comments: list[Any], *, repo: str) -> dict[int, list[dict[str, Any]]]:
+    by_pr: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for comment in comments:
+        if not isinstance(comment, dict):
+            continue
+        for record in _parse_claim_comment(comment, repo=repo):
+            by_pr[int(record["pull_request"])].append(record)
+    return dict(by_pr)
 
 
 def _check_name(check: dict[str, Any]) -> str:
@@ -202,6 +339,7 @@ def _classify_pr(
         "state": state,
         "reason": reason,
         "headRefOid": head_oid or None,
+        "baseRefOid": _base_oid(raw) or None,
         "mergeStateStatus": merge_state,
         "standard_quality_check": quality_state,
         "labels": labels,
@@ -210,24 +348,116 @@ def _classify_pr(
     }
 
 
+def _attach_claim_metadata(row: dict[str, Any], claims: list[dict[str, Any]]) -> None:
+    if not claims:
+        return
+    row["bounty_claims"] = [
+        {key: value for key, value in claim.items() if key != "pull_request"} for claim in claims
+    ]
+    row["matched_claim_urls"] = [
+        str(claim["claim_url"]) for claim in claims if claim.get("claim_url")
+    ]
+    latest = claims[-1]
+    if latest.get("evidence_kind"):
+        row["claim_evidence_kind"] = latest["evidence_kind"]
+    if latest.get("evidence_url"):
+        row["matched_evidence_urls"] = [
+            str(claim["evidence_url"]) for claim in claims if claim.get("evidence_url")
+        ]
+
+
+def _apply_bounty_saturation(
+    row: dict[str, Any],
+    *,
+    claims: list[dict[str, Any]],
+    merge_state: str,
+    head_oid: str,
+    base_oid: str,
+) -> dict[str, Any]:
+    if not claims:
+        if merge_state in DIRTY_MERGE_STATES and row["state"] == "dirty_or_conflicted":
+            row["state"] = "dirty_unclaimed_current_base_candidate"
+            row["reason"] = (
+                "dirty/conflicted PR has no review-bounty claim; "
+                "current-base follow-up may be useful"
+            )
+        return row
+
+    _attach_claim_metadata(row, claims)
+    if row["state"] in SATURATION_PROTECTED_STATES:
+        return row
+
+    latest = claims[-1]
+    claim_head = str(latest.get("head_sha") or "").lower()
+    claim_base = str(latest.get("base_sha") or "").lower()
+    head = head_oid.lower()
+    base = base_oid.lower()
+    evidence_kind = str(latest.get("evidence_kind") or "")
+
+    stale = False
+    stale_reason = "review-bounty claim may be stale"
+    if claim_head and head and claim_head != head:
+        stale = True
+        stale_reason = f"claim head {claim_head[:7]} differs from current head {head[:7]}"
+    elif claim_base and base and claim_base != base:
+        stale = True
+        stale_reason = f"claim base {claim_base[:7]} differs from current base {base[:7]}"
+    elif merge_state in DIRTY_MERGE_STATES and claim_head and head and claim_head == head:
+        stale = True
+        stale_reason = "PR is dirty/conflicted after a clean-current-head bounty claim"
+
+    if stale:
+        row["state"] = "claimed_stale_head_or_base"
+        row["reason"] = stale_reason
+    elif evidence_kind == "pr_comment":
+        row["state"] = "claimed_by_pr_comment"
+        row["reason"] = "review-bounty claim uses PR comment evidence"
+    elif claim_head and head and claim_head == head:
+        row["state"] = "already_claimed_current_head"
+        row["reason"] = "review-bounty claim matches current PR head"
+    else:
+        row["state"] = "already_claimed_on_bounty_issue"
+        row["reason"] = "PR already referenced on review bounty issue"
+    return row
+
+
 def analyze_candidates(
     data: dict[str, Any],
     *,
     reviewer: str,
     sufficient_reviews: int = 1,
+    repo: str | None = None,
 ) -> dict[str, Any]:
     reviewer_login = reviewer.strip().lower()
     if not reviewer_login:
         raise ValueError("reviewer must not be empty")
     if sufficient_reviews < 1:
         raise ValueError("sufficient_reviews must be at least 1")
-    rows = [
-        _classify_pr(raw, reviewer=reviewer_login, sufficient_reviews=sufficient_reviews)
-        for raw in data.get("pull_requests", [])
-        if isinstance(raw, dict) and isinstance(raw.get("number"), int)
-    ]
+
+    effective_repo = repo or (data.get("repo") if isinstance(data.get("repo"), str) else None)
+    claims_by_pr: dict[int, list[dict[str, Any]]] = {}
+    raw_comments = data.get("bounty_claim_comments")
+    saturation_enabled = isinstance(effective_repo, str) and "bounty_claim_comments" in data
+    if saturation_enabled and isinstance(raw_comments, list):
+        claims_by_pr = index_bounty_claims(raw_comments, repo=effective_repo)
+
+    rows: list[dict[str, Any]] = []
+    for raw in data.get("pull_requests", []):
+        if not isinstance(raw, dict) or not isinstance(raw.get("number"), int):
+            continue
+        row = _classify_pr(raw, reviewer=reviewer_login, sufficient_reviews=sufficient_reviews)
+        if saturation_enabled:
+            row = _apply_bounty_saturation(
+                row,
+                claims=claims_by_pr.get(int(raw["number"]), []),
+                merge_state=_merge_state(raw),
+                head_oid=_head_oid(raw),
+                base_oid=_base_oid(raw),
+            )
+        rows.append(row)
+
     counts = Counter(row["state"] for row in rows)
-    return {
+    report: dict[str, Any] = {
         "reviewer": reviewer_login,
         "summary": {
             "pull_requests": len(rows),
@@ -235,6 +465,9 @@ def analyze_candidates(
         },
         "pull_requests": rows,
     }
+    if effective_repo and saturation_enabled:
+        report["bounty_issue_claims_indexed"] = sum(len(items) for items in claims_by_pr.values())
+    return report
 
 
 def _single_line(value: Any) -> str:
@@ -246,9 +479,12 @@ def format_text_report(report: dict[str, Any]) -> str:
     for key, value in report["summary"].items():
         lines.append(f"- {key.replace('_', ' ')}: {value}")
     for row in report["pull_requests"]:
+        claim_note = ""
+        if row.get("matched_claim_urls"):
+            claim_note = f" claims={','.join(row['matched_claim_urls'])}"
         lines.append(
             f"- PR #{row['pull_request']}: {row['state']} - "
-            f"{_single_line(row['title'])} ({_single_line(row['reason'])})"
+            f"{_single_line(row['title'])} ({_single_line(row['reason'])}){claim_note}"
         )
     return "\n".join(lines)
 
@@ -261,9 +497,13 @@ def format_markdown_report(report: dict[str, Any]) -> str:
         label = f"PR #{row['pull_request']}"
         if row.get("url"):
             label = f"[{label}]({row['url']})"
+        claim_note = ""
+        if row.get("matched_claim_urls"):
+            urls = ", ".join(f"`{url}`" for url in row["matched_claim_urls"])
+            claim_note = f" Claims: {urls}."
         lines.append(
             f"- {label}: `{row['state']}` - {_single_line(row['title'])} "
-            f"({_single_line(row['reason'])})"
+            f"({_single_line(row['reason'])}){claim_note}"
         )
     return "\n".join(lines)
 
@@ -297,7 +537,7 @@ def _run_gh_json(args: list[str]) -> Any:
     return json.loads(completed.stdout)
 
 
-def load_live_candidates(repo: str) -> dict[str, Any]:
+def load_live_candidates(repo: str, *, bounty_issue: int | None = None) -> dict[str, Any]:
     prs = _run_gh_json(
         [
             "gh",
@@ -317,6 +557,7 @@ def load_live_candidates(repo: str) -> dict[str, Any]:
                     "url",
                     "author",
                     "headRefOid",
+                    "baseRefOid",
                     "mergeStateStatus",
                     "labels",
                     "statusCheckRollup",
@@ -330,7 +571,25 @@ def load_live_candidates(repo: str) -> dict[str, Any]:
             f"gh pr list reached the {GH_PR_SAFETY_CAP} item safety cap; "
             "use an API-paginated collector before trusting this live report"
         )
-    return {"pull_requests": prs}
+    data: dict[str, Any] = {"repo": repo, "pull_requests": prs}
+    if bounty_issue is not None:
+        issue = _run_gh_json(
+            [
+                "gh",
+                "issue",
+                "view",
+                str(bounty_issue),
+                "--repo",
+                repo,
+                "--json",
+                "comments",
+            ]
+        )
+        comments = issue.get("comments", []) if isinstance(issue, dict) else []
+        if not isinstance(comments, list):
+            comments = []
+        data["bounty_claim_comments"] = comments
+    return data
 
 
 def _load_input(path: str) -> dict[str, Any]:
@@ -358,18 +617,32 @@ def main(argv: list[str] | None = None) -> int:
     source.add_argument("--input", help="Read candidate data from a JSON fixture file.")
     source.add_argument("--repo", help="Collect live open PR data with gh.")
     parser.add_argument("--reviewer", required=True, help="GitHub login of the reviewer.")
+    parser.add_argument(
+        "--bounty-issue",
+        type=int,
+        help="Active review-bounty issue number for claim saturation (live --repo mode only).",
+    )
     parser.add_argument("--sufficient-reviews", type=int, default=1)
     parser.add_argument("--format", choices=["json", "markdown", "text"], default="text")
     args = parser.parse_args(argv)
 
+    if args.input is not None and args.bounty_issue is not None:
+        parser.error("--bounty-issue is only valid in live --repo mode")
+
     if args.input is not None:
         data = _load_input(_require_non_empty_arg(parser, "--input", args.input))
     else:
-        data = load_live_candidates(_require_non_empty_arg(parser, "--repo", args.repo))
+        if args.bounty_issue is not None and args.bounty_issue < 1:
+            parser.error("--bounty-issue must be a positive integer")
+        data = load_live_candidates(
+            _require_non_empty_arg(parser, "--repo", args.repo),
+            bounty_issue=args.bounty_issue,
+        )
     report = analyze_candidates(
         data,
         reviewer=args.reviewer,
         sufficient_reviews=args.sufficient_reviews,
+        repo=data.get("repo") if isinstance(data.get("repo"), str) else None,
     )
     if args.format == "json":
         print(json.dumps(report, indent=2, sort_keys=True))

--- a/tests/test_review_bounty_candidates.py
+++ b/tests/test_review_bounty_candidates.py
@@ -8,9 +8,11 @@ from pathlib import Path
 import pytest
 
 from scripts.review_bounty_candidates import (
+    _apply_bounty_saturation,
     analyze_candidates,
     format_markdown_report,
     format_text_report,
+    index_bounty_claims,
     load_live_candidates,
     main,
 )
@@ -276,3 +278,232 @@ def test_live_candidates_reports_missing_github_cli(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="GitHub CLI executable 'gh' was not found"):
         load_live_candidates("ramimbo/mergework")
+
+
+def _pr(
+    number: int,
+    *,
+    head: str,
+    base: str = "base1",
+    merge_state: str = "CLEAN",
+    reviews: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    return {
+        "number": number,
+        "title": f"PR {number}",
+        "url": f"https://github.com/ramimbo/mergework/pull/{number}",
+        "author": {"login": "alice"},
+        "headRefOid": head,
+        "baseRefOid": base,
+        "mergeStateStatus": merge_state,
+        "labels": [],
+        "statusCheckRollup": _quality_check(),
+        "reviews": reviews or [],
+    }
+
+
+def test_review_bounty_candidates_marks_pr_review_claim_at_current_head() -> None:
+    head = "c" * 40
+    fixture = {
+        "repo": "ramimbo/mergework",
+        "pull_requests": [_pr(784, head=head)],
+        "bounty_claim_comments": [
+            {
+                "html_url": "https://github.com/ramimbo/mergework/issues/654#issuecomment-1",
+                "author": {"login": "bob"},
+                "body": (
+                    "Claiming review evidence "
+                    "https://github.com/ramimbo/mergework/pull/784#pullrequestreview-4406541805\n"
+                    f"head: {head}"
+                ),
+            }
+        ],
+    }
+
+    report = analyze_candidates(fixture, reviewer="reviewer")
+    row = report["pull_requests"][0]
+
+    assert row["state"] == "already_claimed_current_head"
+    assert row["claim_evidence_kind"] == "pr_review"
+    assert row["matched_claim_urls"] == [
+        "https://github.com/ramimbo/mergework/issues/654#issuecomment-1"
+    ]
+
+
+def test_review_bounty_candidates_marks_pr_comment_claim() -> None:
+    fixture = {
+        "repo": "ramimbo/mergework",
+        "pull_requests": [_pr(533, head="head533")],
+        "bounty_claim_comments": [
+            {
+                "html_url": "https://github.com/ramimbo/mergework/issues/654#issuecomment-2",
+                "author": {"login": "bob"},
+                "body": (
+                    "Reviewed via concise PR comment "
+                    "https://github.com/ramimbo/mergework/pull/533#issuecomment-999"
+                ),
+            }
+        ],
+    }
+
+    report = analyze_candidates(fixture, reviewer="reviewer")
+    row = report["pull_requests"][0]
+
+    assert row["state"] == "claimed_by_pr_comment"
+    assert row["claim_evidence_kind"] == "pr_comment"
+
+
+def test_review_bounty_candidates_flags_stale_head_claim() -> None:
+    fixture = {
+        "repo": "ramimbo/mergework",
+        "pull_requests": [_pr(662, head="newhead")],
+        "bounty_claim_comments": [
+            {
+                "html_url": "https://github.com/ramimbo/mergework/issues/654#issuecomment-3",
+                "author": {"login": "bob"},
+                "body": (
+                    "Claiming https://github.com/ramimbo/mergework/pull/662#pullrequestreview-1\n"
+                    "headRefOid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ),
+            }
+        ],
+    }
+
+    report = analyze_candidates(fixture, reviewer="reviewer")
+    row = report["pull_requests"][0]
+
+    assert row["state"] == "claimed_stale_head_or_base"
+    assert "differs from current head" in row["reason"]
+
+
+def test_review_bounty_candidates_flags_dirty_unclaimed_current_base_candidate() -> None:
+    fixture = {
+        "repo": "ramimbo/mergework",
+        "pull_requests": [_pr(662, head="head662", merge_state="DIRTY")],
+        "bounty_claim_comments": [],
+    }
+
+    report = analyze_candidates(fixture, reviewer="reviewer")
+    row = report["pull_requests"][0]
+
+    assert row["state"] == "dirty_unclaimed_current_base_candidate"
+
+
+def test_review_bounty_candidates_claim_without_pr_review_object() -> None:
+    fixture = {
+        "repo": "ramimbo/mergework",
+        "pull_requests": [_pr(784, head="head784", reviews=[])],
+        "bounty_claim_comments": [
+            {
+                "html_url": "https://github.com/ramimbo/mergework/issues/654#issuecomment-4",
+                "author": {"login": "bob"},
+                "body": "Claiming PR #784 with evidence in bounty comment only.",
+            }
+        ],
+    }
+
+    report = analyze_candidates(fixture, reviewer="reviewer")
+    row = report["pull_requests"][0]
+
+    assert row["state"] == "already_claimed_on_bounty_issue"
+    assert row["current_head_human_reviews"] == 0
+
+
+def test_index_bounty_claims_parses_bare_pr_number() -> None:
+    claims = index_bounty_claims(
+        [
+            {
+                "html_url": "https://github.com/ramimbo/mergework/issues/654#issuecomment-5",
+                "author": {"login": "bob"},
+                "body": "Claiming review for PR #784",
+            }
+        ],
+        repo="ramimbo/mergework",
+    )
+
+    assert 784 in claims
+    assert claims[784][0]["evidence_kind"] == "pr_reference"
+
+
+def test_review_bounty_candidates_live_mode_loads_bounty_issue_comments(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(list(args))
+        if args[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps([_pr(784, head="head784")]),
+                stderr="",
+            )
+        if args[:3] == ["gh", "issue", "view"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "comments": [
+                            {
+                                "html_url": "https://github.com/ramimbo/mergework/issues/654#issuecomment-1",
+                                "author": {"login": "bob"},
+                                "body": (
+                                    "Claiming "
+                                    "https://github.com/ramimbo/mergework/pull/784#pullrequestreview-1"
+                                ),
+                            }
+                        ]
+                    }
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected gh call: {args}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    data = load_live_candidates("ramimbo/mergework", bounty_issue=654)
+    report = analyze_candidates(data, reviewer="reviewer", repo=data["repo"])
+
+    assert any(call[:3] == ["gh", "issue", "view"] for call in calls)
+    assert report["pull_requests"][0]["state"] == "already_claimed_on_bounty_issue"
+
+
+def test_review_bounty_candidates_rejects_bounty_issue_in_offline_mode(capsys) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(
+            [
+                "--input",
+                "fixture.json",
+                "--bounty-issue",
+                "654",
+                "--reviewer",
+                "reviewer",
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    assert "--bounty-issue is only valid in live --repo mode" in capsys.readouterr().err
+
+
+def test_apply_bounty_saturation_preserves_current_head_reviewer_state() -> None:
+    row = {
+        "state": "already_reviewed_current_head_by_reviewer",
+        "reason": "reviewer already reviewed current head",
+        "number": 784,
+    }
+    claims = [
+        {
+            "head_sha": "a" * 40,
+            "base_sha": "b" * 40,
+            "evidence_kind": "pr_body",
+            "comment_url": "https://example.test/claim",
+        }
+    ]
+    result = _apply_bounty_saturation(
+        row,
+        claims=claims,
+        merge_state="clean",
+        head_oid="a" * 40,
+        base_oid="b" * 40,
+    )
+    assert result["state"] == "already_reviewed_current_head_by_reviewer"


### PR DESCRIPTION
## Summary

Add review-bounty claim saturation awareness to `scripts/review_bounty_candidates.py` for #797.

## Changes

- `--bounty-issue` live-mode flag loads active review-bounty issue comments via read-only `gh issue view`
- Parse PR review URLs, PR comment URLs, bare PR references, and optional head/base SHAs from claim comments
- New saturation states:
  - `already_claimed_on_bounty_issue`
  - `already_claimed_current_head`
  - `claimed_by_pr_comment`
  - `claimed_stale_head_or_base`
  - `dirty_unclaimed_current_base_candidate`
- JSON/Markdown output includes matched claim URLs for auditability
- Fixture input supports offline `bounty_claim_comments` + `repo`
- Admin runbook documents the new flag

## Verification

```bash
python -m pytest tests/test_review_bounty_candidates.py -q
python -m ruff check scripts/review_bounty_candidates.py tests/test_review_bounty_candidates.py
```

Fixes #797

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review reports now include bounty-claim matching, helping identify claimed, stale, and conflicting pull requests more clearly.
  * Live data can now incorporate claim information from related issue discussions for richer candidate analysis.

* **Bug Fixes**
  * Improved handling of pull requests with outdated claim references and unclaimed dirty/conflicted states.

* **Documentation**
  * Expanded admin runbook guidance for post-deploy checks and GitHub OAuth validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->