### PR TITLE
test(mcp): reject control-padded submit_work_proof format (#819)

### DIFF
--- a/tests/test_api_mcp.py
+++ b/tests/test_api_mcp.py
@@ -2464,6 +2464,27 @@ def test_mcp_submit_work_proof_rejects_invalid_bounty_selectors(
     _assert_invalid_tool_arguments_envelope(response.json(), request_id=request_id)
 
 
+def test_mcp_submit_work_proof_rejects_control_padded_format(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 37,
+            "method": "tools/call",
+            "params": {"name": "submit_work_proof", "arguments": {"format": "\u0085json"}},
+        },
+    )
+
+    assert response.status_code == 200
+    _assert_invalid_tool_arguments_envelope(response.json(), request_id=37)
+
+
 @pytest.mark.parametrize(
     ("arguments", "request_id"),
     [


### PR DESCRIPTION
## Summary

Adds focused regression coverage for #819: `submit_work_proof` must reject raw control-padded `format` values such as `\u0085json` instead of normalizing them to `json`.

## Changes

- `tests/test_api_mcp.py` — assert `/mcp` `tools/call` returns the existing invalid tool arguments envelope for control-padded format input

## Verification

```bash
pytest tests/test_api_mcp.py::test_mcp_submit_work_proof_rejects_control_padded_format -q
pytest tests/test_api_mcp.py -q
```

Fixes #819

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for an MCP API request that uses a control-padded `format` value.
  * Verified the API returns the expected invalid tool arguments response for this malformed input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->