### PR TITLE
Reject unsupported wallet list filters

### DIFF
--- a/app/public_routes.py
+++ b/app/public_routes.py
@@ -39,6 +39,20 @@ from app.status import (
 )
 
 WALLET_SEARCH_QUERY_MAX_LENGTH = 500
+WALLET_LIST_UNSUPPORTED_FILTERS = (
+    "account",
+    "availability",
+    "from_address",
+    "issue_number",
+    "limit",
+    "offset",
+    "repo",
+    "sort",
+    "status",
+    "to_address",
+    "tx_type",
+    "type",
+)
 
 
 def _bounty_filter_params(
@@ -425,6 +439,9 @@ def register_public_routes(
     def wallets_page(request: Request, q: str | None = Query(None)) -> HTMLResponse:
         reject_control_char_query_param(request, "q")
         reject_repeated_query_param(request, "q")
+        reject_unsupported_query_params(
+            request, WALLET_LIST_UNSUPPORTED_FILTERS, context="wallet list"
+        )
         with session_scope(db_url) as session:
             context = wallets_page_context(session, q)
         return templates.TemplateResponse(request, "wallets.html", context)

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -811,6 +811,16 @@ def test_wallet_list_rejects_unsupported_filters(sqlite_url: str, query: str, de
     assert response.json()["detail"] == detail
 
 
+def test_wallet_list_allows_supported_q_filter(sqlite_url: str) -> None:
+    create_schema(sqlite_url)
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get("/wallets?q=mrwk1abc")
+
+    assert response.status_code == 200
+    assert "No registered wallets match this search." in response.text
+
+
 def test_me_page_shows_signed_in_github_claim_balance(sqlite_url: str, monkeypatch) -> None:
     monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
     create_schema(sqlite_url)

--- a/tests/test_wallet_api.py
+++ b/tests/test_wallet_api.py
@@ -789,6 +789,28 @@ def test_wallet_pages_reject_control_character_filters(sqlite_url: str) -> None:
     assert oversized_search_response.json()["detail"] == "q must be at most 500 characters"
 
 
+@pytest.mark.parametrize(
+    ("query", "detail"),
+    (
+        ("type=test_funding", "type is not supported on wallet list"),
+        ("tx_type=wallet_transfer", "tx_type is not supported on wallet list"),
+        ("from_address=mrwk1abc", "from_address is not supported on wallet list"),
+        ("to_address=mrwk1abc", "to_address is not supported on wallet list"),
+        ("account=github:alice", "account is not supported on wallet list"),
+        ("status=open", "status is not supported on wallet list"),
+        ("limit=25", "limit is not supported on wallet list"),
+        ("sort=newest", "sort is not supported on wallet list"),
+    ),
+)
+def test_wallet_list_rejects_unsupported_filters(sqlite_url: str, query: str, detail: str) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+
+    response = client.get(f"/wallets?{query}")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == detail
+
+
 def test_me_page_shows_signed_in_github_claim_balance(sqlite_url: str, monkeypatch) -> None:
     monkeypatch.setenv("MERGEWORK_COOKIE_SECRET", "test-cookie-secret")
     create_schema(sqlite_url)


### PR DESCRIPTION
Related issue #1011

## Summary
- Keeps `/wallets` scoped to its supported `q` search parameter.
- Rejects nearby wallet, account, and transfer filters such as `type`, `tx_type`, `from_address`, `to_address`, `account`, `status`, `limit`, and `sort` with clear 400 responses instead of silently ignoring them.
- Adds focused regression coverage for the wallet-list query guard.

## Duplicate Check
Existing #1011 submissions I found cover transfer prefill, `/me` account shortcuts, account/wallet navigation, wallet search notice rendering, and wallet action links. I did not find an open PR covering unsupported query-filter rejection on the `/wallets` list route.

## Validation
- `./.venv/bin/python -m pytest tests/test_wallet_api.py::test_wallet_pages_reject_control_character_filters tests/test_wallet_api.py::test_wallet_list_rejects_unsupported_filters -q` -> 9 passed, 1 existing Starlette/httpx warning.
- `./.venv/bin/python -m pytest tests/test_wallet_api.py tests/test_public_routes.py tests/test_account_routes.py -q` -> 69 passed, 1 existing Starlette/httpx warning.
- `./.venv/bin/ruff check app/public_routes.py tests/test_wallet_api.py` -> passed.
- `./.venv/bin/ruff format --check app/public_routes.py tests/test_wallet_api.py` -> 2 files already formatted.
- `./.venv/bin/python -m mypy app/public_routes.py` -> success.
- `./.venv/bin/python scripts/docs_smoke.py` -> docs smoke ok.
- `git diff --check` -> clean.
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `7762447113c0e738c8786f302ccb0b9ba7e09cef`.

## Scope Boundary
This is limited to public wallet-list query validation and route tests. It does not change wallet signing payloads, nonce/replay checks, transfer execution, ledger mutation, balance accounting, wallet custody, treasury/admin-token behavior, bridge and exchange behavior, MRWK price behavior, private data, or secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The wallet list page now rejects unsupported filter parameters and returns a clear 400 error instead of proceeding with the request.
  * Requests using invalid wallet list filters now receive specific messages indicating which filter is not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->