### PR TITLE
Guard PR bodies against premature payment wording

### DIFF
--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -337,28 +337,28 @@ def _has_evidence(text: str) -> bool:
 
 
 def _payment_status_language_check(text: str) -> dict[str, str]:
-    if PAYMENT_STATUS_HEADING_RE.search(text):
-        return _check(
-            "payment_status_language",
-            "fail",
-            "replace `Payout boundary` status wording with neutral `Submission status` text",
-        )
-    if PAYMENT_STATUS_BOUNDARY_RE.search(text):
-        return _check(
-            "payment_status_language",
-            "fail",
-            "avoid saying submitted work is not confirmed, earned, accepted, paid, settled, "
-            "received, or withdrawable; use neutral submission-status wording",
-        )
     for line in text.splitlines():
-        if PAYMENT_STATUS_CONTEXT_ALLOW_RE.search(line):
-            continue
         if PAYMENT_STATUS_ASSERTION_RE.search(line):
             return _check(
                 "payment_status_language",
                 "fail",
                 "reserve paid, settled, received, and withdrawable status claims for "
                 "proof-backed ledger outcomes",
+            )
+        if PAYMENT_STATUS_CONTEXT_ALLOW_RE.search(line):
+            continue
+        if PAYMENT_STATUS_HEADING_RE.search(line):
+            return _check(
+                "payment_status_language",
+                "fail",
+                "replace `Payout boundary` status wording with neutral `Submission status` text",
+            )
+        if PAYMENT_STATUS_BOUNDARY_RE.search(line):
+            return _check(
+                "payment_status_language",
+                "fail",
+                "avoid saying submitted work is not confirmed, earned, accepted, paid, settled, "
+                "received, or withdrawable; use neutral submission-status wording",
             )
     return _check(
         "payment_status_language",

--- a/scripts/submission_quality_gate.py
+++ b/scripts/submission_quality_gate.py
@@ -40,6 +40,26 @@ EVIDENCE_RE = re.compile(
     re.IGNORECASE,
 )
 SUMMARY_RE = re.compile(r"\b(summary|what changed|changes?)\b", re.IGNORECASE)
+PAYMENT_STATUS_HEADING_RE = re.compile(
+    r"^\s*(?:#+\s*)?payout boundary\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+PAYMENT_STATUS_BOUNDARY_RE = re.compile(
+    r"\bnot\s+(?:confirmed|earned|accepted|paid|settled|received)\s+(?:or|and)\s+withdrawable\b",
+    re.IGNORECASE,
+)
+PAYMENT_STATUS_ASSERTION_RE = re.compile(
+    r"\b(?:submission|submitted|pending|claim|status|attempt|this work|this pr|bounty)\b"
+    r"[^\n.]{0,80}\b(?:paid|settled|received|withdrawable)\b|"
+    r"\b(?:paid|settled|received|withdrawable)\b[^\n.]{0,80}"
+    r"\b(?:submission|submitted|pending|claim|status|attempt|this work|this pr|bounty)\b",
+    re.IGNORECASE,
+)
+PAYMENT_STATUS_CONTEXT_ALLOW_RE = re.compile(
+    r"\b(?:docs?|documentation|runbook|lifecycle|proof-backed|"
+    r"no\s+(?:payout|payment|ledger|treasury)\s+(?:execution|changes?))\b",
+    re.IGNORECASE,
+)
 GH_TIMEOUT_SECONDS = 30
 DEFAULT_API_HOST = "https://api.mrwk.online"
 DEFAULT_MAX_MAINTAINER_AGE_DAYS = 14
@@ -316,6 +336,37 @@ def _has_evidence(text: str) -> bool:
     return False
 
 
+def _payment_status_language_check(text: str) -> dict[str, str]:
+    if PAYMENT_STATUS_HEADING_RE.search(text):
+        return _check(
+            "payment_status_language",
+            "fail",
+            "replace `Payout boundary` status wording with neutral `Submission status` text",
+        )
+    if PAYMENT_STATUS_BOUNDARY_RE.search(text):
+        return _check(
+            "payment_status_language",
+            "fail",
+            "avoid saying submitted work is not confirmed, earned, accepted, paid, settled, "
+            "received, or withdrawable; use neutral submission-status wording",
+        )
+    for line in text.splitlines():
+        if PAYMENT_STATUS_CONTEXT_ALLOW_RE.search(line):
+            continue
+        if PAYMENT_STATUS_ASSERTION_RE.search(line):
+            return _check(
+                "payment_status_language",
+                "fail",
+                "reserve paid, settled, received, and withdrawable status claims for "
+                "proof-backed ledger outcomes",
+            )
+    return _check(
+        "payment_status_language",
+        "pass",
+        "no premature payment-status wording found",
+    )
+
+
 def _matching_pr_bounty_refs(pr: dict[str, Any]) -> list[int]:
     text = "\n".join(str(pr.get(key) or "") for key in ("title", "body"))
     return _bounty_refs(text)
@@ -480,6 +531,8 @@ def evaluate_submission(data: dict[str, Any]) -> dict[str, Any]:
                 "include concrete test or validation evidence before submission",
             )
         )
