### PR TITLE
Add OpenAPI 400 error response schemas

### DIFF
--- a/app/openapi_request_bodies.py
+++ b/app/openapi_request_bodies.py
@@ -29,6 +29,22 @@ def _json_response(
     }
 
 
+HTTP_ERROR_RESPONSE_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "detail": {
+            "oneOf": [
+                {"type": "string"},
+                {"type": "array", "items": {"type": "object", "additionalProperties": True}},
+            ],
+            "description": "Bounded FastAPI error detail for rejected public API requests.",
+        },
+    },
+    "required": ["detail"],
+}
+
+
 def _object_schema(
     properties: dict[str, Any], *, required: list[str] | None = None, description: str | None = None
 ) -> dict[str, Any]:
@@ -367,6 +383,10 @@ OPTIONAL_ATTEMPT_BODY = {
         "201": _json_response(
             ATTEMPT_REGISTRATION_RESPONSE_SCHEMA, description="Attempt registered."
         ),
+        "400": _json_response(
+            HTTP_ERROR_RESPONSE_SCHEMA,
+            description="Invalid attempt reservation payload.",
+        ),
         "409": _json_response(
             ATTEMPT_CONFLICT_RESPONSE_SCHEMA,
             description="Attempt unavailable or duplicate active attempt.",
@@ -391,6 +411,10 @@ OPTIONAL_ATTEMPT_RELEASE_BODY = {
     ),
     "responses": {
         "200": _json_response(ATTEMPT_RELEASE_RESPONSE_SCHEMA),
+        "400": _json_response(
+            HTTP_ERROR_RESPONSE_SCHEMA,
+            description="Invalid attempt release payload.",
+        ),
     },
 }
 
@@ -409,6 +433,7 @@ WALLET_REGISTER_BODY = {
     ),
     "responses": {
         "200": _json_response(WALLET_RESPONSE_SCHEMA),
+        "400": _json_response(HTTP_ERROR_RESPONSE_SCHEMA, description="Invalid wallet payload."),
     },
 }
 
@@ -430,6 +455,9 @@ SIGNED_WALLET_ACTION_BODY = {
     ),
     "responses": {
         "200": _json_response(WALLET_RESPONSE_SCHEMA),
+        "400": _json_response(
+            HTTP_ERROR_RESPONSE_SCHEMA, description="Invalid signed wallet payload."
+        ),
     },
 }
 
@@ -437,6 +465,9 @@ GITHUB_CLAIM_BODY = {
     "requestBody": SIGNED_WALLET_ACTION_BODY["requestBody"],
     "responses": {
         "200": _json_response(LEDGER_ENTRY_RESPONSE_SCHEMA),
+        "400": _json_response(
+            HTTP_ERROR_RESPONSE_SCHEMA, description="Invalid GitHub claim payload."
+        ),
     },
 }
 
@@ -465,6 +496,10 @@ WALLET_TRANSFER_BODY = {
     ),
     "responses": {
         "200": _json_response(WALLET_TRANSFER_RESPONSE_SCHEMA),
+        "400": _json_response(
+            HTTP_ERROR_RESPONSE_SCHEMA,
+            description="Invalid wallet transfer payload.",
+        ),
     },
 }
 
@@ -484,6 +519,10 @@ TREASURY_PROPOSAL_BODY = {
     ),
     "responses": {
         "200": _json_response(TREASURY_PROPOSAL_RESPONSE_SCHEMA),
+        "400": _json_response(
+            HTTP_ERROR_RESPONSE_SCHEMA,
+            description="Invalid treasury proposal payload.",
+        ),
     },
 }
 
@@ -499,6 +538,10 @@ TREASURY_CHALLENGE_BODY = {
     ),
     "responses": {
         "200": _json_response(TREASURY_CHALLENGE_RESPONSE_SCHEMA),
+        "400": _json_response(
+            HTTP_ERROR_RESPONSE_SCHEMA,
+            description="Invalid treasury challenge payload.",
+        ),
     },
 }
 

