### PR TITLE
Reject unsupported activity filters

### DIFF
--- a/app/activity.py
+++ b/app/activity.py
@@ -11,8 +11,24 @@ from sqlalchemy.orm import Session
 from app.accounts import normalized_account
 from app.control_chars import contains_control_character
 from app.db import session_scope
-from app.query_validation import reject_control_char_query_param, reject_repeated_query_param
+from app.query_validation import (
+    reject_control_char_query_param,
+    reject_repeated_query_param,
+    reject_unsupported_query_params,
+)
 from app.serializers import activity_to_dict
+
+ACTIVITY_UNSUPPORTED_FILTERS = (
+    "limit",
+    "offset",
+    "status",
+    "sort",
+    "repo",
+    "issue_number",
+    "availability",
+    "type",
+    "tx_type",
+)
 
 
 def activity_context(
@@ -46,6 +62,11 @@ def _activity_page_url(account: str | None) -> str:
 
 
 def _validate_activity_filter_params(request: Request) -> None:
+    reject_unsupported_query_params(
+        request,
+        ACTIVITY_UNSUPPORTED_FILTERS,
+        context="activity",
+    )
     for name in ("q", "account"):
         reject_control_char_query_param(request, name)
         reject_repeated_query_param(request, name)

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -346,6 +346,36 @@ def test_activity_query_rejects_control_characters(sqlite_url: str) -> None:
     assert invalid_page_account_response.json()["detail"] == "github login must be valid"
 
 
+def test_activity_routes_reject_unsupported_filters(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    with session_scope(sqlite_url) as session:
+        ensure_genesis(session)
+
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    assert client.get("/api/v1/activity?q=github").status_code == 200
+    assert client.get("/activity?account=github:alice").status_code == 200
+
+    for query, field in (
+        ("limit=10", "limit"),
+        ("status=open", "status"),
+        ("sort=recent", "sort"),
+        ("repo=ramimbo%2Fmergework", "repo"),
+        ("issue_number=935", "issue_number"),
+        ("availability=effectively_open", "availability"),
+        ("type=payment", "type"),
+        ("tx_type=payment", "tx_type"),
+        ("offset=1", "offset"),
+    ):
+        api_response = client.get(f"/api/v1/activity?{query}")
+        page_response = client.get(f"/activity?{query}")
+
+        assert api_response.status_code == 400
+        assert api_response.json()["detail"] == f"{field} is not supported on activity"
+        assert page_response.status_code == 400
+        assert page_response.json()["detail"] == f"{field} is not supported on activity"
+
+
 def test_activity_api_exposes_pending_payouts_separately_from_paid_work(
     sqlite_url: str,
 ) -> None:


### PR DESCRIPTION
Related issue #935

## Summary
- Reject unsupported list and ledger-style filters on `/api/v1/activity` and `/activity` instead of silently ignoring them.
- Keep the supported activity filters (`q` and `account`) unchanged.
- Add focused route coverage for both the JSON API and public activity page.

## Why
The activity feed only supports accepted-work search and exact account scoping. Parameters such as `limit`, `status`, `sort`, `repo`, `issue_number`, `availability`, `type`, `tx_type`, and `offset` are meaningful on other public surfaces, but on activity they were ignored. Returning a clear 400 keeps contributor routing explicit and avoids implying that activity was filtered by unsupported fields.

## Validation
- `./.venv/bin/python -m pytest tests/test_activity.py::test_activity_query_rejects_control_characters tests/test_activity.py::test_activity_routes_reject_unsupported_filters -q` -> 2 passed, 1 existing Starlette/httpx warning
- `./.venv/bin/python -m pytest tests/test_activity.py tests/test_activity_routes.py -q` -> 9 passed, 1 existing Starlette/httpx warning
- `./.venv/bin/ruff check app/activity.py tests/test_activity.py` -> All checks passed
- `./.venv/bin/ruff format --check app/activity.py tests/test_activity.py` -> 2 files already formatted
- `./.venv/bin/python -m mypy app/activity.py` -> Success: no issues found in 1 source file
- `git diff --check` -> clean

## Scope
Public activity route validation and focused tests only. No ledger mutation, wallet behavior, administrative-token behavior, exchange behavior, pricing behavior, private data, or secrets changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Activity pages and API responses now reject unsupported filter and sorting parameters with a clear 400 error.
  * Validation continues to accept the supported activity filters while blocking invalid repeated or malformed inputs.
* **Tests**
  * Added coverage to verify unsupported activity query parameters are rejected consistently for both the web page and API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->