+
+    checks.append(_payment_status_language_check(text))
 
     similar = _similar_open_prs(pull_requests, bounty_ref, _title_from_submission(text))
     if similar:

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -42,6 +42,7 @@ def test_submission_quality_gate_passes_open_bounty_with_evidence(capsys, tmp_pa
         "bounty_payable": "pass",
         "summary_present": "pass",
         "evidence_present": "pass",
+        "payment_status_language": "pass",
         "similar_open_pr": "pass",
     }
 
@@ -62,6 +63,125 @@ def test_submission_quality_gate_script_entrypoint_loads_shared_parser() -> None
 
     assert result.returncode == 0
     assert "usage:" in result.stdout
+
+
+def test_submission_quality_gate_fails_payout_boundary_status_wording() -> None:
+    result = evaluate_submission(
+        {
+            "submission_text": """
+            Summary:
+            Add a focused pre-submission wording guard.
+
+            Refs #319
+
+            Payout boundary:
+            This submission is not confirmed or withdrawable.
+
+            Validation:
+            - pytest passed.
+            """,
+            "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [],
+        }
+    )
+
+    assert result["status"] == "fail"
+    assert {
+        "name": "payment_status_language",
+        "status": "fail",
+        "message": (
+            "replace `Payout boundary` status wording with neutral `Submission status` text"
+        ),
+    } in result["checks"]
+
+
+def test_submission_quality_gate_fails_reserved_payment_status_assertion() -> None:
+    result = evaluate_submission(
+        {
+            "submission_text": """
+            Summary:
+            Add a focused pre-submission wording guard.
+
+            Refs #319
+
+            Submission status:
+            This pending claim is paid.
+
+            Validation:
+            - pytest passed.
+            """,
+            "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [],
+        }
+    )
+
+    assert result["status"] == "fail"
+    assert {
+        "name": "payment_status_language",
+        "status": "fail",
+        "message": (
+            "reserve paid, settled, received, and withdrawable status claims for "
+            "proof-backed ledger outcomes"
+        ),
+    } in result["checks"]
+
+
+def test_submission_quality_gate_accepts_neutral_submission_status_wording() -> None:
+    result = evaluate_submission(
+        {
+            "submission_text": """
+            Summary:
+            Add a focused pre-submission wording guard.
+
+            Refs #319
+
+            Submission status:
+            Maintainer acceptance and any later proof or ledger outcome are tracked
+            separately through the bounty issue and public rows.
+
+            Validation:
+            - pytest passed.
+            """,
+            "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [],
+        }
+    )
+
+    assert result["status"] == "pass"
+    assert {
+        "name": "payment_status_language",
+        "status": "pass",
+        "message": "no premature payment-status wording found",
+    } in result["checks"]
+
+
+def test_submission_quality_gate_allows_technical_and_docs_payment_wording() -> None:
+    result = evaluate_submission(
+        {
+            "submission_text": """
+            Summary:
+            Add a focused pre-submission wording guard.
+
+            Refs #319
+
+            Scope:
+            No payout execution changes are included.
+            Docs explain when proof-backed ledger entries become paid.
+
+            Validation:
+            - pytest passed.
+            """,
+            "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [],
+        }
+    )
+
+    assert result["status"] == "pass"
+    assert {
+        "name": "payment_status_language",
+        "status": "pass",
+        "message": "no premature payment-status wording found",
+    } in result["checks"]
 
 
 def test_submission_quality_gate_accepts_claim_command_reference() -> None:

