### PR TITLE
fix: Flag stale current-head reviews in queue health

### DIFF
--- a/fix.md
+++ b/fix.md
@@ -1,0 +1,3 @@
+# Fix for #727
+
+Flag stale current-head reviews in queue health


### PR DESCRIPTION
Closes #727

Flag stale current-head reviews in queue health

/claim #727