--- a/tests/test_openapi_request_bodies.py
+++ b/tests/test_openapi_request_bodies.py
@@ -8,8 +8,7 @@ from fastapi.testclient import TestClient
 from app.main import create_app
 
 EXPECTED_TTL_STRING_PATTERN = (
-    r"^(?:[6-9][0-9]|[1-9][0-9]{2,4}|[1-5][0-9]{5}|"
-    r"60[0-3][0-9]{3}|604[0-7][0-9]{2}|604800)$"
+    r"^(?:[6-9][0-9]|[1-9][0-9]{2,4}|[1-5][0-9]{5}|" r"60[0-3][0-9]{3}|604[0-7][0-9]{2}|604800)$"
 )
 
 
@@ -365,6 +364,34 @@ def test_public_post_openapi_response_schemas_expose_treasury_fields(sqlite_url:
             "created_at",
         },
     )
+
+
+def test_public_post_openapi_error_responses_expose_detail_contract(
+    sqlite_url: str,
+) -> None:
+    client = TestClient(create_app(database_url=sqlite_url, webhook_secret="secret"))
+    openapi = client.get("/openapi.json").json()
+
+    public_post_paths = (
+        "/api/v1/bounties/{bounty_id}/attempts",
+        "/api/v1/bounty-attempts/{attempt_id}/release",
+        "/api/v1/wallets/register",
+        "/api/v1/wallets/link-github",
+        "/api/v1/github/claim",
+        "/api/v1/transfers",
+        "/api/v1/treasury/proposals",
+        "/api/v1/treasury/proposals/{proposal_id}/challenges",
+    )
+
+    for path in public_post_paths:
+        schema = _post_response_schema(openapi, path, "400")
+        assert schema["additionalProperties"] is False
+        assert set(schema["required"]) == {"detail"}
+        detail_schema = schema["properties"]["detail"]
+        assert {"type": "string"} in detail_schema["oneOf"]
+        assert {"type": "array", "items": {"type": "object", "additionalProperties": True}} in (
+            detail_schema["oneOf"]
+        )
 
 
 def test_attempt_openapi_request_bodies_remain_optional(sqlite_url: str) -> None:


### PR DESCRIPTION
Refs Bounty #944.

## Summary
- Adds a shared OpenAPI schema for FastAPI-style `400` error responses with a required `detail` field.
- Advertises `400` response contracts on the existing public POST endpoints for bounty attempts, attempt release, wallet registration/linking, GitHub claims, transfers, treasury proposals, and treasury challenges.
- Keeps runtime behavior unchanged; this is OpenAPI/client-contract metadata and focused regression coverage only.

## Evidence
- Current head: `421436dcab095138efb4f82b7ed38fb88b3332e7`
- PR state checked 2026-07-10 Australia/Sydney: open, non-draft, `mergeable=true`.
- CodeRabbit generated no actionable comments and passed the bounty-focus/public-artifact checks.
- Changed surfaces: `app/openapi_request_bodies.py`, `tests/test_openapi_request_bodies.py`.

## Validation
- `python -m pytest tests\test_openapi_request_bodies.py -q` -> 10 passed
- `python -m ruff check app\openapi_request_bodies.py tests\test_openapi_request_bodies.py` -> All checks passed
- `python -m ruff format --check app\openapi_request_bodies.py tests\test_openapi_request_bodies.py` -> 2 files already formatted
- `python -m mypy app\openapi_request_bodies.py` -> Success: no issues found in 1 source file
- `python scripts\docs_smoke.py` -> docs smoke ok
- `git diff --check upstream/main...HEAD` -> clean
- `git merge-tree --write-tree upstream/main HEAD` -> clean tree `455be13dcd6cc4d286d157d5735f94cbe0dacf10`

## Scope boundary
No runtime API behavior, ledger mutation, wallet custody/signing, transfer execution, treasury execution, payout execution, admin-token behavior, bridge/exchange/off-ramp/cash-out behavior, MRWK price behavior, private data, or secrets changed.