--- a/tests/test_submission_quality_gate.py
+++ b/tests/test_submission_quality_gate.py
@@ -126,6 +126,36 @@ def test_submission_quality_gate_fails_reserved_payment_status_assertion() -> No
     } in result["checks"]
 
 
+def test_submission_quality_gate_fails_reserved_wording_alongside_allowlisted_terms() -> None:
+    result = evaluate_submission(
+        {
+            "submission_text": """
+            Summary:
+            Add a focused pre-submission wording guard.
+
+            Refs #319
+
+            Per the docs, this submission is paid.
+
+            Validation:
+            - pytest passed.
+            """,
+            "bounties": [{"number": 319, "state": "OPEN", "awards_remaining": 1}],
+            "pull_requests": [],
+        }
+    )
+
+    assert result["status"] == "fail"
+    assert {
+        "name": "payment_status_language",
+        "status": "fail",
+        "message": (
+            "reserve paid, settled, received, and withdrawable status claims for "
+            "proof-backed ledger outcomes"
+        ),
+    } in result["checks"]
+
+
 def test_submission_quality_gate_accepts_neutral_submission_status_wording() -> None:
     result = evaluate_submission(
         {


### PR DESCRIPTION
## Summary

- Add a `payment_status_language` check to `scripts/submission_quality_gate.py` for PR/submission bodies.
- Fail legacy `Payout boundary` wording and premature submitted-claim status assertions using reserved words such as paid, settled, received, and withdrawable.
- Keep neutral `Submission status`, technical no-payout-execution scope, and docs/lifecycle wording passing.

## Evidence

- Confusion, missing step, stale example, or bug this addresses: #1107 documents repeated public PR-body wording drift where submitted work used older payment/status phrasing that maintainers had to correct manually.
- Bounty capacity and active attempts/open PRs checked: Bounty #936 is open on the public GitHub issue and scoped to small maintainability/script improvements; this PR is a focused gate improvement in an existing maintainer-facing script. I also checked recent open issues and #1107 as the specific source evidence.
- Intended files or surfaces: `scripts/submission_quality_gate.py`, `tests/test_submission_quality_gate.py`.
- Expected PR size: small, two files.
- Out of scope: no payout execution, ledger mutation, wallet behavior, treasury behavior, bridge/exchange/off-ramp, price claim, acceptance automation, or admin-token behavior.

## Test Evidence

- [x] `python -m pytest tests/test_submission_quality_gate.py -q` -> 53 passed.
- [x] `python -m ruff format --check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` -> 2 files already formatted.
- [x] `python -m ruff check scripts/submission_quality_gate.py tests/test_submission_quality_gate.py` -> All checks passed.
- [x] `git diff --check` -> passed.

## MRWK

Bounty #936
Refs #1107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Submission checks now flag premature payout/payment-status language, helping keep submission wording accurate and consistent.
  * Text that claims a payout is already paid, settled, received, or withdrawable will now be rejected when used in the wrong context.
  * Neutral status wording and legitimate technical/payment execution references continue to pass validation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->