### PR TITLE
[agent] Flag superseded review bounty rounds (#1033)

### DIFF
--- a/scripts/flag_superseded_review_rounds.py
+++ b/scripts/flag_superseded_review_rounds.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+REVIEW_ROUND_TITLE_RE = re.compile(
+    r"review open MergeWork PRs with evidence,\s*round\s+(\d+)",
+    re.IGNORECASE,
+)
+REQUIRED_LABELS = {"mrwk:bounty", "review"}
+
+
+def _labels(raw: dict[str, Any]) -> set[str]:
+    names: set[str] = set()
+    for label in raw.get("labels", []):
+        if isinstance(label, str):
+            names.add(label)
+        elif isinstance(label, dict) and isinstance(label.get("name"), str):
+            names.add(label["name"])
+    return names
+
+
+def _issue_number(raw: dict[str, Any]) -> int | None:
+    value = raw.get("number", raw.get("issue_number"))
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _round_number(raw: dict[str, Any]) -> int | None:
+    title = str(raw.get("title") or "")
+    match = REVIEW_ROUND_TITLE_RE.search(title)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def is_review_bounty_issue(raw: dict[str, Any]) -> bool:
+    labels = _labels(raw)
+    if not REQUIRED_LABELS.issubset(labels):
+        return False
+    return _round_number(raw) is not None
+
+
+def classify_review_rounds(issues: list[dict[str, Any]]) -> dict[str, Any]:
+    review_issues = [issue for issue in issues if is_review_bounty_issue(issue)]
+    if not review_issues:
+        return {
+            "current_issue_number": None,
+            "current_round": None,
+            "superseded": [],
+            "open_review_rounds": [],
+        }
+
+    numbered = [
+        (issue, _round_number(issue)) for issue in review_issues if _round_number(issue) is not None
+    ]
+    numbered.sort(key=lambda item: (item[1] or 0, _issue_number(item[0]) or 0))
+    open_numbered = [item for item in numbered if str(item[0].get("state") or "").lower() == "open"]
+    if not open_numbered:
+        return {
+            "current_issue_number": None,
+            "current_round": None,
+            "superseded": [],
+            "open_review_rounds": [],
+        }
+    current_issue, current_round = open_numbered[-1]
+    current_number = _issue_number(current_issue)
+
+    superseded: list[dict[str, Any]] = []
+    open_review_rounds: list[dict[str, Any]] = []
+    for issue, round_no in open_numbered:
+        number = _issue_number(issue)
+        if number is None or round_no is None:
+            continue
+        row = {
+            "issue_number": number,
+            "round": round_no,
+            "title": str(issue.get("title") or ""),
+            "state": str(issue.get("state") or "unknown"),
+            "labels": sorted(_labels(issue)),
+        }
+        open_review_rounds.append(row)
+        if number != current_number:
+            superseded.append(
+                {
+                    **row,
+                    "reason": (
+                        f"round {round_no} is older than current live round {current_round}"
+                    ),
+                    "recommended_action": (
+                        f"close, label, or comment pointing reviewers to #{current_number}"
+                    ),
+                }
+            )
+
+    return {
+        "current_issue_number": current_number,
+        "current_round": current_round,
+        "superseded": superseded,
+        "open_review_rounds": open_review_rounds,
+    }
+
+
+def render_report(report: dict[str, Any]) -> str:
+    lines = ["Superseded review bounty round report", ""]
+    current = report.get("current_issue_number")
+    current_round = report.get("current_round")
+    if current is None:
+        lines.append("No open mrwk:bounty + review round issues found.")
+        return "\n".join(lines)
+
+    lines.append(f"Current live review round: #{current} (round {current_round})")
+    lines.append("")
+    superseded = report.get("superseded") or []
+    if not superseded:
+        lines.append("No superseded open review rounds detected.")
+        return "\n".join(lines)
+
+    lines.append("Likely superseded open review rounds:")
+    for row in superseded:
+        lines.append(
+            f"- #{row['issue_number']} round {row['round']} ({row['state']}): {row['reason']}",
+        )
+        lines.append(f"  recommended: {row['recommended_action']}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Identify superseded open review bounty rounds from issue metadata.",
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        help="JSON file with top-level 'issues' list (GitHub issue objects).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print structured JSON instead of a human-readable report.",
+    )
+    parser.add_argument(
+        "--fail-on-superseded",
+        action="store_true",
+        help="Exit 1 when any superseded open review round is found.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.input is None:
+        print("flag_superseded_review_rounds: --input is required", file=sys.stderr)
+        return 2
+
+    payload = json.loads(args.input.read_text(encoding="utf-8"))
+    issues = payload.get("issues", payload if isinstance(payload, list) else [])
+    if not isinstance(issues, list):
+        print("flag_superseded_review_rounds: expected issues list", file=sys.stderr)
+        return 2
+
+    report = classify_review_rounds(issues)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(render_report(report))
+
+    if args.fail_on_superseded and report.get("superseded"):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_flag_superseded_review_rounds.py
+++ b/tests/test_flag_superseded_review_rounds.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import flag_superseded_review_rounds as fsrr
+
+
+def _issue(number: int, round_no: int, state: str = "open") -> dict:
+    return {
+        "number": number,
+        "state": state,
+        "title": (
+            f"MRWK bounty: 40 MRWK - review open MergeWork PRs with evidence, round {round_no}"
+        ),
+        "labels": [{"name": "mrwk:bounty"}, {"name": "review"}],
+    }
+
+
+def test_classify_review_rounds_marks_older_rounds_superseded() -> None:
+    issues = [_issue(643, 17), _issue(654, 18), _issue(838, 19), _issue(933, 20)]
+
+    report = fsrr.classify_review_rounds(issues)
+
+    assert report["current_issue_number"] == 933
+    assert report["current_round"] == 20
+    assert {row["issue_number"] for row in report["superseded"]} == {643, 654, 838}
+
+
+def test_classify_review_rounds_does_not_flag_current_round() -> None:
+    issues = [_issue(933, 20)]
+
+    report = fsrr.classify_review_rounds(issues)
+
+    assert report["superseded"] == []
+
+
+def test_main_fixture_report(tmp_path: Path) -> None:
+    payload = {"issues": [_issue(643, 17), _issue(933, 20)]}
+    fixture = tmp_path / "issues.json"
+    fixture.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert fsrr.main(["--input", str(fixture), "--fail-on-superseded"]) == 1
+
+
+def test_render_report_names_current_round() -> None:
+    report = fsrr.classify_review_rounds([_issue(643, 17), _issue(933, 20)])
+
+    text = fsrr.render_report(report)
+
+    assert "Current live review round: #933 (round 20)" in text
+    assert "#643 round 17" in text
+
+
+def test_classify_review_rounds_ignores_closed_newer_round() -> None:
+    issues = [_issue(643, 17), _issue(933, 20, state="closed")]
+
+    report = fsrr.classify_review_rounds(issues)
+
+    assert report["current_issue_number"] == 643
+    assert report["current_round"] == 17
+    assert report["superseded"] == []


### PR DESCRIPTION
Adds read-only classifier for open review bounty rounds. Fixes #1033. Wallet: Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to review issue lists and flag older open review rounds that have been superseded by newer ones.
  * Supports both human-readable and JSON output, with an option to fail automatically when superseded rounds are found.

* **Bug Fixes**
  * Improves review-round tracking by ignoring closed newer issues when determining the current active round.
  * Adds clearer reporting for the current round and superseded entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->